### PR TITLE
fix continue button on openai endpoint

### DIFF
--- a/src/lib/server/endpoints/openai/openAIChatToTextGenerationStream.ts
+++ b/src/lib/server/endpoints/openai/openAIChatToTextGenerationStream.ts
@@ -22,7 +22,7 @@ export async function* openAIChatToTextGenerationStream(
 				id: tokenId++,
 				text: content ?? "",
 				logprob: 0,
-				special: false,
+				special: last,
 			},
 			generated_text: last ? generatedText : null,
 			details: null,

--- a/src/lib/server/endpoints/openai/openAICompletionToTextGenerationStream.ts
+++ b/src/lib/server/endpoints/openai/openAICompletionToTextGenerationStream.ts
@@ -22,7 +22,7 @@ export async function* openAICompletionToTextGenerationStream(
 				id: tokenId++,
 				text,
 				logprob: 0,
-				special: false,
+				special: last,
 			},
 			generated_text: last ? generatedText : null,
 			details: null,


### PR DESCRIPTION
We weren't properly setting special tokens on openAI endpoints.