### PR TITLE
Use `@postlight/parser` for parsing html text

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
 			"dependencies": {
 				"@huggingface/hub": "^0.5.1",
 				"@huggingface/inference": "^2.2.0",
+				"@postlight/parser": "^2.2.3",
 				"@xenova/transformers": "^2.6.0",
 				"autoprefixer": "^10.4.14",
 				"aws4fetch": "^1.0.17",
@@ -76,6 +77,18 @@
 			"dev": true,
 			"funding": {
 				"url": "https://github.com/sponsors/antfu"
+			}
+		},
+		"node_modules/@babel/runtime-corejs2": {
+			"version": "7.22.15",
+			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.22.15.tgz",
+			"integrity": "sha512-CcAMW2o5uqgeXIXYYPrgmaYj1HOLvQb2DrBi7+bELD4nUVSKk+Sth+yYuGqSRf+aAiOv3sIZJTUiJBhoASJRLg==",
+			"dependencies": {
+				"core-js": "^2.6.12",
+				"regenerator-runtime": "^0.14.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@esbuild/android-arm": {
@@ -665,6 +678,158 @@
 			"resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.21.tgz",
 			"integrity": "sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==",
 			"dev": true
+		},
+		"node_modules/@postlight/ci-failed-test-reporter": {
+			"version": "1.0.26",
+			"resolved": "https://registry.npmjs.org/@postlight/ci-failed-test-reporter/-/ci-failed-test-reporter-1.0.26.tgz",
+			"integrity": "sha512-xfXzxyOiKhco7Gx2OLTe9b66b0dFJw0elg94KGHoQXf5F8JqqFvdo35J8wayGOor64CSMvn+4Bjlu2NKV+yTGA==",
+			"dependencies": {
+				"dotenv": "^6.2.0",
+				"node-fetch": "^2.3.0"
+			},
+			"bin": {
+				"ciftr": "cli.js"
+			}
+		},
+		"node_modules/@postlight/ci-failed-test-reporter/node_modules/dotenv": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.2.0.tgz",
+			"integrity": "sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w==",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/@postlight/parser": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/@postlight/parser/-/parser-2.2.3.tgz",
+			"integrity": "sha512-4/syRvqJARgLN4yH8qtl634WO0+KINjkijU/SmhCJqqh8/aOfv5uQf+SquFpA+JwsAsbGzYQkIxSum29riOreg==",
+			"bundleDependencies": [
+				"jquery",
+				"moment-timezone",
+				"browser-request"
+			],
+			"dependencies": {
+				"@babel/runtime-corejs2": "^7.2.0",
+				"@postlight/ci-failed-test-reporter": "^1.0",
+				"browser-request": "*",
+				"cheerio": "^0.22.0",
+				"difflib": "github:postlight/difflib.js",
+				"ellipsize": "0.1.0",
+				"iconv-lite": "0.5.0",
+				"jquery": "*",
+				"moment": "^2.23.0",
+				"moment-parseformat": "3.0.0",
+				"moment-timezone": "*",
+				"postman-request": "^2.88.1-postman.31",
+				"string-direction": "^0.1.2",
+				"turndown": "^7.1.1",
+				"valid-url": "^1.0.9",
+				"wuzzy": "^0.1.4",
+				"yargs-parser": "^15.0.1"
+			},
+			"bin": {
+				"mercury-parser": "cli.js",
+				"postlight-parser": "cli.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@postlight/parser/node_modules/browser-request": {
+			"version": "0.3.2",
+			"engines": [
+				"node"
+			],
+			"inBundle": true,
+			"dependencies": {
+				"http-headers": "^3.0.1"
+			}
+		},
+		"node_modules/@postlight/parser/node_modules/http-headers": {
+			"version": "3.0.2",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"next-line": "^1.1.0"
+			}
+		},
+		"node_modules/@postlight/parser/node_modules/iconv-lite": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.5.0.tgz",
+			"integrity": "sha512-NnEhI9hIEKHOzJ4f697DMz9IQEXr/MMJ5w64vN2/4Ai+wRnvV7SBrL0KLoRlwaKVghOc7LQ5YkPLuX146b6Ydw==",
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@postlight/parser/node_modules/jquery": {
+			"version": "3.6.0",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/@postlight/parser/node_modules/moment": {
+			"version": "2.29.4",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/@postlight/parser/node_modules/moment-timezone": {
+			"version": "0.5.37",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"moment": ">= 2.9.0"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/@postlight/parser/node_modules/next-line": {
+			"version": "1.1.0",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/@postman/form-data": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@postman/form-data/-/form-data-3.1.1.tgz",
+			"integrity": "sha512-vjh8Q2a8S6UCm/KKs31XFJqEEgmbjBmpPNVV2eVav6905wyFAwaUOBGA1NPBI4ERH9MMZc6w0umFgM6WbEPMdg==",
+			"dependencies": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.8",
+				"mime-types": "^2.1.12"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/@postman/tough-cookie": {
+			"version": "4.1.3-postman.1",
+			"resolved": "https://registry.npmjs.org/@postman/tough-cookie/-/tough-cookie-4.1.3-postman.1.tgz",
+			"integrity": "sha512-txpgUqZOnWYnUHZpHjkfb0IwVH4qJmyq77pPnJLlfhMtdCLMFTEeQHlzQiK906aaNCe4NEB5fGJHo9uzGbFMeA==",
+			"dependencies": {
+				"psl": "^1.1.33",
+				"punycode": "^2.1.1",
+				"universalify": "^0.2.0",
+				"url-parse": "^1.5.3"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/@postman/tunnel-agent": {
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/@postman/tunnel-agent/-/tunnel-agent-0.6.3.tgz",
+			"integrity": "sha512-k57fzmAZ2PJGxfOA4SGR05ejorHbVAa/84Hxh/2nAztjNXc4ZjOm9NUIk6/Z6LCrBvJZqjRZbN8e/nROVUPVdg==",
+			"dependencies": {
+				"safe-buffer": "^5.0.1"
+			},
+			"engines": {
+				"node": "*"
+			}
 		},
 		"node_modules/@protobufjs/aspromise": {
 			"version": "1.1.2",
@@ -1436,7 +1601,6 @@
 			"version": "6.12.6",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
 			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-			"dev": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -1509,6 +1673,22 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/asn1": {
+			"version": "0.2.6",
+			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+			"integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+			"dependencies": {
+				"safer-buffer": "~2.1.0"
+			}
+		},
+		"node_modules/assert-plus": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+			"integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
+			"engines": {
+				"node": ">=0.8"
+			}
+		},
 		"node_modules/assertion-error": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -1555,6 +1735,19 @@
 				"postcss": "^8.1.0"
 			}
 		},
