### PR TITLE
Use a low temperature mistral for tasks

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -213,7 +213,18 @@ MODELS=`[
 
 OLD_MODELS=`[{"name":"bigcode/starcoder"}, {"name":"OpenAssistant/oasst-sft-6-llama-30b-xor"}, {"name":"HuggingFaceH4/zephyr-7b-alpha"}]`
 
-TASK_MODEL='mistralai/Mistral-7B-Instruct-v0.2'
+TASK_MODEL=`{
+      "name": "mistralai/Mistral-7B-Instruct-v0.2",
+      "chatPromptTemplate" : "<s>{{#each messages}}{{#ifUser}}[INST] {{#if @first}}{{#if @root.preprompt}}{{@root.preprompt}}\n{{/if}}{{/if}}{{content}} [/INST]{{/ifUser}}{{#ifAssistant}}{{content}}</s>{{/ifAssistant}}{{/each}}",
+      "parameters": {
+        "temperature": 0.1,
+        "top_p": 0.95,
+        "repetition_penalty": 1.2,
+        "top_k": 50,
+        "truncate": 3072,
+        "max_new_tokens": 1024,
+        "stop": ["</s>"]
+}}`
 
 
 APP_BASE="/chat"


### PR DESCRIPTION
Decouple the task model settings from the normal endpoint settings.

Use a lower temp for the tasks, as they don't benefit from increased randomness in the tokens