### PR TITLE
fix summarization with tgi endpoint

### DIFF
--- a/src/lib/server/models.ts
+++ b/src/lib/server/models.ts
@@ -1,4 +1,5 @@
 import { HF_ACCESS_TOKEN, MODELS, OLD_MODELS } from "$env/static/private";
+import { trimSuffix } from "$lib/utils/trimSuffix";
 import { z } from "zod";
 
 const sagemakerEndpoint = z.object({
@@ -80,6 +81,10 @@ export const models = await Promise.all(
 		...m,
 		userMessageEndToken: m?.userMessageEndToken || m?.messageEndToken,
 		assistantMessageEndToken: m?.assistantMessageEndToken || m?.messageEndToken,
+		endpoints: (m.endpoints || []).map((e) => ({
+			...e,
+			url: trimSuffix(e.url, '/generate_stream'),
+		})),
 		id: m.id || m.name,
 		displayName: m.displayName || m.name,
 		preprompt: m.prepromptUrl ? await fetch(m.prepromptUrl).then((r) => r.text()) : m.preprompt,

--- a/src/routes/conversation/[id]/+server.ts
+++ b/src/routes/conversation/[id]/+server.ts
@@ -125,7 +125,7 @@ export async function POST({ request, fetch, locals, params }) {
 			},
 		});
 	} else {
-		resp = await fetch(randomEndpoint.url, {
+		resp = await fetch(randomEndpoint.url + '/generate_stream', {
 			headers: {
 				"Content-Type": request.headers.get("Content-Type") ?? "application/json",
 				Authorization: randomEndpoint.authorization,


### PR DESCRIPTION
When an tgi endpoint is specified in .env.local the /generate_stream API is used. However, the summarization implementation expects the / API to be used.

To avoid changing the public API. This commit strips the /generate_stream part of the url and applies the appropriate pathname for each chat-ui component.

Fixes #278

PS: Note, that I'm not sure what effect this has when a non-TGI endpoint is used. Maybe `/generate_stream` should not be applied. I don't know the specs for the non-TGI endpoint, can I test it locally?