### PR TITLE
Add Plausible analytics

### DIFF
--- a/.env
+++ b/.env
@@ -97,7 +97,7 @@ TASK_MODEL= # name of the model used for tasks such as summarizing title, creati
 PUBLIC_ORIGIN=#https://huggingface.co
 PUBLIC_SHARE_PREFIX=#https://hf.co/chat
 PUBLIC_GOOGLE_ANALYTICS_ID=#G-XXXXXXXX / Leave empty to disable
-PUBLIC_PLAUSIBLE_DOMAIN=#huggingface.co / Leave empty to disable
+PUBLIC_PLAUSIBLE_SCRIPT_URL=#/js/script.js / Leave empty to disable
 PUBLIC_ANNOUNCEMENT_BANNERS=`[
     {
     "title": "Code Llama 70B is available! 🦙",

--- a/.env
+++ b/.env
@@ -97,6 +97,7 @@ TASK_MODEL= # name of the model used for tasks such as summarizing title, creati
 PUBLIC_ORIGIN=#https://huggingface.co
 PUBLIC_SHARE_PREFIX=#https://hf.co/chat
 PUBLIC_GOOGLE_ANALYTICS_ID=#G-XXXXXXXX / Leave empty to disable
+PUBLIC_PLAUSIBLE_DOMAIN=#huggingface.co / Leave empty to disable
 PUBLIC_ANNOUNCEMENT_BANNERS=`[
     {
     "title": "Code Llama 70B is available! 🦙",

--- a/.env.template
+++ b/.env.template
@@ -235,6 +235,7 @@ RATE_LIMIT=16
 MESSAGES_BEFORE_LOGIN=5# how many messages a user can send in a conversation before having to login. set to 0 to force login right away
 
 PUBLIC_GOOGLE_ANALYTICS_ID=G-8Q63TH4CSL
+PUBLIC_PLAUSIBLE_DOMAIN=huggingface.co
 
 # Not part of the .env but set as other variables in the space
 # ADDRESS_HEADER=X-Forwarded-For

--- a/.env.template
+++ b/.env.template
@@ -235,7 +235,7 @@ RATE_LIMIT=16
 MESSAGES_BEFORE_LOGIN=5# how many messages a user can send in a conversation before having to login. set to 0 to force login right away
 
 PUBLIC_GOOGLE_ANALYTICS_ID=G-8Q63TH4CSL
-PUBLIC_PLAUSIBLE_SCRIPT_URL="/js/script.js"
+PUBLIC_PLAUSIBLE_SCRIPT_URL="https://huggingface.co/js/script.js"
 
 # Not part of the .env but set as other variables in the space
 # ADDRESS_HEADER=X-Forwarded-For

--- a/.env.template
+++ b/.env.template
@@ -235,7 +235,7 @@ RATE_LIMIT=16
 MESSAGES_BEFORE_LOGIN=5# how many messages a user can send in a conversation before having to login. set to 0 to force login right away
 
 PUBLIC_GOOGLE_ANALYTICS_ID=G-8Q63TH4CSL
-PUBLIC_PLAUSIBLE_DOMAIN=huggingface.co
+PUBLIC_PLAUSIBLE_SCRIPT_URL="/js/script.js"
 
 # Not part of the .env but set as other variables in the space
 # ADDRESS_HEADER=X-Forwarded-For

--- a/.env.template
+++ b/.env.template
@@ -235,7 +235,7 @@ RATE_LIMIT=16
 MESSAGES_BEFORE_LOGIN=5# how many messages a user can send in a conversation before having to login. set to 0 to force login right away
 
 PUBLIC_GOOGLE_ANALYTICS_ID=G-8Q63TH4CSL
-PUBLIC_PLAUSIBLE_SCRIPT_URL="https://huggingface.co/js/script.js"
+PUBLIC_PLAUSIBLE_SCRIPT_URL="/js/script.js"
 
 # Not part of the .env but set as other variables in the space
 # ADDRESS_HEADER=X-Forwarded-For

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -4,7 +4,11 @@
 	import { page } from "$app/stores";
 	import "../styles/main.css";
 	import { base } from "$app/paths";
-	import { PUBLIC_APP_DESCRIPTION, PUBLIC_ORIGIN } from "$env/static/public";
+	import {
+		PUBLIC_APP_DESCRIPTION,
+		PUBLIC_ORIGIN,
+		PUBLIC_PLAUSIBLE_DOMAIN,
+	} from "$env/static/public";
 
 	import { shareConversation } from "$lib/shareConversation";
 	import { UrlDependency } from "$lib/types/UrlDependency";
@@ -152,6 +156,10 @@
 		rel="manifest"
 		href="{PUBLIC_ORIGIN || $page.url.origin}{base}/{PUBLIC_APP_ASSETS}/manifest.json"
 	/>
+
+	{#if PUBLIC_PLAUSIBLE_DOMAIN}
+		<script defer data-domain={PUBLIC_PLAUSIBLE_DOMAIN} src="/js/script.js"></script>
+	{/if}
 </svelte:head>
 
 {#if !$settings.ethicsModalAccepted}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -157,8 +157,8 @@
 		href="{PUBLIC_ORIGIN || $page.url.origin}{base}/{PUBLIC_APP_ASSETS}/manifest.json"
 	/>
 
-	{#if PUBLIC_PLAUSIBLE_DOMAIN}
-		<script defer data-domain={PUBLIC_PLAUSIBLE_DOMAIN} src="/js/script.js"></script>
+	{#if PUBLIC_PLAUSIBLE_SCRIPT_URL}
+		<script defer data-domain={new URL(PUBLIC_ORIGIN).hostname} src={PUBLIC_PLAUSIBLE_SCRIPT_URL}></script>
 	{/if}
 </svelte:head>
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -7,7 +7,7 @@
 	import {
 		PUBLIC_APP_DESCRIPTION,
 		PUBLIC_ORIGIN,
-		PUBLIC_PLAUSIBLE_DOMAIN,
+		PUBLIC_PLAUSIBLE_SCRIPT_URL,
 	} from "$env/static/public";
 
 	import { shareConversation } from "$lib/shareConversation";
@@ -158,7 +158,11 @@
 	/>
 
 	{#if PUBLIC_PLAUSIBLE_SCRIPT_URL}
-		<script defer data-domain={new URL(PUBLIC_ORIGIN).hostname} src={PUBLIC_PLAUSIBLE_SCRIPT_URL}></script>
+		<script
+			defer
+			data-domain={new URL(PUBLIC_ORIGIN).hostname}
+			src={PUBLIC_PLAUSIBLE_SCRIPT_URL}
+		></script>
 	{/if}
 </svelte:head>
 


### PR DESCRIPTION
This PR adds plausible analytics, by setting a new env var `PUBLIC_PLAUSIBLE_DOMAIN`

In prod we proxy the plausible script to `/js/script.js` so the script doesn't need to be in huggingchat directly.