+		"node_modules/aws-sign2": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+			"integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/aws4": {
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
+			"integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg=="
+		},
 		"node_modules/aws4fetch": {
 			"version": "1.0.17",
 			"resolved": "https://registry.npmjs.org/aws4fetch/-/aws4fetch-1.0.17.tgz",
@@ -1589,6 +1782,14 @@
 				}
 			]
 		},
+		"node_modules/bcrypt-pbkdf": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+			"integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+			"dependencies": {
+				"tweetnacl": "^0.14.3"
+			}
+		},
 		"node_modules/binary-extensions": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -1613,11 +1814,21 @@
 				"readable-stream": "^3.4.0"
 			}
 		},
+		"node_modules/bluebird": {
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+			"integrity": "sha512-UfFSr22dmHPQqPP9XWHRhq+gWnHCYguQGkXQlbyPtW5qTnhFWA8/iXg765tH0cAjy7l/zPJ1aBTO0g5XgA7kvQ=="
+		},
 		"node_modules/blueimp-md5": {
 			"version": "2.19.0",
 			"resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.19.0.tgz",
 			"integrity": "sha512-DRQrD6gJyy8FbiE4s+bDoXS9hiW3Vbx5uCdwvcCf3zLHL+Iv7LtGHLpr+GZV8rHG8tK766FGYBwRbu8pELTt+w==",
 			"dev": true
+		},
+		"node_modules/boolbase": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+			"integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
 		},
 		"node_modules/brace-expansion": {
 			"version": "1.1.11",
@@ -1769,6 +1980,14 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/camelcase": {
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/camelcase-css": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
@@ -1795,6 +2014,11 @@
 					"url": "https://github.com/sponsors/ai"
 				}
 			]
