### PR TITLE
Show model modal even if only one model is available

### DIFF
--- a/src/lib/components/chat/ChatIntroduction.svelte
+++ b/src/lib/components/chat/ChatIntroduction.svelte
@@ -67,14 +67,12 @@
 					<div class="text-sm text-gray-600 dark:text-gray-400">Current Model</div>
 					<div class="font-semibold">{currentModel.displayName}</div>
 				</div>
-				{#if models.length > 1}
-					<button
-						type="button"
-						on:click={() => (isModelsModalOpen = true)}
-						class="btn ml-auto flex h-7 w-7 self-start rounded-full bg-gray-100 p-1 text-xs hover:bg-gray-100 dark:border-gray-600 dark:bg-gray-800 dark:hover:bg-gray-600"
-						><IconChevron /></button
-					>
-				{/if}
+				<button
+					type="button"
+					on:click={() => (isModelsModalOpen = true)}
+					class="btn ml-auto flex h-7 w-7 self-start rounded-full bg-gray-100 p-1 text-xs hover:bg-gray-100 dark:border-gray-600 dark:bg-gray-800 dark:hover:bg-gray-600"
+					><IconChevron /></button
+				>
 			</div>
 			<ModelCardMetadata variant="dark" model={currentModel} />
 		</div>


### PR DESCRIPTION
this PR removes the check that hides the models modal button if there's only one model.

this is needed because the system prompt setting is hidden behind the models modal.

This is a blocker for example on [the zephyr space](https://huggingfaceh4-zephyr-chat.hf.space/) where they only showcase one model at a time and can't currently set the system prompt

UI is not horrible imo

![image](https://github.com/huggingface/chat-ui/assets/25119303/1f1c5bde-1c5f-4e09-9b1d-93d0e7445ae1)
