### PR TITLE
Shared convos can be opened without being logged in (#266, #270)

### DIFF
--- a/src/lib/components/chat/ChatInput.svelte
+++ b/src/lib/components/chat/ChatInput.svelte
@@ -50,6 +50,7 @@
 		bind:this={textareaElement}
 		{disabled}
 		on:keydown={handleKeydown}
+		on:keypress
 		{placeholder}
 	/>
 </div>

--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -12,6 +12,7 @@
 	import StopGeneratingBtn from "../StopGeneratingBtn.svelte";
 	import type { Model } from "$lib/types/Model";
 	import type { LayoutData } from "../../../routes/$types";
+	import LoginModal from "../LoginModal.svelte";
 
 	export let messages: Message[] = [];
 	export let loading = false;
@@ -21,8 +22,10 @@
 	export let models: Model[];
 	export let settings: LayoutData["settings"];
 
+	export let loginRequired = false;
 	$: isReadOnly = !models.some((model) => model.id === currentModel.id);
 
+	let loginModalOpen = false;
 	let message: string;
 
 	const dispatch = createEventDispatcher<{
@@ -40,6 +43,9 @@
 </script>
 
 <div class="relative min-h-0 min-w-0">
+	{#if loginModalOpen}
+		<LoginModal {settings} on:close={() => (loginModalOpen = false)} />
+	{/if}
 	<ChatMessages
 		{loading}
 		{pending}
@@ -71,6 +77,9 @@
 					placeholder="Ask anything"
 					bind:value={message}
 					on:submit={handleSubmit}
+					on:keypress={() => {
+						if (loginRequired) loginModalOpen = true;
+					}}
 					maxRows={4}
 					disabled={isReadOnly}
 				/>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -91,6 +91,11 @@
 	});
 
 	$: if ($error) onError();
+
+	const requiresLogin =
+		!$page.error &&
+		(data.requiresLogin ? !data.user : !data.settings.ethicsModalAcceptedAt) &&
+		!$page.route.id?.startsWith("/r/");
 </script>
 
 <svelte:head>
@@ -136,7 +141,7 @@
 	{#if isSettingsOpen}
 		<SettingsModal on:close={() => (isSettingsOpen = false)} settings={data.settings} />
 	{/if}
-	{#if !$page.error && (data.requiresLogin ? !data.user : !data.settings.ethicsModalAcceptedAt)}
+	{#if requiresLogin}
 		<LoginModal settings={data.settings} />
 	{/if}
 	<slot />

--- a/src/routes/r/[id]/+page.svelte
+++ b/src/routes/r/[id]/+page.svelte
@@ -24,6 +24,7 @@
 				},
 				body: JSON.stringify({
 					fromShare: $page.params.id,
+					model: data.model,
 				}),
 			});
 

--- a/src/routes/r/[id]/+page.svelte
+++ b/src/routes/r/[id]/+page.svelte
@@ -77,4 +77,6 @@
 	models={data.models}
 	currentModel={findCurrentModel(data.models, data.model)}
 	settings={data.settings}
+	loginRequired={!$page.error &&
+		(data.requiresLogin ? !data.user : !data.settings.ethicsModalAcceptedAt)}
 />


### PR DESCRIPTION
Some users were complaining that you have to be logged in as a user to see a shared conversation.  This PR lets you see shared convos without logging in but as soon as you type in the chat input field, the login modal pops up.

~~This doesn't solve #270 where you can't currently reply to shared conversations anyway. I'm currently investigating a fix for this one.~~ Fixed #270 as well!

Closes #266 
Closes #270 