### PR TITLE
[Frontend] keypress -> keydown

### DIFF
--- a/src/lib/components/SystemPromptModal.svelte
+++ b/src/lib/components/SystemPromptModal.svelte
@@ -12,7 +12,7 @@
 	type="button"
 	class="mx-auto flex items-center gap-1.5 rounded-full border border-gray-100 bg-gray-50 px-3 py-1 text-xs text-gray-500 hover:bg-gray-100 dark:border-gray-800 dark:bg-gray-800 dark:text-gray-400 dark:hover:bg-gray-700"
 	on:click={() => (isOpen = !isOpen)}
-	on:keypress={(e) => e.key === "Enter" && (isOpen = !isOpen)}
+	on:keydown={(e) => e.key === "Enter" && (isOpen = !isOpen)}
 >
 	<CarbonBlockchain class="text-xxs" /> Using Custom System Prompt
 </button>

--- a/src/lib/components/WebSearchToggle.svelte
+++ b/src/lib/components/WebSearchToggle.svelte
@@ -9,13 +9,13 @@
 <div
 	class="flex h-8 cursor-pointer select-none items-center gap-2 rounded-lg border bg-white p-1.5 shadow-sm hover:shadow-none dark:border-gray-800 dark:bg-gray-900"
 	on:click={toggle}
-	on:keypress={toggle}
+	on:keydown={toggle}
 	aria-checked={$webSearchParameters.useSearch}
 	aria-label="web search toggle"
 	role="switch"
 	tabindex="0"
 >
-	<Switch name="useSearch" bind:checked={$webSearchParameters.useSearch} on:click on:keypress />
+	<Switch name="useSearch" bind:checked={$webSearchParameters.useSearch} on:click on:keydown />
 	<div class="whitespace-nowrap text-sm text-gray-800 dark:text-gray-200">Search web</div>
 	<div class="group relative w-max">
 		<CarbonInformation class="text-xs text-gray-500" />

--- a/src/lib/components/chat/ChatMessage.svelte
+++ b/src/lib/components/chat/ChatMessage.svelte
@@ -138,7 +138,7 @@
 		class="group relative -mb-8 flex items-start justify-start gap-4 pb-8 leading-relaxed"
 		role="presentation"
 		on:click={() => (isTapped = !isTapped)}
-		on:keypress={() => (isTapped = !isTapped)}
+		on:keydown={() => (isTapped = !isTapped)}
 	>
 		{#if $page.data?.assistant?.avatar}
 			<img


### PR DESCRIPTION
As discussed [here](https://github.com/huggingface/chat-ui/pull/796#issuecomment-1931894326), replace `keypress ` with `keydown ` since 

<img width="500" alt="Screenshot 2024-02-08 at 12 05 45 AM" src="https://github.com/huggingface/chat-ui/assets/11827707/2e1a0ebd-170b-4150-8925-75ec127f7529">


read more about deprecation [here](https://developer.mozilla.org/en-US/docs/Web/API/Element/keypress_event)