### PR TITLE
Leverage model link to modelUrl when informed

### DIFF
--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -124,7 +124,7 @@
 		<div class="mt-2 flex justify-between self-stretch px-1 text-xs text-gray-400/90 max-sm:gap-2">
 			<p>
 				Model: <a
-					href="https://huggingface.co/{currentModel.name}"
+					href="{currentModel.modelUrl}"
 					target="_blank"
 					rel="noreferrer"
 					class="hover:underline">{currentModel.displayName}</a

--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -124,7 +124,7 @@
 		<div class="mt-2 flex justify-between self-stretch px-1 text-xs text-gray-400/90 max-sm:gap-2">
 			<p>
 				Model: <a
-					href="{currentModel.modelUrl}"
+					href={currentModel.modelUrl || "https://huggingface.co/" + currentModel.name}
 					target="_blank"
 					rel="noreferrer"
 					class="hover:underline">{currentModel.displayName}</a


### PR DESCRIPTION
In the model link placed below the text input, link URL is being built from `currModel.name` and always heading to HuggingFace. 

To generalize to other models, potentially not placed in HuggingFace, this change leverages this `href` to `modelUrl`, when informed, preserving the old behavior, as already being done in other components.