### PR TITLE
Reset app title when clicking new chat

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { goto } from "$app/navigation";
 	import { base } from "$app/paths";
+	import { PUBLIC_APP_NAME } from "$env/static/public";
 	import ChatWindow from "$lib/components/chat/ChatWindow.svelte";
 	import { ERROR_MESSAGES, error } from "$lib/stores/errors";
 	import { pendingMessage } from "$lib/stores/pendingMessage";
@@ -44,6 +45,10 @@
 		}
 	}
 </script>
+
+<svelte:head>
+	<title>{PUBLIC_APP_NAME}</title>
+</svelte:head>
 
 <ChatWindow
 	on:message={(ev) => createConversation(ev.detail)}


### PR DESCRIPTION
In [prod](https://huggingface.co/chat/) if you open a chat, the tab title is the chat summary title as expected.

However if you then click the "new chat" button, the tab title still shows the chat summary title instead of the app name. This PR fixes that.