### PR TITLE
[Small model] Explicitly close AsyncGenerator

### DIFF
--- a/src/lib/server/generateFromDefaultEndpoint.ts
+++ b/src/lib/server/generateFromDefaultEndpoint.ts
@@ -21,6 +21,7 @@ export async function generateFromDefaultEndpoint({
 					generated_text = generated_text.slice(0, -stop.length).trimEnd();
 				}
 			}
+			tokenStream.return();
 			return generated_text;
 		}
 	}


### PR DESCRIPTION
Explicitly close AsyncGenerator when using small model (for generating webquery or sumarization purposes). I couldn't replicate the #691. By explicitly closing the connection of a small model, this might fix #691 if the issue was rooted in some kind of rate limiting around outgoing network requests from Spaces to TGI/inference endpoint