### PR TITLE
trim and remove stop-suffixes from summary

### DIFF
--- a/src/lib/server/generateFromDefaultEndpoint.ts
+++ b/src/lib/server/generateFromDefaultEndpoint.ts
@@ -37,7 +37,16 @@ export async function generateFromDefaultEndpoint(
 		}
 	);
 
-	generated_text = trimSuffix(trimPrefix(generated_text, "<|startoftext|>"), PUBLIC_SEP_TOKEN);
+	generated_text = trimSuffix(
+		trimPrefix(generated_text, "<|startoftext|>"),
+		PUBLIC_SEP_TOKEN
+	).trimEnd();
+
+	for (const stop of [...(newParameters?.stop ?? []), "<|endoftext|>"]) {
+		if (generated_text.endsWith(stop)) {
+			generated_text = generated_text.slice(0, -stop.length).trimEnd();
+		}
+	}
 
 	return generated_text;
 }


### PR DESCRIPTION
The chat generation removes parameters.stop and <|endoftext|> from the generated text. And additionally trims trailing whitespace.

This PR copies that behavior to the summarize functionality, when the summary is produced by a the chat model.