+		},
+		"node_modules/caseless": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+			"integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
 		},
 		"node_modules/chai": {
 			"version": "4.3.7",
@@ -1838,6 +2062,37 @@
 			"engines": {
 				"node": "*"
 			}
+		},
+		"node_modules/cheerio": {
+			"version": "0.22.0",
+			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
+			"integrity": "sha512-8/MzidM6G/TgRelkzDG13y3Y9LxBjCb+8yOEZ9+wwq5gVF2w2pV0wmHvjfT0RvuxGyR7UEuK36r+yYMbT4uKgA==",
+			"dependencies": {
+				"css-select": "~1.2.0",
+				"dom-serializer": "~0.1.0",
+				"entities": "~1.1.1",
+				"htmlparser2": "^3.9.1",
+				"lodash.assignin": "^4.0.9",
+				"lodash.bind": "^4.1.4",
+				"lodash.defaults": "^4.0.1",
+				"lodash.filter": "^4.4.0",
+				"lodash.flatten": "^4.2.0",
+				"lodash.foreach": "^4.3.0",
+				"lodash.map": "^4.4.0",
+				"lodash.merge": "^4.4.0",
+				"lodash.pick": "^4.2.1",
+				"lodash.reduce": "^4.4.0",
+				"lodash.reject": "^4.4.0",
+				"lodash.some": "^4.4.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/cheerio/node_modules/entities": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+			"integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
 		},
 		"node_modules/chokidar": {
 			"version": "3.5.3",
@@ -1976,6 +2231,18 @@
 				"node": ">= 0.6"
 			}
 		},
+		"node_modules/core-js": {
+			"version": "2.6.12",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+			"integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
+			"deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
+			"hasInstallScript": true
+		},
+		"node_modules/core-util-is": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+			"integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="
+		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -1988,6 +2255,25 @@
 			},
 			"engines": {
 				"node": ">= 8"
+			}
+		},
+		"node_modules/css-select": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+			"integrity": "sha512-dUQOBoqdR7QwV90WysXPLXG5LO7nhYBgiWVfxF80DKPF8zx1t/pUd2FYy73emg3zrjtM6dzmYgbHKfV2rxiHQA==",
+			"dependencies": {
+				"boolbase": "~1.0.0",
+				"css-what": "2.1",
+				"domutils": "1.5.1",
+				"nth-check": "~1.0.1"
+			}
+		},
+		"node_modules/css-what": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
+			"integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==",
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/cssesc": {
@@ -2010,6 +2296,17 @@
 			},
 			"engines": {
 				"node": ">=14"
+			}
+		},
+		"node_modules/dashdash": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+			"integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
+			"dependencies": {
+				"assert-plus": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=0.10"
 			}
 		},
 		"node_modules/data-urls": {
@@ -2086,6 +2383,14 @@
 				"supports-color": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/decamelize": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+			"integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/decimal.js": {
@@ -2178,6 +2483,13 @@
 			"resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
 			"integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw=="
 		},
+		"node_modules/difflib": {
+			"version": "0.2.6",
+			"resolved": "git+ssh://git@github.com/postlight/difflib.js.git#32e8e38c7fcd935241b9baab71bb432fd9b166ed",
+			"dependencies": {
+				"heap": ">= 0.2.0"
+			}
+		},
 		"node_modules/dir-glob": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -2207,6 +2519,25 @@
 				"node": ">=6.0.0"
 			}
 		},
+		"node_modules/dom-serializer": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
+			"integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
+			"dependencies": {
+				"domelementtype": "^1.3.0",
+				"entities": "^1.1.1"
+			}
+		},
+		"node_modules/dom-serializer/node_modules/entities": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+			"integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
+		},
+		"node_modules/domelementtype": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+			"integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
+		},
 		"node_modules/domexception": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
