### PR TITLE
Fix model identification when creating conversations

### DIFF
--- a/src/routes/conversation/+server.ts
+++ b/src/routes/conversation/+server.ts
@@ -39,7 +39,7 @@ export const POST: RequestHandler = async ({ locals, request }) => {
 		);
 	}
 
-	const model = models.find((m) => m.name === values.model);
+	const model = models.find((m) => (m.id || m.name) === values.model);
 
 	if (!model) {
 		throw error(400, "Invalid model");


### PR DESCRIPTION
PR #181 introduced a model ID field so that models could be switched out without breaking existing conversations. However, the new conversation endpoint incorrectly uses the model name instead of ID, so without this fix it was not possible to have a model with a different ID and name.