### PR TITLE
[fix] If APP_BASE is empty, go to '/' instead of an empty string.

### DIFF
--- a/src/routes/assistant/[assistantId]/+page.svelte
+++ b/src/routes/assistant/[assistantId]/+page.svelte
@@ -97,7 +97,7 @@
 					// `result` is an `ActionResult` object
 					if (result.type === "success") {
 						$settings.activeModel = data.assistant._id;
-						goto(`${base}`);
+						goto(`${base}` || '/');
 					} else {
 						await applyAction(result);
 					}

--- a/src/routes/assistant/[assistantId]/+page.svelte
+++ b/src/routes/assistant/[assistantId]/+page.svelte
@@ -97,7 +97,7 @@
 					// `result` is an `ActionResult` object
 					if (result.type === "success") {
 						$settings.activeModel = data.assistant._id;
-						goto(`${base}` || '/');
+						goto(`${base}` || "/");
 					} else {
 						await applyAction(result);
 					}


### PR DESCRIPTION
If the APP_BASE env is an empty string, you won't be able to launch an assistant from the "Popular Assistants" page by clicking 'Start chatting'. This fixes that problem.

Fixes issue #770 
