### PR TITLE
Update share behaviour

### DIFF
--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -24,7 +24,6 @@
 	import UploadBtn from "../UploadBtn.svelte";
 	import file2base64 from "$lib/utils/file2base64";
 	import { useSettingsStore } from "$lib/stores/settings";
-	import { isConversationShared } from "$lib/stores/shareConversation";
 
 	export let messages: Message[] = [];
 	export let loading = false;
@@ -41,6 +40,8 @@
 	let loginModalOpen = false;
 	let message: string;
 	let timeout: ReturnType<typeof setTimeout>;
+	let isSharedRecently = false;  
+    $: $page.params.id && (isSharedRecently = false);
 
 	const dispatch = createEventDispatcher<{
 		message: string;
@@ -77,15 +78,15 @@
 
 	const settings = useSettingsStore();
 
-	$: {
-		if ($isConversationShared) {
-			if (timeout) {
+	function onShare(){
+		dispatch("share");  
+		isSharedRecently = true;
+		if (timeout) {
 				clearTimeout(timeout);
 			}
 			timeout = setTimeout(() => {
-				$isConversationShared = false;
+				isSharedRecently = false;
 			}, 2000);
-		}
 	}
 
 	onDestroy(() => {
@@ -248,11 +249,11 @@
 					<button
 						class="flex flex-none items-center hover:text-gray-400 max-sm:rounded-lg max-sm:bg-gray-50 max-sm:px-2.5 dark:max-sm:bg-gray-800"
 						type="button"
-						class:hover:underline={!$isConversationShared}
-						on:click={() => dispatch("share")}
-						disabled={$isConversationShared}
+						class:hover:underline={!isSharedRecently}
+						on:click={onShare}
+						disabled={isSharedRecently}
 					>
-						{#if $isConversationShared}
+						{#if isSharedRecently}
 							<CarbonCheckmark class="text-[.6rem] sm:mr-1.5 sm:text-green-500" />
 							<div class="text-green-600 max-sm:hidden">Copied to clipboard</div>
 						{:else}

--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -40,8 +40,8 @@
 	let loginModalOpen = false;
 	let message: string;
 	let timeout: ReturnType<typeof setTimeout>;
-	let isSharedRecently = false;  
-    $: $page.params.id && (isSharedRecently = false);
+	let isSharedRecently = false;
+	$: $page.params.id && (isSharedRecently = false);
 
 	const dispatch = createEventDispatcher<{
 		message: string;
@@ -78,15 +78,15 @@
 
 	const settings = useSettingsStore();
 
-	function onShare(){
-		dispatch("share");  
+	function onShare() {
+		dispatch("share");
 		isSharedRecently = true;
 		if (timeout) {
-				clearTimeout(timeout);
-			}
-			timeout = setTimeout(() => {
-				isSharedRecently = false;
-			}, 2000);
+			clearTimeout(timeout);
+		}
+		timeout = setTimeout(() => {
+			isSharedRecently = false;
+		}, 2000);
 	}
 
 	onDestroy(() => {

--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -257,7 +257,7 @@
 							<CarbonCheckmark class="text-[.6rem] sm:mr-1.5 sm:text-green-600" />
 							<div class="text-green-600 max-sm:hidden">Link copied to clipboard</div>
 						{:else}
-							<CarbonExport class="sm:text-primary-500 text-[.6rem] sm:mr-1.5" />
+							<CarbonExport class="text-[.6rem] sm:mr-1.5 sm:text-primary-500" />
 							<div class="max-sm:hidden">Share this conversation</div>
 						{/if}
 					</button>

--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -254,10 +254,10 @@
 						disabled={isSharedRecently}
 					>
 						{#if isSharedRecently}
-							<CarbonCheckmark class="text-[.6rem] sm:mr-1.5 sm:text-green-500" />
-							<div class="text-green-600 max-sm:hidden">Copied to clipboard</div>
+							<CarbonCheckmark class="text-[.6rem] sm:mr-1.5 sm:text-green-600" />
+							<div class="text-green-600 max-sm:hidden">Link copied to clipboard</div>
 						{:else}
-							<CarbonExport class="text-[.6rem] sm:mr-1.5 sm:text-primary-500" />
+							<CarbonExport class="sm:text-primary-500 text-[.6rem] sm:mr-1.5" />
 							<div class="max-sm:hidden">Share this conversation</div>
 						{/if}
 					</button>

--- a/src/lib/shareConversation.ts
+++ b/src/lib/shareConversation.ts
@@ -8,7 +8,7 @@ export async function shareConversation(id: string, title: string) {
 	try {
 		if (id.length === 7) {
 			const url = get(page).url;
-			share(getShareUrl(url, id), title);
+			await share(getShareUrl(url, id), title);
 		} else {
 			const res = await fetch(`${base}/conversation/${id}/share`, {
 				method: "POST",
@@ -24,7 +24,7 @@ export async function shareConversation(id: string, title: string) {
 			}
 
 			const { url } = await res.json();
-			share(url, title);
+			await share(url, title);
 		}
 	} catch (err) {
 		error.set(ERROR_MESSAGES.default);

--- a/src/lib/stores/shareConversation.ts
+++ b/src/lib/stores/shareConversation.ts
@@ -1,3 +1,0 @@
-import { writable } from "svelte/store";
-
-export const isConversationShared = writable<boolean>(false);

--- a/src/lib/stores/shareConversation.ts
+++ b/src/lib/stores/shareConversation.ts
@@ -1,0 +1,3 @@
+import { writable } from "svelte/store";
+
+export const isConversationShared = writable<boolean>(false);

--- a/src/lib/utils/share.ts
+++ b/src/lib/utils/share.ts
@@ -1,7 +1,10 @@
-export function share(url: string, title: string) {
+import { isConversationShared } from "$lib/stores/shareConversation";
+
+export async function share(url: string, title: string) {
 	if (navigator.share) {
 		navigator.share({ url, title });
 	} else {
-		prompt("Copy this public url to share:", url);
+		await navigator.clipboard.writeText(url);
+		isConversationShared.set(true);
 	}
 }

--- a/src/lib/utils/share.ts
+++ b/src/lib/utils/share.ts
@@ -1,10 +1,7 @@
-import { isConversationShared } from "$lib/stores/shareConversation";
-
 export async function share(url: string, title: string) {
 	if (navigator.share) {
 		navigator.share({ url, title });
 	} else {
 		await navigator.clipboard.writeText(url);
-		isConversationShared.set(true);
 	}
 }


### PR DESCRIPTION
### TLDR: Change the current share conversation behaviour for desktop:

[internal slack link](https://huggingface.slack.com/archives/C052EKHD1U0/p1697718356502049?thread_ts=1697717286.065219&cid=C052EKHD1U0)

Currently: when you click `share conversation`, chat-ui opens [window.prompt](https://developer.mozilla.org/en-US/docs/Web/API/Window/prompt)

With this PR: just like [hf.co collection](https://huggingface.co/docs/hub/collections) sharing 
![Screenshot 2023-12-19 at 3 11 59 PM](https://github.com/huggingface/chat-ui/assets/11827707/92ce1352-a226-4c19-958a-4f38b61f300e)

when you click `share conversation`, chat-ui saves the share url in user's clipboard and the share btn text becomes `Copied to clipboard` for 2 seconds
![Screenshot 2023-12-19 at 3 11 36 PM](https://github.com/huggingface/chat-ui/assets/11827707/c267eda8-aa7c-4b24-a187-dc3814f0471c)


#### For mobile, nothing changes:

It shows the mobile share window as before
<img src="https://github.com/huggingface/chat-ui/assets/11827707/81161a57-5187-4731-9237-6c23324c8790" width="200px">
