### PR TITLE
Add support for OpenAI API

### DIFF
--- a/.env
+++ b/.env
@@ -92,3 +92,6 @@ PUBLIC_APP_DISCLAIMER=#set to 1 to show a disclaimer on login page
 # PUBLIC_APP_COLOR=yellow
 # PUBLIC_APP_DATA_SHARING=1
 # PUBLIC_APP_DISCLAIMER=1
+
+CHATGPT_API_KEY=#sk-.... your chatgpt api key here
+CHATGPT_MODEL=#gpt-4-32k	the model to use for chatgpt: (https://platform.openai.com/docs/models)

--- a/.env
+++ b/.env
@@ -92,6 +92,3 @@ PUBLIC_APP_DISCLAIMER=#set to 1 to show a disclaimer on login page
 # PUBLIC_APP_COLOR=yellow
 # PUBLIC_APP_DATA_SHARING=1
 # PUBLIC_APP_DISCLAIMER=1
-
-CHATGPT_API_KEY=#sk-.... your chatgpt api key here
-CHATGPT_MODEL=#gpt-4-32k	the model to use for chatgpt: (https://platform.openai.com/docs/models)

--- a/README.md
+++ b/README.md
@@ -162,11 +162,11 @@ MODELS=`[
 
 You can change things like the parameters, or customize the preprompt to better suit your needs. You can also add more models by adding more objects to the array, with different preprompts for example.
 
-#### Custom prompt templates:
+#### Custom prompt templates
 
 By default the prompt is constructed using `userMessageToken`, `assistantMessageToken`, `userMessageEndToken`, `assistantMessageEndToken`, `preprompt` parameters and a series of default templates.
 
-However, these templates can be modified by setting the `chatPromptTemplate` and `webSearchQueryPromptTemplate` parameters. Note that if WebSearch is not enabled, only `chatPromptTemplate` needs to be set. The template language is https://handlebarsjs.com. The templates have access to the model's prompt parameters (`preprompt`, etc.). However, if the templates are specified it is recommended to inline the prompt parameters, as using the references (`{{preprompt}}`) is deprecated.
+However, these templates can be modified by setting the `chatPromptTemplate` and `webSearchQueryPromptTemplate` parameters. Note that if WebSearch is not enabled, only `chatPromptTemplate` needs to be set. The template language is <https://handlebarsjs.com>. The templates have access to the model's prompt parameters (`preprompt`, etc.). However, if the templates are specified it is recommended to inline the prompt parameters, as using the references (`{{preprompt}}`) is deprecated.
 
 For example:
 
@@ -298,6 +298,30 @@ If the model being hosted will be available on multiple servers/instances add th
 ...
 ]
 
+```
+
+### OpenAI API
+
+You can also specify your OpenAI API key as an endpoint for chat-ui. The config goes like this:
+
+```json
+  "endpoints": [{
+    "host": "openai",
+    "apiKey": "sk-...",
+    "model": "gpt-3.5-turbo",
+    "temperature": 0.9,
+    "max_tokens": 100
+  }],
+```
+
+Note that with the `"openai"` host the following parameters are required:
+
+```json
+  "userMessageToken": "<|user|>",
+  "assistantMessageToken": "<|assistant|>",
+  "userMessageEndToken": "</s>",
+  "assistantMessageEndToken": "</s>",
+  "preprompt": "<|system|>You are a helpful assistant...</s>",
 ```
 
 ## Deploying to a HF Space

--- a/src/lib/server/generateFromDefaultEndpoint.ts
+++ b/src/lib/server/generateFromDefaultEndpoint.ts
@@ -4,6 +4,7 @@ import { trimSuffix } from "$lib/utils/trimSuffix";
 import { trimPrefix } from "$lib/utils/trimPrefix";
 import { PUBLIC_SEP_TOKEN } from "$lib/constants/publicSepToken";
 import { AwsClient } from "aws4fetch";