@@ -2218,6 +2549,28 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/domhandler": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+			"integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+			"dependencies": {
+				"domelementtype": "1"
+			}
+		},
+		"node_modules/domino": {
+			"version": "2.1.6",
+			"resolved": "https://registry.npmjs.org/domino/-/domino-2.1.6.tgz",
+			"integrity": "sha512-3VdM/SXBZX2omc9JF9nOPCtDaYQ67BGp5CoLpIQlO2KCAPETs8TcDHacF26jXadGbvUteZzRTeos2fhID5+ucQ=="
+		},
+		"node_modules/domutils": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+			"integrity": "sha512-gSu5Oi/I+3wDENBsOWBiRK1eoGxcywYSqg3rR960/+EfY0CF4EX1VPkgHOZ3WiS/Jg2DtliF6BhWcHlfpYUcGw==",
+			"dependencies": {
+				"dom-serializer": "0",
+				"domelementtype": "1"
+			}
+		},
 		"node_modules/dotenv": {
 			"version": "16.0.3",
 			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
@@ -2226,10 +2579,24 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/ecc-jsbn": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+			"integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
+			"dependencies": {
+				"jsbn": "~0.1.0",
+				"safer-buffer": "^2.1.0"
+			}
+		},
 		"node_modules/electron-to-chromium": {
 			"version": "1.4.359",
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.359.tgz",
 			"integrity": "sha512-OoVcngKCIuNXtZnsYoqlCvr0Cf3NIPzDIgwUfI9bdTFjXCrr79lI0kwQstLPZ7WhCezLlGksZk/BFAzoXC7GDw=="
+		},
+		"node_modules/ellipsize": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/ellipsize/-/ellipsize-0.1.0.tgz",
+			"integrity": "sha512-5gxbEjcb/Z2n6TTmXZx9wVi3N/DOzE7RXY3Xg9dakDuhX/izwumB9rGjeWUV6dTA0D0+juvo+JonZgNR9sgA5A=="
 		},
 		"node_modules/end-of-stream": {
 			"version": "1.4.4",
@@ -2608,11 +2975,23 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/extend": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+		},
+		"node_modules/extsprintf": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+			"integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
+			"engines": [
+				"node >=0.6.0"
+			]
+		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-			"dev": true
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
 		},
 		"node_modules/fast-diff": {
 			"version": "1.2.0",
@@ -2654,8 +3033,7 @@
 		"node_modules/fast-json-stable-stringify": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-			"dev": true
+			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
 		},
 		"node_modules/fast-levenshtein": {
 			"version": "2.0.6",
@@ -2734,6 +3112,14 @@
 			"integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
 			"dev": true
 		},
+		"node_modules/forever-agent": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+			"integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/form-data": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
@@ -2806,6 +3192,14 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/getpass": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+			"integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
+			"dependencies": {
+				"assert-plus": "^1.0.0"
 			}
 		},
 		"node_modules/github-from-package": {
@@ -2928,6 +3322,27 @@
 				"uglify-js": "^3.1.4"
 			}
 		},
+		"node_modules/har-schema": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+			"integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/har-validator": {
+			"version": "5.1.5",
+			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+			"integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+			"deprecated": "this library is no longer supported",
+			"dependencies": {
+				"ajv": "^6.12.3",
+				"har-schema": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/has": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -2953,6 +3368,11 @@
 			"resolved": "https://registry.npmjs.org/hash-wasm/-/hash-wasm-4.9.0.tgz",
 			"integrity": "sha512-7SW7ejyfnRxuOc7ptQHSf4LDoZaWOivfzqw+5rpcQku0nHfmicPKE51ra9BiRLAmT8+gGLestr1XroUkqdjL6w=="
 		},
+		"node_modules/heap": {
+			"version": "0.2.7",
+			"resolved": "https://registry.npmjs.org/heap/-/heap-0.2.7.tgz",
+			"integrity": "sha512-2bsegYkkHO+h/9MGbn6KWcE45cHZgPANo5LXF7EvWdT0yT2EguSVO1nDgU5c8+ZOPwp2vMNa7YFsJhVcDR9Sdg=="
+		},
 		"node_modules/highlight.js": {
 			"version": "11.7.0",
 			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.7.0.tgz",
@@ -2972,6 +3392,24 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/htmlparser2": {
+			"version": "3.10.1",
+			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
+			"integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
+			"dependencies": {
+				"domelementtype": "^1.3.1",
+				"domhandler": "^2.3.0",
+				"domutils": "^1.5.1",
+				"entities": "^1.1.1",
+				"inherits": "^2.0.1",
+				"readable-stream": "^3.1.1"
+			}
+		},
+		"node_modules/htmlparser2/node_modules/entities": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+			"integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
+		},
 		"node_modules/http-proxy-agent": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
@@ -2983,6 +3421,19 @@
 			},
 			"engines": {
 				"node": ">= 6"
+			}
+		},
+		"node_modules/http-signature": {
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.3.6.tgz",
+			"integrity": "sha512-3adrsD6zqo4GsTqtO7FyrejHNv+NgiIfAfv68+jVlFmSr9OGy7zrxONceFRLKvnnZA5jbxQBX1u9PpB6Wi32Gw==",
+			"dependencies": {
+				"assert-plus": "^1.0.0",
+				"jsprim": "^2.0.2",
+				"sshpk": "^1.14.1"
+			},
+			"engines": {
+				"node": ">=0.10"
 			}
 		},
 		"node_modules/https-proxy-agent": {
@@ -3209,11 +3660,21 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/is-typedarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+			"integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
+		},
 		"node_modules/isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
 			"dev": true
