### PR TITLE
Standardize HF_ACCESS_TOKEN -> HF_TOKEN

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -24,7 +24,7 @@ jobs:
           SERPER_API_KEY: ${{ secrets.SERPER_API_KEY }}
           OPENID_CONFIG: ${{ secrets.OPENID_CONFIG }}
           MONGODB_URL: ${{ secrets.MONGODB_URL }}
-          HF_ACCESS_TOKEN: ${{ secrets.HF_ACCESS_TOKEN }}
+          HF_DEPLOYMENT_TOKEN: ${{ secrets.HF_DEPLOYMENT_TOKEN }}
         run: npm run updateProdEnv
   sync-to-hub:
     runs-on: ubuntu-latest
@@ -39,5 +39,5 @@ jobs:
           lfs: true
       - name: Push to hub
         env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
-        run: git push https://nsarrazin:$HF_TOKEN@huggingface.co/spaces/huggingchat/chat-ui main
+          HF_DEPLOYMENT_TOKEN: ${{ secrets.HF_DEPLOYMENT_TOKEN }}
+        run: git push https://nsarrazin:$HF_DEPLOYMENT_TOKEN@huggingface.co/spaces/huggingchat/chat-ui main

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -20,5 +20,5 @@ jobs:
           lfs: true
       - name: Push to hub
         env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
-        run: git push https://nsarrazin:$HF_TOKEN@huggingface.co/spaces/huggingchat/chat-ui-staging main
+          HF_DEPLOYMENT_TOKEN: ${{ secrets.HF_DEPLOYMENT_TOKEN }}
+        run: git push https://nsarrazin:$HF_DEPLOYMENT_TOKEN@huggingface.co/spaces/huggingchat/chat-ui-staging main

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you don't want to configure, setup, and launch your own Chat UI yourself, you
 
 You can deploy your own customized Chat UI instance with any supported [LLM](https://huggingface.co/models?pipeline_tag=text-generation&sort=trending) of your choice on [Hugging Face Spaces](https://huggingface.co/spaces). To do so, use the chat-ui template [available here](https://huggingface.co/new-space?template=huggingchat/chat-ui-template).
 
-Set `HUGGING_FACE_HUB_TOKEN` in [Space secrets](https://huggingface.co/docs/hub/spaces-overview#managing-secrets-and-environment-variables) to deploy a model with gated access or a model in a private repository. It's also compatible with [Inference for PROs](https://huggingface.co/blog/inference-pro) curated list of powerful models with higher rate limits. Make sure to create your personal token first in your [User Access Tokens settings](https://huggingface.co/settings/tokens).
+Set `HF_TOKEN` in [Space secrets](https://huggingface.co/docs/hub/spaces-overview#managing-secrets-and-environment-variables) to deploy a model with gated access or a model in a private repository. It's also compatible with [Inference for PROs](https://huggingface.co/blog/inference-pro) curated list of powerful models with higher rate limits. Make sure to create your personal token first in your [User Access Tokens settings](https://huggingface.co/settings/tokens).
 
 Read the full tutorial [here](https://huggingface.co/docs/hub/spaces-sdks-docker-chatui#chatui-on-spaces).
 
@@ -42,7 +42,7 @@ Start by creating a `.env.local` file in the root of the repository. The bare mi
 
 ```env
 MONGODB_URL=<the URL to your MongoDB instance>
-HF_ACCESS_TOKEN=<your access token>
+HF_TOKEN=<your access token>
 ```
 
 ### Database
@@ -397,7 +397,7 @@ You can then add the generated information and the `authorization` parameter to 
 ]
 ```
 
-Please note that if `HF_ACCESS_TOKEN` is also set or not empty, it will take precedence.
+Please note that if `HF_TOKEN` is also set or not empty, it will take precedence.
 
 #### Models hosted on multiple custom endpoints
 

--- a/scripts/updateProdEnv.ts
+++ b/scripts/updateProdEnv.ts
@@ -1,11 +1,11 @@
 import fs from "fs";
 
-const HF_TOKEN = process.env.HF_TOKEN; // token used for pushing to hub
+const HF_DEPLOYMENT_TOKEN = process.env.HF_DEPLOYMENT_TOKEN; // token used for pushing to hub
 
 const SERPER_API_KEY = process.env.SERPER_API_KEY;
 const OPENID_CONFIG = process.env.OPENID_CONFIG;
 const MONGODB_URL = process.env.MONGODB_URL;
-const HF_ACCESS_TOKEN = process.env.HF_ACCESS_TOKEN; // token used for API requests in prod
+const HF_TOKEN = process.env.HF_TOKEN ?? process.env.HF_ACCESS_TOKEN; // token used for API requests in prod
 
 // Read the content of the file .env.template
 const PUBLIC_CONFIG = fs.readFileSync(".env.template", "utf8");
@@ -15,7 +15,7 @@ const full_config = `${PUBLIC_CONFIG}
 MONGODB_URL=${MONGODB_URL}
 OPENID_CONFIG=${OPENID_CONFIG}
 SERPER_API_KEY=${SERPER_API_KEY}
-HF_ACCESS_TOKEN=${HF_ACCESS_TOKEN}
+HF_TOKEN=${HF_TOKEN}
 `;
 
 // Make an HTTP POST request to add the space secrets
@@ -27,7 +27,7 @@ fetch(`https://huggingface.co/api/spaces/huggingchat/chat-ui/secrets`, {
 		description: `Env variable for HuggingChat. Last updated ${new Date().toISOString()}`,
 	}),
 	headers: {
-		Authorization: `Bearer ${HF_TOKEN}`,
+		Authorization: `Bearer ${HF_DEPLOYMENT_TOKEN}`,
 		"Content-Type": "application/json",
 	},
 });

