### PR TITLE
Add support for SerpStack API

### DIFF
--- a/.env
+++ b/.env
@@ -16,7 +16,7 @@ HF_ACCESS_TOKEN=#LEGACY! Use HF_TOKEN instead
 YDC_API_KEY=#your docs.you.com api key here
 SERPER_API_KEY=#your serper.dev api key here
 SERPAPI_KEY=#your serpapi key here
-SERPSTACKAPI_KEY=#your serpstack api key here
+SERPSTACK_API_KEY=#your serpstack api key here
 USE_LOCAL_WEBSEARCH=#set to true to parse google results yourself, overrides other API keys
 
 WEBSEARCH_ALLOWLIST=`[]` # if it's defined, allow websites from only this list.

--- a/.env
+++ b/.env
@@ -16,6 +16,7 @@ HF_ACCESS_TOKEN=#LEGACY! Use HF_TOKEN instead
 YDC_API_KEY=#your docs.you.com api key here
 SERPER_API_KEY=#your serper.dev api key here
 SERPAPI_KEY=#your serpapi key here
+SERPSTACKAPI_KEY=#your serpstack api key here
 USE_LOCAL_WEBSEARCH=#set to true to parse google results yourself, overrides other API keys
 
 WEBSEARCH_ALLOWLIST=`[]` # if it's defined, allow websites from only this list.

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ PUBLIC_APP_DISCLAIMER=
 
 ### Web Search config
 
