### PR TITLE
Add mixtral to models list in huggingchat

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -150,6 +150,34 @@ MODELS=`[
         "prompt": "How do I make a delicious lemon cheesecake?"
       }
     ]
+  },
+  {
+    "name" : "mistralai/Mixtral-8x7B-Instruct-v0.1",
+    "description" : "The latest MoE model from Mistral AI! 8x7B and outperforms Llama 2 70B in most benchmarks.",
+    "websiteUrl" : "https://mistral.ai/news/mixtral-of-experts/",
+    "preprompt" : "",
+    "chatPromptTemplate": "<s> {{#each messages}}{{#ifUser}}[INST]{{#if @first}}{{#if @root.preprompt}}{{@root.preprompt}}\n{{/if}}{{/if}} {{content}} [/INST]{{/ifUser}}{{#ifAssistant}} {{content}}</s> {{/ifAssistant}}{{/each}}",
+    "parameters" : {
+      "temperature" : 0.6,
+      "top_p" : 0.95,
+      "repetition_penalty" : 1.2,
+      "top_k" : 50,
+      "truncate" : 24576,
+      "max_new_tokens" : 8192,
+      "stop" : ["</s>"]
+    },
+    "promptExamples" : [
+      {
+        "title": "Write an email from bullet list",
+        "prompt": "As a restaurant owner, write a professional email to the supplier to get these products every week: \n\n- Wine (x10)\n- Eggs (x24)\n- Bread (x12)"
+      }, {
+        "title": "Code a snake game",
+        "prompt": "Code a basic snake game in python, give explanations for each step."
+      }, {
+        "title": "Assist in a task",
+        "prompt": "How do I make a delicious lemon cheesecake?"
+      }
+    ]
   }
 ]`
 

--- a/.env.template
+++ b/.env.template
@@ -162,8 +162,8 @@ MODELS=`[
       "top_p" : 0.95,
       "repetition_penalty" : 1.2,
       "top_k" : 50,
-      "truncate" : 24576,
-      "max_new_tokens" : 8192,
+      "truncate" : 3072,
+      "max_new_tokens" : 1024,
       "stop" : ["</s>"]
     },
     "promptExamples" : [

--- a/PROMPTS.md
+++ b/PROMPTS.md
@@ -43,3 +43,9 @@ System: {{preprompt}}\nUser:{{#each messages}}{{#ifUser}}{{content}}\nFalcon:{{/
 ```env
 <s>{{#each messages}}{{#ifUser}}GPT4 User: {{#if @first}}{{#if @root.preprompt}}{{@root.preprompt}}\n{{/if}}{{/if}}{{content}}<|end_of_turn|>GPT4 Assistant: {{/ifUser}}{{#ifAssistant}}{{content}}<|end_of_turn|>{{/ifAssistant}}{{/each}}
 ```
+
+## Mixtral
+
+```env
+<s> {{#each messages}}{{#ifUser}}[INST]{{#if @first}}{{#if @root.preprompt}}{{@root.preprompt}}\n{{/if}}{{/if}} {{content}} [/INST]{{/ifUser}}{{#ifAssistant}} {{content}}</s> {{/ifAssistant}}{{/each}}
+```


### PR DESCRIPTION
Prompt template is very slightly different from mistral (extra whitespaces) so I added an entry to `PROMPTS.md` and checked that it was outputting the correct prompt vs the example in the [model card](https://huggingface.co/mistralai/Mixtral-8x7B-Instruct-v0.1).