+		},
+		"node_modules/isstream": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+			"integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
 		},
 		"node_modules/jiti": {
 			"version": "1.18.2",
@@ -3261,6 +3722,11 @@
 			"bin": {
 				"js-yaml": "bin/js-yaml.js"
 			}
+		},
+		"node_modules/jsbn": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+			"integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg=="
 		},
 		"node_modules/jsdom": {
 			"version": "22.0.0",
@@ -3326,11 +3792,15 @@
 				"node": ">=14"
 			}
 		},
+		"node_modules/json-schema": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+			"integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
+		},
 		"node_modules/json-schema-traverse": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-			"dev": true
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
 		},
 		"node_modules/json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
@@ -3338,11 +3808,30 @@
 			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
 			"dev": true
 		},
+		"node_modules/json-stringify-safe": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+			"integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
+		},
 		"node_modules/jsonc-parser": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
 			"integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
 			"dev": true
+		},
+		"node_modules/jsprim": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-2.0.2.tgz",
+			"integrity": "sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==",
+			"engines": [
+				"node >=0.6.0"
+			],
+			"dependencies": {
+				"assert-plus": "1.0.0",
+				"extsprintf": "1.3.0",
+				"json-schema": "0.4.0",
+				"verror": "1.10.0"
+			}
 		},
 		"node_modules/katex": {
 			"version": "0.16.8",
@@ -3446,8 +3935,17 @@
 		"node_modules/lodash": {
 			"version": "4.17.21",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-			"dev": true
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+		},
+		"node_modules/lodash.assignin": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/lodash.assignin/-/lodash.assignin-4.2.0.tgz",
+			"integrity": "sha512-yX/rx6d/UTVh7sSVWVSIMjfnz95evAgDFdb1ZozC35I9mSFCkmzptOzevxjgbQUsc78NR44LVHWjsoMQXy9FDg=="
+		},
+		"node_modules/lodash.bind": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-4.2.1.tgz",
+			"integrity": "sha512-lxdsn7xxlCymgLYo1gGvVrfHmkjDiyqVv62FAeF2i5ta72BipE1SLxw8hPEPLhD4/247Ijw07UQH7Hq/chT5LA=="
 		},
 		"node_modules/lodash.castarray": {
 			"version": "4.4.0",
@@ -3455,17 +3953,61 @@
 			"integrity": "sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==",
 			"dev": true
 		},
+		"node_modules/lodash.defaults": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+			"integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
+		},
+		"node_modules/lodash.filter": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
+			"integrity": "sha512-pXYUy7PR8BCLwX5mgJ/aNtyOvuJTdZAo9EQFUvMIYugqmJxnrYaANvTbgndOzHSCSR0wnlBBfRXJL5SbWxo3FQ=="
+		},
+		"node_modules/lodash.flatten": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+			"integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g=="
+		},
+		"node_modules/lodash.foreach": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
+			"integrity": "sha512-aEXTF4d+m05rVOAUG3z4vZZ4xVexLKZGF0lIxuHZ1Hplpk/3B6Z1+/ICICYRLm7c41Z2xiejbkCkJoTlypoXhQ=="
+		},
 		"node_modules/lodash.isplainobject": {
 			"version": "4.0.6",
 			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
 			"integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
 			"dev": true
 		},
+		"node_modules/lodash.map": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
+			"integrity": "sha512-worNHGKLDetmcEYDvh2stPCrrQRkP20E4l0iIS7F8EvzMqBBi7ltvFN5m1HvTf1P7Jk1txKhvFcmYsCr8O2F1Q=="
+		},
 		"node_modules/lodash.merge": {
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-			"dev": true
+			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+		},
+		"node_modules/lodash.pick": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+			"integrity": "sha512-hXt6Ul/5yWjfklSGvLQl8vM//l3FtyHZeuelpzK6mm99pNvN9yTDruNZPEJZD1oWrqo+izBmB7oUfWgcCX7s4Q=="
+		},
+		"node_modules/lodash.reduce": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/lodash.reduce/-/lodash.reduce-4.6.0.tgz",
+			"integrity": "sha512-6raRe2vxCYBhpBu+B+TtNGUzah+hQjVdu3E17wfusjyrXBka2nBS8OH/gjVZ5PvHOhWmIZTYri09Z6n/QfnNMw=="
+		},
+		"node_modules/lodash.reject": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/lodash.reject/-/lodash.reject-4.6.0.tgz",
+			"integrity": "sha512-qkTuvgEzYdyhiJBx42YPzPo71R1aEr0z79kAv7Ixg8wPFEjgRgJdUsGMG3Hf3OYSF/kHI79XhNlt+5Ar6OzwxQ=="
+		},
+		"node_modules/lodash.some": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
+			"integrity": "sha512-j7MJE+TuT51q9ggt4fSgVqro163BEFjAt3u97IqU+JA2DkWl80nFTrowzLpZ/BnpN7rrl0JA/593NAdd8p/scQ=="
 		},
 		"node_modules/long": {
 			"version": "4.0.0",
@@ -3690,6 +4232,11 @@
 				"ufo": "^1.1.2"
 			}
 		},
