### PR TITLE
allow different user and assistant end-token

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ MODELS=`[
     "userMessageToken": "<|prompter|>", # This does not need to be a token, can be any string
     "assistantMessageToken": "<|assistant|>", # This does not need to be a token, can be any string
     "messageEndToken": "<|endoftext|>", # This does not need to be a token, can be any string
+    # "userMessageEndToken": "", # Applies only to user messages, messageEndToken has no effect if specified. Can be any string.
+    # "assistantMessageEndToken": "", # Applies only to assistant messages, messageEndToken has no effect if specified. Can be any string.
     "preprompt": "Below are a series of dialogues between various people and an AI assistant. The AI tries to be helpful, polite, honest, sophisticated, emotionally aware, and humble-but-knowledgeable. The assistant is happy to help with almost anything, and will do its best to understand exactly what is needed. It also tries to avoid giving false or misleading information, and it caveats when it isn't entirely sure about the right answer. That said, the assistant is practical and really does its best, and doesn't let caution get too much in the way of being useful.\n-----\n",
     "promptExamples": [
       {

--- a/src/lib/buildPrompt.ts
+++ b/src/lib/buildPrompt.ts
@@ -15,17 +15,17 @@ export async function buildPrompt(
 ): Promise<string> {
 	const prompt =
 		messages
-			.map(
-				(m) =>
-					(m.from === "user"
-						? model.userMessageToken + m.content
-						: model.assistantMessageToken + m.content) +
-					(model.messageEndToken
-						? m.content.endsWith(model.messageEndToken)
-							? ""
-							: model.messageEndToken
-						: "")
-			)
+			.map((m) => (
+				m.from === "user" ? (
+					model.userMessageToken +
+					m.content +
+					(m.content.endsWith(model.userMessageEndToken) ? "" : model.userMessageEndToken)
+				) : (
+					model.assistantMessageToken +
+					m.content +
+					(m.content.endsWith(model.assistantMessageEndToken) ? "" : model.assistantMessageEndToken)
+				)
+			))
 			.join("") + model.assistantMessageToken;
 
 	let webPrompt = "";
@@ -41,7 +41,7 @@ export async function buildPrompt(
 			webPrompt =
 				model.assistantMessageToken +
 				`The following context was found while searching the internet: ${webSearch.summary}` +
-				model.messageEndToken;
+				model.assistantMessageEndToken;
 		}
 	}
 	const finalPrompt =

--- a/src/lib/buildPrompt.ts
+++ b/src/lib/buildPrompt.ts
@@ -13,19 +13,20 @@ export async function buildPrompt(
 	model: BackendModel,
 	webSearchId?: string
 ): Promise<string> {
+	const userEndToken = model.userMessageEndToken ?? model.messageEndToken;
+	const assistantEndToken = model.assistantMessageEndToken ?? model.messageEndToken;
+
 	const prompt =
 		messages
-			.map((m) => (
-				m.from === "user" ? (
-					model.userMessageToken +
-					m.content +
-					(m.content.endsWith(model.userMessageEndToken) ? "" : model.userMessageEndToken)
-				) : (
-					model.assistantMessageToken +
-					m.content +
-					(m.content.endsWith(model.assistantMessageEndToken) ? "" : model.assistantMessageEndToken)
-				)
-			))
+			.map((m) =>
+				m.from === "user"
+					? model.userMessageToken +
+					  m.content +
+					  (m.content.endsWith(userEndToken) ? "" : userEndToken)
+					: model.assistantMessageToken +
+					  m.content +
+					  (m.content.endsWith(assistantEndToken) ? "" : assistantEndToken)
+			)
 			.join("") + model.assistantMessageToken;
 
 	let webPrompt = "";

--- a/src/lib/components/NavMenu.svelte
+++ b/src/lib/components/NavMenu.svelte
@@ -18,7 +18,11 @@
 		id: string;
 		title: string;
 	}> = [];
+
+	export let canLogin: boolean;
 	export let user: LayoutData["user"];
+
+	export let loginModalVisible;
 </script>
 
 <div class="sticky top-0 flex flex-none items-center justify-between px-3 py-3.5 max-sm:pt-0">
@@ -60,6 +64,15 @@
 				Sign Out
 			</button>
 		</form>
+	{/if}
+	{#if canLogin}
+		<button
+			on:click={() => (loginModalVisible = true)}
+			type="button"
+			class="flex h-9 flex-none items-center gap-1.5 rounded-lg pl-3 pr-2 text-gray-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-700"
+		>
+			Login
+		</button>
 	{/if}
 	<button
 		on:click={switchTheme}

--- a/src/lib/components/SettingsModal.svelte
+++ b/src/lib/components/SettingsModal.svelte
@@ -8,8 +8,10 @@
 	import { enhance } from "$app/forms";
 	import { base } from "$app/paths";
 	import { PUBLIC_APP_DATA_SHARING } from "$env/static/public";
+	import type { Model } from "$lib/types/Model";
 
 	export let settings: Pick<Settings, "shareConversationsWithModelAuthors">;
+	export let models: Array<Model>;
 
 	let shareConversationsWithModelAuthors = settings.shareConversationsWithModelAuthors;
 	let isConfirmingDeletion = false;
@@ -52,22 +54,21 @@
 				<p class="text-gray-800">
 					You can change this setting at any time, it applies to all your conversations.
 				</p>
-				<p class="text-gray-800">
-					Read more about model authors,
-					<a
-						href="https://open-assistant.io/"
-						target="_blank"
-						rel="noreferrer"
-						class="underline decoration-gray-300 hover:decoration-gray-700">Open Assistant</a
-					>
-					or
-					<a
-						href="https://ai.meta.com/llama/"
-						target="_blank"
-						rel="noreferrer"
-						class="underline decoration-gray-300 hover:decoration-gray-700">Meta AI</a
-					>.
-				</p>
+				<div>
+					<p class="text-gray-800 ">Read more about model authors:</p>
+					<ul class="list-inside list-disc">
+						{#each models as model}
+							<li class="list-item">
+								<a
+									href={model["websiteUrl"]}
+									target="_blank"
+									rel="noreferrer"
+									class="underline decoration-gray-300 hover:decoration-gray-700">{model["name"]}</a
+								>
+							</li>
+						{/each}
+					</ul>
+				</div>
 			{/if}
 			<form
 				method="post"

--- a/src/lib/server/generateFromDefaultEndpoint.ts
+++ b/src/lib/server/generateFromDefaultEndpoint.ts
@@ -37,7 +37,16 @@ export async function generateFromDefaultEndpoint(
 		}
 	);
 
-	generated_text = trimSuffix(trimPrefix(generated_text, "<|startoftext|>"), PUBLIC_SEP_TOKEN);
+	generated_text = trimSuffix(
+		trimPrefix(generated_text, "<|startoftext|>"),
+		PUBLIC_SEP_TOKEN
+	).trimEnd();
+
+	for (const stop of [...(newParameters?.stop ?? []), "<|endoftext|>"]) {
+		if (generated_text.endsWith(stop)) {
+			generated_text = generated_text.slice(0, -stop.length).trimEnd();
+		}
+	}
 
 	return generated_text;
 }

--- a/src/lib/server/models.ts
+++ b/src/lib/server/models.ts
@@ -14,9 +14,11 @@ const modelsRaw = z
 			modelUrl: z.string().url().optional(),
 			datasetName: z.string().min(1).optional(),
 			datasetUrl: z.string().url().optional(),
-			userMessageToken: z.string().min(1),
-			assistantMessageToken: z.string().min(1),
-			messageEndToken: z.string().min(1).optional(),
+			userMessageToken: z.string(),
+			userMessageEndToken: z.string().default(""),
+			assistantMessageToken: z.string(),
+			assistantMessageEndToken: z.string().default(""),
+			messageEndToken: z.string().default(""),
 			preprompt: z.string().default(""),
 			prepromptUrl: z.string().url().optional(),
 			promptExamples: z
@@ -52,6 +54,8 @@ const modelsRaw = z
 export const models = await Promise.all(
 	modelsRaw.map(async (m) => ({
 		...m,
+		userMessageEndToken: m?.userMessageEndToken || m?.messageEndToken,
+		assistantMessageEndToken: m?.assistantMessageEndToken || m?.messageEndToken,
 		id: m.id || m.name,
 		displayName: m.displayName || m.name,
 		preprompt: m.prepromptUrl ? await fetch(m.prepromptUrl).then((r) => r.text()) : m.preprompt,

--- a/src/lib/server/websearch/generateQuery.ts
+++ b/src/lib/server/websearch/generateQuery.ts
@@ -6,13 +6,13 @@ export async function generateQuery(messages: Message[], model: BackendModel) {
 	const promptSearchQuery =
 		model.userMessageToken +
 		"The following messages were written by a user, trying to answer a question." +
-		model.messageEndToken +
+		model.userMessageEndToken +
 		messages
 			.filter((message) => message.from === "user")
-			.map((message) => model.userMessageToken + message.content + model.messageEndToken) +
+			.map((message) => model.userMessageToken + message.content + model.userMessageEndToken) +
 		model.userMessageToken +
 		"What plain-text english sentence would you input into Google to answer the last question? Answer with a short (10 words max) simple sentence." +
-		model.messageEndToken +
+		model.userMessageEndToken +
 		model.assistantMessageToken +
 		"Query: ";
 

--- a/src/lib/server/websearch/summarizeWeb.ts
+++ b/src/lib/server/websearch/summarizeWeb.ts
@@ -29,10 +29,10 @@ export async function summarizeWeb(content: string, query: string, model: Backen
 			.split(" ")
 			.slice(0, model.parameters?.truncate ?? 0)
 			.join(" ") +
-		model.messageEndToken +
+		model.userMessageEndToken +
 		model.userMessageToken +
 		`The text above should be summarized to best answer the query: ${query}.` +
-		model.messageEndToken +
+		model.userMessageEndToken +
 		model.assistantMessageToken +
 		"Summary: ";
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -176,7 +176,11 @@
 		<Toast message={currentError} />
 	{/if}
 	{#if isSettingsOpen}
-		<SettingsModal on:close={() => (isSettingsOpen = false)} settings={data.settings} />
+		<SettingsModal
+			on:close={() => (isSettingsOpen = false)}
+			settings={data.settings}
+			models={data.models}
+		/>
 	{/if}
 	{#if requiresLogin && data.messagesBeforeLogin === 0}
 		<LoginModal settings={data.settings} />

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -99,6 +99,8 @@
 		(data.requiresLogin
 			? !data.user
 			: !data.settings.ethicsModalAcceptedAt && !!PUBLIC_APP_DISCLAIMER);
+
+	let loginModalVisible = false;
 </script>
 
 <svelte:head>
@@ -156,6 +158,8 @@
 		<NavMenu
 			conversations={data.conversations}
 			user={data.user}
+			canLogin={data.user === undefined && data.requiresLogin}
+			bind:loginModalVisible
 			on:shareConversation={(ev) => shareConversation(ev.detail.id, ev.detail.title)}
 			on:deleteConversation={(ev) => deleteConversation(ev.detail)}
 			on:clickSettings={() => (isSettingsOpen = true)}
@@ -166,6 +170,8 @@
 		<NavMenu
 			conversations={data.conversations}
 			user={data.user}
+			canLogin={data.user === undefined && data.requiresLogin}
+			bind:loginModalVisible
 			on:shareConversation={(ev) => shareConversation(ev.detail.id, ev.detail.title)}
 			on:deleteConversation={(ev) => deleteConversation(ev.detail)}
 			on:clickSettings={() => (isSettingsOpen = true)}
@@ -182,7 +188,7 @@
 			models={data.models}
 		/>
 	{/if}
-	{#if requiresLogin && data.messagesBeforeLogin === 0}
+	{#if (requiresLogin && data.messagesBeforeLogin === 0) || loginModalVisible}
 		<LoginModal settings={data.settings} />
 	{/if}
 	<slot />


### PR DESCRIPTION
For models like Llama2, the EndToken is not the same for a userMessage and an assistantMessage. This implements `userMessageEndToken` and `assistantMessageEndToken` which overwrites the messageEndToken behavior.

This PR also allows empty strings as `userMessageToken` and `assistantMessageToken` and makes this the default. This adds additional flexibility, which is required in the case of Llama2 where the first userMessage is effectively different because of the system message.

Note that because `userMessageEndToken` and `assistantMessageToken` are nearly always concatenated, it is almost redundant to have both. The exception is `generateQuery` for websearch which have several consecutive user messages.

---

Documentation for the correct prompting:
* https://huggingface.co/blog/llama2#how-to-prompt-llama-2
* https://github.com/facebookresearch/llama/blob/6c7fe276574e78057f917549435a2554000a876d/llama/generation.py#L213

**With the existing config provided in https://github.com/huggingface/chat-ui/issues/361#issuecomment-1644010150**

```json
{
    "userMessageToken": "[INST]",
    "assistantMessageToken": "[/INST]",
    "messageEndToken": "</s>",
    "preprompt": "[INST]<<SYS>>\nYou are a helpful, respectful and honest assistant. Always answer as helpfully as possible, while being safe. Your answers should not include any harmful, unethical, racist, sexist, toxic, dangerous, or illegal content. Please ensure that your responses are socially unbiased and positive in nature.\n\nIf a question does not make any sense, or is not factually coherent, explain why instead of answering something not correct. If you don't know the answer to a question, please don't share false information.<</SYS>>\n\n[/INST]"
}
```

the prompt becomes incorrect:

```
[INST]<<SYS>>
You are a helpful, respectful and honest assistant. Always answer as helpfully as possible, while being safe. Your answers should not include any harmful, unethical, racist, sexist, toxic, dangerous, or illegal content. Please ensure that your responses are socially unbiased and positive in nature.

