### PR TITLE
🗃️ Create index on users.username

### DIFF
--- a/src/lib/server/database.ts
+++ b/src/lib/server/database.ts
@@ -70,6 +70,8 @@ client.on("open", () => {
 	settings.createIndex({ assistants: 1 }).catch(console.error);
 	users.createIndex({ hfUserId: 1 }, { unique: true }).catch(console.error);
 	users.createIndex({ sessionId: 1 }, { unique: true, sparse: true }).catch(console.error);
+	// No unicity because due to renames & outdated info from oauth provider, there may be the same username on different users
+	users.createIndex({ username: 1 }).catch(console.error);
 	messageEvents.createIndex({ createdAt: 1 }, { expireAfterSeconds: 60 }).catch(console.error);
 	sessions.createIndex({ expiresAt: 1 }, { expireAfterSeconds: 0 }).catch(console.error);
 	sessions.createIndex({ sessionId: 1 }, { unique: true }).catch(console.error);

--- a/src/routes/assistants/+page.server.ts
+++ b/src/routes/assistants/+page.server.ts
@@ -26,7 +26,7 @@ export const load = async ({ url, locals }) => {
 
 	// fetch the top assistants sorted by user count from biggest to smallest, filter out all assistants with only 1 users. filter by model too if modelId is provided
 	const filter: Filter<Assistant> = {
-		modelId: modelId ?? { $exists: true },
+		...(modelId && { modelId }),
 		...(!createdByCurrentUser && { userCount: { $gt: 1 } }),
 		...(createdByName ? { createdByName } : { featured: true }),
 	};


### PR DESCRIPTION
With 300k users (:exploding_head:) this was a slow query.

Happened on pages like these: https://huggingface.co/chat/assistants?user=julien-c

We may want to link to https://huggingface.co/chat/assistants?userId=xxxx instead, as in some edge cases two users can have the same `username`. But leaving it up to you for another PR

**Note:** index is already in prod