### PR TITLE
Allow customising defaultQuery for native Azure OpenAI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,9 +353,12 @@ MODELS=`[{
   "endpoints": [
       {
           "type": "openai",
-          "baseURL": "https://gateway.example.com/v1",
+          "baseURL": "https://{resource-name}.openai.azure.com/openai/deployments/{deployment-id}",
           "defaultHeaders": {
-              "x-portkey-config": '{"provider":"azure-openai","resource_name":"abc-fr","deployment_id":"gpt-4-1106-preview","api_version":"2023-03-15-preview","api_key":"abc...xyz"}'
+              "api-key": "{api-key}"
+          },
+          "defaultQuery": {
+              "api-version": "2023-05-15"
           }
       }
   ]

--- a/src/lib/server/endpoints/openai/endpointOai.ts
+++ b/src/lib/server/endpoints/openai/endpointOai.ts
@@ -15,12 +15,13 @@ export const endpointOAIParametersSchema = z.object({
 		.union([z.literal("completions"), z.literal("chat_completions")])
 		.default("chat_completions"),
 	defaultHeaders: z.record(z.string()).optional(),
+	defaultQuery: z.record(z.string()).optional(),
 });
 
 export async function endpointOai(
 	input: z.input<typeof endpointOAIParametersSchema>
 ): Promise<Endpoint> {
-	const { baseURL, apiKey, completion, model, defaultHeaders } =
+	const { baseURL, apiKey, completion, model, defaultHeaders, defaultQuery } =
 		endpointOAIParametersSchema.parse(input);
 	let OpenAI;
 	try {
@@ -33,6 +34,7 @@ export async function endpointOai(
 		apiKey: apiKey ?? "sk-",
 		baseURL,
 		defaultHeaders,
+		defaultQuery,
 	});
 
 	if (completion === "completions") {


### PR DESCRIPTION
The api-version is a required query parameter for Azure OpenAI, by supporting this we can support it without a gateway like portkey.

---

P.S. I apologise for the flurry of PRs, please let me know if you'd like me to roll them up.