### PR TITLE
[Fix] on cancel operations, preerve previous URL query params

### DIFF
--- a/src/routes/assistant/[assistantId]/+page.svelte
+++ b/src/routes/assistant/[assistantId]/+page.svelte
@@ -15,7 +15,7 @@
 
 	afterNavigate(({ from }) => {
 		if (!from?.url.pathname.includes("settings")) {
-			previousPage = from?.url.pathname || previousPage;
+			previousPage = from?.url.toString() || previousPage;
 		}
 	});
 

--- a/src/routes/settings/+layout.svelte
+++ b/src/routes/settings/+layout.svelte
@@ -25,7 +25,7 @@
 
 	afterNavigate(({ from }) => {
 		if (!from?.url.pathname.includes("settings")) {
-			previousPage = from?.url.pathname || previousPage;
+			previousPage = from?.url.toString() || previousPage;
 		}
 	});
 


### PR DESCRIPTION
On cancel operations, preerve previous URL query params

correct behaviour: 


https://github.com/huggingface/chat-ui/assets/11827707/3720a8e6-0872-4f1d-bbad-107a5cbff8fa


