### PR TITLE
Make compatible with Microsoft Entra (v1 and v2 tokens)

### DIFF
--- a/src/lib/types/User.ts
+++ b/src/lib/types/User.ts
@@ -7,6 +7,6 @@ export interface User extends Timestamps {
 	username?: string;
 	name: string;
 	email?: string;
-	avatarUrl: string;
+	avatarUrl: string | undefined;
 	hfUserId: string;
 }

--- a/src/routes/login/callback/updateUser.ts
+++ b/src/routes/login/callback/updateUser.ts
@@ -18,6 +18,12 @@ export async function updateUser(params: {
 }) {
 	const { userData, locals, cookies, userAgent, ip } = params;
 
+	// Microsoft Entra v1 tokens do not provide preferred_username, instead the username is provided in the upn
+	// claim. See https://learn.microsoft.com/en-us/entra/identity-platform/access-token-claims-reference
+	if (!userData.preferred_username && userData.upn) {
+		userData.preferred_username = userData.upn as string;
+	}
+
 	const {
 		preferred_username: username,
 		name,

--- a/src/routes/login/callback/updateUser.ts
+++ b/src/routes/login/callback/updateUser.ts
@@ -28,7 +28,7 @@ export async function updateUser(params: {
 		.object({
 			preferred_username: z.string().optional(),
 			name: z.string(),
-			picture: z.string(),
+			picture: z.string().optional(),
 			sub: z.string(),
 			email: z.string().email().optional(),
 		})


### PR DESCRIPTION
Some identity providers (such as Microsoft Entra, formerly Azure AD) do not provide or support the picture claim. This patch makes it optional.

Additionally, the Microsoft Entra v1 tokens do not provide the `preferred_username` claim, instead providing the username in the non-standard `upn` claim.

Fixes #629