### PR TITLE
Add option to unlist a model

### DIFF
--- a/src/lib/server/models.ts
+++ b/src/lib/server/models.ts
@@ -65,6 +65,7 @@ const modelConfig = z.object({
 		.passthrough()
 		.optional(),
 	multimodal: z.boolean().default(false),
+	unlisted: z.boolean().default(false),
 });
 
 const modelsRaw = z.array(modelConfig).parse(JSON.parse(MODELS));
@@ -156,4 +157,7 @@ export const smallModel = TASK_MODEL
 	  defaultModel
 	: defaultModel;
 
-export type BackendModel = Optional<typeof defaultModel, "preprompt" | "parameters" | "multimodal">;
+export type BackendModel = Optional<
+	typeof defaultModel,
+	"preprompt" | "parameters" | "multimodal" | "unlisted"
+>;

--- a/src/lib/types/Model.ts
+++ b/src/lib/types/Model.ts
@@ -14,4 +14,5 @@ export type Model = Pick<
 	| "datasetUrl"
 	| "preprompt"
 	| "multimodal"
+	| "unlisted"
 >;

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -27,6 +27,17 @@ export const load: LayoutServerLoad = async ({ locals, depends }) => {
 		});
 	}
 
+	// if the model is unlisted, set the active model to the default model
+	if (
+		settings?.activeModel &&
+		models.find((m) => m.id === settings?.activeModel)?.unlisted === true
+	) {
+		settings.activeModel = defaultModel.id;
+		await collections.settings.updateOne(authCondition(locals), {
+			$set: { activeModel: defaultModel.id },
+		});
+	}
+
 	// get the number of messages where `from === "assistant"` across all conversations.
 	const totalMessages =
 		(
@@ -89,6 +100,7 @@ export const load: LayoutServerLoad = async ({ locals, depends }) => {
 			parameters: model.parameters,
 			preprompt: model.preprompt,
 			multimodal: model.multimodal,
+			unlisted: model.unlisted,
 		})),
 		oldModels,
 		user: locals.user && {

--- a/src/routes/conversation/+server.ts
+++ b/src/routes/conversation/+server.ts
@@ -39,6 +39,15 @@ export const POST: RequestHandler = async ({ locals, request }) => {
 	}
 
 	const model = models.find((m) => m.name === values.model);
+
+	if (!model) {
+		throw error(400, "Invalid model");
+	}
+
+	if (model.unlisted) {
+		throw error(400, "Can't start a conversation with an unlisted model");
+	}
+
 	// Use the model preprompt if there is no conversation/preprompt in the request body
 	preprompt = preprompt === undefined ? model?.preprompt : preprompt;
 

--- a/src/routes/settings/+layout.svelte
+++ b/src/routes/settings/+layout.svelte
@@ -48,7 +48,7 @@
 		<div
 			class="col-span-1 flex flex-col overflow-y-auto whitespace-nowrap max-md:-mx-4 max-md:h-[160px] max-md:border md:pr-6"
 		>
-			{#each data.models as model}
+			{#each data.models.filter((el) => !el.unlisted) as model}
 				<a
 					href="{base}/settings/{model.id}"
 					class="group flex h-11 flex-none items-center gap-3 pl-3 pr-2 text-gray-500 hover:bg-gray-100 md:rounded-xl {model.id ===

--- a/src/routes/settings/[...model]/+page.ts
+++ b/src/routes/settings/[...model]/+page.ts
@@ -4,7 +4,9 @@ import { redirect } from "@sveltejs/kit";
 export async function load({ parent, params }) {
 	const data = await parent();
 
-	if (!data.models.map(({ id }) => id).includes(params.model)) {
+	const model = data.models.find(({ id }) => id === params.model);
+
+	if (!model || model.unlisted) {
 		throw redirect(302, `${base}/settings`);
 	}
 


### PR DESCRIPTION
This PR adds a new option for a model, if `unlisted` is set to true, we:

* hide it in the settings
* if the `activeModel` is `unlisted` redirect to the default model
* Prevent the user from starting new conversations with the model
* allow the user to continue existing conversations with the model