### PR TITLE
🔧 Standardize environment config

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,7 @@
+MONGODB_URL=mongodb://localhost:27017
+MONGODB_DB_NAME=chat-ui
+HF_TOKEN=#your huggingface token here
+
 PUBLIC_MODEL_ENDPOINT=https://api-inference.huggingface.co/models/OpenAssistant/oasst-sft-1-pythia-12b
 PUBLIC_MODEL_NAME=OpenAssistant/oasst-sft-1-pythia-12b
 PUBLIC_MODEL_TAGLINE=This is the first iteration English supervised-fine-tuning (SFT) model of the <a class="underline" href="https://github.com/LAION-AI/Open-Assistant">Open-Assistant</a> project. It is based on a Pythia 12B that was fine-tuned on ~22k human demonstrations of assistant conversations collected through the <a class="underline" href="https://open-assistant.io/">https://open-assistant.io/</a> human feedback web app before March 7, 2023.

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,9 @@ RUN npm i
 
 RUN chown -R 1000:1000 /app
 
-RUN --mount=type=secret,id=PUBLIC_MODEL_ENDPOINT,mode=0444,required=true \
-   PUBLIC_MODEL_ENDPOINT=$(cat /run/secrets/PUBLIC_MODEL_ENDPOINT) npm run build
+RUN --mount=type=secret,id=DOTENV_LOCAL,mode=0444,required=true cat /run/secrets/DOTENV_LOCAL > .env.local
+   
+RUN npm run build
 
 ENV PORT 7860
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ npm run dev
 
 Default configuration is in `.env`. Put custom config and secrets in `.env.local`, it will override the values in `.env`.
 
+Check out [.env](./.env) to see what needs to be set.
+
 ## Building
 
 To create a production version of your app:

--- a/src/routes/api/conversation/+server.ts
+++ b/src/routes/api/conversation/+server.ts
@@ -1,4 +1,4 @@
-import { env } from '$env/dynamic/private';
+import { HF_TOKEN } from '$env/static/private';
 import { PUBLIC_MODEL_ENDPOINT } from '$env/static/public';
 
 export async function POST({ request }) {
@@ -6,7 +6,7 @@ export async function POST({ request }) {
 		headers: {
 			...request.headers,
 			'Content-Type': 'application/json',
-			Authorization: `Basic ${env.HF_TOKEN}`
+			Authorization: `Basic ${HF_TOKEN}`
 		},
 		method: 'POST',
 		body: await request.text()


### PR DESCRIPTION
Basically, put all the custom env (secret & non-secret) in a `.env.local` file.

The plan is to store the contents of `.env.local` in the `DOTENV_LOCAL` secret in HF spaces, and `DOTENV_LOCAL` **variable** in github (to be able to reveal it)

Benefits is only one variable to set in the secrets, and a readable `Dockerfile`