### PR TITLE
add deprecated GA v3

### DIFF
--- a/.env
+++ b/.env
@@ -16,6 +16,7 @@ PUBLIC_ASSISTANT_MESSAGE_TOKEN=<|assistant|>
 PUBLIC_SEP_TOKEN=</s>
 PUBLIC_PREPROMPT="Below are a series of dialogues between various people and an AI assistant. The AI tries to be helpful, polite, honest, sophisticated, emotionally aware, and humble-but-knowledgeable. The assistant is happy to help with almost anything, and will do its best to understand exactly what is needed. It also tries to avoid giving false or misleading information, and it caveats when it isn't entirely sure about the right answer. That said, the assistant is practical and really does its best, and doesn't let caution get too much in the way of being useful."
 PUBLIC_GOOGLE_ANALYTICS_ID=#G-XXXXXXXX / Leave empty to disable
+PUBLIC_DEPRECATED_GOOGLE_ANALYTICS_ID=#UA-XXXXXXXX-X / Leave empty to disable
 
 # Copy this in .env.local with and replace "hf_<token>" your HF token from https://huggingface.co/settings/token
 # You can also change the model from OpenAssistant/oasst-sft-4-pythia-12b-epoch-3.5 to your own model

--- a/src/app.html
+++ b/src/app.html
@@ -15,6 +15,7 @@
 
 			// For some reason, Sveltekit doesn't let us load env variables from .env here, so we load it from hooks.server.ts
 			window.gaId = "%gaId%";
+			window.gaIdDeprecated = "%gaIdDeprecated%";
 		</script>
 		%sveltekit.head%
 	</head>
@@ -39,6 +40,33 @@
 				gtag("consent", "default", { ad_storage: "denied", analytics_storage: "denied" });
 				/// ^ See https://developers.google.com/tag-platform/gtagjs/reference#consent
 				/// TODO: ask the user for their consent and update this with gtag('consent', 'update')
+			}
+		</script>
+
+		<!-- Google Analytics v3 (deprecated on 1 July 2023) -->
+		<script>
+			if (window.gaIdDeprecated) {
+				(function (i, s, o, g, r, a, m) {
+					i["GoogleAnalyticsObject"] = r;
+					(i[r] =
+						i[r] ||
+						function () {
+							(i[r].q = i[r].q || []).push(arguments);
+						}),
+						(i[r].l = 1 * new Date());
+					(a = s.createElement(o)), (m = s.getElementsByTagName(o)[0]);
+					a.async = 1;
+					a.src = g;
+					m.parentNode.insertBefore(a, m);
+				})(
+					window,
+					document,
+					"script",
+					"https://www.google-analytics.com/analytics.js",
+					"ganalytics"
+				);
+				ganalytics("create", window.gaIdDeprecated, "auto");
+				ganalytics("send", "pageview");
 			}
 		</script>
 	</body>

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,7 +1,10 @@
 import { dev } from "$app/environment";
 import { COOKIE_NAME } from "$env/static/private";
 import type { Handle } from "@sveltejs/kit";
-import { PUBLIC_GOOGLE_ANALYTICS_ID } from "$env/static/public";
+import {
+	PUBLIC_GOOGLE_ANALYTICS_ID,
+	PUBLIC_DEPRECATED_GOOGLE_ANALYTICS_ID,
+} from "$env/static/public";
 import { addYears } from "date-fns";
 
 export const handle: Handle = async ({ event, resolve }) => {
@@ -24,12 +27,14 @@ export const handle: Handle = async ({ event, resolve }) => {
 	const response = await resolve(event, {
 		transformPageChunk: (chunk) => {
 			// For some reason, Sveltekit doesn't let us load env variables from .env in the app.html template
-			if (replaced || !chunk.html.includes("%gaId%")) {
+			if (replaced || !chunk.html.includes("%gaId%") || !chunk.html.includes("%gaIdDeprecated%")) {
 				return chunk.html;
 			}
 			replaced = true;
 
-			return chunk.html.replace("%gaId%", PUBLIC_GOOGLE_ANALYTICS_ID);
+			return chunk.html
+				.replace("%gaId%", PUBLIC_GOOGLE_ANALYTICS_ID)
+				.replace("%gaIdDeprecated%", PUBLIC_DEPRECATED_GOOGLE_ANALYTICS_ID);
 		},
 	});
 


### PR DESCRIPTION
Until we get acclimated to the new GA4 UI, add the deprecated GA3.
Note it will be deprecated on 1st of July 2023.

I left "deprecated" in strings so we remember to remove this asap.

![image](https://user-images.githubusercontent.com/527559/235892227-401c182a-9af5-45a4-8d8b-135cd0b0d0f4.png)

ref: https://huggingface.slack.com/archives/C052EKHD1U0/p1683106471036939