### PR TITLE
Add support for passing an API key or any other custom token in the authorization header

### DIFF
--- a/.env
+++ b/.env
@@ -9,6 +9,7 @@ COOKIE_NAME=hf-chat
 HF_ACCESS_TOKEN=#hf_<token> from from https://huggingface.co/settings/token
 HF_API_ROOT=https://api-inference.huggingface.co/models
 OPENAI_API_KEY=#your openai api key here
+CUSTOM_AUTHORIZATION_TOKEN="" #your custom Authorization header
 
 # used to activate search with web functionality. disabled if none are defined. choose one of the following:
 YDC_API_KEY=#your docs.you.com api key here

--- a/.env
+++ b/.env
@@ -9,7 +9,6 @@ COOKIE_NAME=hf-chat
 HF_ACCESS_TOKEN=#hf_<token> from from https://huggingface.co/settings/token
 HF_API_ROOT=https://api-inference.huggingface.co/models
 OPENAI_API_KEY=#your openai api key here
-CUSTOM_AUTHORIZATION_TOKEN="" #your custom Authorization header
 
 # used to activate search with web functionality. disabled if none are defined. choose one of the following:
 YDC_API_KEY=#your docs.you.com api key here

--- a/README.md
+++ b/README.md
@@ -397,6 +397,27 @@ You can then add the generated information and the `authorization` parameter to 
 ]
 ```
 
+#### API Key or other
+
+In case your custom endpoint does not support `Basic` or `Bearer` authentication and you need to pass an `API Key` or any other custom token in the authorization header, add the following to your `.env.local`:
+```env
+"endpoints": [
+{
+  "type": "tgi",
+  "url": "https://HOST:PORT",
+  "authorization": "API_KEY_OR_TOKEN",
+}
+]
+# or "authorization": "Key API_KEY_OR_TOKEN"
+```
+
+As an alternative, you can specify the `CUSTOM_AUTHORIZATION_TOKEN` in `.env.local` to use the same authorization header across all custom TGI endpoints:
+```env
+CUSTOM_AUTHORIZATION_TOKEN="API_KEY_OR_TOKEN"
+```
+
+Please note that if `HF_ACCESS_TOKEN` is also set or not empty, it will take precedence.
+
 #### Models hosted on multiple custom endpoints
 
 If the model being hosted will be available on multiple servers/instances add the `weight` parameter to your `.env.local`. The `weight` will be used to determine the probability of requesting a particular endpoint.

--- a/README.md
+++ b/README.md
@@ -397,27 +397,6 @@ You can then add the generated information and the `authorization` parameter to 
 ]
 ```
 
-#### API Key or other
-
-In case your custom endpoint does not support `Basic` or `Bearer` authentication and you need to pass an `API Key` or any other custom token in the authorization header, add the following to your `.env.local`:
-
-```env
-"endpoints": [
-{
-  "type": "tgi",
-  "url": "https://HOST:PORT",
-  "authorization": "API_KEY_OR_TOKEN",
-}
-]
-# or "authorization": "Key API_KEY_OR_TOKEN"
-```
-
-As an alternative, you can specify the `CUSTOM_AUTHORIZATION_TOKEN` in `.env.local` to use the same authorization header across all custom TGI endpoints:
-
-```env
-CUSTOM_AUTHORIZATION_TOKEN="API_KEY_OR_TOKEN"
-```
-
 Please note that if `HF_ACCESS_TOKEN` is also set or not empty, it will take precedence.
 
 #### Models hosted on multiple custom endpoints

--- a/README.md
+++ b/README.md
@@ -400,6 +400,7 @@ You can then add the generated information and the `authorization` parameter to 
 #### API Key or other
 
 In case your custom endpoint does not support `Basic` or `Bearer` authentication and you need to pass an `API Key` or any other custom token in the authorization header, add the following to your `.env.local`:
+
 ```env
 "endpoints": [
 {
@@ -412,6 +413,7 @@ In case your custom endpoint does not support `Basic` or `Bearer` authentication
 ```
 
 As an alternative, you can specify the `CUSTOM_AUTHORIZATION_TOKEN` in `.env.local` to use the same authorization header across all custom TGI endpoints:
