### PR TITLE
Feature/multi rag

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,7 @@
 	"editor.formatOnSave": true,
 	"editor.defaultFormatter": "esbenp.prettier-vscode",
 	"editor.codeActionsOnSave": {
-		"source.fixAll": true
+		"source.fixAll": "explicit"
 	},
 	"eslint.validate": ["javascript", "svelte"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,7 @@
 	"editor.formatOnSave": true,
 	"editor.defaultFormatter": "esbenp.prettier-vscode",
 	"editor.codeActionsOnSave": {
-		"source.fixAll": "explicit"
+		"source.fixAll": true
 	},
 	"eslint.validate": ["javascript", "svelte"]
 }

--- a/src/lib/buildPrompt.ts
+++ b/src/lib/buildPrompt.ts
@@ -13,7 +13,11 @@ interface buildPromptOptions {
 	id?: Conversation["_id"];
 	model: BackendModel;
 	locals?: App.Locals;
-	ragContext?: RagContext;
+	ragContexts?: {
+		webSearch?: RagContextWebSearch;
+		pdfChat?: RagContext;
+		// Add more context types as needed
+	};
 	preprompt?: string;
 	files?: File[];
 }
@@ -21,14 +25,24 @@ interface buildPromptOptions {
 export async function buildPrompt({
 	messages,
 	model,
-	ragContext,
+	ragContexts,
 	preprompt,
 	id,
 }: buildPromptOptions): Promise<string> {
-	if (ragContext) {
-		const { type: ragType } = ragContext;
-		messages = RAGs[ragType].buildPrompt(messages, ragContext as RagContextWebSearch);
+	if (ragContexts) {
+		for (const [ragKey, ragContext] of Object.entries(ragContexts)) {
+			if (ragKey == "webSearch" && ragContext) {
+				messages = RAGs.webSearch.buildPrompt(messages, ragContext as RagContextWebSearch);
+			}
+			if (ragKey == "pdfChat" && ragContext) {
+				messages = RAGs.pdfChat.buildPrompt(messages, ragContext as RagContext);
+			}
+		}
 	}
+	// if (ragContext) {
+	// 	const { type: ragType } = ragContext;
+	// 	messages = RAGs[ragType].buildPrompt(messages, ragContext as RagContextWebSearch);
+	// }
 
 	// section to handle potential files input
 	if (model.multimodal) {

--- a/src/lib/buildPrompt.ts
+++ b/src/lib/buildPrompt.ts
@@ -39,10 +39,6 @@ export async function buildPrompt({
 			}
 		}
 	}
-	// if (ragContext) {
-	// 	const { type: ragType } = ragContext;
-	// 	messages = RAGs[ragType].buildPrompt(messages, ragContext as RagContextWebSearch);
-	// }
 
 	// section to handle potential files input
 	if (model.multimodal) {

--- a/src/lib/server/endpoints/aws/endpointAws.ts
+++ b/src/lib/server/endpoints/aws/endpointAws.ts
@@ -39,7 +39,7 @@ export async function endpointAws(
 	return async ({ conversation }) => {
 		const prompt = await buildPrompt({
 			messages: conversation.messages,
-			ragContext: conversation.messages[conversation.messages.length - 1].ragContext,
+			ragContexts: conversation.messages[conversation.messages.length - 1].ragContexts,
 			preprompt: conversation.preprompt,
 			model,
 		});

--- a/src/lib/server/endpoints/llamacpp/endpointLlamacpp.ts
+++ b/src/lib/server/endpoints/llamacpp/endpointLlamacpp.ts
@@ -22,7 +22,7 @@ export function endpointLlamacpp(
 	return async ({ conversation }) => {
 		const prompt = await buildPrompt({
 			messages: conversation.messages,
-			ragContext: conversation.messages[conversation.messages.length - 1].ragContext,
+			ragContexts: conversation.messages[conversation.messages.length - 1].ragContexts,
 			preprompt: conversation.preprompt,
 			model,
 		});

--- a/src/lib/server/endpoints/ollama/endpointOllama.ts
+++ b/src/lib/server/endpoints/ollama/endpointOllama.ts
@@ -17,7 +17,7 @@ export function endpointOllama(input: z.input<typeof endpointOllamaParametersSch
 	return async ({ conversation }) => {
 		const prompt = await buildPrompt({
 			messages: conversation.messages,
-			ragContext: conversation.messages[conversation.messages.length - 1].ragContext,
+			ragContexts: conversation.messages[conversation.messages.length - 1].ragContexts,
 			preprompt: conversation.preprompt,
 			model,
 		});

--- a/src/lib/server/endpoints/openai/endpointOai.ts
+++ b/src/lib/server/endpoints/openai/endpointOai.ts
@@ -59,7 +59,7 @@ export async function endpointOai(
 			let messages = conversation.messages;
 			const ragContext = conversation.messages[conversation.messages.length - 1].ragContexts;
 
-			if (ragContext && ragContext.type === "webSearch") {
+			if (ragContext && ragContext.webSearch) {
 				const webSearchContext = ragContext as RagContextWebSearch;
 				const lastMsg = messages.slice(-1)[0];
 				const messagesWithoutLastUsrMsg = messages.slice(0, -1);

--- a/src/lib/server/endpoints/openai/endpointOai.ts
+++ b/src/lib/server/endpoints/openai/endpointOai.ts
@@ -41,7 +41,7 @@ export async function endpointOai(
 					model: model.id ?? model.name,
 					prompt: await buildPrompt({
 						messages: conversation.messages,
-						ragContext: conversation.messages[conversation.messages.length - 1].ragContext,
+						ragContexts: conversation.messages[conversation.messages.length - 1].ragContexts,
 						preprompt: conversation.preprompt,
 						model,
 					}),
@@ -57,7 +57,7 @@ export async function endpointOai(
 	} else if (completion === "chat_completions") {
 		return async ({ conversation }) => {
 			let messages = conversation.messages;
-			const ragContext = conversation.messages[conversation.messages.length - 1].ragContext;
+			const ragContext = conversation.messages[conversation.messages.length - 1].ragContexts;
 
 			if (ragContext && ragContext.type === "webSearch") {
 				const webSearchContext = ragContext as RagContextWebSearch;

--- a/src/lib/server/endpoints/tgi/endpointTgi.ts
+++ b/src/lib/server/endpoints/tgi/endpointTgi.ts
@@ -18,7 +18,7 @@ export function endpointTgi(input: z.input<typeof endpointTgiParametersSchema>):
 	return async ({ conversation }) => {
 		const prompt = await buildPrompt({
 			messages: conversation.messages,
-			ragContext: conversation.messages[conversation.messages.length - 1].ragContext,
+			ragContexts: conversation.messages[conversation.messages.length - 1].ragContexts,
 			preprompt: conversation.preprompt,
 			model,
 			id: conversation._id,

--- a/src/lib/server/rag/rag.ts
+++ b/src/lib/server/rag/rag.ts
@@ -24,13 +24,8 @@ export interface RAG<T extends RagContext = RagContext> {
 }
 
 type RAGUnion = RAG<RagContext> | RAG<RagContextWebSearch>;
-
-// list of all rags
-export const RAGs: {
-	[Key in RAGType]: RAGUnion;
-} = {
-	webSearch: ragWebsearch,
-	pdfChat: ragPdfchat,
-};
-
+namespace RAGs {
+	export const webSearch = ragWebsearch;
+	export const pdfChat = ragPdfchat;
+}
 export default RAGs;

--- a/src/lib/server/rag/rag.ts
+++ b/src/lib/server/rag/rag.ts
@@ -28,4 +28,5 @@ namespace RAGs {
 	export const webSearch = ragWebsearch;
 	export const pdfChat = ragPdfchat;
 }
+
 export default RAGs;

--- a/src/lib/types/Message.ts
+++ b/src/lib/types/Message.ts
@@ -9,7 +9,10 @@ export type Message = Partial<Timestamps> & {
 	content: string;
 	updates?: MessageUpdate[];
 	webSearchId?: RagContextWebSearch["_id"]; // legacy version
-	ragContext?: RagContext;
+	ragContexts?: {
+		webSearch?: RagContextWebSearch;
+		pdfChat?: RagContext;
+	};
 	score?: -1 | 0 | 1;
 	files?: string[]; // can contain either the hash of the file or the b64 encoded image data on the client side when uploading
 };


### PR DESCRIPTION
## Extend RAG Contexts to Support PDF and WebSearch Simultaneously

Enhanced the RAG context to support both PDF and web search in parallel. Here are the main changes made:

1. **Refactor `buildPrompt` function:** Refactored the `buildPrompt` function and its implementations to support multiple RAG contexts. Specifically adjusted for web search and PDF chat. Accommodates more than one RAG context.

2. **Update conversation endpoints:** Updated the conversation endpoints in the `server` to match the refactored `buildPrompt` function, replacing `ragContext` with `ragContexts`. This ensures that the conversation can handle these two types of contexts.

3. **Update `rag.ts`:** Updated `rag.ts` to export webSearch and pdfChat separately from the `RAGs` namespace. This makes their usage in the code more explicit.

4. **Alter `Message` type:** Altered the `Message` type to include `ragContexts` which will hold the `webSearch` and `pdfChat` contexts.

5. **Adapt POST method:** Adapted the POST method in `routes/conversation/[id]/+server.ts` to make use of the new `ragContexts`. Consequently, whichever context is retrieved, it is set in the relevant field of the last message in the conversation.
