### PR TITLE
Add latex support with marked-katex-extension

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
 				"eslint": "^8.28.0",
 				"eslint-config-prettier": "^8.5.0",
 				"eslint-plugin-svelte": "^2.27.3",
+				"marked-katex-extension": "^3.0.6",
 				"prettier": "^2.8.0",
 				"prettier-plugin-svelte": "^2.8.1",
 				"prettier-plugin-tailwindcss": "^0.2.7",
@@ -1000,6 +1001,12 @@
 			"version": "7.0.11",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
 			"integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+			"dev": true
+		},
+		"node_modules/@types/katex": {
+			"version": "0.16.3",
+			"resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.3.tgz",
+			"integrity": "sha512-CeVMX9EhVUW8MWnei05eIRks4D5Wscw/W9Byz1s3PA+yJvcdvq9SaDjiUKvRvEgjpdTyJMjQA43ae4KTwsvOPg==",
 			"dev": true
 		},
 		"node_modules/@types/long": {
@@ -3328,6 +3335,31 @@
 			"integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
 			"dev": true
 		},
+		"node_modules/katex": {
+			"version": "0.16.8",
+			"resolved": "https://registry.npmjs.org/katex/-/katex-0.16.8.tgz",
+			"integrity": "sha512-ftuDnJbcbOckGY11OO+zg3OofESlbR5DRl2cmN8HeWeeFIV7wTXvAOx8kEjZjobhA+9wh2fbKeO6cdcA9Mnovg==",
+			"dev": true,
+			"funding": [
+				"https://opencollective.com/katex",
+				"https://github.com/sponsors/katex"
+			],
+			"dependencies": {
+				"commander": "^8.3.0"
+			},
+			"bin": {
+				"katex": "cli.js"
+			}
+		},
+		"node_modules/katex/node_modules/commander": {
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+			"integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+			"dev": true,
+			"engines": {
+				"node": ">= 12"
+			}
+		},
 		"node_modules/kleur": {
 			"version": "4.1.5",
 			"resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
@@ -3482,6 +3514,19 @@
 			},
 			"engines": {
 				"node": ">= 12"
+			}
+		},
+		"node_modules/marked-katex-extension": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/marked-katex-extension/-/marked-katex-extension-3.0.6.tgz",
+			"integrity": "sha512-X1XPjXVFcE0zo6oCcHuIOUrFCzUNMOPXqh05c18kNEB/htLSohrJTzOSWhDnNyVynoTiYrl8IhwZu6C0lTNFAQ==",
+			"dev": true,
+			"dependencies": {
+				"@types/katex": "^0.16.2",
+				"katex": "^0.16.8"
+			},
+			"peerDependencies": {
+				"marked": ">=4 <10"
 			}
 		},
 		"node_modules/md5-hex": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
 		"eslint": "^8.28.0",
 		"eslint-config-prettier": "^8.5.0",
 		"eslint-plugin-svelte": "^2.27.3",
+		"marked-katex-extension": "^3.0.6",
 		"prettier": "^2.8.0",
 		"prettier-plugin-svelte": "^2.8.1",
 		"prettier-plugin-tailwindcss": "^0.2.7",

--- a/src/lib/components/chat/ChatMessage.svelte
+++ b/src/lib/components/chat/ChatMessage.svelte
@@ -59,10 +59,18 @@
 	let loadingEl: IconLoading;
 	let pendingTimeout: ReturnType<typeof setTimeout>;
 
