### PR TITLE
Use JSON5 for parsing all config vars

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
 				"highlight.js": "^11.7.0",
 				"image-size": "^1.0.2",
 				"jsdom": "^22.0.0",
+				"json5": "^2.2.3",
 				"marked": "^4.3.0",
 				"mongodb": "^5.8.0",
 				"nanoid": "^4.0.2",
@@ -3596,6 +3597,17 @@
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
 			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
 			"dev": true
+		},
+		"node_modules/json5": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+			"bin": {
+				"json5": "lib/cli.js"
+			},
+			"engines": {
+				"node": ">=6"
+			}
 		},
 		"node_modules/jsonc-parser": {
 			"version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
 		"highlight.js": "^11.7.0",
 		"image-size": "^1.0.2",
 		"jsdom": "^22.0.0",
+		"json5": "^2.2.3",
 		"marked": "^4.3.0",
 		"mongodb": "^5.8.0",
 		"nanoid": "^4.0.2",

--- a/src/lib/components/chat/ChatIntroduction.svelte
+++ b/src/lib/components/chat/ChatIntroduction.svelte
@@ -12,6 +12,7 @@
 	import { findCurrentModel } from "$lib/utils/models";
 	import { base } from "$app/paths";
 	import { useSettingsStore } from "$lib/stores/settings";
+	import JSON5 from "json5";
 
 	export let currentModel: Model;
 	export let models: Model[];
@@ -21,7 +22,7 @@
 	$: currentModelMetadata = findCurrentModel(models, $settings.activeModel);
 
 	const announcementBanners = PUBLIC_ANNOUNCEMENT_BANNERS
-		? JSON.parse(PUBLIC_ANNOUNCEMENT_BANNERS)
+		? JSON5.parse(PUBLIC_ANNOUNCEMENT_BANNERS)
 		: [];
 
 	const dispatch = createEventDispatcher<{ message: string }>();

--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -15,6 +15,7 @@ import { z } from "zod";
 import { dev } from "$app/environment";
 import type { Cookies } from "@sveltejs/kit";
 import { collections } from "./database";
+import JSON5 from "json5";
 
 export interface OIDCSettings {
 	redirectURI: string;
@@ -40,7 +41,7 @@ const OIDConfig = z
 		TOLERANCE: stringWithDefault(OPENID_TOLERANCE),
 		RESOURCE: stringWithDefault(OPENID_RESOURCE),
 	})
-	.parse(JSON.parse(OPENID_CONFIG));
+	.parse(JSON5.parse(OPENID_CONFIG));
 
 export const requiresUser = !!OIDConfig.CLIENT_ID && !!OIDConfig.CLIENT_SECRET;
 

--- a/src/lib/server/models.ts
+++ b/src/lib/server/models.ts
@@ -13,6 +13,8 @@ import endpoints, { endpointSchema, type Endpoint } from "./endpoints/endpoints"
 import endpointTgi from "./endpoints/tgi/endpointTgi";
 import { sum } from "$lib/utils/sum";
 
+import JSON5 from "json5";
+
 type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>;
 
 const modelConfig = z.object({
@@ -68,7 +70,7 @@ const modelConfig = z.object({
 	unlisted: z.boolean().default(false),
 });
 
-const modelsRaw = z.array(modelConfig).parse(JSON.parse(MODELS));
+const modelsRaw = z.array(modelConfig).parse(JSON5.parse(MODELS));
 
 const processModel = async (m: z.infer<typeof modelConfig>) => ({
 	...m,
@@ -138,7 +140,7 @@ export const oldModels = OLD_MODELS
 					displayName: z.string().min(1).optional(),
 				})
 			)
-			.parse(JSON.parse(OLD_MODELS))
+			.parse(JSON5.parse(OLD_MODELS))
 			.map((m) => ({ ...m, id: m.id || m.name, displayName: m.displayName || m.name }))
 	: [];
 
@@ -151,7 +153,7 @@ export const validateModel = (_models: BackendModel[]) => {
 
 export const smallModel = TASK_MODEL
 	? (models.find((m) => m.name === TASK_MODEL) ||
-			(await processModel(modelConfig.parse(JSON.parse(TASK_MODEL))).then((m) =>
+			(await processModel(modelConfig.parse(JSON5.parse(TASK_MODEL))).then((m) =>
 				addEndpoint(m)
 			))) ??
 	  defaultModel

--- a/src/lib/server/websearch/generateQuery.ts
+++ b/src/lib/server/websearch/generateQuery.ts
@@ -3,11 +3,12 @@ import { format } from "date-fns";
 import { generateFromDefaultEndpoint } from "../generateFromDefaultEndpoint";
 import { WEBSEARCH_ALLOWLIST, WEBSEARCH_BLOCKLIST } from "$env/static/private";
 import { z } from "zod";
+import JSON5 from "json5";
 
 const listSchema = z.array(z.string()).default([]);
 
-const allowList = listSchema.parse(JSON.parse(WEBSEARCH_ALLOWLIST));
-const blockList = listSchema.parse(JSON.parse(WEBSEARCH_BLOCKLIST));
+const allowList = listSchema.parse(JSON5.parse(WEBSEARCH_ALLOWLIST));
+const blockList = listSchema.parse(JSON5.parse(WEBSEARCH_BLOCKLIST));
 
 const queryModifier = [
 	...allowList.map((item) => "site:" + item),


### PR DESCRIPTION
This should help with issues like #670 and a lot of others we've seen in the past where users were getting confused about their configs not parsing properly.

Most of the times it's due do trailing commas, comments in the JSON or similar. Using [JSON5](https://json5.org/) solves all of these.

I tested it with the huggingchat prod config and it works fine.