+		"node_modules/moment-parseformat": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/moment-parseformat/-/moment-parseformat-3.0.0.tgz",
+			"integrity": "sha512-dVgXe6b6DLnv4CHG7a1zUe5mSXaIZ3c6lSHm/EKeVeQI2/4pwe0VRde8OyoCE1Ro2lKT5P6uT9JElF7KDLV+jw=="
+		},
 		"node_modules/mongodb": {
 			"version": "5.8.0",
 			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.8.0.tgz",
@@ -3827,6 +4374,44 @@
 			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
 			"integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA=="
 		},
+		"node_modules/node-fetch": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+			"integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+			"dependencies": {
+				"whatwg-url": "^5.0.0"
+			},
+			"engines": {
+				"node": "4.x || >=6.0.0"
+			},
+			"peerDependencies": {
+				"encoding": "^0.1.0"
+			},
+			"peerDependenciesMeta": {
+				"encoding": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/node-fetch/node_modules/tr46": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+		},
+		"node_modules/node-fetch/node_modules/webidl-conversions": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+		},
+		"node_modules/node-fetch/node_modules/whatwg-url": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+			"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+			"dependencies": {
+				"tr46": "~0.0.3",
+				"webidl-conversions": "^3.0.0"
+			}
+		},
 		"node_modules/node-gyp-build": {
 			"version": "4.6.1",
 			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.1.tgz",
@@ -3877,10 +4462,26 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/nth-check": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
+			"integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
+			"dependencies": {
+				"boolbase": "~1.0.0"
+			}
+		},
 		"node_modules/nwsapi": {
 			"version": "2.2.4",
 			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.4.tgz",
 			"integrity": "sha512-NHj4rzRo0tQdijE9ZqAx6kYDcoRwYwSYzCA8MY3JzfxlrvEU0jhnhJT9BhqhJs7I/dKcrDm6TyulaRqZPIhN5g=="
+		},
+		"node_modules/oauth-sign": {
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+			"engines": {
+				"node": "*"
+			}
 		},
 		"node_modules/object-assign": {
 			"version": "4.1.1",
@@ -4152,6 +4753,11 @@
 				"node": "*"
 			}
 		},
+		"node_modules/performance-now": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+			"integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
+		},
 		"node_modules/picocolors": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -4355,6 +4961,38 @@
 			},
 			"engines": {
 				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+			}
+		},
+		"node_modules/postman-request": {
+			"version": "2.88.1-postman.33",
+			"resolved": "https://registry.npmjs.org/postman-request/-/postman-request-2.88.1-postman.33.tgz",
+			"integrity": "sha512-uL9sCML4gPH6Z4hreDWbeinKU0p0Ke261nU7OvII95NU22HN6Dk7T/SaVPaj6T4TsQqGKIFw6/woLZnH7ugFNA==",
+			"dependencies": {
+				"@postman/form-data": "~3.1.1",
+				"@postman/tough-cookie": "~4.1.3-postman.1",
+				"@postman/tunnel-agent": "^0.6.3",
+				"aws-sign2": "~0.7.0",
+				"aws4": "^1.12.0",
+				"brotli": "^1.3.3",
+				"caseless": "~0.12.0",
+				"combined-stream": "~1.0.6",
+				"extend": "~3.0.2",
+				"forever-agent": "~0.6.1",
+				"har-validator": "~5.1.3",
+				"http-signature": "~1.3.1",
+				"is-typedarray": "~1.0.0",
+				"isstream": "~0.1.2",
+				"json-stringify-safe": "~5.0.1",
+				"mime-types": "^2.1.35",
+				"oauth-sign": "~0.9.0",
+				"performance-now": "^2.1.0",
+				"qs": "~6.5.3",
+				"safe-buffer": "^5.1.2",
+				"stream-length": "^1.0.2",
+				"uuid": "^8.3.2"
+			},
+			"engines": {
+				"node": ">= 6"
 			}
 		},
 		"node_modules/prebuild-install": {
@@ -4598,6 +5236,14 @@
 				"teleport": ">=0.2.0"
 			}
 		},
