### PR TITLE
Set message id on server side

### DIFF
--- a/src/routes/conversation/[id]/+page.svelte
+++ b/src/routes/conversation/[id]/+page.svelte
@@ -111,14 +111,12 @@
 
 			files = [];
 
-			const responseId = randomUUID();
 			const response = await fetch(`${base}/conversation/${$page.params.id}`, {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({
 					inputs: message,
 					id: messageId,
-					response_id: responseId,
 					is_retry: isRetry,
 					web_search: $webSearchParameters.useSearch,
 					files: isRetry ? undefined : resizedImages,

--- a/src/routes/conversation/[id]/+server.ts
+++ b/src/routes/conversation/[id]/+server.ts
@@ -90,7 +90,6 @@ export async function POST({ request, locals, params, getClientAddress }) {
 
 	const {
 		inputs: newPrompt,
-		response_id: responseId,
 		id: messageId,
 		is_retry,
 		web_search: webSearch,
@@ -99,7 +98,6 @@ export async function POST({ request, locals, params, getClientAddress }) {
 		.object({
 			inputs: z.string().trim().min(1),
 			id: z.optional(z.string().uuid()),
-			response_id: z.optional(z.string().uuid()),
 			is_retry: z.optional(z.boolean()),
 			web_search: z.optional(z.boolean()),
 			files: z.optional(z.array(z.string())),
@@ -268,7 +266,7 @@ export async function POST({ request, locals, params, getClientAddress }) {
 										content: output.token.text.trimStart(),
 										webSearch: webSearchResults,
 										updates: updates,
-										id: (responseId as Message["id"]) || crypto.randomUUID(),
+										id: crypto.randomUUID(),
 										createdAt: new Date(),
 										updatedAt: new Date(),
 									},


### PR DESCRIPTION
Not sure why this existed, maybe a legacy feature that wasn't fully cleaned out? There was an optional params for setting a message id from the front-end, but it was just doing `crypto.randomUUID` there so I moved it to the back-end.