### PR TITLE
Add CodeLlama-70b-Instruct-hf

### DIFF
--- a/.env
+++ b/.env
@@ -99,9 +99,9 @@ PUBLIC_SHARE_PREFIX=#https://hf.co/chat
 PUBLIC_GOOGLE_ANALYTICS_ID=#G-XXXXXXXX / Leave empty to disable
 PUBLIC_ANNOUNCEMENT_BANNERS=`[
     {
-    "title": "Llama v2 is live on HuggingChat! 🦙",
+    "title": "Code Llama 70B is live on HuggingChat! 🦙💻",
     "linkTitle": "Announcement",
-    "linkHref": "https://huggingface.co/blog/llama2"
+    "linkHref": "https://ai.meta.com/blog/code-llama-large-language-model-coding/"
   }
 ]`
 

--- a/.env
+++ b/.env
@@ -99,7 +99,7 @@ PUBLIC_SHARE_PREFIX=#https://hf.co/chat
 PUBLIC_GOOGLE_ANALYTICS_ID=#G-XXXXXXXX / Leave empty to disable
 PUBLIC_ANNOUNCEMENT_BANNERS=`[
     {
-    "title": "Code Llama 70B is live on HuggingChat! 🦙💻",
+    "title": "Code Llama 70B is live! 🦙",
     "linkTitle": "Announcement",
     "linkHref": "https://ai.meta.com/blog/code-llama-large-language-model-coding/"
   }

--- a/.env.template
+++ b/.env.template
@@ -89,16 +89,16 @@ MODELS=`[
       }
     },
     {
-      "name": "codellama/CodeLlama-34b-Instruct-hf",
-      "displayName": "codellama/CodeLlama-34b-Instruct-hf",
-      "description": "Code Llama, a state of the art code model from Meta.",
+      "name": "codellama/CodeLlama-70b-Instruct-hf",
+      "displayName": "codellama/CodeLlama-70b-Instruct-hf",
+      "description": "Code Llama, a state of the art code model from Meta. Now in 70B!",
       "websiteUrl": "https://about.fb.com/news/2023/08/code-llama-ai-for-coding/",
       "userMessageToken": "",
       "userMessageEndToken": " [/INST] ",
       "assistantMessageToken": "",
       "assistantMessageEndToken": " </s><s>[INST] ",
       "preprompt": " ",
-      "chatPromptTemplate" : "<s>[INST] <<SYS>>\n{{preprompt}}\n<</SYS>>\n\n{{#each messages}}{{#ifUser}}{{content}} [/INST] {{/ifUser}}{{#ifAssistant}}{{content}} </s><s>[INST] {{/ifAssistant}}{{/each}}",
+      "chatPromptTemplate" : "<s>{{#if @root.preprompt}}\nSource: system\n\n {{@root.preprompt}} <step> {{/if}}{{#each messages}}{{#ifUser}}\nSource: user\n\n {{content}} <step> {{/ifUser}}{{#ifAssistant}}\nSource: assistant\n\n {{content}} <step> {{/ifAssistant}}{{/each}}\n\n Source: assistant\nDestination: user",
       "promptExamples": [
         {
           "title": "Fibonacci in Python",
@@ -118,7 +118,7 @@ MODELS=`[
         "top_k": 50,
         "truncate": 4096,
         "max_new_tokens": 4096,
-        "stop": [" </s><s>[INST] "]
+        "stop": ["<step>", "Source:", " <step>"]
       }
       },
     {
@@ -217,7 +217,8 @@ OLD_MODELS=`[
   {"name":"HuggingFaceH4/zephyr-7b-alpha"},
   {"name":"openchat/openchat_3.5"},
   {"name":"openchat/openchat-3.5-1210"},
-  {"name": "tiiuae/falcon-180B-chat"}
+  {"name": "tiiuae/falcon-180B-chat"},
+  {"name": "codellama/CodeLlama-34b-Instruct-hf"}
 ]`
 
 TASK_MODEL='mistralai/Mistral-7B-Instruct-v0.1'

--- a/.env.template
+++ b/.env.template
@@ -98,7 +98,7 @@ MODELS=`[
       "assistantMessageToken": "",
       "assistantMessageEndToken": " </s><s>[INST] ",
       "preprompt": " ",
-      "chatPromptTemplate" : "<s>{{#if @root.preprompt}}\nSource: system\n\n {{@root.preprompt}} <step> {{/if}}{{#each messages}}{{#ifUser}}Source: user\n\n {{content}} <step> {{/ifUser}}{{#ifAssistant}}Source: assistant\n\n {{content}} <step> {{/ifAssistant}}{{/each}}\n\n Source: assistant\nDestination: user\n\n",
+      "chatPromptTemplate" : "<s>{{#if @root.preprompt}}Source: system\n\n {{@root.preprompt}} <step> {{/if}}{{#each messages}}{{#ifUser}}Source: user\n\n {{content}} <step> {{/ifUser}}{{#ifAssistant}}Source: assistant\n\n {{content}} <step> {{/ifAssistant}}{{/each}}\n\n Source: assistant\nDestination: user\n\n",
       "promptExamples": [
         {
           "title": "Fibonacci in Python",

--- a/.env.template
+++ b/.env.template
@@ -98,7 +98,7 @@ MODELS=`[
       "assistantMessageToken": "",
       "assistantMessageEndToken": " </s><s>[INST] ",
       "preprompt": "",
-      "chatPromptTemplate" : "<s>{{#if @root.preprompt}}Source: system\n\n {{@root.preprompt}} <step> {{/if}}{{#each messages}}{{#ifUser}}Source: user\n\n {{content}} <step> {{/ifUser}}{{#ifAssistant}}Source: assistant\n\n {{content}} <step> {{/ifAssistant}}{{/each}}\n\n Source: assistant\nDestination: user\n\n",
+      "chatPromptTemplate" : "<s>{{#if @root.preprompt}}Source: system\n\n {{@root.preprompt}} <step> {{/if}}{{#each messages}}{{#ifUser}}Source: user\n\n {{content}} <step> {{/ifUser}}{{#ifAssistant}}Source: assistant\n\n {{content}} <step> {{/ifAssistant}}{{/each}}Source: assistant\nDestination: user\n\n ",
       "promptExamples": [
         {
           "title": "Fibonacci in Python",

--- a/.env.template
+++ b/.env.template
@@ -92,11 +92,7 @@ MODELS=`[
       "name": "codellama/CodeLlama-70b-Instruct-hf",
       "displayName": "codellama/CodeLlama-70b-Instruct-hf",
       "description": "Code Llama, a state of the art code model from Meta. Now in 70B!",
-      "websiteUrl": "https://about.fb.com/news/2023/08/code-llama-ai-for-coding/",
-      "userMessageToken": "",
-      "userMessageEndToken": " [/INST] ",
-      "assistantMessageToken": "",
-      "assistantMessageEndToken": " </s><s>[INST] ",
+      "websiteUrl": "https://ai.meta.com/blog/code-llama-large-language-model-coding/",
       "preprompt": "",
       "chatPromptTemplate" : "<s>{{#if @root.preprompt}}Source: system\n\n {{@root.preprompt}} <step> {{/if}}{{#each messages}}{{#ifUser}}Source: user\n\n {{content}} <step> {{/ifUser}}{{#ifAssistant}}Source: assistant\n\n {{content}} <step> {{/ifAssistant}}{{/each}}Source: assistant\nDestination: user\n\n ",
       "promptExamples": [

--- a/.env.template
+++ b/.env.template
@@ -118,7 +118,7 @@ MODELS=`[
         "top_k": 50,
         "truncate": 4096,
         "max_new_tokens": 4096,
-        "stop": ["<step>", " <step>"],
+        "stop": ["<step>", " <step>", " <step> "],
       }
       },
     {

--- a/.env.template
+++ b/.env.template
@@ -98,7 +98,7 @@ MODELS=`[
       "assistantMessageToken": "",
       "assistantMessageEndToken": " </s><s>[INST] ",
       "preprompt": " ",
-      "chatPromptTemplate" : "<s>{{#if @root.preprompt}}\nSource: system\n\n {{@root.preprompt}} <step> {{/if}}{{#each messages}}{{#ifUser}}Source: user\n\n {{content}} <step> {{/ifUser}}{{#ifAssistant}}Source: assistant\n\n {{content}} <step> {{/ifAssistant}}{{/each}}\n\n Source: assistant\nDestination: user\n\n ",
+      "chatPromptTemplate" : "<s>{{#if @root.preprompt}}\nSource: system\n\n {{@root.preprompt}} <step> {{/if}}{{#each messages}}{{#ifUser}}Source: user\n\n {{content}} <step> {{/ifUser}}{{#ifAssistant}}Source: assistant\n\n {{content}} <step> {{/ifAssistant}}{{/each}}\n\n Source: assistant\nDestination: user\n\n",
       "promptExamples": [
         {
           "title": "Fibonacci in Python",

--- a/.env.template
+++ b/.env.template
@@ -97,7 +97,7 @@ MODELS=`[
       "userMessageEndToken": " [/INST] ",
       "assistantMessageToken": "",
       "assistantMessageEndToken": " </s><s>[INST] ",
-      "preprompt": " ",
+      "preprompt": "",
       "chatPromptTemplate" : "<s>{{#if @root.preprompt}}Source: system\n\n {{@root.preprompt}} <step> {{/if}}{{#each messages}}{{#ifUser}}Source: user\n\n {{content}} <step> {{/ifUser}}{{#ifAssistant}}Source: assistant\n\n {{content}} <step> {{/ifAssistant}}{{/each}}\n\n Source: assistant\nDestination: user\n\n",
       "promptExamples": [
         {

--- a/.env.template
+++ b/.env.template
@@ -98,7 +98,7 @@ MODELS=`[
       "assistantMessageToken": "",
       "assistantMessageEndToken": " </s><s>[INST] ",
       "preprompt": " ",
-      "chatPromptTemplate" : "<s>{{#if @root.preprompt}}\nSource: system\n\n {{@root.preprompt}} <step> {{/if}}{{#each messages}}{{#ifUser}}\nSource: user\n\n {{content}} <step> {{/ifUser}}{{#ifAssistant}}\nSource: assistant\n\n {{content}} <step> {{/ifAssistant}}{{/each}}\n\n Source: assistant\nDestination: user",
+      "chatPromptTemplate" : "<s>{{#if @root.preprompt}}\nSource: system\n\n {{@root.preprompt}} <step> {{/if}}{{#each messages}}{{#ifUser}}Source: user\n\n {{content}} <step> {{/ifUser}}{{#ifAssistant}}Source: assistant\n\n {{content}} <step> {{/ifAssistant}}{{/each}}\n\n Source: assistant\nDestination: user\n\n ",
       "promptExamples": [
         {
           "title": "Fibonacci in Python",
@@ -118,7 +118,7 @@ MODELS=`[
         "top_k": 50,
         "truncate": 4096,
         "max_new_tokens": 4096,
-        "stop": ["<step>", "Source:", " <step>"]
+        "stop": ["<step>", " <step>"],
       }
       },
     {

--- a/PROMPTS.md
+++ b/PROMPTS.md
@@ -55,3 +55,9 @@ System: {{preprompt}}\nUser:{{#each messages}}{{#ifUser}}{{content}}\nFalcon:{{/
 ```env
 {{#if @root.preprompt}}<|im_start|>system\n{{@root.preprompt}}<|im_end|>\n{{/if}}{{#each messages}}{{#ifUser}}<|im_start|>user\n{{content}}<|im_end|>\n<|im_start|>assistant\n{{/ifUser}}{{#ifAssistant}}{{content}}<|im_end|>\n{{/ifAssistant}}{{/each}}
 ```
+
+## CodeLlama 70B
+
+````env
+<s>{{#if @root.preprompt}}\nSource: system\n\n {{@root.preprompt}} <step> {{/if}}{{#each messages}}{{#ifUser}}\nSource: user\n\n {{content}} <step> {{/ifUser}}{{#ifAssistant}}\nSource: assistant\n\n {{content}} <step> {{/ifAssistant}}{{/each}}\n\n Source: assistant\nDestination: user```
+````

--- a/PROMPTS.md
+++ b/PROMPTS.md
@@ -58,6 +58,6 @@ System: {{preprompt}}\nUser:{{#each messages}}{{#ifUser}}{{content}}\nFalcon:{{/
 
 ## CodeLlama 70B
 
-````env
-<s>{{#if @root.preprompt}}Source: system\n\n {{@root.preprompt}} <step> {{/if}}{{#each messages}}{{#ifUser}}Source: user\n\n {{content}} <step> {{/ifUser}}{{#ifAssistant}}Source: assistant\n\n {{content}} <step> {{/ifAssistant}}{{/each}}\n\n Source: assistant\nDestination: user\n\n```
-````
+```env
+<s>{{#if @root.preprompt}}Source: system\n\n {{@root.preprompt}} <step> {{/if}}{{#each messages}}{{#ifUser}}Source: user\n\n {{content}} <step> {{/ifUser}}{{#ifAssistant}}Source: assistant\n\n {{content}} <step> {{/ifAssistant}}{{/each}}Source: assistant\nDestination: user\n\n ``
+```

--- a/PROMPTS.md
+++ b/PROMPTS.md
@@ -58,6 +58,5 @@ System: {{preprompt}}\nUser:{{#each messages}}{{#ifUser}}{{content}}\nFalcon:{{/
 
 ## CodeLlama 70B
 
-````env
-<s>{{#if @root.preprompt}}\nSource: system\n\n {{@root.preprompt}} <step> {{/if}}{{#each messages}}{{#ifUser}}\nSource: user\n\n {{content}} <step> {{/ifUser}}{{#ifAssistant}}\nSource: assistant\n\n {{content}} <step> {{/ifAssistant}}{{/each}}\n\n Source: assistant\nDestination: user```
-````
+```env
+<s>{{#if @root.preprompt}}\nSource: system\n\n {{@root.preprompt}} <step> {{/if}}{{#each messages}}{{#ifUser}}Source: user\n\n {{content}} <step> {{/ifUser}}{{#ifAssistant}}Source: assistant\n\n {{content}} <step> {{/ifAssistant}}{{/each}}\n\n Source: assistant\nDestination: user\n\n ```

--- a/PROMPTS.md
+++ b/PROMPTS.md
@@ -58,5 +58,6 @@ System: {{preprompt}}\nUser:{{#each messages}}{{#ifUser}}{{content}}\nFalcon:{{/
 
 ## CodeLlama 70B
 
-```env
-<s>{{#if @root.preprompt}}\nSource: system\n\n {{@root.preprompt}} <step> {{/if}}{{#each messages}}{{#ifUser}}Source: user\n\n {{content}} <step> {{/ifUser}}{{#ifAssistant}}Source: assistant\n\n {{content}} <step> {{/ifAssistant}}{{/each}}\n\n Source: assistant\nDestination: user\n\n ```
+````env
+<s>{{#if @root.preprompt}}\nSource: system\n\n {{@root.preprompt}} <step> {{/if}}{{#each messages}}{{#ifUser}}Source: user\n\n {{content}} <step> {{/ifUser}}{{#ifAssistant}}Source: assistant\n\n {{content}} <step> {{/ifAssistant}}{{/each}}\n\n Source: assistant\nDestination: user\n\n```
+````

--- a/PROMPTS.md
+++ b/PROMPTS.md
@@ -59,5 +59,5 @@ System: {{preprompt}}\nUser:{{#each messages}}{{#ifUser}}{{content}}\nFalcon:{{/
 ## CodeLlama 70B
 
 ````env
-<s>{{#if @root.preprompt}}\nSource: system\n\n {{@root.preprompt}} <step> {{/if}}{{#each messages}}{{#ifUser}}Source: user\n\n {{content}} <step> {{/ifUser}}{{#ifAssistant}}Source: assistant\n\n {{content}} <step> {{/ifAssistant}}{{/each}}\n\n Source: assistant\nDestination: user\n\n```
+<s>{{#if @root.preprompt}}Source: system\n\n {{@root.preprompt}} <step> {{/if}}{{#each messages}}{{#ifUser}}Source: user\n\n {{content}} <step> {{/ifUser}}{{#ifAssistant}}Source: assistant\n\n {{content}} <step> {{/ifAssistant}}{{/each}}\n\n Source: assistant\nDestination: user\n\n```
 ````

--- a/src/routes/conversation/[id]/+server.ts
+++ b/src/routes/conversation/[id]/+server.ts
@@ -312,6 +312,7 @@ export async function POST({ request, locals, params, getClientAddress }) {
 					} else {
 						let interrupted = !output.token.special;
 						// add output.generated text to the last message
+						// strip end tokens from the output.generated_text
 						const text = (model.parameters.stop ?? []).reduce((acc: string, curr: string) => {
 							if (acc.endsWith(curr)) {
 								interrupted = false;

--- a/src/routes/conversation/[id]/+server.ts
+++ b/src/routes/conversation/[id]/+server.ts
@@ -310,13 +310,22 @@ export async function POST({ request, locals, params, getClientAddress }) {
 							}
 						}
 					} else {
+						let interrupted = !output.token.special;
 						// add output.generated text to the last message
+						const text = (model.parameters.stop ?? []).reduce((acc: string, curr: string) => {
+							if (acc.endsWith(curr)) {
+								interrupted = false;
+								return acc.slice(0, acc.length - curr.length);
+							}
+							return acc;
+						}, output.generated_text.trimEnd());
+
 						messages = [
 							...messages.slice(0, -1),
 							{
 								...messages[messages.length - 1],
-								content: previousContent + output.generated_text,
-								interrupted: !output.token.special, // if its a special token it finished on its own, else it was interrupted
+								content: previousContent + text,
+								interrupted, // if its a special token it finished on its own, else it was interrupted
 								updates,
 								updatedAt: new Date(),
 							},


### PR DESCRIPTION
This PR adds CodeLlama-70b-Instruct-hf to HuggingChat. I had to make sure we were properly stripping the end tokens, but here we go, it should work!