### PR TITLE
Add support for websearch retries

### DIFF
--- a/src/lib/components/OpenWebSearchResults.svelte
+++ b/src/lib/components/OpenWebSearchResults.svelte
@@ -13,7 +13,7 @@
 
 	let detailsOpen: boolean;
 	let error: boolean;
-	$: error = webSearchMessages.some((message) => message.type === "error");
+	$: error = webSearchMessages[webSearchMessages.length - 2]?.type === "error";
 </script>
 
 <details

--- a/src/routes/conversation/[id]/web-search/+server.ts
+++ b/src/routes/conversation/[id]/web-search/+server.ts
@@ -58,9 +58,9 @@ export async function GET({ params, locals, url }) {
 				updatedAt: new Date(),
 			};
 
-			function appendUpdate(message: string, args?: string[]) {
+			function appendUpdate(message: string, args?: string[], type?: "error" | "update") {
 				webSearch.messages.push({
-					type: "update",
+					type: type ?? "update",
 					message,
 					args,
 				});
@@ -91,12 +91,23 @@ export async function GET({ params, locals, url }) {
 					text = webSearch.knowledgeGraph;
 					appendUpdate("Found a Google knowledge page");
 				} else if (webSearch.results.length > 0) {
-					// otherwise we use the top result from search
-					const topUrl = webSearch.results[0];
-					appendUpdate("Browsing first result", [JSON.stringify(topUrl)]);
+					let tries = 0;
 
-					text = await parseWeb(topUrl);
-					if (!text) throw new Error("text of the webpage is null");
+					while (!text && tries < 3) {
+						const searchUrl = webSearch.results[tries];
+						appendUpdate("Browsing result", [JSON.stringify(searchUrl)]);
+						try {
+							if (tries < 4) {
+								throw new Error("test error");
+							}
+							text = await parseWeb(searchUrl);
+							if (!text) throw new Error("text of the webpage is null");
+						} catch (e) {
+							appendUpdate("Error parsing webpage", [], "error");
+							tries++;
+						}
+					}
+					if (!text) throw new Error("No text found on the first 3 results");
 				} else {
 					throw new Error("No results found for this search query");
 				}

--- a/src/routes/conversation/[id]/web-search/+server.ts
+++ b/src/routes/conversation/[id]/web-search/+server.ts
@@ -97,9 +97,6 @@ export async function GET({ params, locals, url }) {
 						const searchUrl = webSearch.results[tries];
 						appendUpdate("Browsing result", [JSON.stringify(searchUrl)]);
 						try {
-							if (tries < 4) {
-								throw new Error("test error");
-							}
 							text = await parseWeb(searchUrl);
 							if (!text) throw new Error("text of the webpage is null");
 						} catch (e) {


### PR DESCRIPTION
In case some error occurs during the webpage parsing, we can now retry up to 3 times to get a result. 

![image](https://github.com/huggingface/chat-ui/assets/25119303/1b2141f7-5e41-451c-a1d1-81063bc4187a)
