### PR TITLE
Disable cache on tgi endpoint

### DIFF
--- a/src/lib/server/endpoints/tgi/endpointTgi.ts
+++ b/src/lib/server/endpoints/tgi/endpointTgi.ts
@@ -26,12 +26,15 @@ export function endpointTgi({
 			id: conversation._id,
 		});
 
-		return textGenerationStream({
-			parameters: { ...model.parameters, return_full_text: false },
-			model: url,
-			inputs: prompt,
-			accessToken,
-		});
+		return textGenerationStream(
+			{
+				parameters: { ...model.parameters, return_full_text: false },
+				model: url,
+				inputs: prompt,
+				accessToken,
+			},
+			{ use_cache: false }
+		);
 	};
 }
 


### PR DESCRIPTION
This was making the retry function useless for getting new responses