### PR TITLE
🩹 Fix proxified headers + remove guard in hook

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -6,17 +6,14 @@ export const handle: Handle = async ({ event, resolve }) => {
 
 	event.locals.sessionId = token || crypto.randomUUID();
 
-	// Setting a cookie breaks /api/conversation, maybe due to the proxy
-	if (!event.url.pathname.startsWith('/api')) {
-		// Refresh cookie expiration date
-		event.cookies.set('session', event.locals.sessionId, {
-			path: '/',
-			sameSite: 'lax',
-			secure: true,
-			httpOnly: true,
-			expires: addYears(new Date(), 1)
-		});
-	}
+	// Refresh cookie expiration date
+	event.cookies.set('session', event.locals.sessionId, {
+		path: '/',
+		sameSite: 'lax',
+		secure: true,
+		httpOnly: true,
+		expires: addYears(new Date(), 1)
+	});
 
 	const response = await resolve(event);
 

--- a/src/routes/api/conversation/+server.ts
+++ b/src/routes/api/conversation/+server.ts
@@ -2,13 +2,18 @@ import { HF_TOKEN } from '$env/static/private';
 import { PUBLIC_MODEL_ENDPOINT } from '$env/static/public';
 
 export async function POST({ request, fetch }) {
-	return await fetch(PUBLIC_MODEL_ENDPOINT, {
+	const resp = await fetch(PUBLIC_MODEL_ENDPOINT, {
 		headers: {
-			...request.headers,
-			'Content-Type': 'application/json',
+			'Content-Type': request.headers.get('Content-Type') ?? 'application/json',
 			Authorization: `Basic ${HF_TOKEN}`
 		},
 		method: 'POST',
 		body: await request.text()
+	});
+
+	return new Response(resp.body, {
+		headers: Object.fromEntries(resp.headers.entries()),
+		status: resp.status,
+		statusText: resp.statusText
 	});
 }


### PR DESCRIPTION
Fix #23 

In the end we only forward the content-type, there are other sensitive headers like the cookie that we don't want to forward. 

We also create a new "Headers" object in the response, so that the hook down the line can add the cookie header.