+		"node_modules/qs": {
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+			"integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
+			"engines": {
+				"node": ">=0.6"
+			}
+		},
 		"node_modules/querystringify": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
@@ -4697,6 +5343,11 @@
 			"engines": {
 				"node": ">=8.10.0"
 			}
+		},
+		"node_modules/regenerator-runtime": {
+			"version": "0.14.0",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
+			"integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
 		},
 		"node_modules/regexpp": {
 			"version": "3.2.0",
@@ -5102,6 +5753,30 @@
 				"memory-pager": "^1.0.2"
 			}
 		},
+		"node_modules/sshpk": {
+			"version": "1.17.0",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
+			"integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
+			"dependencies": {
+				"asn1": "~0.2.3",
+				"assert-plus": "^1.0.0",
+				"bcrypt-pbkdf": "^1.0.0",
+				"dashdash": "^1.12.0",
+				"ecc-jsbn": "~0.1.1",
+				"getpass": "^0.1.1",
+				"jsbn": "~0.1.0",
+				"safer-buffer": "^2.0.2",
+				"tweetnacl": "~0.14.0"
+			},
+			"bin": {
+				"sshpk-conv": "bin/sshpk-conv",
+				"sshpk-sign": "bin/sshpk-sign",
+				"sshpk-verify": "bin/sshpk-verify"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/stackback": {
 			"version": "0.0.2",
 			"resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -5113,6 +5788,14 @@
 			"resolved": "https://registry.npmjs.org/std-env/-/std-env-3.3.3.tgz",
 			"integrity": "sha512-Rz6yejtVyWnVjC1RFvNmYL10kgjC49EOghxWn0RFqlCHGFpQx+Xe7yW3I4ceK1SGrWIGMjD5Kbue8W/udkbMJg==",
 			"dev": true
+		},
+		"node_modules/stream-length": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/stream-length/-/stream-length-1.0.2.tgz",
+			"integrity": "sha512-aI+qKFiwoDV4rsXiS7WRoCt+v2RX1nUj17+KJC5r2gfh5xoSJIfP6Y3Do/HtvesFcTSWthIuJ3l1cvKQY/+nZg==",
+			"dependencies": {
+				"bluebird": "^2.6.2"
+			}
 		},
 		"node_modules/streamsearch": {
 			"version": "1.1.0",
@@ -5138,6 +5821,11 @@
 			"dependencies": {
 				"safe-buffer": "~5.2.0"
 			}
+		},
+		"node_modules/string-direction": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/string-direction/-/string-direction-0.1.2.tgz",
+			"integrity": "sha512-NJHQRg6GlOEMLA6jEAlSy21KaXvJDNoAid/v6fBAJbqdvOEIiPpCrIPTHnl4636wUF/IGyktX5A9eddmETb1Cw=="
 		},
 		"node_modules/strip-ansi": {
 			"version": "6.0.1",
@@ -5685,6 +6373,19 @@
 				"node": "*"
 			}
 		},
+		"node_modules/turndown": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/turndown/-/turndown-7.1.2.tgz",
+			"integrity": "sha512-ntI9R7fcUKjqBP6QU8rBK2Ehyt8LAzt3UBT9JR9tgo6GtuKvyUzpayWmeMKJw1DPdXzktvtIT8m2mVXz+bL/Qg==",
+			"dependencies": {
+				"domino": "^2.1.6"
+			}
+		},
+		"node_modules/tweetnacl": {
+			"version": "0.14.5",
+			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+			"integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
+		},
 		"node_modules/type-check": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -5847,7 +6548,6 @@
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
 			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-			"dev": true,
 			"dependencies": {
 				"punycode": "^2.1.0"
 			}
@@ -5866,10 +6566,36 @@
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
 		},
+		"node_modules/uuid": {
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+			"bin": {
+				"uuid": "dist/bin/uuid"
+			}
+		},
+		"node_modules/valid-url": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
+			"integrity": "sha512-QQDsV8OnSf5Uc30CKSwG9lnhMPe6exHtTXLRYX8uMwKENy640pU+2BgBL0LRbDh/eYRahNCS7aewCx0wf3NYVA=="
+		},
 		"node_modules/varint": {
 			"version": "5.0.2",
 			"resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
 			"integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
+		},
+		"node_modules/verror": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+			"integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
+			"engines": [
+				"node >=0.6.0"
+			],
+			"dependencies": {
+				"assert-plus": "^1.0.0",
+				"core-util-is": "1.0.2",
+				"extsprintf": "^1.2.0"
+			}
 		},
 		"node_modules/vite": {
 			"version": "4.3.9",
@@ -6178,6 +6904,14 @@
 				}
 			}
 		},
