### PR TITLE
[#547] fix stream generation bug

### DIFF
--- a/src/routes/conversation/[id]/+page.svelte
+++ b/src/routes/conversation/[id]/+page.svelte
@@ -140,7 +140,7 @@
 			const reader = response?.body?.pipeThrough(encoder).getReader();
 			let finalAnswer = "";
 
-			// set str queue 
+			// set str queue
 			// ex) if the last response is => {"type": "stream", "token":
 			// It should be => {"type": "stream", "token": "Hello"} = prev_input_chunk + "Hello"}
 			let prev_input_chunk = [""];
@@ -148,7 +148,6 @@
 			// this is a bit ugly
 			// we read the stream until we get the final answer
 			while (finalAnswer === "") {
-
 				// check for abort
 				if (isAborted) {
 					reader?.cancel();

--- a/src/routes/conversation/[id]/+page.svelte
+++ b/src/routes/conversation/[id]/+page.svelte
@@ -140,10 +140,14 @@
 			const reader = response?.body?.pipeThrough(encoder).getReader();
 			let finalAnswer = "";
 
+			// set str queue 
+			// ex) if the last response is => {"type": "stream", "token":
+			// It should be => {"type": "stream", "token": "Hello"} = prev_input_chunk + "Hello"}
+			let prev_input_chunk = [""];
+
 			// this is a bit ugly
 			// we read the stream until we get the final answer
 			while (finalAnswer === "") {
-				await new Promise((r) => setTimeout(r, 25));
 
 				// check for abort
 				if (isAborted) {
@@ -162,6 +166,8 @@
 					if (!value) {
 						return;
 					}
+
+					value = prev_input_chunk.pop() + value;
 
 					// if it's not done we parse the value, which contains all messages
 					const inputs = value.split("\n");
@@ -210,6 +216,10 @@
 							}
 						} catch (parseError) {
 							// in case of parsing error we wait for the next message
+
+							if (el === inputs[inputs.length - 1]) {
+								prev_input_chunk.push(el);
+							}
 							return;
 						}
 					});

--- a/src/routes/conversation/[id]/+server.ts
+++ b/src/routes/conversation/[id]/+server.ts
@@ -200,7 +200,7 @@ export async function POST({ request, locals, params, getClientAddress }) {
 					// 4096 of spaces to make sure the browser doesn't blocking buffer that holding the response
 					controller.enqueue(" ".repeat(4096));
 				}
-				if (newUpdate.token === "") {
+				if (newUpdate.type === "stream" && newUpdate.token === "") {
 					return;
 				}
 			}

--- a/src/routes/conversation/[id]/+server.ts
+++ b/src/routes/conversation/[id]/+server.ts
@@ -194,7 +194,7 @@ export async function POST({ request, locals, params, getClientAddress }) {
 				if (newUpdate.token === "") {
 					return;
 				}
-				
+
 				if (newUpdate.type !== "stream") {
 					updates.push(newUpdate);
 				}

--- a/src/routes/conversation/[id]/+server.ts
+++ b/src/routes/conversation/[id]/+server.ts
@@ -191,12 +191,12 @@ export async function POST({ request, locals, params, getClientAddress }) {
 			const updates: MessageUpdate[] = [];
 
 			function update(newUpdate: MessageUpdate) {
-				if (newUpdate.token === "") {
-					return;
-				}
-
 				if (newUpdate.type !== "stream") {
 					updates.push(newUpdate);
+				}
+
+				if (newUpdate.token === "") {
+					return;
 				}
 				controller.enqueue(JSON.stringify(newUpdate) + "\n");
 

--- a/src/routes/conversation/[id]/+server.ts
+++ b/src/routes/conversation/[id]/+server.ts
@@ -198,8 +198,7 @@ export async function POST({ request, locals, params, getClientAddress }) {
 
 				if (newUpdate.type === "finalAnswer") {
 					// 4096 of spaces to make sure the browser doesn't blocking buffer that holding the response
-					let placeholder = " ".repeat(4096);
-					controller.enqueue(placeholder);
+					controller.enqueue(" ".repeat(4096));
 				}
 				if (newUpdate.token === "") {
 					return;

--- a/src/routes/conversation/[id]/+server.ts
+++ b/src/routes/conversation/[id]/+server.ts
@@ -195,6 +195,15 @@ export async function POST({ request, locals, params, getClientAddress }) {
 					updates.push(newUpdate);
 				}
 				controller.enqueue(JSON.stringify(newUpdate) + "\n");
+
+				if (newUpdate.type === "finalAnswer") {
+					// 4096 of spaces to make sure the browser doesn't blocking buffer that holding the response
+					let placeholder = " ".repeat(4096);
+					controller.enqueue(placeholder);
+				}
+				if (newUpdate.token === "") {
+					return;
+				}
 			}
 
 			update({ type: "status", status: "started" });

--- a/src/routes/conversation/[id]/+server.ts
+++ b/src/routes/conversation/[id]/+server.ts
@@ -195,7 +195,7 @@ export async function POST({ request, locals, params, getClientAddress }) {
 					updates.push(newUpdate);
 				}
 
-				if (newUpdate.token === "") {
+				if (newUpdate.type === "stream" && newUpdate.token === "") {
 					return;
 				}
 				controller.enqueue(JSON.stringify(newUpdate) + "\n");

--- a/src/routes/conversation/[id]/+server.ts
+++ b/src/routes/conversation/[id]/+server.ts
@@ -191,6 +191,10 @@ export async function POST({ request, locals, params, getClientAddress }) {
 			const updates: MessageUpdate[] = [];
 
 			function update(newUpdate: MessageUpdate) {
+				if (newUpdate.token === "") {
+					return;
+				}
+				
 				if (newUpdate.type !== "stream") {
 					updates.push(newUpdate);
 				}
@@ -199,9 +203,6 @@ export async function POST({ request, locals, params, getClientAddress }) {
 				if (newUpdate.type === "finalAnswer") {
 					// 4096 of spaces to make sure the browser doesn't blocking buffer that holding the response
 					controller.enqueue(" ".repeat(4096));
-				}
-				if (newUpdate.type === "stream" && newUpdate.token === "") {
-					return;
 				}
 			}
 


### PR DESCRIPTION
[#547] Fix Stream Generation Bugs.

1. When the token is sliced by edge of buffer, it can merge with previous chunk. previous chunk is stored when the chunk raised parse error.
2. As the final generation is hanged when the length of final stream is less than buffer size, push the placeholder when the stream is final stage.