### PR TITLE
[Assistants] Fix/clear searchParams while changing models

### DIFF
--- a/src/lib/components/Pagination.svelte
+++ b/src/lib/components/Pagination.svelte
@@ -12,8 +12,8 @@
 	$: pageIndex = parseInt($page.url.searchParams.get("p") ?? "0");
 	$: pageIndexes = getPageIndexes(pageIndex, numTotalPages);
 
-	function getHref(pageIdx: number) {
-		const newUrl = new URL($page.url);
+	function getHref(url: URL | string, pageIdx: number) {
+		const newUrl = new URL(url);
 		newUrl.searchParams.set("p", pageIdx.toString());
 		return newUrl.toString();
 	}
@@ -66,7 +66,7 @@
 		>
 			<li>
 				<PaginationArrow
-					href={getHref(pageIndex - 1)}
+					href={getHref($page.url, pageIndex - 1)}
 					direction="previous"
 					isDisabled={pageIndex - 1 < 0}
 				/>
@@ -81,7 +81,7 @@
 							: ''}
 						"
 						class:pointer-events-none={pageIdx === ELLIPSIS_IDX || pageIndex === pageIdx}
-						href={getHref(pageIdx)}
+						href={getHref($page.url, pageIdx)}
 					>
 						{pageIdx === ELLIPSIS_IDX ? "..." : pageIdx + 1}
 					</a>
@@ -89,7 +89,7 @@
 			{/each}
 			<li>
 				<PaginationArrow
-					href={getHref(pageIndex + 1)}
+					href={getHref($page.url, pageIndex + 1)}
 					direction="next"
 					isDisabled={pageIndex + 1 >= numTotalPages}
 				/>

--- a/src/routes/assistants/+page.svelte
+++ b/src/routes/assistants/+page.svelte
@@ -18,9 +18,8 @@
 
 	const onModelChange = (e: Event) => {
 		const newUrl = new URL($page.url);
-		if ((e.target as HTMLSelectElement).value === "") {
-			newUrl.searchParams.delete("modelId");
-		} else {
+		newUrl.search = ""; // clear searchParams (such as "p" for pagination)
+		if ((e.target as HTMLSelectElement).value) {
 			newUrl.searchParams.set("modelId", (e.target as HTMLSelectElement).value);
 		}
 		goto(newUrl);


### PR DESCRIPTION
Fixes a bug: pagination query needs to be removed when changing a model. Otherwise, it can result in a query "?modelId={someModel}&p={someNumber}" & depending on that `someNumber` it can result in empty models page since the backend makes mongo cursor skips based on `someNumber`

https://github.com/huggingface/chat-ui/assets/11827707/44d5ee3f-1126-4e81-837b-ec21243ba42b

