### PR TITLE
Save user message on request (#337)

### DIFF
--- a/src/routes/conversation/[id]/+server.ts
+++ b/src/routes/conversation/[id]/+server.ts
@@ -129,6 +129,19 @@ export async function POST({ request, fetch, locals, params, getClientAddress })
 		}
 	}
 
+	await collections.conversations.updateOne(
+		{
+			_id: convId,
+		},
+		{
+			$set: {
+				messages,
+				title: conv.title,
+				updatedAt: new Date(),
+			},
+		}
+	);
+
 	// we now build the stream
 	const stream = new ReadableStream({
 		async start(controller) {


### PR DESCRIPTION
Closes #337

You can test it by setting a model name that doesn't exist in your `.env.local` and then when the request fail, the user message should still be in the new conversation.