### PR TITLE
Optimize dynamic import on vite startup

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,4 +9,7 @@ export default defineConfig({
 			compiler: "svelte",
 		}),
 	],
+	optimizeDeps: {
+		include: ["browser-image-resizer"],
+	},
 });


### PR DESCRIPTION
I was running into an occasional DX annoyance where on my first message, vite would optimize the dynamically imported `browser-image-resizer` lib, which would reload the page and lose my message.

This PR fixes that