### PR TITLE
Put API feature behind feature flag

### DIFF
--- a/.env
+++ b/.env
@@ -120,6 +120,7 @@ PUBLIC_APP_DATA_SHARING=#set to 1 to enable options & text regarding data sharin
 PUBLIC_APP_DISCLAIMER=#set to 1 to show a disclaimer on login page
 LLM_SUMMERIZATION=true
 
+EXPOSE_API=true
 # PUBLIC_APP_NAME=HuggingChat
 # PUBLIC_APP_ASSETS=huggingchat
 # PUBLIC_APP_COLOR=yellow

--- a/.env.template
+++ b/.env.template
@@ -225,3 +225,5 @@ PUBLIC_GOOGLE_ANALYTICS_ID=G-8Q63TH4CSL
 # Not part of the .env but set as other variables in the space
 # ADDRESS_HEADER=X-Forwarded-For
 # XFF_DEPTH=2
+
+EXPOSE_API=false

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,4 +1,4 @@
-import { COOKIE_NAME, MESSAGES_BEFORE_LOGIN } from "$env/static/private";
+import { COOKIE_NAME, EXPOSE_API, MESSAGES_BEFORE_LOGIN } from "$env/static/private";
 import type { Handle } from "@sveltejs/kit";
 import {
 	PUBLIC_GOOGLE_ANALYTICS_ID,
@@ -13,6 +13,10 @@ import { sha256 } from "$lib/utils/sha256";
 import { addWeeks } from "date-fns";
 
 export const handle: Handle = async ({ event, resolve }) => {
+	if (event.url.pathname.startsWith(`${base}/api`) && EXPOSE_API !== "true") {
+		return new Response("API is disabled", { status: 403 });
+	}
+
 	function errorResponse(status: number, message: string) {
 		const sendJson =
 			event.request.headers.get("accept")?.includes("application/json") ||


### PR DESCRIPTION
This PR puts the API behind a feature flag, `EXPOSE_API`, it's turned on by default and currently turned off for prod config. Could be changed though!