### PR TITLE
Use all CPUs in prod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ RUN npm run build
 
 ENV PORT 7860
 
-CMD ["pm2", "start", "build/index.js" ,"-i", "2"]
+CMD ["pm2", "start", "build/index.js" ,"-i", "2", "--no-daemon"]


### PR DESCRIPTION
Fix #56 

I have to hardcode the number of CPUs because somehow `-i max` gives me 16 instances.

https://huggingface.co/spaces/coyotte508/chat-ui running with 2 cores