If a question does not make any sense, or is not factually coherent, explain why instead of answering something not correct. If you don't know the answer to a question, please don't share false information.<</SYS>>

[/INST][INST]{{user message 1}}</s>[/INST] {{assistant message 1}}</s>[INST]{{user message 2}}</s>[/INST]
```

**However, with this PR, the following config is possible:**

```json
  {
    "userMessageToken": "",
    "userMessageEndToken": " [/INST] ",
    "assistantMessageToken": "",
    "assistantMessageEndToken": " </s><s>[INST] ",
    "preprompt": "<s>[INST] <<SYS>>\nYou are a helpful, respectful and honest assistant. Always answer as helpfully as possible, while being safe. Your answers should not include any harmful, unethical, racist, sexist, toxic, dangerous, or illegal content. Please ensure that your responses are socially unbiased and positive in nature.\n\nIf a question does not make any sense, or is not factually coherent, explain why instead of answering something not correct. If you don't know the answer to a question, please don't share false information.\n<</SYS>>\n\n"
}
```

the prompt has the correct formatting:

```
<s>[INST] <<SYS>>
You are a helpful, respectful and honest assistant. Always answer as helpfully as possible, while being safe. Your answers should not include any harmful, unethical, racist, sexist, toxic, \ndangerous, or illegal content. Please ensure that your responses are socially unbiased and positive in nature.

If a question does not make any sense, or is not factually coherent, explain why instead of answering something not correct. If you don't know the answer to a question, please don't share false information.
<</SYS>>

{{user message 1}} [/INST] {{assistant message 1}} </s><s>[INST] {{user message 2}} [/INST] {{assistant message 2}} </s><s>[INST] {{user message 3}} [/INST]
```