### PR TITLE
[Assistnats] Fix pagination numTotalPages

### DIFF
--- a/src/lib/components/Pagination.svelte
+++ b/src/lib/components/Pagination.svelte
@@ -8,7 +8,7 @@
 
 	const ELLIPSIS_IDX = -1 as const;
 
-	const numTotalPages = Math.ceil(numTotalItems / numItemsPerPage);
+	$: numTotalPages = Math.ceil(numTotalItems / numItemsPerPage);
 	$: pageIndex = parseInt($page.url.searchParams.get("p") ?? "0");
 	$: pageIndexes = getPageIndexes(pageIndex);
 


### PR DESCRIPTION
`numTotalPages` should be reactive because sveltekit is making a partial reload rather than full reload.

Atm, there is this bug

