### PR TITLE
Add tests for endpoints code

### DIFF
--- a/src/lib/server/endpoints/tgi/endpointTgi.spec.ts
+++ b/src/lib/server/endpoints/tgi/endpointTgi.spec.ts
@@ -1,0 +1,40 @@
+import type { Conversation } from "$lib/types/Conversation";
+import { expect, test } from "vitest";
+import endpointTgi from "./endpointTgi";
+import { HF_ACCESS_TOKEN, HF_API_ROOT } from "$env/static/private";
+import { addEndpoint, processModel, modelConfig } from "$lib/server/models";
+
+test("endpoint-tgi", async () => {
+	const conversation: Pick<Conversation, "messages"> = {
+		messages: [
+			{
+				id: "0000-0000-0000-0000-0000",
+				from: "user",
+				content: "hello world",
+			},
+		],
+	};
+
+	const model = await processModel(
+		modelConfig.parse({
+			name: "mistralai/Mistral-7B-Instruct-v0.1",
+			chatPromptTemplate:
+				"<s>{{#each messages}}{{#ifUser}}[INST] {{#if @first}}{{#if @root.preprompt}}{{@root.preprompt}}\n{{/if}}{{/if}}{{content}} [/INST]{{/ifUser}}{{#ifAssistant}}{{content}}</s>{{/ifAssistant}}{{/each}}",
+		})
+	).then(addEndpoint);
+
+	const tokenStream = await endpointTgi({
+		accessToken: HF_ACCESS_TOKEN ?? "",
+		model,
+		weight: 1,
+		type: "tgi",
+		url: `${HF_API_ROOT}/${model.name}`,
+	})({
+		conversation,
+	});
+
+	const out = (await tokenStream.next()).value;
+
+	expect(out).toBeDefined();
+	expect(out && out.token.text).toBeTruthy;
+});

--- a/src/lib/server/models.ts
+++ b/src/lib/server/models.ts
@@ -8,7 +8,7 @@ import { sum } from "$lib/utils/sum";
 
 type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>;
 
-const modelConfig = z.object({
+export const modelConfig = z.object({
 	/** Used as an identifier in DB */
 	id: z.string().optional(),
 	/** Used to link to the model page, and for inference */
@@ -62,7 +62,7 @@ const modelConfig = z.object({
 
 const modelsRaw = z.array(modelConfig).parse(JSON.parse(MODELS));
 
-const processModel = async (m: z.infer<typeof modelConfig>) => ({
+export const processModel = async (m: z.infer<typeof modelConfig>) => ({
 	...m,
 	userMessageEndToken: m?.userMessageEndToken || m?.messageEndToken,
 	assistantMessageEndToken: m?.assistantMessageEndToken || m?.messageEndToken,
@@ -73,7 +73,7 @@ const processModel = async (m: z.infer<typeof modelConfig>) => ({
 	parameters: { ...m.parameters, stop_sequences: m.parameters?.stop },
 });
 
-const addEndpoint = (m: Awaited<ReturnType<typeof processModel>>) => ({
+export const addEndpoint = (m: Awaited<ReturnType<typeof processModel>>) => ({
 	...m,
 	getEndpoint: async (): Promise<Endpoint> => {
 		if (!m.endpoints) {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from "vitest/config";
+import { sveltekit } from "@sveltejs/kit/vite";
+
+export default defineConfig({
+	plugins: [sveltekit()],
+});


### PR DESCRIPTION
very WIP, will refactor to reuse most of the code between endpoints

plan is to test the following endpoints:

- [x] HF Inference API
- [ ] Locally hosted TGI
- [ ] Locally hosted llama.cpp server
- [ ] OpenAI compatible (maybe openAI directly?)
- [ ] AWS SageMaker (will require spinning up an endpoint dynamically in a workflow and destroying it afterwards)
- [ ] AWS Lambda (same caveat as sagemaker)

And I will need to put all of this in a github action, testing the locally hosted services will be challenging, not sure yet how to spin them up inside the action.