### PR TITLE
Fix share link when already created

### DIFF
--- a/src/routes/conversation/[id]/share/+server.ts
+++ b/src/routes/conversation/[id]/share/+server.ts
@@ -24,7 +24,7 @@ export async function POST({ params, url, locals }) {
 	if (existingShare) {
 		return new Response(
 			JSON.stringify({
-				url: `${PUBLIC_ORIGIN || url.origin}${base}/r/${existingShare._id}`,
+				url: getShareUrl(url, existingShare._id),
 			}),
 			{ headers: { "Content-Type": "application/json" } }
 		);
@@ -43,8 +43,12 @@ export async function POST({ params, url, locals }) {
 
 	return new Response(
 		JSON.stringify({
-			url: `${PUBLIC_ORIGIN || url.origin}${base}/r/${shared._id}`,
+			url: getShareUrl(url, shared._id),
 		}),
 		{ headers: { "Content-Type": "application/json" } }
 	);
+}
+
+function getShareUrl(url: URL, shareId: string): string {
+	return `${PUBLIC_ORIGIN || url.origin}${base}/r/${shareId}`;
 }


### PR DESCRIPTION
Copying from https://github.com/huggingface/chat-ui/blob/8fa68e8ce925d925a46090a49a1cd6f3bc8d82f4/src/routes/conversation/%5Bid%5D/share/%2Bserver.ts#L46

since the generation is correct during the first-time click on the share button

See https://huggingface.slack.com/archives/C3YL4AWG1/p1682451304515499?thread_ts=1682100786.405899&cid=C3YL4AWG1