### PR TITLE
Implement general awsEndpoint + lambda integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ You can then add the generated information and the `authorization` parameter to 
 
 ### AWS Endpoints
 
-You can also specify your AWS endpoints for chat-ui, e.g. a sagemaker endpoint or a lambda function URL. 
+You can also specify your AWS endpoints for chat-ui, e.g. a sagemaker endpoint or a lambda function URL.
 The config goes like this:
 
 ```json
@@ -282,8 +282,8 @@ The config goes like this:
 ]
 ```
 
-You can get the `accessKey` and `secretKey` from your AWS user, under programmatic access. 
-The following endpoint services are currently enabled: "sagemaker" and "lambda." 
+You can get the `accessKey` and `secretKey` from your AWS user, under programmatic access.
+The following endpoint services are currently enabled: "sagemaker" and "lambda."
 If you intend to utilize "lambda," please ensure that you specify the corresponding "region" as well.
 
 #### Client Certificate Authentication (mTLS)

--- a/README.md
+++ b/README.md
@@ -262,23 +262,29 @@ You can then add the generated information and the `authorization` parameter to 
 
 ```
 
-### Amazon SageMaker
+### AWS Endpoints
 
-You can also specify your Amazon SageMaker instance as an endpoint for chat-ui. The config goes like this:
+You can also specify your AWS endpoints for chat-ui, e.g. a sagemaker endpoint or a lambda function URL. 
+The config goes like this:
 
-```
-"endpoints": [
+```json
+	"endpoints": [
     {
-      "host" : "sagemaker",
-      "url": "", // your aws sagemaker url here
-      "accessKey": "",
-      "secretKey" : "",
-      "sessionToken": "", // optional
-      "weight": 1
-    }
+        "host": "aws",
+        "service": "", // the service type, either "sagemaker" or "lambda"
+        "url": "",
+        "accessKey": "",
+        "secretKey": "",
+        "sessionToken": "", // optional
+        "region": "", // required if service = "lambda"
+        "weight": 1
+	}
+]
 ```
 
-You can get the `accessKey` and `secretKey` from your AWS user, under programmatic access.
+You can get the `accessKey` and `secretKey` from your AWS user, under programmatic access. 
+The following endpoint services are currently enabled: "sagemaker" and "lambda." 
+If you intend to utilize "lambda," please ensure that you specify the corresponding "region" as well.
 
 #### Client Certificate Authentication (mTLS)
 

--- a/src/lib/server/generateFromDefaultEndpoint.ts
+++ b/src/lib/server/generateFromDefaultEndpoint.ts
@@ -27,7 +27,7 @@ export async function generateFromDefaultEndpoint(
 
 	let resp: Response;
 
-	if (randomEndpoint.host === "sagemaker") {
+	if (randomEndpoint.host === "aws") {
 		const requestParams = JSON.stringify({
 			...newParameters,
 			inputs: prompt,
@@ -37,7 +37,8 @@ export async function generateFromDefaultEndpoint(
 			accessKeyId: randomEndpoint.accessKey,
 			secretAccessKey: randomEndpoint.secretKey,
 			sessionToken: randomEndpoint.sessionToken,
-			service: "sagemaker",
+			region: randomEndpoint.region,
+			service: randomEndpoint.service,
 		});
 
 		resp = await aws.fetch(randomEndpoint.url, {

--- a/src/lib/server/models.ts
+++ b/src/lib/server/models.ts
@@ -16,7 +16,7 @@ const awsEndpoint = z.object({
 	accessKey: z.string().min(1),
 	secretKey: z.string().min(1),
 	sessionToken: z.string().optional(),
-	region: z.string().optional()
+	region: z.string().optional(),
 });
 
 const tgiEndpoint = z.object({

--- a/src/routes/conversation/[id]/+server.ts
+++ b/src/routes/conversation/[id]/+server.ts
@@ -111,7 +111,7 @@ export async function POST({ request, fetch, locals, params }) {
 	const abortController = new AbortController();
 
 	let resp: Response;
-	if (randomEndpoint.host === "sagemaker") {
+	if (randomEndpoint.host === "aws") {
 		const requestParams = JSON.stringify({
 			...json,
 			inputs: prompt,
@@ -121,7 +121,8 @@ export async function POST({ request, fetch, locals, params }) {
 			accessKeyId: randomEndpoint.accessKey,
 			secretAccessKey: randomEndpoint.secretKey,
 			sessionToken: randomEndpoint.sessionToken,
-			service: "sagemaker",
+			region: randomEndpoint.region,
+			service: randomEndpoint.service,
 		});
 
 		resp = await aws.fetch(randomEndpoint.url, {


### PR DESCRIPTION
This small refactoring PR implements a general `awsEndpoint`, enabeling the user to not only connect sagemaker endpoints, but also lambda function URLs that require AWS_IAM authentication.
I had to implement this change for my personal setup, because upon requesting an LLM generation, the lambda performs additional scaling logic to provision / delete the sagemaker endpoint to save LLM hosting costs. I think that everyone could benefit from this functionality.