### PR TITLE
Add negating pattern to not ignore .env.local when running docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,4 @@ node_modules/
 .svelte-kit/
 .env*
 !.env
+!.env.local


### PR DESCRIPTION
This PR aims to fix the cause of the "Building Dockerfile failing" problem explained in [issue#637](https://github.com/huggingface/chat-ui/issues/637).

You can see the fix itself in my [comment](https://github.com/huggingface/chat-ui/issues/637#issuecomment-1857673358) to the aforementioned issue.