--- a/src/lib/server/endpoints/llamacpp/endpointLlamacpp.ts
+++ b/src/lib/server/endpoints/llamacpp/endpointLlamacpp.ts
@@ -1,4 +1,4 @@
-import { HF_ACCESS_TOKEN } from "$env/static/private";
+import { HF_TOKEN } from "$env/static/private";
 import { buildPrompt } from "$lib/buildPrompt";
 import type { TextGenerationStreamOutput } from "@huggingface/inference";
 import type { Endpoint } from "../endpoints";
@@ -9,7 +9,7 @@ export const endpointLlamacppParametersSchema = z.object({
 	model: z.any(),
 	type: z.literal("llamacpp"),
 	url: z.string().url().default("http://127.0.0.1:8080"),
-	accessToken: z.string().min(1).default(HF_ACCESS_TOKEN),
+	accessToken: z.string().min(1).default(HF_TOKEN),
 });
 
 export function endpointLlamacpp(

--- a/src/lib/server/endpoints/tgi/endpointTgi.ts
+++ b/src/lib/server/endpoints/tgi/endpointTgi.ts
@@ -1,4 +1,4 @@
-import { HF_ACCESS_TOKEN } from "$env/static/private";
+import { HF_TOKEN } from "$env/static/private";
 import { buildPrompt } from "$lib/buildPrompt";
 import { textGenerationStream } from "@huggingface/inference";
 import type { Endpoint } from "../endpoints";
@@ -9,7 +9,7 @@ export const endpointTgiParametersSchema = z.object({
 	model: z.any(),
 	type: z.literal("tgi"),
 	url: z.string().url(),
-	accessToken: z.string().default(HF_ACCESS_TOKEN),
+	accessToken: z.string().default(HF_TOKEN),
 	authorization: z.string().optional(),
 });
 
@@ -35,7 +35,7 @@ export function endpointTgi(input: z.input<typeof endpointTgiParametersSchema>):
 				use_cache: false,
 				fetch: async (endpointUrl, info) => {
 					if (info && authorization && !accessToken) {
-						// Set authorization header if it is defined and HF_ACCESS_TOKEN is empty
+						// Set authorization header if it is defined and HF_TOKEN is empty
 						info.headers = {
 							...info.headers,
 							Authorization: authorization,

--- a/src/lib/server/models.ts
+++ b/src/lib/server/models.ts
@@ -1,4 +1,4 @@
-import { HF_ACCESS_TOKEN, HF_API_ROOT, MODELS, OLD_MODELS, TASK_MODEL } from "$env/static/private";
+import { HF_TOKEN, HF_API_ROOT, MODELS, OLD_MODELS, TASK_MODEL } from "$env/static/private";
 import type { ChatTemplateInput } from "$lib/types/Template";
 import { compileTemplate } from "$lib/utils/template";
 import { z } from "zod";
@@ -80,7 +80,7 @@ const addEndpoint = (m: Awaited<ReturnType<typeof processModel>>) => ({
 			return endpointTgi({
 				type: "tgi",
 				url: `${HF_API_ROOT}/${m.name}`,
-				accessToken: HF_ACCESS_TOKEN,
+				accessToken: HF_TOKEN,
 				weight: 1,
 				model: m,
 			});


### PR DESCRIPTION
Same as https://github.com/xenova/transformers.js/pull/431 and https://github.com/huggingface/huggingface.js/pull/391.
Related to [slack thread](https://huggingface.slack.com/archives/C021H1P1HKR/p1701775450614369?thread_ts=1701719404.424999&cid=C021H1P1HKR) (internal).

This PR standardizes the name of the environment variable used to make requests with a HF API token. The goal is to harmonize it across the HF ecosystem. For what I've seen, both `HF_TOKEN` and `HF_ACCESS_TOKEN` are defined in this repo. What this PR does is:
- rename `HF_ACCESS_TOKEN` to `HF_TOKEN` => the token used for api request
- rename `HF_TOKEN` to `HF_DEPLOYMENT_TOKEN` => the token used to deploy chat-ui to production. This looks like an internal secret.

Given this switch, there is a chance that we mismatch an old `HF_TOKEN` (for deployment) with a new `HF_TOKEN` (for api requests). Do we only need to change github secrets or is there a possibility that users conifgured chat-ui in their own environment with the old `HF_TOKEN` as environment variable? In that case, do you have an idea how to solve this? In any case, please let me know if there's anytime to change.

**TODO before merging** update `HF_TOKEN => HF_DEPLOYMENT_TOKEN` and `HF_ACCESS_TOKEN => HF_TOKEN` in Github repo secrets.

cc @xenova @julien-c