### PR TITLE
♻️ Better invalidation mechanism

### DIFF
--- a/src/lib/types/UrlDependency.ts
+++ b/src/lib/types/UrlDependency.ts
@@ -1,0 +1,4 @@
+/* eslint-disable no-shadow */
+export enum UrlDependency {
+	ConversationList = "conversation:list",
+}

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,14 +1,17 @@
 import type { LayoutServerLoad } from "./$types";
 import { collections } from "$lib/server/database";
 import type { Conversation } from "$lib/types/Conversation";
+import { UrlDependency } from "$lib/types/UrlDependency";
 
-export const load: LayoutServerLoad = async (event) => {
+export const load: LayoutServerLoad = async ({ locals, depends }) => {
 	const { conversations } = collections;
+
+	depends(UrlDependency.ConversationList);
 
 	return {
 		conversations: await conversations
 			.find({
-				sessionId: event.locals.sessionId,
+				sessionId: locals.sessionId,
 			})
 			.sort({ updatedAt: -1 })
 			.project<Pick<Conversation, "title" | "_id" | "updatedAt" | "createdAt">>({

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { goto, invalidateAll } from "$app/navigation";
+	import { goto, invalidate } from "$app/navigation";
 	import { page } from "$app/stores";
 	import "../styles/main.css";
 	import type { LayoutData } from "./$types";
@@ -7,6 +7,7 @@
 	import CarbonTrashCan from "~icons/carbon/trash-can";
 	import CarbonExport from "~icons/carbon/export";
 	import { base } from "$app/paths";
+	import { UrlDependency } from "$lib/types/UrlDependency";
 
 	export let data: LayoutData;
 
@@ -67,7 +68,7 @@
 			}
 
 			if ($page.params.id !== id) {
-				await invalidateAll();
+				await invalidate(UrlDependency.ConversationList);
 			} else {
 				await goto(base || "/", { invalidateAll: true });
 			}


### PR DESCRIPTION
To sum it up, `invalidate(() => true)` and `invalidateAll()` have different behaviors :exploding_head: 

`invalidate` only invalidates based on `fetch` calls done. Since we do MongoDB call, it doesn't trigger anything. We can define custom things to invalidate with `depends` and invalidate on them.