+	const renderer = new marked.Renderer();
+	// For code blocks with simple backticks
+	renderer.codespan = (code) => {
+		// Unsanitize double-sanitized code
+		return `<code>${code.replaceAll("&amp;", "&")}</code>`;
+	};
+
 	const options: marked.MarkedOptions = {
 		// ...marked.getDefaults(), // Breaks katex
 		gfm: true,
 		breaks: true,
+		renderer,
 	};
 
 	marked.use(

--- a/src/lib/components/chat/ChatMessage.svelte
+++ b/src/lib/components/chat/ChatMessage.svelte
@@ -185,7 +185,7 @@
 				"
 			>
 				<button
-					class="btn rounded-sm p-1 text-sm text-gray-400 hover:text-gray-500 focus:ring-0 dark:text-gray-400 dark:hover:text-gray-300
+					class="btn rounded-sm p-1 text-sm text-gray-400 focus:ring-0 hover:text-gray-500 dark:text-gray-400 dark:hover:text-gray-300
 					{message.score && message.score > 0
 						? 'text-green-500 hover:text-green-500 dark:text-green-400 hover:dark:text-green-400'
 						: ''}"
@@ -196,7 +196,7 @@
 					<CarbonThumbsUp class="h-[1.14em] w-[1.14em]" />
 				</button>
 				<button
-					class="btn rounded-sm p-1 text-sm text-gray-400 hover:text-gray-500 focus:ring-0 dark:text-gray-400 dark:hover:text-gray-300
+					class="btn rounded-sm p-1 text-sm text-gray-400 focus:ring-0 hover:text-gray-500 dark:text-gray-400 dark:hover:text-gray-300
 					{message.score && message.score < 0
 						? 'text-red-500 hover:text-red-500 dark:text-red-400 hover:dark:text-red-400'
 						: ''}"

--- a/src/lib/components/chat/ChatMessage.svelte
+++ b/src/lib/components/chat/ChatMessage.svelte
@@ -66,8 +66,13 @@
 		return `<code>${code.replaceAll("&amp;", "&")}</code>`;
 	};
 
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	const { extensions, ...defaults } = marked.getDefaults() as marked.MarkedOptions & {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		extensions: any;
+	};
 	const options: marked.MarkedOptions = {
-		// ...marked.getDefaults(), // Breaks katex
+		...defaults,
 		gfm: true,
 		breaks: true,
 		renderer,

--- a/src/lib/components/chat/ChatMessage.svelte
+++ b/src/lib/components/chat/ChatMessage.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { marked } from "marked";
+	import markedKatex from "marked-katex-extension";
 	import type { Message } from "$lib/types/Message";
 	import { afterUpdate, createEventDispatcher } from "svelte";
 	import { deepestChild } from "$lib/utils/deepestChild";
@@ -58,20 +59,18 @@
 	let loadingEl: IconLoading;
 	let pendingTimeout: ReturnType<typeof setTimeout>;
 
-	const renderer = new marked.Renderer();
-
-	// For code blocks with simple backticks
-	renderer.codespan = (code) => {
-		// Unsanitize double-sanitized code
-		return `<code>${code.replaceAll("&amp;", "&")}</code>`;
-	};
-
 	const options: marked.MarkedOptions = {
-		...marked.getDefaults(),
+		// ...marked.getDefaults(), // Breaks katex
 		gfm: true,
 		breaks: true,
-		renderer,
 	};
+
+	marked.use(
+		markedKatex({
+			throwOnError: false,
+			// output: "html",
+		})
+	);
 
 	$: tokens = marked.lexer(sanitizeMd(message.content));
 
@@ -140,7 +139,7 @@
 						<CodeBlock lang={token.lang} code={unsanitizeMd(token.text)} />
 					{:else}
 						<!-- eslint-disable-next-line svelte/no-at-html-tags -->
-						{@html marked(token.raw, options)}
+						{@html marked.parse(token.raw, options)}
 					{/if}
 				{/each}
 			</div>
@@ -150,7 +149,7 @@
 					<div class="text-gray-400">Sources:</div>
 					{#each webSearchSources as { link, title, hostname }}
 						<a
-							class="flex items-center gap-2 whitespace-nowrap rounded-lg border bg-white px-2 py-1.5 leading-none hover:border-gray-300  dark:border-gray-800 dark:bg-gray-900 dark:hover:border-gray-700"
+							class="flex items-center gap-2 whitespace-nowrap rounded-lg border bg-white px-2 py-1.5 leading-none hover:border-gray-300 dark:border-gray-800 dark:bg-gray-900 dark:hover:border-gray-700"
 							href={link}
 							target="_blank"
 						>
@@ -173,7 +172,7 @@
 				"
 			>
 				<button
-					class="btn rounded-sm p-1 text-sm text-gray-400 focus:ring-0 hover:text-gray-500 dark:text-gray-400 dark:hover:text-gray-300
+					class="btn rounded-sm p-1 text-sm text-gray-400 hover:text-gray-500 focus:ring-0 dark:text-gray-400 dark:hover:text-gray-300
 					{message.score && message.score > 0
 						? 'text-green-500 hover:text-green-500 dark:text-green-400 hover:dark:text-green-400'
 						: ''}"
@@ -184,7 +183,7 @@
 					<CarbonThumbsUp class="h-[1.14em] w-[1.14em]" />
 				</button>
 				<button
-					class="btn rounded-sm p-1 text-sm text-gray-400 focus:ring-0 hover:text-gray-500 dark:text-gray-400 dark:hover:text-gray-300
+					class="btn rounded-sm p-1 text-sm text-gray-400 hover:text-gray-500 focus:ring-0 dark:text-gray-400 dark:hover:text-gray-300
 					{message.score && message.score < 0
 						? 'text-red-500 hover:text-red-500 dark:text-red-400 hover:dark:text-red-400'
 						: ''}"

--- a/src/routes/conversation/[id]/+page.svelte
+++ b/src/routes/conversation/[id]/+page.svelte
@@ -270,6 +270,12 @@
 
 <svelte:head>
 	<title>{title}</title>
+	<link
+		rel="stylesheet"
+		href="https://cdn.jsdelivr.net/npm/katex@0.16.8/dist/katex.min.css"
+		integrity="sha384-GvrOXuhMATgEsSwCs4smul74iXGOixntILdUW9XmUC6+HX0sLNAK3q71HotJqlAn"
+		crossorigin="anonymous"
+	/>
 </svelte:head>
 
 <ChatWindow


### PR DESCRIPTION
Add the latex support (https://github.com/huggingface/chat-ui/issues/446) by leveraging the [marked-katex-extension](https://github.com/UziTech/marked-katex-extension).

<img width="915" alt="Screenshot 2023-09-18 at 23 32 12" src="https://github.com/huggingface/chat-ui/assets/11278197/ef3b39bc-4f7c-4b13-a6c3-52fc8d7c985c">
<img width="645" alt="Screenshot 2023-09-18 at 23 32 48" src="https://github.com/huggingface/chat-ui/assets/11278197/5a2e6b23-63dd-4dc0-81b9-f641d7b80807">

<img width="439" alt="Screenshot 2023-09-18 at 23 32 27" src="https://github.com/huggingface/chat-ui/assets/11278197/b8c47311-0c67-4d35-b798-5b26a27d1986">

This don't work in codeblock (for every format): This is expected and good

<img width="529" alt="Screenshot 2023-09-18 at 23 35 08" src="https://github.com/huggingface/chat-ui/assets/11278197/3380338c-2aec-43a1-963f-32afc79fd907">

I didn't try every latex format.

Math equation work well with ChatGPT they may have:
- Include a preprompt to get a specific format and tell the LLM to format as latex
- Make some postprocess (not likely)