### PR TITLE
fix deepestChild function throwing error

### DIFF
--- a/src/lib/utils/deepestChild.ts
+++ b/src/lib/utils/deepestChild.ts
@@ -1,7 +1,7 @@
-export function deepestChild(el: HTMLElement) {
+export function deepestChild(el: HTMLElement): HTMLElement {
 	let newEl = el;
-	while (newEl.hasChildNodes()) {
-		newEl = newEl.lastElementChild as HTMLElement;
+	if (newEl.lastElementChild && newEl.lastElementChild.nodeType !== Node.TEXT_NODE) {
+		return deepestChild(newEl.lastElementChild as HTMLElement);
 	}
 	return newEl;
 }

--- a/src/lib/utils/deepestChild.ts
+++ b/src/lib/utils/deepestChild.ts
@@ -1,7 +1,6 @@
 export function deepestChild(el: HTMLElement): HTMLElement {
-	const newEl = el;
-	if (newEl.lastElementChild && newEl.lastElementChild.nodeType !== Node.TEXT_NODE) {
-		return deepestChild(newEl.lastElementChild as HTMLElement);
+	if (el.lastElementChild && el.lastElementChild.nodeType !== Node.TEXT_NODE) {
+		return deepestChild(el.lastElementChild as HTMLElement);
 	}
-	return newEl;
+	return el;
 }

--- a/src/lib/utils/deepestChild.ts
+++ b/src/lib/utils/deepestChild.ts
@@ -1,5 +1,5 @@
 export function deepestChild(el: HTMLElement): HTMLElement {
-	let newEl = el;
+	const newEl = el;
 	if (newEl.lastElementChild && newEl.lastElementChild.nodeType !== Node.TEXT_NODE) {
 		return deepestChild(newEl.lastElementChild as HTMLElement);
 	}


### PR DESCRIPTION
- Fix function not returning the deepest child
- Fix function failing with `null` and a console error:
```
caught TypeError: Cannot read properties of null (reading 'hasChildNodes')
    at deepestChild (deepestChild.ts:3:15)
    at ChatMessage.svelte:75:15
```

It's a hard one to test because it only happens when the server takes a while to return a token (doesn't happen often).