### PR TITLE
Add optional timestamps to messages

### DIFF
--- a/src/lib/types/Message.ts
+++ b/src/lib/types/Message.ts
@@ -1,7 +1,9 @@
-export interface Message {
+import type { Timestamps } from "./Timestamps";
+
+export type Message = Partial<Timestamps> & {
 	from: "user" | "assistant";
 	id: ReturnType<typeof crypto.randomUUID>;
 	content: string;
 	webSearchId?: string;
 	score?: -1 | 0 | 1;
-}
+};

--- a/src/lib/utils/hashConv.ts
+++ b/src/lib/utils/hashConv.ts
@@ -1,0 +1,12 @@
+import type { Conversation } from "$lib/types/Conversation";
+import { sha256 } from "./sha256";
+
+export async function hashConv(conv: Conversation) {
+	// messages contains the conversation message but only the immutable part
+	const messages = conv.messages.map((message) => {
+		return (({ from, id, content, webSearchId }) => ({ from, id, content, webSearchId }))(message);
+	});
+
+	const hash = await sha256(JSON.stringify(messages));
+	return hash;
+}

--- a/src/routes/conversation/[id]/+server.ts
+++ b/src/routes/conversation/[id]/+server.ts
@@ -59,12 +59,18 @@ export async function POST({ request, fetch, locals, params }) {
 			}
 			return [
 				...conv.messages.slice(0, retryMessageIdx),
-				{ content: newPrompt, from: "user", id: messageId as Message["id"] },
+				{ content: newPrompt, from: "user", id: messageId as Message["id"], updatedAt: new Date() },
 			];
 		}
 		return [
 			...conv.messages,
-			{ content: newPrompt, from: "user", id: (messageId as Message["id"]) || crypto.randomUUID() },
+			{
+				content: newPrompt,
+				from: "user",
+				id: (messageId as Message["id"]) || crypto.randomUUID(),
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			},
 		];
 	})() satisfies Message[];
 
@@ -116,6 +122,8 @@ export async function POST({ request, fetch, locals, params }) {
 			content: generated_text,
 			webSearchId: web_search_id,
 			id: (responseId as Message["id"]) || crypto.randomUUID(),
+			createdAt: new Date(),
+			updatedAt: new Date(),
 		});
 
 		await collections.conversations.updateOne(

--- a/src/routes/conversation/[id]/share/+server.ts
+++ b/src/routes/conversation/[id]/share/+server.ts
@@ -3,7 +3,7 @@ import { PUBLIC_ORIGIN, PUBLIC_SHARE_PREFIX } from "$env/static/public";
 import { authCondition } from "$lib/server/auth";
 import { collections } from "$lib/server/database";
 import type { SharedConversation } from "$lib/types/SharedConversation";
-import { sha256 } from "$lib/utils/sha256";
+import { hashConv } from "$lib/utils/hashConv.js";
 import { error } from "@sveltejs/kit";
 import { ObjectId } from "mongodb";
 import { nanoid } from "nanoid";
@@ -18,7 +18,7 @@ export async function POST({ params, url, locals }) {
 		throw error(404, "Conversation not found");
 	}
 
-	const hash = await sha256(JSON.stringify(conversation.messages));
+	const hash = await hashConv(conversation);
 
 	const existingShare = await collections.sharedConversations.findOne({ hash });
 

--- a/src/routes/search/[id]/+server.ts
+++ b/src/routes/search/[id]/+server.ts
@@ -1,5 +1,5 @@
 import { collections } from "$lib/server/database";
-import { sha256 } from "$lib/utils/sha256";
+import { hashConv } from "$lib/utils/hashConv.js";
 import { error } from "@sveltejs/kit";
 import { ObjectId } from "mongodb";
 
@@ -23,7 +23,7 @@ export async function GET({ params, locals }) {
 	}
 
 	// there's no better way to see if a conversation has been shared, so we hash the messages and see if there's a shared conversation with the same hash
-	const hash = await sha256(JSON.stringify(conv.messages));
+	const hash = await hashConv(conv);
 	const sharedConv = await collections.sharedConversations.findOne({
 		hash: hash,
 	});


### PR DESCRIPTION
We keep track of conversation timestamps, but we don't do it yet for messages. 

With those timestamps we could in the future get a better understanding of usage but also we could compute average response time from the model and cool things like that.