### PR TITLE
Fix auth on websearch

### DIFF
--- a/src/lib/buildPrompt.ts
+++ b/src/lib/buildPrompt.ts
@@ -2,24 +2,42 @@ import type { BackendModel } from "./server/models";
 import type { Message } from "./types/Message";
 import { collections } from "$lib/server/database";
 import { ObjectId } from "mongodb";
+import { authCondition } from "./server/auth";
 /**
  * Convert [{user: "assistant", content: "hi"}, {user: "user", content: "hello"}] to:
  *
  * <|assistant|>hi<|endoftext|><|prompter|>hello<|endoftext|><|assistant|>
  */
 
-export async function buildPrompt(
-	messages: Pick<Message, "from" | "content">[],
-	model: BackendModel,
-	webSearchId?: string,
-	preprompt?: string
-): Promise<string> {
+interface buildPromptOptions {
+	messages: Pick<Message, "from" | "content">[];
+	model: BackendModel;
+	locals?: App.Locals;
+	webSearchId?: string;
+	preprompt?: string;
+}
+
+export async function buildPrompt({
+	messages,
+	model,
+	locals,
+	webSearchId,
+	preprompt,
+}: buildPromptOptions): Promise<string> {
 	if (webSearchId) {
 		const webSearch = await collections.webSearches.findOne({
 			_id: new ObjectId(webSearchId),
 		});
 
 		if (!webSearch) throw new Error("Web search not found");
+		if (!locals) throw new Error("User not authenticated");
+
+		const conversation = await collections.conversations.findOne({
+			_id: webSearch.convId,
+			...authCondition(locals),
+		});
+
+		if (!conversation) throw new Error("Conversation not found");
 
 		if (webSearch.summary) {
 			messages = [

--- a/src/routes/conversation/[id]/+server.ts
+++ b/src/routes/conversation/[id]/+server.ts
@@ -98,12 +98,13 @@ export async function POST({ request, fetch, locals, params }) {
 		];
 	})() satisfies Message[];
 
-	const prompt = await buildPrompt(
+	const prompt = await buildPrompt({
 		messages,
 		model,
-		web_search_id,
-		settings?.customPrompts?.[model.id]
-	);
+		webSearchId: web_search_id,
+		preprompt: settings?.customPrompts?.[model.id],
+		locals: locals,
+	});
 
 	const randomEndpoint = modelEndpoint(model);
 

--- a/src/routes/conversation/[id]/message/[messageId]/prompt/+server.ts
+++ b/src/routes/conversation/[id]/message/[messageId]/prompt/+server.ts
@@ -31,7 +31,10 @@ export async function GET({ params, locals }) {
 		throw error(404, "Conversation model not found");
 	}
 
-	const prompt = await buildPrompt(conv.messages.slice(0, messageIndex + 1), model);
+	const prompt = await buildPrompt({
+		messages: conv.messages.slice(0, messageIndex + 1),
+		model: model,
+	});
 
 	return new Response(
 		JSON.stringify(

--- a/src/routes/conversation/[id]/summarize/+server.ts
+++ b/src/routes/conversation/[id]/summarize/+server.ts
@@ -24,7 +24,10 @@ export async function POST({ params, locals }) {
 		`Please summarize the following message as a single sentence of less than 5 words:\n` +
 		firstMessage?.content;
 
-	const prompt = await buildPrompt([{ from: "user", content: userPrompt }], defaultModel);
+	const prompt = await buildPrompt({
+		messages: [{ from: "user", content: userPrompt }],
+		model: defaultModel,
+	});
 	const generated_text = await generateFromDefaultEndpoint(prompt);
 
 	if (generated_text) {

--- a/src/routes/r/[id]/message/[messageId]/prompt/+server.ts
+++ b/src/routes/r/[id]/message/[messageId]/prompt/+server.ts
@@ -26,7 +26,7 @@ export async function GET({ params }) {
 		throw error(404, "Conversation model not found");
 	}
 
-	const prompt = await buildPrompt(conv.messages.slice(0, messageIndex + 1), model);
+	const prompt = await buildPrompt({ messages: conv.messages.slice(0, messageIndex + 1), model });
 
 	return new Response(
 		JSON.stringify(


### PR DESCRIPTION
This PR fixes the issue we were having with the websearch.

`buildPrompt` was updated so that if a `webSearchId` is passed, we first check the `convId` associated with the web search. 

We can then make sure that the user making the request is allowed to see the conversation. If the user is not allowed to see the conversation, we assume that he is not allowed to see the websearch either. 

I can no longer reproduce the issue when testing with this PR.

Function is a bit messy but the fix should work.

