### PR TITLE
Fix social thumbnails: images

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
 				"satori": "^0.10.11",
 				"satori-html": "^0.3.2",
 				"serpapi": "^1.1.1",
+				"sharp": "^0.33.2",
 				"tailwind-scrollbar": "^3.0.0",
 				"tailwindcss": "^3.4.0",
 				"zod": "^3.22.3"
@@ -134,6 +135,15 @@
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.0.3",
 				"@jridgewell/sourcemap-codec": "^1.4.10"
+			}
+		},
+		"node_modules/@emnapi/runtime": {
+			"version": "0.45.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-0.45.0.tgz",
+			"integrity": "sha512-Txumi3td7J4A/xTTwlssKieHKTGl3j4A1tglBx72auZ49YK7ePY6XZricgIg9mnZT4xPfA+UPCUdnhRuEFDL+w==",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
 			}
 		},
 		"node_modules/@esbuild/android-arm": {
@@ -647,6 +657,437 @@
 				"debug": "^4.3.4",
 				"kolorist": "^1.7.0",
 				"local-pkg": "^0.4.3"
+			}
+		},
+		"node_modules/@img/sharp-darwin-arm64": {
+			"version": "0.33.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.2.tgz",
+			"integrity": "sha512-itHBs1rPmsmGF9p4qRe++CzCgd+kFYktnsoR1sbIAfsRMrJZau0Tt1AH9KVnufc2/tU02Gf6Ibujx+15qRE03w==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"glibc": ">=2.26",
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+				"npm": ">=9.6.5",
+				"pnpm": ">=7.1.0",
+				"yarn": ">=3.2.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-darwin-arm64": "1.0.1"
+			}
+		},
+		"node_modules/@img/sharp-darwin-x64": {
+			"version": "0.33.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.2.tgz",
+			"integrity": "sha512-/rK/69Rrp9x5kaWBjVN07KixZanRr+W1OiyKdXcbjQD6KbW+obaTeBBtLUAtbBsnlTTmWthw99xqoOS7SsySDg==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"glibc": ">=2.26",
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+				"npm": ">=9.6.5",
+				"pnpm": ">=7.1.0",
+				"yarn": ">=3.2.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-darwin-x64": "1.0.1"
+			}
+		},
+		"node_modules/@img/sharp-libvips-darwin-arm64": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.1.tgz",
+			"integrity": "sha512-kQyrSNd6lmBV7O0BUiyu/OEw9yeNGFbQhbxswS1i6rMDwBBSX+e+rPzu3S+MwAiGU3HdLze3PanQ4Xkfemgzcw==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"macos": ">=11",
+				"npm": ">=9.6.5",
+				"pnpm": ">=7.1.0",
+				"yarn": ">=3.2.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-darwin-x64": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.1.tgz",
+			"integrity": "sha512-eVU/JYLPVjhhrd8Tk6gosl5pVlvsqiFlt50wotCvdkFGf+mDNBJxMh+bvav+Wt3EBnNZWq8Sp2I7XfSjm8siog==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"macos": ">=10.13",
+				"npm": ">=9.6.5",
+				"pnpm": ">=7.1.0",
+				"yarn": ">=3.2.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linux-arm": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.1.tgz",
+			"integrity": "sha512-FtdMvR4R99FTsD53IA3LxYGghQ82t3yt0ZQ93WMZ2xV3dqrb0E8zq4VHaTOuLEAuA83oDawHV3fd+BsAPadHIQ==",
+			"cpu": [
+				"arm"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"glibc": ">=2.28",
+				"npm": ">=9.6.5",
+				"pnpm": ">=7.1.0",
+				"yarn": ">=3.2.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linux-arm64": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.1.tgz",
+			"integrity": "sha512-bnGG+MJjdX70mAQcSLxgeJco11G+MxTz+ebxlz8Y3dxyeb3Nkl7LgLI0mXupoO+u1wRNx/iRj5yHtzA4sde1yA==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"glibc": ">=2.26",
+				"npm": ">=9.6.5",
+				"pnpm": ">=7.1.0",
+				"yarn": ">=3.2.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linux-s390x": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.1.tgz",
+			"integrity": "sha512-3+rzfAR1YpMOeA2zZNp+aYEzGNWK4zF3+sdMxuCS3ey9HhDbJ66w6hDSHDMoap32DueFwhhs3vwooAB2MaK4XQ==",
+			"cpu": [
+				"s390x"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"glibc": ">=2.28",
+				"npm": ">=9.6.5",
+				"pnpm": ">=7.1.0",
+				"yarn": ">=3.2.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linux-x64": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.1.tgz",
+			"integrity": "sha512-3NR1mxFsaSgMMzz1bAnnKbSAI+lHXVTqAHgc1bgzjHuXjo4hlscpUxc0vFSAPKI3yuzdzcZOkq7nDPrP2F8Jgw==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"glibc": ">=2.26",
+				"npm": ">=9.6.5",
+				"pnpm": ">=7.1.0",
+				"yarn": ">=3.2.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.1.tgz",
+			"integrity": "sha512-5aBRcjHDG/T6jwC3Edl3lP8nl9U2Yo8+oTl5drd1dh9Z1EBfzUKAJFUDTDisDjUwc7N4AjnPGfCA3jl3hY8uDg==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"musl": ">=1.2.2",
+				"npm": ">=9.6.5",
+				"pnpm": ">=7.1.0",
+				"yarn": ">=3.2.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linuxmusl-x64": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.1.tgz",
+			"integrity": "sha512-dcT7inI9DBFK6ovfeWRe3hG30h51cBAP5JXlZfx6pzc/Mnf9HFCQDLtYf4MCBjxaaTfjCCjkBxcy3XzOAo5txw==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"musl": ">=1.2.2",
+				"npm": ">=9.6.5",
+				"pnpm": ">=7.1.0",
+				"yarn": ">=3.2.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-linux-arm": {
+			"version": "0.33.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.2.tgz",
+			"integrity": "sha512-Fndk/4Zq3vAc4G/qyfXASbS3HBZbKrlnKZLEJzPLrXoJuipFNNwTes71+Ki1hwYW5lch26niRYoZFAtZVf3EGA==",
+			"cpu": [
+				"arm"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"glibc": ">=2.28",
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+				"npm": ">=9.6.5",
+				"pnpm": ">=7.1.0",
+				"yarn": ">=3.2.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linux-arm": "1.0.1"
+			}
+		},
+		"node_modules/@img/sharp-linux-arm64": {
+			"version": "0.33.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.2.tgz",
+			"integrity": "sha512-pz0NNo882vVfqJ0yNInuG9YH71smP4gRSdeL09ukC2YLE6ZyZePAlWKEHgAzJGTiOh8Qkaov6mMIMlEhmLdKew==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"glibc": ">=2.26",
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+				"npm": ">=9.6.5",
+				"pnpm": ">=7.1.0",
+				"yarn": ">=3.2.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linux-arm64": "1.0.1"
+			}
+		},
+		"node_modules/@img/sharp-linux-s390x": {
+			"version": "0.33.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.2.tgz",
+			"integrity": "sha512-MBoInDXDppMfhSzbMmOQtGfloVAflS2rP1qPcUIiITMi36Mm5YR7r0ASND99razjQUpHTzjrU1flO76hKvP5RA==",
+			"cpu": [
+				"s390x"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"glibc": ">=2.28",
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+				"npm": ">=9.6.5",
+				"pnpm": ">=7.1.0",
+				"yarn": ">=3.2.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linux-s390x": "1.0.1"
+			}
+		},
+		"node_modules/@img/sharp-linux-x64": {
+			"version": "0.33.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.2.tgz",
+			"integrity": "sha512-xUT82H5IbXewKkeF5aiooajoO1tQV4PnKfS/OZtb5DDdxS/FCI/uXTVZ35GQ97RZXsycojz/AJ0asoz6p2/H/A==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"glibc": ">=2.26",
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+				"npm": ">=9.6.5",
+				"pnpm": ">=7.1.0",
+				"yarn": ">=3.2.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linux-x64": "1.0.1"
+			}
+		},
+		"node_modules/@img/sharp-linuxmusl-arm64": {
+			"version": "0.33.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.2.tgz",
+			"integrity": "sha512-F+0z8JCu/UnMzg8IYW1TMeiViIWBVg7IWP6nE0p5S5EPQxlLd76c8jYemG21X99UzFwgkRo5yz2DS+zbrnxZeA==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"musl": ">=1.2.2",
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+				"npm": ">=9.6.5",
+				"pnpm": ">=7.1.0",
+				"yarn": ">=3.2.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linuxmusl-arm64": "1.0.1"
+			}
+		},
+		"node_modules/@img/sharp-linuxmusl-x64": {
+			"version": "0.33.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.2.tgz",
+			"integrity": "sha512-+ZLE3SQmSL+Fn1gmSaM8uFusW5Y3J9VOf+wMGNnTtJUMUxFhv+P4UPaYEYT8tqnyYVaOVGgMN/zsOxn9pSsO2A==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"musl": ">=1.2.2",
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+				"npm": ">=9.6.5",
+				"pnpm": ">=7.1.0",
+				"yarn": ">=3.2.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linuxmusl-x64": "1.0.1"
+			}
+		},
+		"node_modules/@img/sharp-wasm32": {
+			"version": "0.33.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.2.tgz",
+			"integrity": "sha512-fLbTaESVKuQcpm8ffgBD7jLb/CQLcATju/jxtTXR1XCLwbOQt+OL5zPHSDMmp2JZIeq82e18yE0Vv7zh6+6BfQ==",
+			"cpu": [
+				"wasm32"
+			],
+			"optional": true,
+			"dependencies": {
+				"@emnapi/runtime": "^0.45.0"
+			},
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+				"npm": ">=9.6.5",
+				"pnpm": ">=7.1.0",
+				"yarn": ">=3.2.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-win32-ia32": {
+			"version": "0.33.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.2.tgz",
+			"integrity": "sha512-okBpql96hIGuZ4lN3+nsAjGeggxKm7hIRu9zyec0lnfB8E7Z6p95BuRZzDDXZOl2e8UmR4RhYt631i7mfmKU8g==",
+			"cpu": [
+				"ia32"
+			],
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+				"npm": ">=9.6.5",
+				"pnpm": ">=7.1.0",
+				"yarn": ">=3.2.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-win32-x64": {
+			"version": "0.33.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.2.tgz",
+			"integrity": "sha512-E4magOks77DK47FwHUIGH0RYWSgRBfGdK56kIHSVeB9uIS4pPFr4N2kIVsXdQQo4LzOsENKV5KAhRlRL7eMAdg==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+				"npm": ">=9.6.5",
+				"pnpm": ">=7.1.0",
+				"yarn": ">=3.2.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
 			}
 		},
 		"node_modules/@jridgewell/gen-mapping": {
@@ -1715,6 +2156,28 @@
 			},
 			"optionalDependencies": {
 				"onnxruntime-node": "1.14.0"
+			}
+		},
+		"node_modules/@xenova/transformers/node_modules/sharp": {
+			"version": "0.32.6",
+			"resolved": "https://registry.npmjs.org/sharp/-/sharp-0.32.6.tgz",
+			"integrity": "sha512-KyLTWwgcR9Oe4d9HwCwNM2l7+J0dUQwn/yf7S0EnTtb0eVS4RxO0eUSvxPtzT4F3SY+C4K6fqdv/DO27sJ/v/w==",
+			"hasInstallScript": true,
+			"dependencies": {
+				"color": "^4.2.3",
+				"detect-libc": "^2.0.2",
+				"node-addon-api": "^6.1.0",
+				"prebuild-install": "^7.1.1",
+				"semver": "^7.5.4",
+				"simple-get": "^4.0.1",
+				"tar-fs": "^3.0.4",
+				"tunnel-agent": "^0.6.0"
+			},
+			"engines": {
+				"node": ">=14.15.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
 			}
 		},
 		"node_modules/abab": {
@@ -4392,9 +4855,9 @@
 			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
 		},
 		"node_modules/node-abi": {
-			"version": "3.47.0",
-			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.47.0.tgz",
-			"integrity": "sha512-2s6B2CWZM//kPgwnuI0KrYwNjfdByE25zvAaEpq9IH4zcNsarH8Ihu/UuX6XMPEogDAxkuUFeZn60pXNHAqn3A==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.54.0.tgz",
+			"integrity": "sha512-p7eGEiQil0YUV3ItH4/tBb781L5impVmmx2E9FRKF7d18XXzp4PGT2tdYMFY6wQqgxD0IwNZOiSJ0/K0fSi/OA==",
 			"dependencies": {
 				"semver": "^7.3.5"
 			},
@@ -5671,25 +6134,42 @@
 			"dev": true
 		},
 		"node_modules/sharp": {
-			"version": "0.32.6",
-			"resolved": "https://registry.npmjs.org/sharp/-/sharp-0.32.6.tgz",
-			"integrity": "sha512-KyLTWwgcR9Oe4d9HwCwNM2l7+J0dUQwn/yf7S0EnTtb0eVS4RxO0eUSvxPtzT4F3SY+C4K6fqdv/DO27sJ/v/w==",
+			"version": "0.33.2",
+			"resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.2.tgz",
+			"integrity": "sha512-WlYOPyyPDiiM07j/UO+E720ju6gtNtHjEGg5vovUk1Lgxyjm2LFO+37Nt/UI3MMh2l6hxTWQWi7qk3cXJTutcQ==",
 			"hasInstallScript": true,
 			"dependencies": {
 				"color": "^4.2.3",
 				"detect-libc": "^2.0.2",
-				"node-addon-api": "^6.1.0",
-				"prebuild-install": "^7.1.1",
-				"semver": "^7.5.4",
-				"simple-get": "^4.0.1",
-				"tar-fs": "^3.0.4",
-				"tunnel-agent": "^0.6.0"
+				"semver": "^7.5.4"
 			},
 			"engines": {
-				"node": ">=14.15.0"
+				"libvips": ">=8.15.1",
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-darwin-arm64": "0.33.2",
+				"@img/sharp-darwin-x64": "0.33.2",
+				"@img/sharp-libvips-darwin-arm64": "1.0.1",
+				"@img/sharp-libvips-darwin-x64": "1.0.1",
+				"@img/sharp-libvips-linux-arm": "1.0.1",
+				"@img/sharp-libvips-linux-arm64": "1.0.1",
+				"@img/sharp-libvips-linux-s390x": "1.0.1",
+				"@img/sharp-libvips-linux-x64": "1.0.1",
+				"@img/sharp-libvips-linuxmusl-arm64": "1.0.1",
+				"@img/sharp-libvips-linuxmusl-x64": "1.0.1",
+				"@img/sharp-linux-arm": "0.33.2",
+				"@img/sharp-linux-arm64": "0.33.2",
+				"@img/sharp-linux-s390x": "0.33.2",
+				"@img/sharp-linux-x64": "0.33.2",
+				"@img/sharp-linuxmusl-arm64": "0.33.2",
+				"@img/sharp-linuxmusl-x64": "0.33.2",
+				"@img/sharp-wasm32": "0.33.2",
+				"@img/sharp-win32-ia32": "0.33.2",
+				"@img/sharp-win32-x64": "0.33.2"
 			}
 		},
 		"node_modules/shebang-command": {
@@ -5878,9 +6358,9 @@
 			"dev": true
 		},
 		"node_modules/streamx": {
-			"version": "2.15.1",
-			"resolved": "https://registry.npmjs.org/streamx/-/streamx-2.15.1.tgz",
-			"integrity": "sha512-fQMzy2O/Q47rgwErk/eGeLu/roaFWV0jVsogDmrszM9uIw8L5OA+t+V93MgYlufNptfjmYR1tOMWhei/Eh7TQA==",
+			"version": "2.15.6",
+			"resolved": "https://registry.npmjs.org/streamx/-/streamx-2.15.6.tgz",
+			"integrity": "sha512-q+vQL4AAz+FdfT137VF69Cc/APqUbxy+MDOImRrMvchJpigHj9GksgDU2LYbO9rx7RX6osWgxJB2WxhYv4SZAw==",
 			"dependencies": {
 				"fast-fifo": "^1.1.0",
 				"queue-tick": "^1.0.1"
@@ -6334,9 +6814,9 @@
 			}
 		},
 		"node_modules/tar-stream": {
-			"version": "3.1.6",
-			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.6.tgz",
-			"integrity": "sha512-B/UyjYwPpMBv+PaFSWAmtYjwdrlEaZQEhMIBFNC5oEG8lpiW8XjcSdmEaClj28ArfKScKHs2nshz3k2le6crsg==",
+			"version": "3.1.7",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+			"integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
 			"dependencies": {
 				"b4a": "^1.6.4",
 				"fast-fifo": "^1.2.0",
@@ -6544,7 +7024,7 @@
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
 			"integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
-			"dev": true
+			"devOptional": true
 		},
 		"node_modules/tunnel-agent": {
 			"version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
 		"satori": "^0.10.11",
 		"satori-html": "^0.3.2",
 		"serpapi": "^1.1.1",
+		"sharp": "^0.33.2",
 		"tailwind-scrollbar": "^3.0.0",
 		"tailwindcss": "^3.4.0",
 		"zod": "^3.22.3"

--- a/src/routes/assistant/[assistantId]/thumbnail.png/ChatThumbnail.svelte
+++ b/src/routes/assistant/[assistantId]/thumbnail.png/ChatThumbnail.svelte
@@ -1,24 +1,23 @@
 <script lang="ts">
-	import { base } from "$app/paths";
-	import { PUBLIC_APP_ASSETS } from "$env/static/public";
-
-	export let href: string = "";
 	export let name: string;
 	export let description: string = "";
 	export let createdByName: string | undefined;
-	export let avatarUrl: string | undefined;
+	export let avatar: string | undefined;
 
-	const imgUrl = `${href}${base}/${PUBLIC_APP_ASSETS}/logo.svg`;
+	import logo from "../../../../../static/huggingchat/logo.svg?raw";
 </script>
 
 <div class="flex h-full w-full flex-col items-center justify-center bg-black p-2">
 	<div class="flex w-full max-w-[540px] items-start justify-center text-white">
-		{#if avatarUrl}
-			<img class="h-64 w-64 rounded-full" src={avatarUrl} alt="avatar" />
+		{#if avatar}
+			<img class="h-64 w-64 rounded-full" src={avatar} alt="avatar" />
 		{/if}
 		<div class="ml-10 flex flex-col items-start">
 			<p class="mb-2 mt-0 text-3xl font-normal text-gray-400">
-				<img class="mr-1.5 h-8 w-8" src={imgUrl} alt="app logo" />
+				<span class="mr-1.5 h-8 w-8">
+					<!-- eslint-disable-next-line -->
+					{@html logo}
+				</span>
 				AI assistant
 			</p>
 			<h1 class="m-0 {name.length < 38 ? 'text-5xl' : 'text-4xl'} font-black">


### PR DESCRIPTION
Turns out satori is really slow at rendering PNG, so converting images server-side to JPEG reduces the render time drastically.

We also import the logo directly as an SVG. 

This requires a new dependency, `sharp` for converting images but it works great, pretty happy with it.