+
 ```env
 CUSTOM_AUTHORIZATION_TOKEN="API_KEY_OR_TOKEN"
 ```

--- a/src/lib/server/endpoints/aws/endpointAws.ts
+++ b/src/lib/server/endpoints/aws/endpointAws.ts
@@ -15,21 +15,18 @@ export const endpointAwsParametersSchema = z.object({
 	region: z.string().optional(),
 });
 
-export async function endpointAws({
-	url,
-	accessKey,
-	secretKey,
-	sessionToken,
-	model,
-	region,
-	service,
-}: z.infer<typeof endpointAwsParametersSchema>): Promise<Endpoint> {
+export async function endpointAws(
+	input: z.input<typeof endpointAwsParametersSchema>
+): Promise<Endpoint> {
 	let AwsClient;
 	try {
 		AwsClient = (await import("aws4fetch")).AwsClient;
 	} catch (e) {
 		throw new Error("Failed to import aws4fetch");
 	}
+
+	const { url, accessKey, secretKey, sessionToken, model, region, service } =
+		endpointAwsParametersSchema.parse(input);
 
 	const aws = new AwsClient({
 		accessKeyId: accessKey,

--- a/src/lib/server/endpoints/llamacpp/endpointLlamacpp.ts
+++ b/src/lib/server/endpoints/llamacpp/endpointLlamacpp.ts
@@ -12,10 +12,10 @@ export const endpointLlamacppParametersSchema = z.object({
 	accessToken: z.string().min(1).default(HF_ACCESS_TOKEN),
 });
 
-export function endpointLlamacpp({
-	url,
-	model,
-}: z.infer<typeof endpointLlamacppParametersSchema>): Endpoint {
+export function endpointLlamacpp(
+	input: z.input<typeof endpointLlamacppParametersSchema>
+): Endpoint {
+	const { url, model } = endpointLlamacppParametersSchema.parse(input);
 	return async ({ conversation }) => {
 		const prompt = await buildPrompt({
 			messages: conversation.messages,

--- a/src/lib/server/endpoints/ollama/endpointOllama.ts
+++ b/src/lib/server/endpoints/ollama/endpointOllama.ts
@@ -11,11 +11,9 @@ export const endpointOllamaParametersSchema = z.object({
 	ollamaName: z.string().min(1).optional(),
 });
 
-export function endpointOllama({
-	url,
-	model,
-	ollamaName,
-}: z.infer<typeof endpointOllamaParametersSchema>): Endpoint {
+export function endpointOllama(input: z.input<typeof endpointOllamaParametersSchema>): Endpoint {
+	const { url, model, ollamaName } = endpointOllamaParametersSchema.parse(input);
+
 	return async ({ conversation }) => {
 		const prompt = await buildPrompt({
 			messages: conversation.messages,

--- a/src/lib/server/endpoints/openai/endpointOai.ts
+++ b/src/lib/server/endpoints/openai/endpointOai.ts
@@ -16,12 +16,10 @@ export const endpointOAIParametersSchema = z.object({
 		.default("chat_completions"),
 });
 
-export async function endpointOai({
-	baseURL,
-	apiKey,
-	completion,
-	model,
-}: z.infer<typeof endpointOAIParametersSchema>): Promise<Endpoint> {
+export async function endpointOai(
+	input: z.input<typeof endpointOAIParametersSchema>
+): Promise<Endpoint> {
+	const { baseURL, apiKey, completion, model } = endpointOAIParametersSchema.parse(input);
 	let OpenAI;
 	try {
 		OpenAI = (await import("openai")).OpenAI;

--- a/src/lib/server/endpoints/tgi/endpointTgi.ts
+++ b/src/lib/server/endpoints/tgi/endpointTgi.ts
@@ -13,12 +13,8 @@ export const endpointTgiParametersSchema = z.object({
 	authorization: z.string().default(CUSTOM_AUTHORIZATION_TOKEN),
 });
 
-export function endpointTgi({
-	url,
-	accessToken,
-	model,
-	authorization,
-}: z.infer<typeof endpointTgiParametersSchema>): Endpoint {
+export function endpointTgi(input: z.input<typeof endpointTgiParametersSchema>): Endpoint {
+	const { url, accessToken, model, authorization } = endpointTgiParametersSchema.parse(input);
 	return async ({ conversation }) => {
 		const prompt = await buildPrompt({
 			messages: conversation.messages,

--- a/src/lib/server/endpoints/tgi/endpointTgi.ts
+++ b/src/lib/server/endpoints/tgi/endpointTgi.ts
@@ -34,7 +34,6 @@ export function endpointTgi(input: z.input<typeof endpointTgiParametersSchema>):
 			{
 				use_cache: false,
 				fetch: async (endpointUrl, info) => {
-					// authEmpty can be skipped
 					if (info && authorization && !accessToken) {
 						// Set authorization header if it is defined and HF_ACCESS_TOKEN is empty
 						info.headers = {

--- a/src/lib/server/endpoints/tgi/endpointTgi.ts
+++ b/src/lib/server/endpoints/tgi/endpointTgi.ts
@@ -37,20 +37,20 @@ export function endpointTgi({
 			},
 			{
 				use_cache: false,
-				fetch: async (url, info) => {
+				fetch: async (endpointUrl, info) => {
 					// authEmpty can be skipped
-					let authEmpty = typeof authorization === 'string' && authorization.length === 0;
-					let hfTokenEmpty = typeof accessToken === 'string' && accessToken.length === 0;
+					const authEmpty = typeof authorization === "string" && authorization.length === 0;
+					const hfTokenEmpty = typeof accessToken === "string" && accessToken.length === 0;
 					if (info && !authEmpty && hfTokenEmpty) {
 						// Set authorization header if it is defined and HF_ACCESS_TOKEN is empty
 						if (info.headers) {
 							info.headers.Authorization = authorization;
 						} else {
-							info.headers = {"Authorization": authorization};
+							info.headers = { Authorization: authorization };
 						}
 					}
-					return fetch(url, info)
-				}
+					return fetch(endpointUrl, info);
+				},
 			}
 		);
 	};


### PR DESCRIPTION
Dear Huggingface team, let me start by saying that I really appreciate all your work and the awesome Chat UI that you've built.

I've created this PR to help add support for passing in an API key (or other custom token) in the authorization header. 

This is needed to make the Chat UI communicate with a custom TGI endpoint that requires an API key, but does not support `Basic` or `Bearer` authentication.

To this end, I have:

- added the new CUSTOM_AUTHORIZATION_TOKEN variable to the `.env` file. The variable can be left empty;
- defined a custom wrapper in [src/lib/server/endpoints/tgi/endpointTgi.ts](https://github.com/huggingface/chat-ui/blob/010f7322eef5802cf565df89522b0c49d4d49849/src/lib/server/endpoints/tgi/endpointTgi.ts#L40) which adds the authorization header before the fetch() method is called;
- updated the README.md accordingly with a new `API Key or other` section under `Custom endpoint authorization`.

This works in the following way.

We can pass the (same or different) API key or custom token separately for each endpoint by adding the following to the `.env.local`:
```env
"endpoints": [
{
  "type": "tgi",
  "url": "https://HOST:PORT",
  "authorization": "API_KEY_OR_TOKEN",
}
]
# or "authorization": "Key API_KEY_OR_TOKEN"
```

As an alternative, if `CUSTOM_AUTHORIZATION_TOKEN` is specified in `.env.local`, the same authorization header is used across all custom TGI endpoints:
```env
CUSTOM_AUTHORIZATION_TOKEN="API_KEY_OR_TOKEN"
```

The custom wrapper is written so that if the `HF_ACCESS_TOKEN` is provided in `.env.local` (the token is added to the headers in a call to [makeRequestOptions()](https://github.com/huggingface/huggingface.js/blob/ccfb044414a235270cb82d8b586f81785ad04eba/packages/inference/src/lib/makeRequestOptions.ts#L33) from [textGenerationStream()](https://github.com/huggingface/chat-ui/blob/010f7322eef5802cf565df89522b0c49d4d49849/src/lib/server/endpoints/tgi/endpointTgi.ts#L31)), it will take precedence in either case.