### PR TITLE
Add a more visible retry button on failure to generate

### DIFF
--- a/src/lib/components/RetryBtn.svelte
+++ b/src/lib/components/RetryBtn.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	import CarbonRotate360 from "~icons/carbon/rotate-360";
+
+	export let classNames = "";
+</script>
+
+<button
+	type="button"
+	on:click
+	class="btn flex h-9 rounded-lg border bg-white px-3 py-1 text-red-500 shadow-sm transition-all hover:bg-gray-100 dark:border-gray-600 dark:bg-gray-700 dark:hover:bg-gray-600 {classNames}"
+>
+	<CarbonRotate360 class="-ml-1 mr-2 text-red-500" /> Retry
+</button>

--- a/src/lib/components/RetryBtn.svelte
+++ b/src/lib/components/RetryBtn.svelte
@@ -7,7 +7,7 @@
 <button
 	type="button"
 	on:click
-	class="btn flex h-9 rounded-lg border bg-white px-3 py-1 text-red-500 shadow-sm transition-all hover:bg-gray-100 dark:border-gray-600 dark:bg-gray-700 dark:hover:bg-gray-600 {classNames}"
+	class="btn flex h-8 rounded-lg border bg-white px-3 py-1 text-gray-500 shadow-sm transition-all hover:bg-gray-100 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600 {classNames}"
 >
-	<CarbonRotate360 class="-ml-1 mr-2 text-red-500" /> Retry
+	<CarbonRotate360 class="mr-2 text-xs " /> Retry
 </button>

--- a/src/lib/components/StopGeneratingBtn.svelte
+++ b/src/lib/components/StopGeneratingBtn.svelte
@@ -9,5 +9,5 @@
 	on:click
 	class="btn flex h-8 rounded-lg border bg-white px-3 py-1 shadow-sm transition-all hover:bg-gray-100 dark:border-gray-600 dark:bg-gray-700 dark:hover:bg-gray-600 {classNames}"
 >
-	<CarbonStopFilledAlt class="-ml-1 mr-1 h-[1.25rem] w-[1.1875rem] text-gray-400" /> Stop generating
+	<CarbonStopFilledAlt class="-ml-1 mr-1 h-[1.25rem] w-[1.1875rem] text-gray-300" /> Stop generating
 </button>

--- a/src/lib/components/StopGeneratingBtn.svelte
+++ b/src/lib/components/StopGeneratingBtn.svelte
@@ -7,7 +7,7 @@
 <button
 	type="button"
 	on:click
-	class="btn flex h-9 rounded-lg border bg-white px-3 py-1 shadow-sm transition-all hover:bg-gray-100 dark:border-gray-600 dark:bg-gray-700 dark:hover:bg-gray-600 {classNames}"
+	class="btn flex h-8 rounded-lg border bg-white px-3 py-1 shadow-sm transition-all hover:bg-gray-100 dark:border-gray-600 dark:bg-gray-700 dark:hover:bg-gray-600 {classNames}"
 >
 	<CarbonStopFilledAlt class="-ml-1 mr-1 h-[1.25rem] w-[1.1875rem] text-gray-400" /> Stop generating
 </button>

--- a/src/lib/components/WebSearchToggle.svelte
+++ b/src/lib/components/WebSearchToggle.svelte
@@ -7,7 +7,7 @@
 </script>
 
 <div
-	class="flex h-9 cursor-pointer select-none items-center gap-2 rounded-xl border bg-white p-1.5 shadow-sm hover:shadow-none dark:border-gray-800 dark:bg-gray-900"
+	class="flex h-8 cursor-pointer select-none items-center gap-2 rounded-lg border bg-white p-1.5 shadow-sm hover:shadow-none dark:border-gray-800 dark:bg-gray-900"
 	on:click={toggle}
 	on:keypress={toggle}
 	aria-checked={$webSearchParameters.useSearch}

--- a/src/lib/components/chat/ChatInput.svelte
+++ b/src/lib/components/chat/ChatInput.svelte
@@ -48,7 +48,6 @@
 		rows="1"
 		class="scrollbar-custom absolute top-0 m-0 h-full w-full resize-none scroll-p-3 overflow-x-hidden overflow-y-scroll border-0 bg-transparent p-3 outline-none focus:ring-0 focus-visible:ring-0"
 		class:text-gray-400={disabled}
-		class:text-red-500={error}
 		bind:value
 		bind:this={textareaElement}
 		{disabled}

--- a/src/lib/components/chat/ChatInput.svelte
+++ b/src/lib/components/chat/ChatInput.svelte
@@ -6,7 +6,6 @@
 	export let maxRows: null | number = null;
 	export let placeholder = "";
 	export let disabled = false;
-	export let error = false;
 
 	// Approximate width from which we disable autofocus
 	const TABLET_VIEWPORT_WIDTH = 768;

