### PR TITLE
Make data sharing disclosure a little clearer

### DIFF
--- a/src/lib/components/LoginModal.svelte
+++ b/src/lib/components/LoginModal.svelte
@@ -33,8 +33,8 @@
 			misinformation. Do not use this application for high-stakes decisions or advice.
 		</p>
 		<p class="px-2 text-sm text-gray-500">
-			⚠️ <b>Data sharing:</b> Your conversations will be shared with the authors of the model
-			you use unless you disable data sharing in the HuggingChat settings.
+			⚠️ <b>Data sharing:</b> Your conversations will be shared with the authors of the model you use
+			unless you disable data sharing in the HuggingChat settings.
 		</p>
 		<form
 			action="{base}/{$page.data.requiresLogin ? 'login' : 'settings'}"

--- a/src/lib/components/LoginModal.svelte
+++ b/src/lib/components/LoginModal.svelte
@@ -33,7 +33,8 @@
 			misinformation. Do not use this application for high-stakes decisions or advice.
 		</p>
 		<p class="px-2 text-sm text-gray-500">
-			Your conversations will be shared with model authors unless you disable it from your settings.
+			⚠️ <b>Data sharing:</b> Your conversations will be shared with the authors of the model
+			you use unless you disable data sharing in the HuggingChat settings.
 		</p>
 		<form
 			action="{base}/{$page.data.requiresLogin ? 'login' : 'settings'}"


### PR DESCRIPTION
Quick proposed update so the disclosure draws the eye a little more - currently it's easy to miss

<img width="1321" alt="image" src="https://github.com/huggingface/chat-ui/assets/3841370/02767d24-90cd-4e57-92fc-4db8162a0bcb">

