### PR TITLE
🐛 Fix settings modal not resetting its state

### DIFF
--- a/src/lib/components/SettingsModal.svelte
+++ b/src/lib/components/SettingsModal.svelte
@@ -10,6 +10,8 @@
 
 	export let settings: Pick<Settings, "shareConversationsWithModelAuthors">;
 
+	let shareConversationsWithModelAuthors = settings.shareConversationsWithModelAuthors;
+
 	const dispatch = createEventDispatcher<{ close: void }>();
 </script>
 
@@ -35,7 +37,7 @@
 			{/each}
 			<Switch
 				name="shareConversationsWithModelAuthors"
-				bind:checked={settings.shareConversationsWithModelAuthors}
+				bind:checked={shareConversationsWithModelAuthors}
 			/>
 			Share conversations with model authors
 		</label>

--- a/src/lib/components/SettingsModal.svelte
+++ b/src/lib/components/SettingsModal.svelte
@@ -10,7 +10,7 @@
 
 	export let settings: Pick<Settings, "shareConversationsWithModelAuthors">;
 
-	let shareConversationsWithModelAuthors = settings.shareConversationsWithModelAuthors;
+	$: shareConversationsWithModelAuthors = settings.shareConversationsWithModelAuthors;
 
 	const dispatch = createEventDispatcher<{ close: void }>();
 </script>

--- a/src/lib/components/SettingsModal.svelte
+++ b/src/lib/components/SettingsModal.svelte
@@ -10,7 +10,7 @@
 
 	export let settings: Pick<Settings, "shareConversationsWithModelAuthors">;
 
-	$: shareConversationsWithModelAuthors = settings.shareConversationsWithModelAuthors;
+	let shareConversationsWithModelAuthors = settings.shareConversationsWithModelAuthors;
 
 	const dispatch = createEventDispatcher<{ close: void }>();
 </script>


### PR DESCRIPTION
Fix the following bug:
- Open the settings modal, change "Share conversations with model authors", close the modal without "applying"
- Re-open modal, setting is still the same, making you think it was taken into consideration

This is because the input is mutating the `settings` prop.