### PR TITLE
Option for running websearch locally

### DIFF
--- a/.env
+++ b/.env
@@ -14,6 +14,7 @@ OPENAI_API_KEY=#your openai api key here
 YDC_API_KEY=#your docs.you.com api key here
 SERPER_API_KEY=#your serper.dev api key here
 SERPAPI_KEY=#your serpapi key here
+USE_LOCAL_WEBSEARCH=#set to true to parse google results yourself, overrides other API keys
 
 # Parameters to enable open id login
 OPENID_CONFIG=`{

--- a/src/lib/server/websearch/runWebSearch.ts
+++ b/src/lib/server/websearch/runWebSearch.ts
@@ -15,6 +15,8 @@ import { getWebSearchProvider } from "./searchWeb";
 const MAX_N_PAGES_SCRAPE = 10 as const;
 const MAX_N_PAGES_EMBED = 5 as const;
 
+const DOMAIN_BLOCKLIST = ["youtube.com", "twitter.com"];
+
 export async function runWebSearch(
 	conv: Conversation,
 	prompt: string,
@@ -45,14 +47,14 @@ export async function runWebSearch(
 		const results = await searchWeb(webSearch.searchQuery);
 		webSearch.results =
 			(results.organic_results &&
-				results.organic_results.map((el: { title: string; link: string; text?: string }) => {
+				results.organic_results.map((el: { title?: string; link: string; text?: string }) => {
 					const { title, link, text } = el;
 					const { hostname } = new URL(link);
 					return { title, link, hostname, text };
 				})) ??
 			[];
 		webSearch.results = webSearch.results
-			.filter(({ link }) => !link.includes("youtube.com")) // filter out youtube links
+			.filter(({ link }) => !DOMAIN_BLOCKLIST.some((el) => link.includes(el))) // filter out blocklist links
 			.slice(0, MAX_N_PAGES_SCRAPE); // limit to first 10 links only
 
 		let paragraphChunks: { source: WebSearchSource; text: string }[] = [];

--- a/src/lib/server/websearch/searchWeb.ts
+++ b/src/lib/server/websearch/searchWeb.ts
@@ -14,7 +14,8 @@ export function getWebSearchProvider() {
 export async function searchWeb(query: string) {
 	if (USE_LOCAL_WEBSEARCH) {
 		return await searchWebLocal(query);
-	} else if (SERPER_API_KEY) {
+	}
+	if (SERPER_API_KEY) {
 		return await searchWebSerper(query);
 	}
 	if (YDC_API_KEY) {

--- a/src/lib/server/websearch/searchWeb.ts
+++ b/src/lib/server/websearch/searchWeb.ts
@@ -1,8 +1,9 @@
 import type { YouWebSearch } from "../../types/WebSearch";
 import { WebSearchProvider } from "../../types/WebSearch";
-import { SERPAPI_KEY, SERPER_API_KEY, YDC_API_KEY } from "$env/static/private";
+import { SERPAPI_KEY, SERPER_API_KEY, USE_LOCAL_WEBSEARCH, YDC_API_KEY } from "$env/static/private";
 import { getJson } from "serpapi";
 import type { GoogleParameters } from "serpapi";
+import { searchWebLocal } from "./searchWebLocal";
 
 // get which SERP api is providing web results
 export function getWebSearchProvider() {
@@ -11,7 +12,9 @@ export function getWebSearchProvider() {
 
 // Show result as JSON
 export async function searchWeb(query: string) {
-	if (SERPER_API_KEY) {
+	if (USE_LOCAL_WEBSEARCH) {
+		return await searchWebLocal(query);
+	} else if (SERPER_API_KEY) {
 		return await searchWebSerper(query);
 	}
 	if (YDC_API_KEY) {

--- a/src/lib/server/websearch/searchWebLocal.ts
+++ b/src/lib/server/websearch/searchWebLocal.ts
@@ -1,0 +1,44 @@
+import { JSDOM, VirtualConsole } from "jsdom";
+
+export async function searchWebLocal(query: string) {
+	const abortController = new AbortController();
+	setTimeout(() => abortController.abort(), 10000);
+
+	const htmlString = await fetch("https://www.google.com/search?hl=en&q=" + query, {
+		signal: abortController.signal,
+	})
+		.then((response) => response.text())
+		.catch();
+
+	const virtualConsole = new VirtualConsole();
+
+	virtualConsole.on("error", () => {
+		// No-op to skip console errors.
+	});
+
+	// put the html string into a DOM
+	const dom = new JSDOM(htmlString ?? "", {
+		virtualConsole,
+	});
+
+	const { document } = dom.window;
+	// get all a documents with href tag
+
+	const links = document.querySelectorAll("a");
+
+	if (!links.length) {
+		throw new Error(`webpage doesn't have any "a" element`);
+	}
+
+	// take url that start wirth /url?q=
+	// and strip them up to '&sa='
+	const linksHref = Array.from(links)
+		.filter((el) => el.href?.startsWith("/url?q=") && !el.href.includes("google.com/"))
+		.map((el) => {
+			const link = el.href;
+			return link.slice("/url?q=".length, link.indexOf("&sa="));
+		});
+
+	// combine text contents from paragraphs and then remove newlines and multiple spaces
+	return { organic_results: [...new Set(linksHref)].map((link) => ({ link })) };
+}

--- a/src/lib/server/websearch/searchWebLocal.ts
+++ b/src/lib/server/websearch/searchWebLocal.ts
@@ -31,6 +31,7 @@ export async function searchWebLocal(query: string) {
 	}
 
 	// take url that start wirth /url?q=
+	// and do not contain google.com links
 	// and strip them up to '&sa='
 	const linksHref = Array.from(links)
 		.filter((el) => el.href?.startsWith("/url?q=") && !el.href.includes("google.com/"))
@@ -39,6 +40,6 @@ export async function searchWebLocal(query: string) {
 			return link.slice("/url?q=".length, link.indexOf("&sa="));
 		});
 
-	// combine text contents from paragraphs and then remove newlines and multiple spaces
+	// remove duplicate links and map links to the correct object shape
 	return { organic_results: [...new Set(linksHref)].map((link) => ({ link })) };
 }


### PR DESCRIPTION
This PR adds a new env variable `USE_LOCAL_WEBSEARCH`. If it is set to `true`, we fetch the search results directly from the google search page, without using any external APIs.

From my testing it works fairly well, probably doesn't scale very much, and we don't intend to use it in production but it is probably good enough for local users.

I also extended the domain blocklist to block twitter links since these don't render without JS enabled.

This PR closes #553 

cc @mishig25 