### PR TITLE
Pass stop sequences properly to TGI

### DIFF
--- a/src/lib/server/models.ts
+++ b/src/lib/server/models.ts
@@ -129,7 +129,7 @@ export const oldModels = OLD_MODELS
 			.map((m) => ({ ...m, id: m.id || m.name, displayName: m.displayName || m.name }))
 	: [];
 
-export type BackendModel = Optional<(typeof models)[0], "preprompt">;
+export type BackendModel = Optional<(typeof models)[0], "preprompt" | "parameters">;
 export type Endpoint = z.infer<typeof endpoint>;
 
 export const defaultModel = models[0];

--- a/src/lib/server/models.ts
+++ b/src/lib/server/models.ts
@@ -111,6 +111,7 @@ export const models = await Promise.all(
 		id: m.id || m.name,
 		displayName: m.displayName || m.name,
 		preprompt: m.prepromptUrl ? await fetch(m.prepromptUrl).then((r) => r.text()) : m.preprompt,
+		parameters: { ...m.parameters, stop_sequences: m.parameters?.stop },
 	}))
 );
 


### PR DESCRIPTION
TGI can accept `stop_sequences` as a parameter, which we weren't passing before. This simple fix propagates the stop sequences to the backend.