### PR TITLE
add saslprep package for mongodb authentication

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
 				"openid-client": "^5.4.2",
 				"parquetjs": "^0.11.2",
 				"postcss": "^8.4.31",
+				"saslprep": "^1.0.3",
 				"serpapi": "^1.1.1",
 				"tailwind-scrollbar": "^3.0.0",
 				"tailwindcss": "^3.4.0",
@@ -3840,8 +3841,7 @@
 		"node_modules/memory-pager": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
-			"integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
-			"optional": true
+			"integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg=="
 		},
 		"node_modules/merge-stream": {
 			"version": "2.0.0",
@@ -5267,6 +5267,17 @@
 				"rimraf": "bin.js"
 			}
 		},
+		"node_modules/saslprep": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
+			"integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
+			"dependencies": {
+				"sparse-bitfield": "^3.0.3"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/saxes": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -5497,7 +5508,6 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
 			"integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
-			"optional": true,
 			"dependencies": {
 				"memory-pager": "^1.0.2"
 			}

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
 		"openid-client": "^5.4.2",
 		"parquetjs": "^0.11.2",
 		"postcss": "^8.4.31",
+		"saslprep": "^1.0.3",
 		"serpapi": "^1.1.1",
 		"tailwind-scrollbar": "^3.0.0",
 		"tailwindcss": "^3.4.0",


### PR DESCRIPTION
Including authentication in the MONGODB_URL will result in the following warning:
```MONGODB_URL=mongodb://<username>:<password>@127.0.0.1:27017```

```Warning: no saslprep library specified. Passwords will not be sanitized```

Adding  the saslprep package removes the warning.
