### PR TITLE
Add support for HF summarization endpoint in the websearch

### DIFF
--- a/src/lib/server/websearch/summarizeWeb.ts
+++ b/src/lib/server/websearch/summarizeWeb.ts
@@ -1,7 +1,22 @@
+import { HF_ACCESS_TOKEN } from "$env/static/private";
+import { HfInference } from "@huggingface/inference";
 import { generateFromDefaultEndpoint } from "../generateFromDefaultEndpoint";
 import type { BackendModel } from "../models";
 
 export async function summarizeWeb(content: string, query: string, model: BackendModel) {
+	// if HF_ACCESS_TOKEN is set, we use a HF dedicated endpoint for summarization
+	if (HF_ACCESS_TOKEN) {
+		return (
+			await new HfInference(HF_ACCESS_TOKEN).summarization({
+				model: "facebook/bart-large-cnn",
+				inputs: content,
+				parameters: {
+					max_length: 512,
+				},
+			})
+		).summary_text;
+	}
+	// else we use the LLM to generate a summary
 	const summaryPrompt =
 		model.userMessageToken +
 		content

--- a/src/lib/server/websearch/summarizeWeb.ts
+++ b/src/lib/server/websearch/summarizeWeb.ts
@@ -5,17 +5,23 @@ import type { BackendModel } from "../models";
 
 export async function summarizeWeb(content: string, query: string, model: BackendModel) {
 	// if HF_ACCESS_TOKEN is set, we use a HF dedicated endpoint for summarization
-	if (HF_ACCESS_TOKEN) {
-		return (
-			await new HfInference(HF_ACCESS_TOKEN).summarization({
-				model: "facebook/bart-large-cnn",
-				inputs: content,
-				parameters: {
-					max_length: 512,
-				},
-			})
-		).summary_text;
+	try {
+		if (HF_ACCESS_TOKEN) {
+			const summary = (
+				await new HfInference(HF_ACCESS_TOKEN).summarization({
+					model: "facebook/bart-large-cnn",
+					inputs: content,
+					parameters: {
+						max_length: 512,
+					},
+				})
+			).summary_text;
+			return summary;
+		}
+	} catch (e) {
+		console.log(e);
 	}
+
 	// else we use the LLM to generate a summary
 	const summaryPrompt =
 		model.userMessageToken +


### PR DESCRIPTION
If the user has set an `HF_ACCESS_TOKEN` we use it to call up an inference endpoint trained for summarization. If the user didn't set their token, we use their LLM endpoint (could be self-hosted w/ no HF token)  to try and make a summary the old way.

In my local testing this returns more accurate & faster summaries and it would also help reduce the load on the LLM endpoint. (summarization takes a huge context window which is much larger than most conversations)

I'm not sure if the model I chose is optimal as there are multiple models that support summarization. I'm also not sure if we could get rate limited by the API since the calls for all users would be coming from one server using the prod HF token.

