### PR TITLE
Clarify that model 'tokens' are not actual tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,9 +117,9 @@ MODELS=`[
     "datasetName": "OpenAssistant/oasst1",
     "description": "A good alternative to ChatGPT",
     "websiteUrl": "https://open-assistant.io",
-    "userMessageToken": "<|prompter|>",
-    "assistantMessageToken": "<|assistant|>",
-    "messageEndToken": "</s>",
+    "userMessageToken": "<|prompter|>", # This does not need to be a token, can be any string
+    "assistantMessageToken": "<|assistant|>", # This does not need to be a token, can be any string
+    "messageEndToken": "<|endoftext|>", # This does not need to be a token, can be any string
     "preprompt": "Below are a series of dialogues between various people and an AI assistant. The AI tries to be helpful, polite, honest, sophisticated, emotionally aware, and humble-but-knowledgeable. The assistant is happy to help with almost anything, and will do its best to understand exactly what is needed. It also tries to avoid giving false or misleading information, and it caveats when it isn't entirely sure about the right answer. That said, the assistant is practical and really does its best, and doesn't let caution get too much in the way of being useful.\n-----\n",
     "promptExamples": [
       {
@@ -139,7 +139,8 @@ MODELS=`[
       "repetition_penalty": 1.2,
       "top_k": 50,
       "truncate": 1000,
-      "max_new_tokens": 1024
+      "max_new_tokens": 1024,
+      "stop": ["<|endoftext|>"]  # This does not need to be tokens, can be any list of strings
     }
   }
 ]`


### PR DESCRIPTION
The `userMessageToken`, `assistantMessageToken`, `messageEndToken`, and `parameters.stop` settings in `MODELS` do not have to be a token. They can be any string.

This also uses `<|endoftext|>` rather than `</s>` as that is the stop token according to the documentation, and it sets that as the stop token in `parameters.stop` to demonstrate the usage of `stop`.