### PR TITLE
Factor out HF_API_ROOT to allow different inference endpoints

### DIFF
--- a/.env
+++ b/.env
@@ -7,6 +7,7 @@ MONGODB_DIRECT_CONNECTION=false
 
 COOKIE_NAME=hf-chat
 HF_ACCESS_TOKEN=#hf_<token> from from https://huggingface.co/settings/token
+HF_API_ROOT=https://api-inference.huggingface.co/models
 
 # used to activate search with web functionality. disabled if none are defined. choose one of the following:
 SERPER_API_KEY=#your serper.dev api key here

--- a/src/lib/server/modelEndpoint.ts
+++ b/src/lib/server/modelEndpoint.ts
@@ -1,4 +1,4 @@
-import { HF_ACCESS_TOKEN } from "$env/static/private";
+import { HF_ACCESS_TOKEN, HF_API_ROOT } from "$env/static/private";
 import { sum } from "$lib/utils/sum";
 import type { BackendModel } from "./models";
 
@@ -12,7 +12,7 @@ export function modelEndpoint(model: BackendModel): {
 } {
 	if (!model.endpoints) {
 		return {
-			url: `https://api-inference.huggingface.co/models/${model.name}`,
+			url: `${HF_API_ROOT}/${model.name}`,
 			authorization: `Bearer ${HF_ACCESS_TOKEN}`,
 			weight: 1,
 		};


### PR DESCRIPTION
Changed the hard-coding of the inference api endpoint into something configured in `.env` or `.env.local`

This is similar to #326, but is generic enough to allow arbitrary inference endpoints to be swapped in.