### PR TITLE
Add prompts templates to a markdown doc

### DIFF
--- a/PROMPTS.md
+++ b/PROMPTS.md
@@ -1,0 +1,29 @@
+# Prompt templates
+
+These are the templates used to format the conversation history for different models used in HuggingChat. Set them in your `.env.local` [like so](https://github.com/huggingface/chat-ui#chatprompttemplate).
+
+## Llama 2
+
+```env
+<s>[INST] <<SYS>>\n{{preprompt}}\n<</SYS>>\n\n{{#each messages}}{{#ifUser}}{{content}} [/INST] {{/ifUser}}{{#ifAssistant}}{{content}} </s><s>[INST] {{/ifAssistant}}{{/each}}
+```
+
+## CodeLlama
+
+```env
+<s>[INST] <<SYS>>\n{{preprompt}}\n<</SYS>>\n\n{{#each messages}}{{#ifUser}}{{content}} [/INST] {{/ifUser}}{{#ifAssistant}}{{content}} </s><s>[INST] {{/ifAssistant}}{{/each}}
+```
+
+## Falcon
+
+```env
+System: {{preprompt}}\nUser:{{#each messages}}{{#ifUser}}{{content}}\nFalcon:{{/ifUser}}{{#ifAssistant}}{{content}}\nUser:{{/ifAssistant}}{{/each}}
+```
+
+## Mistral
+
+> Mistral doesn't support preprompts, so the recommended way is to add it in the first user message.
+
+```env
+<s>{{#each messages}}{{#ifUser}}[INST] {{#if @first}}{{#if @root.preprompt}}{{@root.preprompt}}\n{{/if}}{{/if}} {{content}} [/INST]{{/ifUser}}{{#ifAssistant}}{{content}}</s> {{/ifAssistant}}{{/each}}
+```

--- a/PROMPTS.md
+++ b/PROMPTS.md
@@ -22,8 +22,6 @@ System: {{preprompt}}\nUser:{{#each messages}}{{#ifUser}}{{content}}\nFalcon:{{/
 
 ## Mistral
 
-> Mistral doesn't support preprompts, so the recommended way is to add it in the first user message.
-
 ```env
 <s>{{#each messages}}{{#ifUser}}[INST] {{#if @first}}{{#if @root.preprompt}}{{@root.preprompt}}\n{{/if}}{{/if}} {{content}} [/INST]{{/ifUser}}{{#ifAssistant}}{{content}}</s> {{/ifAssistant}}{{/each}}
 ```

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ For example:
 
 When quering the model for a chat response, the `chatPromptTemplate` template is used. `messages` is an array of chat messages, it has the format `[{ content: string }, ...]`. To idenify if a message is a user message or an assistant message the `ifUser` and `ifAssistant` block helpers can be used.
 
-The following is the default `chatPromptTemplate`, although newlines and indentiation have been added for readability.
+The following is the default `chatPromptTemplate`, although newlines and indentiation have been added for readability. You can find the prompts used in production for HuggingChat [here](https://github.com/huggingface/chat-ui/blob/main/PROMPTS.md).
 
 ```prompt
 {{preprompt}}


### PR DESCRIPTION
We sometimes get questions about our prompt formatting from users who want to replicate it in their own setup. 

I want to make them easily accessible in a standalone document so that I can also point to them from the docker chat-ui template docs.