### PR TITLE
[websearch] Enable lazy construction of `feature-extraction` pipeline

### DIFF
--- a/src/lib/server/websearch/sentenceSimilarity.ts
+++ b/src/lib/server/websearch/sentenceSimilarity.ts
@@ -1,4 +1,4 @@
-import type { Tensor } from "@xenova/transformers";
+import type { Tensor, Pipeline } from "@xenova/transformers";
 import { pipeline, dot } from "@xenova/transformers";
 
 // see here: https://github.com/nmslib/hnswlib/blob/359b2ba87358224963986f709e593d799064ace6/README.md?plain=1#L34
@@ -6,8 +6,18 @@ function innerProduct(tensor1: Tensor, tensor2: Tensor) {
 	return 1.0 - dot(tensor1.data, tensor2.data);
 }
 
-const modelId = "Xenova/gte-small";
-const extractor = await pipeline("feature-extraction", modelId);
+// Use the Singleton pattern to enable lazy construction of the pipeline.
+class PipelineSingleton {
+	static modelId = "Xenova/gte-small";
+	static instance: Promise<Pipeline> | null = null;
+	static async getInstance() {
+		if (this.instance === null) {
+			this.instance = pipeline("feature-extraction", this.modelId);
+		}
+		return this.instance;
+	}
+}
+
 // see https://huggingface.co/thenlper/gte-small/blob/d8e2604cadbeeda029847d19759d219e0ce2e6d8/README.md?code=true#L2625
 export const MAX_SEQ_LEN = 512 as const;
 
@@ -17,6 +27,8 @@ export async function findSimilarSentences(
 	{ topK = 5 }: { topK: number }
 ) {
 	const input = [query, ...sentences];
+
+	const extractor = await PipelineSingleton.getInstance();
 	const output: Tensor = await extractor(input, { pooling: "mean", normalize: true });
 
 	const queryTensor: Tensor = output[0];


### PR DESCRIPTION
This PR enables lazy construction of the `feature-extraction` pipeline used in websearch. Should fix #528 and #548.

(Note: I haven't been able to test this yet, due to issues with GitHub codespaces; cc @nsarrazin)