+		"node_modules/wuzzy": {
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/wuzzy/-/wuzzy-0.1.8.tgz",
+			"integrity": "sha512-FUzKQepFSTnANsDYwxpIzGJ/dIJaqxuMre6tzzbvWwFAiUHPsI1nVQVCLK4Xqr67KO7oYAK0kaCcI/+WYj/7JA==",
+			"dependencies": {
+				"lodash": "^4.17.15"
+			}
+		},
 		"node_modules/xml-name-validator": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
@@ -6202,6 +6936,15 @@
 			"integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
 			"engines": {
 				"node": ">= 6"
+			}
+		},
+		"node_modules/yargs-parser": {
+			"version": "15.0.3",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.3.tgz",
+			"integrity": "sha512-/MVEVjTXy/cGAjdtQf8dW3V9b97bPN7rNn8ETj6BmAQL7ibC7O1Q9SPJbGjgh3SlwoBNXMzj/ZGIj8mBgl12YA==",
+			"dependencies": {
+				"camelcase": "^5.0.0",
+				"decamelize": "^1.2.0"
 			}
 		},
 		"node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
 	"dependencies": {
 		"@huggingface/hub": "^0.5.1",
 		"@huggingface/inference": "^2.2.0",
+		"@postlight/parser": "^2.2.3",
 		"@xenova/transformers": "^2.6.0",
 		"autoprefixer": "^10.4.14",
 		"aws4fetch": "^1.0.17",

--- a/src/lib/server/websearch/parseWeb.ts
+++ b/src/lib/server/websearch/parseWeb.ts
@@ -1,32 +1,29 @@
-import { JSDOM, VirtualConsole } from "jsdom";
+import Parser from "@postlight/parser";
+
+interface ParserResult {
+	title: string | null;
+	content: string | null;
+	author: string | null;
+	date_published: string | null;
+	lead_image_url: string | null;
+	url: string;
+	error?: boolean;
+	message?: string;
+}
 
 export async function parseWeb(url: string) {
 	const abortController = new AbortController();
 	setTimeout(() => abortController.abort(), 10000);
-	const htmlString = await fetch(url, { signal: abortController.signal })
-		.then((response) => response.text())
-		.catch();
-
-	const virtualConsole = new VirtualConsole();
-	virtualConsole.on("error", () => {
-		// No-op to skip console errors.
-	});
-
-	// put the html string into a DOM
-	const dom = new JSDOM(htmlString ?? "", {
-		virtualConsole,
-	});
-
-	const { document } = dom.window;
-	const textElTags = "p";
-	const paragraphs = document.querySelectorAll(textElTags);
-	if (!paragraphs.length) {
-		throw new Error(`webpage doesn't have any "${textElTags}" element`);
+	const result = (await Parser.parse(url, { contentType: "text" })) as ParserResult;
+	if (result.error) {
+		throw new Error(result.message);
 	}
-	const paragraphTexts = Array.from(paragraphs).map((p) => p.textContent);
 
-	// combine text contents from paragraphs and then remove newlines and multiple spaces
-	const text = paragraphTexts.join(" ").replace(/ {2}|\r\n|\n|\r/gm, "");
-
-	return text;
+	let { content } = result;
+	// remove newlines and multiple spaces
+	content = content?.replace(/ {2}|\r\n|\n|\r/gm, "") ?? null;
+	if (!content) {
+		throw new Error(`parser couldn't find any text content`);
+	}
+	return content;
 }


### PR DESCRIPTION
Comparing HTML text parsers:
* jsdom (parse only `<p>` elements) (current approach)
* https://github.com/mozilla/readability
* https://github.com/postlight/parser

From the tests below, that you can see https://github.com/postlight/parser is producing slightly better results. Please let me know what you think of these prompt tests on different parsers

Find all the data of prompts and generations: <a href="https://docs.google.com/spreadsheets/d/1pNoDa00d-yoOQt5SwVczDeOO8atsbY3YTK002FwUIPU/edit#gid=719616982"> Google Sheet <img width="800" alt="image" src="https://github.com/huggingface/chat-ui/assets/11827707/dd29e7ad-af8a-458a-9ec2-618bc44f53ff"> </a>