+import { base } from "$app/paths";
 
 interface Parameters {
 	temperature: number;
@@ -13,7 +14,8 @@ interface Parameters {
 }
 export async function generateFromDefaultEndpoint(
 	prompt: string,
-	parameters?: Partial<Parameters>
+	fetch: typeof window.fetch = window.fetch,
+	parameters?: Partial<Parameters>,
 ) {
 	const newParameters = {
 		...defaultModel.parameters,
@@ -48,6 +50,24 @@ export async function generateFromDefaultEndpoint(
 				"Content-Type": "application/json",
 			},
 		});
+	} else if (randomEndpoint.host === "openai") {
+		resp = await fetch(`${base}/openai`, {
+			headers: {
+				"Content-Type": "application/json",
+			},
+			method: "POST",
+			body: JSON.stringify({
+				stream: false,
+				prompt: prompt,
+				url: randomEndpoint.url,
+				apiKey: randomEndpoint.apiKey,
+				model: randomEndpoint.model,
+				temperature: randomEndpoint.temperature,
+				max_tokens: randomEndpoint.max_tokens,
+			}),
+			signal: abortController.signal,
+		});
+
 	} else {
 		resp = await fetch(randomEndpoint.url, {
 			headers: {

--- a/src/routes/conversation/[id]/+server.ts
+++ b/src/routes/conversation/[id]/+server.ts
@@ -17,6 +17,7 @@ import { error } from "@sveltejs/kit";
 import { ObjectId } from "mongodb";
 import { z } from "zod";
 import { AwsClient } from "aws4fetch";
+import { base } from "$app/paths";
 
 export async function POST({ request, fetch, locals, params, getClientAddress }) {
 	const id = z.string().parse(params.id);
@@ -141,6 +142,24 @@ export async function POST({ request, fetch, locals, params, getClientAddress })
 				"Content-Type": "application/json",
 			},
 		});
+	} else if (randomEndpoint.host === "openai") {
+		resp = await fetch(`${base}/openai`, {
+			headers: {
+				"Content-Type": request.headers.get("Content-Type") ?? "application/json",
+			},
+			method: "POST",
+			body: JSON.stringify({
+				stream: true,
+				prompt: prompt,
+				url: randomEndpoint.url,
+				apiKey: randomEndpoint.apiKey,
+				model: randomEndpoint.model,
+				temperature: randomEndpoint.temperature,
+				max_tokens: randomEndpoint.max_tokens,
+			}),
+			signal: abortController.signal,
+		});
+
 	} else {
 		resp = await fetch(randomEndpoint.url, {
 			headers: {

--- a/src/routes/conversation/[id]/summarize/+server.ts
+++ b/src/routes/conversation/[id]/summarize/+server.ts
@@ -8,7 +8,7 @@ import { ERROR_MESSAGES } from "$lib/stores/errors.js";
 import { error } from "@sveltejs/kit";
 import { ObjectId } from "mongodb";
 
-export async function POST({ params, locals, getClientAddress }) {
+export async function POST({ params, locals, getClientAddress, fetch }) {
 	const convId = new ObjectId(params.id);
 
 	const conversation = await collections.conversations.findOne({
@@ -47,7 +47,7 @@ export async function POST({ params, locals, getClientAddress }) {
 		messages: [{ from: "user", content: userPrompt }],
 		model: defaultModel,
 	});
-	const generated_text = await generateFromDefaultEndpoint(prompt);
+	const generated_text = await generateFromDefaultEndpoint(prompt, fetch);
 
 	if (generated_text) {
 		await collections.conversations.updateOne(
@@ -65,8 +65,8 @@ export async function POST({ params, locals, getClientAddress }) {
 		JSON.stringify(
 			generated_text
 				? {
-						title: generated_text,
-				  }
+					title: generated_text,
+				}
 				: {}
 		),
 		{ headers: { "Content-Type": "application/json" } }

--- a/src/routes/openai/+server.ts
+++ b/src/routes/openai/+server.ts
@@ -63,8 +63,6 @@ export async function POST({ request }) {
             signal: request.signal
         });
 
-    console.log(stream.body);
-
 
     if (body.stream && stream.body) {
         return new Response(streamData(stream.body), {
@@ -73,9 +71,12 @@ export async function POST({ request }) {
             }
         });
     } else {
+        const generated_text = await stream.json().then(
+            (data) => data.choices[0].message.content
+        );
         return new Response(
             JSON.stringify([{
-                generated_text: stream.choices[0]?.message.content
+                generated_text: generated_text
             }]),
             { headers: { "Content-Type": "application/json" } }
         );
@@ -86,7 +87,6 @@ async function* streamData(openaiStream: ReadableStream<Uint8Array>) {
     const decoder = new TextDecoder();
     const textEncoder = new TextEncoder();
     let generated_text = '';
-    console.log(openaiStream);
     for await (const chunk of openaiStream) {
         const decodedChunk = decoder.decode(chunk);
 

--- a/src/routes/openai/+server.ts
+++ b/src/routes/openai/+server.ts
@@ -1,0 +1,119 @@
+import { OPENAI_API_KEY } from '$env/static/private';
+
+const FORMAT_REGEX = RegExp(/<\|(system|user|assistant)\|>([^<]+)<\/s>/g);
+
+interface ChatCompletionMessageParam {
+    content: string | null;
+    role: 'system' | 'user' | 'assistant';
+}
+
+export interface ChatCompletion {
+    id: string;
+    choices: {
+        finish_reason: 'stop' | 'length' | 'function_call';
+        delta: {
+            content: string | null;
+            role: 'system' | 'user' | 'assistant';
+        };
+        index: number;
+    }[];
+    created: number;
+    model: string;
+    object: string;
+    usage?: {
+        completion_tokens: number;
+        prompt_tokens: number;
+        total_tokens: number;
+    }
+}
+
+
+function formatMessages(prompt: string) {
+    const messages: ChatCompletionMessageParam[] = [];
+    let match;
+    while ((match = FORMAT_REGEX.exec(prompt)) !== null) {
+        messages.push({
+            role: match[1] as 'system' | 'user' | 'assistant',
+            content: match[2].trim()
+        });
+    }
+    return messages;
+}
+export async function POST({ request }) {
+    const body = await request.json();
+    const prompt = body.prompt;
+
+    const messages = formatMessages(prompt)
+
+    const stream = await fetch(
+        body.url || "https://api.openai.com/v1/chat/completions",
+        {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': "Bearer " + body.apiKey,
+            },
+            body: JSON.stringify({
+                messages: messages,
+                stream: body.stream,
+                model: body?.model,
+                temperature: body?.temperature,
+                max_tokens: body?.max_tokens,
+            }),
+            signal: request.signal
+        });
+
+    console.log(stream.body);
+
+
+    if (body.stream && stream.body) {
+        return new Response(streamData(stream.body), {
+            headers: {
+                'content-type': 'text/event-stream',
+            }
+        });
+    } else {
+        return new Response(
+            JSON.stringify([{
+                generated_text: stream.choices[0]?.message.content
+            }]),
+            { headers: { "Content-Type": "application/json" } }
+        );
+    }
+}
+
+async function* streamData(openaiStream: ReadableStream<Uint8Array>) {
+    const decoder = new TextDecoder();
+    const textEncoder = new TextEncoder();
+    let generated_text = '';
+    console.log(openaiStream);
+    for await (const chunk of openaiStream) {
+        const decodedChunk = decoder.decode(chunk);
+
+        // Clean up the data
+        const lines = decodedChunk
+            .split("\n")
+            .map((line) => line.replace("data: ", ""))
+            .filter((line) => line.length > 0)
+            .filter((line) => line !== "[DONE]")
+            .map((line) => JSON.parse(line));
+
+        for (const line of lines as ChatCompletion[]) {
+            const is_last_chunk = line.choices[0]?.finish_reason === 'stop';
+            const text = line.choices[0]?.delta.content || '';
+            generated_text += text;
+            const hf_chunk = {
+                token: {
+                    id: is_last_chunk ? 0 : Math.floor(Math.random() * 1000),
+                    text: is_last_chunk ? "" : text,
+                    logprob: 0,
+                    special: is_last_chunk ? true : false,
+                },
+                generated_text: is_last_chunk ? generated_text : null,
+                details: null,
+            };
+
+            yield textEncoder.encode("data:" + JSON.stringify(hf_chunk) + "\n\n");
+        }
+    }
+}


### PR DESCRIPTION
This PR add the support for the OpenAI API

This implementation add a new route `/openai/` that wrap the OpenAI API in a HuggingFace Inferencer fashion.
This route return a StreamingResponse if the `stream` parameter is set to `true`.
I did try to mimic the HuggingFace Inferencer as much as possible.

To call internal `/openai/` route in `generateFromDefaultEndpoint` I added the sveltekit fetch in argument.
Maybe it's not the best way to do it ...

I did a little update of the `README.md` to add some explanations about the OpenAI API.


https://github.com/huggingface/chat-ui/assets/11278197/9c6181ad-9a48-4ec5-bf90-143b5af30e23

---

TODO: 
- [x] Fix the `max_new_tokens` issue
- [ ] Improve the README.md documentation
- [x] Improve the /openai route to be more generic

