### PR TITLE
fix docs regarding TGI endpoint url

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ To do this, you can add your own endpoints to the `MODELS` variable in `.env.loc
 
 {
 // rest of the model config here
-"endpoints": [{"url": "https://HOST:PORT/generate_stream"}]
+"endpoints": [{"url": "https://HOST:PORT"}]
 }
 
 ```
@@ -191,7 +191,7 @@ You can then add the generated information and the `authorization` parameter to 
 
 "endpoints": [
 {
-"url": "https://HOST:PORT/generate_stream",
+"url": "https://HOST:PORT",
 "authorization": "Basic VVNFUjpQQVNT",
 }
 ]
@@ -232,11 +232,11 @@ If the model being hosted will be available on multiple servers/instances add th
 
 "endpoints": [
 {
-"url": "https://HOST:PORT/generate_stream",
+"url": "https://HOST:PORT",
 "weight": 1
 }
 {
-"url": "https://HOST:PORT/generate_stream",
+"url": "https://HOST:PORT",
 "weight": 2
 }
 ...


### PR DESCRIPTION
The README specify to use a `/generate_stream` url, when using a custom TGI endpoint. This is incorrect, as it breaks APIs, such as the conversation summary that depends on the `/` TGI interface.

This turns out to be a documentation-only bug, as `/` will point to `/generate_stream` when `stream: true` is set in the request JSON.

Simply using the `/` url as the TGI endpoint therefore fixes the summarization bug.

Fixes: #278