### PR TITLE
fix inert attribute didn't removed properly after modal close

### DIFF
--- a/src/lib/components/Modal.svelte
+++ b/src/lib/components/Modal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createEventDispatcher, onDestroy, onMount } from "svelte";
+	import { afterUpdate, createEventDispatcher, onDestroy, onMount } from "svelte";
 	import { cubicOut } from "svelte/easing";
 	import { fade } from "svelte/transition";
 	import Portal from "./Portal.svelte";
@@ -33,8 +33,8 @@
 
 	onDestroy(() => {
 		if (!browser) return;
-		// remove inert attribute if this is the last modal
-		if (document.querySelectorAll('[role="dialog"]:not(#app *)').length === 1) {
+		// remove inert attribute if this is the second last modal
+		if (document.querySelectorAll('[role="dialog"]:not(#app *)').length === 2) {
 			document.getElementById("app")?.removeAttribute("inert");
 		}
 	});


### PR DESCRIPTION
Hi team, I noticed a bug that after close the setting modal, whole site will be ignored due to #app node didn't remove the inert attribute.
It seems like the document.querySelectorAll('[role="dialog"]:not(#app *)') in onDestroy hook in Modal.svelte file selected 2 nodes because it runs before rerender.So I modify the condition to 2 instead of 1.
love your huggingface chat bot,best wishes :D
![modal close error](https://github.com/huggingface/chat-ui/assets/30712768/e6ee0468-d467-40a0-9c80-91a4cfbf6e32)
