### PR TITLE
Avoid duplicate MONGODB_URL in env local

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,17 +1,23 @@
+ENV_LOCAL_PATH=/app/.env.local
+
 if test -z "${DOTENV_LOCAL}" ; then
-    if ! test -f "/app/.env.local" ; then
+    if ! test -f "${ENV_LOCAL_PATH}" ; then
         echo "DOTENV_LOCAL was not found in the ENV variables and .env.local is not set using a bind volume. We are using the default .env config."
     fi;
 else
     echo "DOTENV_LOCAL was found in the ENV variables. Creating .env.local file."
-    cat <<< "$DOTENV_LOCAL" > /app/.env.local
+    cat <<< "$DOTENV_LOCAL" > ${ENV_LOCAL_PATH}
 fi;
 
 if [ "$INCLUDE_DB" = "true" ] ; then
-    echo "INCLUDE_DB is set to true. Appending MONGODB_URL"
+    echo "INCLUDE_DB is set to true."
 
-    touch /app/.env.local
-    echo -e "\nMONGODB_URL=mongodb://localhost:27017" >> /app/.env.local
+    MONGODB_CONFIG="MONGODB_URL=mongodb://localhost:27017"
+    if ! grep -q "^${MONGODB_CONFIG}$" ${ENV_LOCAL_PATH}; then
+      echo "Appending MONGODB_URL"
+      touch /app/.env.local
+      echo -e "\n${MONGODB_CONFIG}" >> ${ENV_LOCAL_PATH}
+    fi
 
     mkdir -p /data/db
     mongod &


### PR DESCRIPTION
When using the `chat-ui-db` docker container, avoid adding a duplicate line:
```
MONGODB_URL=mongodb://localhost:27017
```
to `/app/.env.local` file every time the container is started.