### PR TITLE
[Login Modal] Fix not showing properly on mobile

### DIFF
--- a/src/lib/components/chat/ChatInput.svelte
+++ b/src/lib/components/chat/ChatInput.svelte
@@ -53,7 +53,7 @@
 		on:keydown={handleKeydown}
 		on:compositionstart={() => (isCompositionOn = true)}
 		on:compositionend={() => (isCompositionOn = false)}
-		on:keypress
+		on:beforeinput
 		{placeholder}
 	/>
 </div>

--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -212,7 +212,7 @@
 								placeholder="Ask anything"
 								bind:value={message}
 								on:submit={handleSubmit}
-								on:keypress={(ev) => {
+								on:beforeinput={(ev) => {
 									if ($page.data.loginRequired) {
 										ev.preventDefault();
 										loginModalOpen = true;


### PR DESCRIPTION
Logic from https://github.com/huggingface/chat-ui/pull/526 was good/working as expected. However, on mobile, the login modal was not showing up after user has reached the limit of messages.

| before | with this pr |
|---------|---------|
|<img src="https://github.com/huggingface/chat-ui/assets/11827707/29d466d7-6dd6-422a-9443-051d0cd616d4">   |<img src="https://github.com/huggingface/chat-ui/assets/11827707/886efef8-ecd6-4375-9ed4-a1c7ab45930b">   |