--- a/src/lib/components/chat/ChatInput.svelte
+++ b/src/lib/components/chat/ChatInput.svelte
@@ -6,6 +6,7 @@
 	export let maxRows: null | number = null;
 	export let placeholder = "";
 	export let disabled = false;
+	export let error = false;
 
 	// Approximate width from which we disable autofocus
 	const TABLET_VIEWPORT_WIDTH = 768;
@@ -46,6 +47,8 @@
 		tabindex="0"
 		rows="1"
 		class="scrollbar-custom absolute top-0 m-0 h-full w-full resize-none scroll-p-3 overflow-x-hidden overflow-y-scroll border-0 bg-transparent p-3 outline-none focus:ring-0 focus-visible:ring-0"
+		class:text-gray-400={disabled}
+		class:text-red-500={error}
 		bind:value
 		bind:this={textareaElement}
 		{disabled}

--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -87,24 +87,21 @@
 	<div
 		class="dark:via-gray-80 pointer-events-none absolute inset-x-0 bottom-0 z-0 mx-auto flex w-full max-w-3xl flex-col items-center justify-center bg-gradient-to-t from-white via-white/80 to-white/0 px-3.5 py-4 dark:border-gray-800 dark:from-gray-900 dark:to-gray-900/0 max-md:border-t max-md:bg-white max-md:dark:bg-gray-900 sm:px-5 md:py-8 xl:max-w-4xl [&>*]:pointer-events-auto"
 	>
-		<div class="flex w-full pb-3 max-md:justify-between">
+		<div class="flex w-full pb-3">
 			{#if settings?.searchEnabled}
 				<WebSearchToggle />
 			{/if}
 			{#if loading}
-				<StopGeneratingBtn
-					classNames={settings?.searchEnabled ? "md:-translate-x-1/2 md:mx-auto" : "mx-auto"}
-					on:click={() => dispatch("stop")}
-				/>
+				<StopGeneratingBtn classNames="ml-auto" on:click={() => dispatch("stop")} />
 			{/if}
 			{#if lastIsError}
 				<RetryBtn
+					classNames="ml-auto"
 					on:click={() =>
 						dispatch("retry", {
 							id: messages[messages.length - 1].id,
 							content: messages[messages.length - 1].content,
 						})}
-					classNames={settings?.searchEnabled ? "md:-translate-x-1/2 md:mx-auto" : "mx-auto"}
 				/>
 			{/if}
 		</div>
@@ -175,7 +172,7 @@
 					type="button"
 					on:click={() => dispatch("share")}
 				>
-					<CarbonExport class="text-[.6rem] sm:mr-1.5 sm:text-primary-500" />
+					<CarbonExport class="sm:text-primary-500 text-[.6rem] sm:mr-1.5" />
 					<div class="max-sm:hidden">Share this conversation</div>
 				</button>
 			{/if}

--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -175,7 +175,7 @@
 					type="button"
 					on:click={() => dispatch("share")}
 				>
-					<CarbonExport class="sm:text-primary-500 text-[.6rem] sm:mr-1.5" />
+					<CarbonExport class="text-[.6rem] sm:mr-1.5 sm:text-primary-500" />
 					<div class="max-sm:hidden">Share this conversation</div>
 				</button>
 			{/if}

--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -112,11 +112,7 @@
 		>
 			<div class="flex w-full flex-1 border-none bg-transparent">
 				{#if lastIsError}
-					<ChatInput
-						value="Sorry, something went wrong. Please try again."
-						disabled={true}
-						error={true}
-					/>
+					<ChatInput value="Sorry, something went wrong. Please try again." disabled={true} />
 				{:else}
 					<ChatInput
 						placeholder="Ask anything"
@@ -172,7 +168,7 @@
 					type="button"
 					on:click={() => dispatch("share")}
 				>
-					<CarbonExport class="sm:text-primary-500 text-[.6rem] sm:mr-1.5" />
+					<CarbonExport class="text-[.6rem] sm:mr-1.5 sm:text-primary-500" />
 					<div class="max-sm:hidden">Share this conversation</div>
 				</button>
 			{/if}

--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -117,8 +117,7 @@
 				{#if lastIsError}
 					<ChatInput
 						value="Sorry, something went wrong. Please try again."
-						maxRows={4}
-						disabled={isReadOnly || lastIsError}
+						disabled={true}
 						error={true}
 					/>
 				{:else}


### PR DESCRIPTION
How to test:

1. Edit `.env.template` so that inside of `MODELS` one of the `"name"` is not a real model
2. `npm run updateLocalEnv` 
3. Then start the server and start a conversation with the non-existent model, you should see the new button/message.
![image](https://github.com/huggingface/chat-ui/assets/25119303/d44bc9de-5991-4e92-910f-4cd4cfe771ac)
