### PR TITLE
Fixes "invalid url" error in websearch 

### DIFF
--- a/src/lib/server/websearch/runWebSearch.ts
+++ b/src/lib/server/websearch/runWebSearch.ts
@@ -48,11 +48,17 @@ export async function runWebSearch(
 		webSearch.results =
 			(results.organic_results &&
 				results.organic_results.map((el: { title?: string; link: string; text?: string }) => {
-					const { title, link, text } = el;
-					const { hostname } = new URL(link);
-					return { title, link, hostname, text };
+					try {
+						const { title, link, text } = el;
+						const { hostname } = new URL(link);
+						return { title, link, hostname, text };
+					} catch (e) {
+						// Ignore Errors
+						return null;
+					}
 				})) ??
 			[];
+		webSearch.results = webSearch.results.filter(value => value !== null);
 		webSearch.results = webSearch.results
 			.filter(({ link }) => !DOMAIN_BLOCKLIST.some((el) => link.includes(el))) // filter out blocklist links
 			.slice(0, MAX_N_PAGES_SCRAPE); // limit to first 10 links only

--- a/src/lib/server/websearch/runWebSearch.ts
+++ b/src/lib/server/websearch/runWebSearch.ts
@@ -58,7 +58,7 @@ export async function runWebSearch(
 					}
 				})) ??
 			[];
-		webSearch.results = webSearch.results.filter(value => value !== null);
+		webSearch.results = webSearch.results.filter((value) => value !== null);
 		webSearch.results = webSearch.results
 			.filter(({ link }) => !DOMAIN_BLOCKLIST.some((el) => link.includes(el))) // filter out blocklist links
 			.slice(0, MAX_N_PAGES_SCRAPE); // limit to first 10 links only


### PR DESCRIPTION
I have fixed the issue #656 

This issue was occuring because local web search sometimes extract invalid url.
So this line causes error:
`const { hostname } = new URL(link);` 

Now I have added exception handling around it.