### PR TITLE
Fix line break markdown

### DIFF
--- a/src/lib/components/chat/ChatMessage.svelte
+++ b/src/lib/components/chat/ChatMessage.svelte
@@ -13,7 +13,7 @@
 			.replace(/<\|[a-z]+\|$/, "")
 			.replace(/<$/, "")
 			.replaceAll(/<\|[a-z]+\|>/g, " ")
-			.replaceAll(/<br\s?\/?>/g, "\n")
+			.replaceAll(/<br\s?\/?>/gi, "\n")
 			.trim()
 			.replaceAll("&", "&amp;")
 			.replaceAll("<", "&lt;");


### PR DESCRIPTION
- transform `<br>` tags in markdown to \n before they get sanitized
- fix line breaks in responses not being properly rendered to `<br>` tags by Marker

closes #128