### PR TITLE
Update embedding model for WebSearch

### DIFF
--- a/src/lib/server/websearch/sentenceSimilarity.ts
+++ b/src/lib/server/websearch/sentenceSimilarity.ts
@@ -6,15 +6,18 @@ function innerProduct(tensor1: Tensor, tensor2: Tensor) {
 	return 1.0 - dot(tensor1.data, tensor2.data);
 }
 
-const extractor = await pipeline("feature-extraction", "Xenova/gte-base");
+const extractor = await pipeline("feature-extraction", "Xenova/bge-small-en-v1.5");
+const queryInstruction = "Represent this sentence for searching relevant passages: ";
 
 export async function findSimilarSentences(
 	query: string,
 	sentences: string[],
 	{ topK = 5 }: { topK: number }
 ) {
+	query = queryInstruction + query;
 	const input = [query, ...sentences];
-	const output: Tensor = await extractor(input, { pooling: "mean", normalize: true });
+	let output: Tensor = await extractor(input, { pooling: "none", normalize: true });
+	output = output.slice(null, 0); // CLS pooling
 
 	const queryTensor: Tensor = output[0];
 	const sentencesTensor: Tensor = output.slice([1, input.length - 1]);

--- a/src/lib/server/websearch/sentenceSimilarity.ts
+++ b/src/lib/server/websearch/sentenceSimilarity.ts
@@ -6,7 +6,7 @@ function innerProduct(tensor1: Tensor, tensor2: Tensor) {
 	return 1.0 - dot(tensor1.data, tensor2.data);
 }
 
-const extractor = await pipeline("feature-extraction", "Xenova/gte-base");
+const extractor = await pipeline("feature-extraction", "Xenova/gte-small");
 
 export async function findSimilarSentences(
 	query: string,

--- a/src/lib/server/websearch/sentenceSimilarity.ts
+++ b/src/lib/server/websearch/sentenceSimilarity.ts
@@ -6,16 +6,14 @@ function innerProduct(tensor1: Tensor, tensor2: Tensor) {
 	return 1.0 - dot(tensor1.data, tensor2.data);
 }
 
-const extractor = await pipeline("feature-extraction", "Xenova/e5-small-v2");
+const extractor = await pipeline("feature-extraction", "Xenova/gte-base");
 
 export async function findSimilarSentences(
 	query: string,
 	sentences: string[],
 	{ topK = 5 }: { topK: number }
 ) {
-	// this preprocessing step is suggested for e5-small-v2 model
-	// see more: https://huggingface.co/intfloat/e5-small-v2/blob/main/README.md?code=true#L2631
-	const input = [`query: ${query}`, ...sentences.map((s) => `passage: ${s}`)];
+	const input = [query, ...sentences];
 	const output: Tensor = await extractor(input, { pooling: "mean", normalize: true });
 
 	const queryTensor: Tensor = output[0];

--- a/src/lib/server/websearch/sentenceSimilarity.ts
+++ b/src/lib/server/websearch/sentenceSimilarity.ts
@@ -6,18 +6,15 @@ function innerProduct(tensor1: Tensor, tensor2: Tensor) {
 	return 1.0 - dot(tensor1.data, tensor2.data);
 }
 
-const extractor = await pipeline("feature-extraction", "Xenova/bge-small-en-v1.5");
-const queryInstruction = "Represent this sentence for searching relevant passages: ";
+const extractor = await pipeline("feature-extraction", "Xenova/gte-base");
 
 export async function findSimilarSentences(
 	query: string,
 	sentences: string[],
 	{ topK = 5 }: { topK: number }
 ) {
-	query = queryInstruction + query;
 	const input = [query, ...sentences];
-	let output: Tensor = await extractor(input, { pooling: "none", normalize: true });
-	output = output.slice(null, 0); // CLS pooling
+	const output: Tensor = await extractor(input, { pooling: "mean", normalize: true });
 
 	const queryTensor: Tensor = output[0];
 	const sentencesTensor: Tensor = output.slice([1, input.length - 1]);


### PR DESCRIPTION
Following @xenova [suggestion](https://github.com/huggingface/chat-ui/pull/427#discussion_r1324386594), I went to [MTEB leaderboard](https://huggingface.co/spaces/mteb/leaderboard) and tested 4 models:

* [intfloat/e5-small-v2](https://huggingface.co/intfloat/e5-small-v2) (note: currently used model)
* [thenlper/gte-small](https://huggingface.co/thenlper/gte-small)
* [thenlper/gte-base](https://huggingface.co/thenlper/gte-base)
* [BAAI/bge-small-en-v1.5](https://huggingface.co/BAAI/bge-small-en-v1.5)

### My analysis

1. All the embedding models produced pretty much same results. Therefore, let's use the smallest one: gte-smal (0.07GB), which is 2X smaller than currently used model of e5-small-v2 (0.13GB)
2. The next step for updating websearch results should be: 1. better web scraping; 2. better prompting

Find all the data of prompts and generations: <a href="https://docs.google.com/spreadsheets/d/1pNoDa00d-yoOQt5SwVczDeOO8atsbY3YTK002FwUIPU/edit?usp=sharing"> Google Sheet <img width="800" alt="image" src="https://github.com/huggingface/chat-ui/assets/11827707/0a241db7-f139-4726-8cda-59e69f9f26ea"> </a>