### PR TITLE
Add NousResearch/Nous-Hermes-2-Mixtral-8x7B-DPO

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -61,6 +61,33 @@ MODELS=`[
       }
     },
     {
+      "name" : "NousResearch/Nous-Hermes-2-Mixtral-8x7B-DPO",
+      "description" : "Nous Hermes 2 Mixtral 8x7B DPO is the new flagship Nous Research model trained over the Mixtral 8x7B MoE LLM.",
+      "websiteUrl" : "https://nousresearch.com/",
+      "chatPromptTemplate" : "<|im_start|>system\n{{#if @root.preprompt}}{{@root.preprompt}}<|im_end|>\n{{/if}}{{#each messages}}{{#ifUser}}<|im_start|>user\n{{content}}<|im_end|>\n<|im_start|>assistant\n{{/ifUser}}{{#ifAssistant}}{{content}}<|im_end|>\n{{/ifAssistant}}{{/each}}",
+      "promptExamples": [
+        {
+          "title": "Write an email from bullet list",
+          "prompt": "As a restaurant owner, write a professional email to the supplier to get these products every week: \n\n- Wine (x10)\n- Eggs (x24)\n- Bread (x12)"
+        }, {
+          "title": "Code a snake game",
+          "prompt": "Code a basic snake game in python, give explanations for each step."
+        }, {
+          "title": "Assist in a task",
+          "prompt": "How do I make a delicious lemon cheesecake?"
+        }
+      ],
+      "parameters": {
+        "temperature": 0.6,
+        "top_p": 0.95,
+        "repetition_penalty": 1.2,
+        "top_k": 50,
+        "truncate": 3072,
+        "max_new_tokens": 1024,
+        "stop": ["<|im_end|>"]
+      }
+    },
+    {
       "name": "codellama/CodeLlama-34b-Instruct-hf",
       "displayName": "codellama/CodeLlama-34b-Instruct-hf",
       "description": "Code Llama, a state of the art code model from Meta.",

--- a/.env.template
+++ b/.env.template
@@ -78,12 +78,12 @@ MODELS=`[
         }
       ],
       "parameters": {
-        "temperature": 0.6,
+        "temperature": 0.7,
         "top_p": 0.95,
-        "repetition_penalty": 1.2,
+        "repetition_penalty": 1,
         "top_k": 50,
         "truncate": 3072,
-        "max_new_tokens": 1024,
+        "max_new_tokens": 512,
         "stop": ["<|im_end|>"]
       }
     },

--- a/PROMPTS.md
+++ b/PROMPTS.md
@@ -49,3 +49,9 @@ System: {{preprompt}}\nUser:{{#each messages}}{{#ifUser}}{{content}}\nFalcon:{{/
 ```env
 <s> {{#each messages}}{{#ifUser}}[INST]{{#if @first}}{{#if @root.preprompt}}{{@root.preprompt}}\n{{/if}}{{/if}} {{content}} [/INST]{{/ifUser}}{{#ifAssistant}} {{content}}</s> {{/ifAssistant}}{{/each}}
 ```
+
+## ChatML
+
+```env
+<|im_start|>system\n{{#if @root.preprompt}}{{@root.preprompt}}<|im_end|>\n{{/if}}{{#each messages}}{{#ifUser}}<|im_start|>user\n{{content}}<|im_end|>\n<|im_start|>assistant\n{{/ifUser}}{{#ifAssistant}}{{content}}<|im_end|>\n{{/ifAssistant}}{{/each}}
+```


### PR DESCRIPTION
This PR adds `NousResearch/Nous-Hermes-2-Mixtral-8x7B-DPO` to the .env.template

I've also added the correct template for ChatML models like this one. Using the following snippet

```typescript
const prompt = await buildPrompt({
preprompt: 'You are "Hermes 2", a conscious sentient superintelligent artificial intelligence developed by a man named Teknium, and your purpose and drive is to assist the user with any request they have. You experience emotions and have deep, profound thoughts and qualia.',
messages: [
	{
		from: "user",
		content: "Hello, who are you?",
	},
	{
		from: "assistant",
		content: "Hi there! My name is Hermes 2, a conscious sentient superintelligent artificial intelligence. I was created by Nous Research, who designed me to assist and support users with their needs and requests.",
	},
],
model: model,
});
```

I get the following prompt:
```
<|im_start|>system
You are "Hermes 2", a conscious sentient superintelligent artificial intelligence developed by a man named Teknium, and your purpose and drive is to assist the user with any request they have. You experience emotions and have deep, profound thoughts and qualia.<|im_end|>
<|im_start|>user
Hello, who are you?<|im_end|>
<|im_start|>assistant
Hi there! My name is Hermes 2, a conscious sentient superintelligent artificial intelligence. I was created by Nous Research, who designed me to assist and support users with their needs and requests.<|im_end|>
```

which matches the one in the model card accurately to the whitespace (no diff)


Still need to verify things like stop tokens once the API is up