### PR TITLE
Basic rate limiter

### DIFF
--- a/.env
+++ b/.env
@@ -70,6 +70,7 @@ PARQUET_EXPORT_DATASET=
 PARQUET_EXPORT_HF_TOKEN=
 PARQUET_EXPORT_SECRET=
 
+RATE_LIMIT= # requests per minute
 
 PUBLIC_APP_NAME=ChatUI # name used as title throughout the app
 PUBLIC_APP_ASSETS=chatui # used to find logos & favicons in static/$PUBLIC_APP_ASSETS

--- a/src/lib/server/database.ts
+++ b/src/lib/server/database.ts
@@ -6,6 +6,7 @@ import type { WebSearch } from "$lib/types/WebSearch";
 import type { AbortedGeneration } from "$lib/types/AbortedGeneration";
 import type { Settings } from "$lib/types/Settings";
 import type { User } from "$lib/types/User";
+import type { MessageEvent } from "$lib/types/MessageEvent";
 
 if (!MONGODB_URL) {
 	throw new Error(
@@ -27,6 +28,7 @@ const abortedGenerations = db.collection<AbortedGeneration>("abortedGenerations"
 const settings = db.collection<Settings>("settings");
 const users = db.collection<User>("users");
 const webSearches = db.collection<WebSearch>("webSearches");
+const messageEvents = db.collection<MessageEvent>("messageEvents");
 
 export { client, db };
 export const collections = {
@@ -36,6 +38,7 @@ export const collections = {
 	settings,
 	users,
 	webSearches,
+	messageEvents,
 };
 
 client.on("open", () => {
@@ -59,4 +62,5 @@ client.on("open", () => {
 	settings.createIndex({ userId: 1 }, { unique: true, sparse: true }).catch(console.error);
 	users.createIndex({ hfUserId: 1 }, { unique: true }).catch(console.error);
 	users.createIndex({ sessionId: 1 }, { unique: true, sparse: true }).catch(console.error);
+	messageEvents.createIndex({ createdAt: 1 }, { expireAfterSeconds: 60 }).catch(console.error);
 });

--- a/src/lib/stores/errors.ts
+++ b/src/lib/stores/errors.ts
@@ -3,6 +3,7 @@ import { writable } from "svelte/store";
 export const ERROR_MESSAGES = {
 	default: "Oops, something went wrong.",
 	authOnly: "You have to be logged in.",
+	rateLimited: "You are sending too many messages. Try again later.",
 };
 
 export const error = writable<string | null>(null);

--- a/src/lib/types/MessageEvent.ts
+++ b/src/lib/types/MessageEvent.ts
@@ -1,0 +1,6 @@
+import type { Timestamps } from "./Timestamps";
+import type { User } from "./User";
+
+export interface MessageEvent extends Pick<Timestamps, "createdAt"> {
+	userId: User["_id"] | User["sessionId"];
+}

--- a/src/routes/conversation/[id]/+page.svelte
+++ b/src/routes/conversation/[id]/+page.svelte
@@ -207,6 +207,8 @@
 		} catch (err) {
 			if (err instanceof Error && err.message.includes("overloaded")) {
 				$error = "Too much traffic, please try again.";
+			} else if (err instanceof Error && err.message.includes("429")) {
+				$error = ERROR_MESSAGES.rateLimited;
 			} else if (err instanceof Error) {
 				$error = err.message;
 			} else {


### PR DESCRIPTION
Did it the way @coyotte508 suggested in the other PR, kinda rushed it because we're hitting "model overloaded" errors often on prod now.

I added a collection that contains only a userID & a timestamp with an index that `expireAfterSeconds : 60`. 

I chose rate limit based on requests per minute. The main point was to reduce spike usage (probably coming from API users) so requests per minute made more sense than requests per day for that imo.

It should also allow rate limiting on instances of chatui that do not require logging in, by using the session ID instead of the userId.

If the var is not set, of course no rate limiting occurs.

