### PR TITLE
Make chat title summarization non blocking

### DIFF
--- a/src/routes/conversation/[id]/+server.ts
+++ b/src/routes/conversation/[id]/+server.ts
@@ -199,14 +199,16 @@ export async function POST({ request, locals, params, getClientAddress }) {
 
 			update({ type: "status", status: "started" });
 
-			if (conv.title === "New Chat" && messages.length === 1) {
-				try {
-					conv.title = (await summarize(newPrompt)) ?? conv.title;
-					update({ type: "status", status: "title", message: conv.title });
-				} catch (e) {
-					console.error(e);
+			const summarizeIfNeeded = (async () => {
+				if (conv.title === "New Chat" && messages.length === 1) {
+					try {
+						conv.title = (await summarize(newPrompt)) ?? conv.title;
+						update({ type: "status", status: "title", message: conv.title });
+					} catch (e) {
+						console.error(e);
+					}
 				}
-			}
+			})();
 
 			await collections.conversations.updateOne(
 				{
@@ -312,6 +314,7 @@ export async function POST({ request, locals, params, getClientAddress }) {
 				text: messages[messages.length - 1].content,
 			});
 
+			await summarizeIfNeeded;
 			return;
 		},
 		async cancel() {


### PR DESCRIPTION
Before, we would generate the chat title before starting to stream tokens. 

That means that the time to first token was the full response time of the summarization task + the inital latency of the chat model.

Now they both run in parallel, which will help when the task model is slow.