-You can enable the web search through an API by adding `YDC_API_KEY` ([docs.you.com](https://docs.you.com)) or `SERPER_API_KEY` ([serper.dev](https://serper.dev/)) or `SERPAPI_KEY` ([serpapi.com](https://serpapi.com/)) to your `.env.local`.
+You can enable the web search through an API by adding `YDC_API_KEY` ([docs.you.com](https://docs.you.com)) or `SERPER_API_KEY` ([serper.dev](https://serper.dev/)) or `SERPAPI_KEY` ([serpapi.com](https://serpapi.com/)) or `SERPSTACK_API_KEY` ([serpstack.com](https://serpstack.com/)) to your `.env.local`.
 
 You can also simply enable the local websearch by setting `USE_LOCAL_WEBSEARCH=true` in your `.env.local`.
 

--- a/src/lib/server/websearch/searchWeb.ts
+++ b/src/lib/server/websearch/searchWeb.ts
@@ -1,6 +1,12 @@
 import type { YouWebSearch } from "../../types/WebSearch";
 import { WebSearchProvider } from "../../types/WebSearch";
-import { SERPAPI_KEY, SERPER_API_KEY, SERPSTACK_API_KEY, USE_LOCAL_WEBSEARCH, YDC_API_KEY } from "$env/static/private";
+import {
+	SERPAPI_KEY,
+	SERPER_API_KEY,
+	SERPSTACK_API_KEY,
+	USE_LOCAL_WEBSEARCH,
+	YDC_API_KEY,
+} from "$env/static/private";
 import { getJson } from "serpapi";
 import type { GoogleParameters } from "serpapi";
 import { searchWebLocal } from "./searchWebLocal";
@@ -105,14 +111,16 @@ export async function searchWebYouApi(query: string) {
 }
 
 export async function searchSerpStack(query: string) {
-	const response = await fetch(`http://api.serpstack.com/search?access_key=${SERPSTACK_API_KEY}&query=${query}&hl=en&gl=us`, {
-		method: "GET",
-		headers: {
-			"Content-type": "application/json; charset=UTF-8",
-		},
-	});
+	const response = await fetch(
+		`http://api.serpstack.com/search?access_key=${SERPSTACK_API_KEY}&query=${query}&hl=en&gl=us`,
+		{
+			method: "GET",
+			headers: {
+				"Content-type": "application/json; charset=UTF-8",
+			},
+		}
+	);
 
-	/* eslint-disable @typescript-eslint/no-explicit-any */
 	const data = (await response.json()) as Record<string, any>;
 
 	if (!response.ok) {
@@ -122,12 +130,13 @@ export async function searchSerpStack(query: string) {
 		);
 	}
 
-	const resultsWithSnippets =  data["organic_results"]
-	.map(({ title, url, snippet }: { title: string; url: string; snippet: string | undefined }) => ({
-		title,
-		link: url,
-		text: snippet || "",
-	}))
+	const resultsWithSnippets = data["organic_results"].map(
+		({ title, url, snippet }: { title: string; url: string; snippet: string | undefined }) => ({
+			title,
+			link: url,
+			text: snippet || "",
+		})
+	);
 
 	return {
 		organic_results: resultsWithSnippets ?? [],

--- a/src/lib/server/websearch/searchWeb.ts
+++ b/src/lib/server/websearch/searchWeb.ts
@@ -1,6 +1,6 @@
 import type { YouWebSearch } from "../../types/WebSearch";
 import { WebSearchProvider } from "../../types/WebSearch";
-import { SERPAPI_KEY, SERPER_API_KEY, SERPSTACKAPI_KEY, USE_LOCAL_WEBSEARCH, YDC_API_KEY } from "$env/static/private";
+import { SERPAPI_KEY, SERPER_API_KEY, SERPSTACK_API_KEY, USE_LOCAL_WEBSEARCH, YDC_API_KEY } from "$env/static/private";
 import { getJson } from "serpapi";
 import type { GoogleParameters } from "serpapi";
 import { searchWebLocal } from "./searchWebLocal";
@@ -24,7 +24,7 @@ export async function searchWeb(query: string) {
 	if (SERPAPI_KEY) {
 		return await searchWebSerpApi(query);
 	}
-	if (SERPSTACKAPI_KEY) {
+	if (SERPSTACK_API_KEY) {
 		return await searchSerpStack(query);
 	}
 	throw new Error("No You.com or Serper.dev or SerpAPI key found");
@@ -105,7 +105,7 @@ export async function searchWebYouApi(query: string) {
 }
 
 export async function searchSerpStack(query: string) {
-	const response = await fetch(`http://api.serpstack.com/search?access_key=${SERPSTACKAPI_KEY}&query=${query}&hl=en&gl=us`, {
+	const response = await fetch(`http://api.serpstack.com/search?access_key=${SERPSTACK_API_KEY}&query=${query}&hl=en&gl=us`, {
 		method: "GET",
 		headers: {
 			"Content-type": "application/json; charset=UTF-8",

--- a/src/lib/server/websearch/searchWeb.ts
+++ b/src/lib/server/websearch/searchWeb.ts
@@ -1,6 +1,6 @@
 import type { YouWebSearch } from "../../types/WebSearch";
 import { WebSearchProvider } from "../../types/WebSearch";
-import { SERPAPI_KEY, SERPER_API_KEY, USE_LOCAL_WEBSEARCH, YDC_API_KEY } from "$env/static/private";
+import { SERPAPI_KEY, SERPER_API_KEY, SERPSTACKAPI_KEY, USE_LOCAL_WEBSEARCH, YDC_API_KEY } from "$env/static/private";
 import { getJson } from "serpapi";
 import type { GoogleParameters } from "serpapi";
 import { searchWebLocal } from "./searchWebLocal";
@@ -23,6 +23,9 @@ export async function searchWeb(query: string) {
 	}
 	if (SERPAPI_KEY) {
 		return await searchWebSerpApi(query);
+	}
+	if (SERPSTACKAPI_KEY) {
+		return await searchSerpStack(query);
 	}
 	throw new Error("No You.com or Serper.dev or SerpAPI key found");
 }
@@ -98,5 +101,35 @@ export async function searchWebYouApi(query: string) {
 
 	return {
 		organic_results: formattedResultsWithSnippets,
+	};
+}
+
+export async function searchSerpStack(query: string) {
+	const response = await fetch(`http://api.serpstack.com/search?access_key=${SERPSTACKAPI_KEY}&query=${query}&hl=en&gl=us`, {
+		method: "GET",
+		headers: {
+			"Content-type": "application/json; charset=UTF-8",
+		},
+	});
+
+	/* eslint-disable @typescript-eslint/no-explicit-any */
+	const data = (await response.json()) as Record<string, any>;
+
+	if (!response.ok) {
+		throw new Error(
+			data["error"] ??
+				`SerpStack API returned error code ${response.status} - ${response.statusText}`
+		);
+	}
+
+	const resultsWithSnippets =  data["organic_results"]
+	.map(({ title, url, snippet }: { title: string; url: string; snippet: string | undefined }) => ({
+		title,
+		link: url,
+		text: snippet || "",
+	}))
+
+	return {
+		organic_results: resultsWithSnippets ?? [],
 	};
 }

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -8,6 +8,7 @@ import { DEFAULT_SETTINGS } from "$lib/types/Settings";
 import {
 	SERPAPI_KEY,
 	SERPER_API_KEY,
+	SERPSTACKAPI_KEY,
 	MESSAGES_BEFORE_LOGIN,
 	YDC_API_KEY,
 	USE_LOCAL_WEBSEARCH,
@@ -77,7 +78,7 @@ export const load: LayoutServerLoad = async ({ locals, depends }) => {
 			}))
 			.toArray(),
 		settings: {
-			searchEnabled: !!(SERPAPI_KEY || SERPER_API_KEY || YDC_API_KEY || USE_LOCAL_WEBSEARCH),
+			searchEnabled: !!(SERPAPI_KEY || SERPER_API_KEY || SERPSTACKAPI_KEY ||  YDC_API_KEY || USE_LOCAL_WEBSEARCH),
 			ethicsModalAccepted: !!settings?.ethicsModalAcceptedAt,
 			ethicsModalAcceptedAt: settings?.ethicsModalAcceptedAt ?? null,
 			activeModel: settings?.activeModel ?? DEFAULT_SETTINGS.activeModel,

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -78,7 +78,13 @@ export const load: LayoutServerLoad = async ({ locals, depends }) => {
 			}))
 			.toArray(),
 		settings: {
-			searchEnabled: !!(SERPAPI_KEY || SERPER_API_KEY || SERPSTACK_API_KEY ||  YDC_API_KEY || USE_LOCAL_WEBSEARCH),
+			searchEnabled: !!(
+				SERPAPI_KEY ||
+				SERPER_API_KEY ||
+				SERPSTACK_API_KEY ||
+				YDC_API_KEY ||
+				USE_LOCAL_WEBSEARCH
+			),
 			ethicsModalAccepted: !!settings?.ethicsModalAcceptedAt,
 			ethicsModalAcceptedAt: settings?.ethicsModalAcceptedAt ?? null,
 			activeModel: settings?.activeModel ?? DEFAULT_SETTINGS.activeModel,

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -8,7 +8,7 @@ import { DEFAULT_SETTINGS } from "$lib/types/Settings";
 import {
 	SERPAPI_KEY,
 	SERPER_API_KEY,
-	SERPSTACKAPI_KEY,
+	SERPSTACK_API_KEY,
 	MESSAGES_BEFORE_LOGIN,
 	YDC_API_KEY,
 	USE_LOCAL_WEBSEARCH,
@@ -78,7 +78,7 @@ export const load: LayoutServerLoad = async ({ locals, depends }) => {
 			}))
 			.toArray(),
 		settings: {
-			searchEnabled: !!(SERPAPI_KEY || SERPER_API_KEY || SERPSTACKAPI_KEY ||  YDC_API_KEY || USE_LOCAL_WEBSEARCH),
+			searchEnabled: !!(SERPAPI_KEY || SERPER_API_KEY || SERPSTACK_API_KEY ||  YDC_API_KEY || USE_LOCAL_WEBSEARCH),
 			ethicsModalAccepted: !!settings?.ethicsModalAcceptedAt,
 			ethicsModalAcceptedAt: settings?.ethicsModalAcceptedAt ?? null,
 			activeModel: settings?.activeModel ?? DEFAULT_SETTINGS.activeModel,


### PR DESCRIPTION
This PR adds support for [serpstack](https://serpstack.com) following a similar format to the other SERP providers. 

The `SERPSTACK_API_KEY` is added to the .env and when provided with a valid API key, web search should use Serp Stack.