### PR TITLE
✨ Add stats on conversations

### DIFF
--- a/.env
+++ b/.env
@@ -109,9 +109,9 @@ PUBLIC_ANNOUNCEMENT_BANNERS=`[
 
 PARQUET_EXPORT_DATASET=
 PARQUET_EXPORT_HF_TOKEN=
-PARQUET_EXPORT_SECRET=
+ADMIN_API_SECRET=# secret to admin API calls, like computing usage stats or exporting parquet data
 
-ADMIN_API_SECRET=# secret to admin API calls, like computing usage stats
+PARQUET_EXPORT_SECRET=#DEPRECATED, use ADMIN_API_SECRET instead
 
 RATE_LIMIT= # requests per minute
 MESSAGES_BEFORE_LOGIN=# how many messages a user can send in a conversation before having to login. set to 0 to force login right away

--- a/.env
+++ b/.env
@@ -111,6 +111,8 @@ PARQUET_EXPORT_DATASET=
 PARQUET_EXPORT_HF_TOKEN=
 PARQUET_EXPORT_SECRET=
 
+ADMIN_API_SECRET=# secret to admin API calls, like computing usage stats
+
 RATE_LIMIT= # requests per minute
 MESSAGES_BEFORE_LOGIN=# how many messages a user can send in a conversation before having to login. set to 0 to force login right away
 

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -26,6 +26,7 @@ jobs:
           MONGODB_URL: ${{ secrets.MONGODB_URL }}
           HF_DEPLOYMENT_TOKEN: ${{ secrets.HF_DEPLOYMENT_TOKEN }}
           WEBHOOK_URL_REPORT_ASSISTANT: ${{ secrets.WEBHOOK_URL_REPORT_ASSISTANT }}
+          ADMIN_API_SECRET: ${{ secrets.ADMIN_API_SECRET }}
         run: npm run updateProdEnv
   sync-to-hub:
     runs-on: ubuntu-latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -4093,10 +4093,17 @@
 			"resolved": "https://registry.npmjs.org/int53/-/int53-0.2.4.tgz",
 			"integrity": "sha512-a5jlKftS7HUOhkUyYD7j2sJ/ZnvWiNlZS1ldR+g1ifQ+/UuZXIE+YTc/lK1qGj/GwAU5F8Z0e1eVq2t1J5Ob2g=="
 		},
-		"node_modules/ip": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
-			"integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ=="
+		"node_modules/ip-address": {
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+			"integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+			"dependencies": {
+				"jsbn": "1.1.0",
+				"sprintf-js": "^1.1.3"
+			},
+			"engines": {
+				"node": ">= 12"
+			}
 		},
 		"node_modules/is-arrayish": {
 			"version": "0.3.2",
@@ -4266,6 +4273,11 @@
 			"bin": {
 				"js-yaml": "bin/js-yaml.js"
 			}
+		},
+		"node_modules/jsbn": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+			"integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="
 		},
 		"node_modules/jsdom": {
 			"version": "22.0.0",
@@ -6294,15 +6306,15 @@
 			"integrity": "sha512-YIK6I2lsH072UE0aOFxxY1dPDCS43I5ktqHpeAsuLNYWkE5pGxRGWfDM4/vSUfNzXjC1Ivzt3qx31PCLmc9yqg=="
 		},
 		"node_modules/socks": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
-			"integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
+			"version": "2.7.3",
+			"resolved": "https://registry.npmjs.org/socks/-/socks-2.7.3.tgz",
+			"integrity": "sha512-vfuYK48HXCTFD03G/1/zkIls3Ebr2YNa4qU9gHDZdblHLiqhJrJGkY3+0Nx0JpN9qBhJbVObc1CNciT1bIZJxw==",
 			"dependencies": {
-				"ip": "^2.0.0",
+				"ip-address": "^9.0.5",
 				"smart-buffer": "^4.2.0"
 			},
 			"engines": {
-				"node": ">= 10.13.0",
+				"node": ">= 10.0.0",
 				"npm": ">= 3.0.0"
 			}
 		},
@@ -6344,6 +6356,11 @@
 			"dependencies": {
 				"memory-pager": "^1.0.2"
 			}
+		},
+		"node_modules/sprintf-js": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+			"integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
 		},
 		"node_modules/stackback": {
 			"version": "0.0.2",

--- a/scripts/updateProdEnv.ts
+++ b/scripts/updateProdEnv.ts
@@ -7,6 +7,7 @@ const OPENID_CONFIG = process.env.OPENID_CONFIG;
 const MONGODB_URL = process.env.MONGODB_URL;
 const HF_TOKEN = process.env.HF_TOKEN ?? process.env.HF_ACCESS_TOKEN; // token used for API requests in prod
 const WEBHOOK_URL_REPORT_ASSISTANT = process.env.WEBHOOK_URL_REPORT_ASSISTANT; // slack webhook url used to get "report assistant" events
+const ADMIN_API_SECRET = process.env.ADMIN_API_SECRET;
 
 // Read the content of the file .env.template
 const PUBLIC_CONFIG = fs.readFileSync(".env.template", "utf8");
@@ -18,6 +19,7 @@ OPENID_CONFIG=${OPENID_CONFIG}
 SERPER_API_KEY=${SERPER_API_KEY}
 HF_TOKEN=${HF_TOKEN}
 WEBHOOK_URL_REPORT_ASSISTANT=${WEBHOOK_URL_REPORT_ASSISTANT}
+ADMIN_API_SECRET=${ADMIN_API_SECRET}
 `;
 
 // Make an HTTP POST request to add the space secrets

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,4 +1,10 @@
-import { COOKIE_NAME, EXPOSE_API, MESSAGES_BEFORE_LOGIN } from "$env/static/private";
+import {
+	ADMIN_API_SECRET,
+	COOKIE_NAME,
+	EXPOSE_API,
+	MESSAGES_BEFORE_LOGIN,
+	PARQUET_EXPORT_SECRET,
+} from "$env/static/private";
 import type { Handle } from "@sveltejs/kit";
 import {
 	PUBLIC_GOOGLE_ANALYTICS_ID,
@@ -27,6 +33,18 @@ export const handle: Handle = async ({ event, resolve }) => {
 				"content-type": sendJson ? "application/json" : "text/plain",
 			},
 		});
+	}
+
+	if (event.url.pathname.startsWith(`${base}/admin/`) || event.url.pathname === `${base}/admin`) {
+		const ADMIN_SECRET = ADMIN_API_SECRET || PARQUET_EXPORT_SECRET;
+
+		if (!ADMIN_SECRET) {
+			return errorResponse(500, "Admin API is not configured");
+		}
+
+		if (event.request.headers.get("Authorization") !== `Bearer ${ADMIN_SECRET}`) {
+			return errorResponse(401, "Unauthorized");
+		}
 	}
 
 	const token = event.cookies.get(COOKIE_NAME);

--- a/src/lib/server/database.ts
+++ b/src/lib/server/database.ts
@@ -77,15 +77,28 @@ client.on("open", () => {
 	conversations.createIndex({ updatedAt: 1 }).catch(console.error);
 	// Not strictly necessary, could use _id, but more convenient. Also for stats
 	conversations.createIndex({ createdAt: 1 }).catch(console.error);
+	// To do stats on conversation messages
+	conversations.createIndex({ "messages.createdAt": 1 }, { sparse: true }).catch(console.error);
+	// Unique index for stats
 	conversationStats
 		.createIndex(
 			{
+				type: 1,
 				"date.field": 1,
-				"date.day": 1,
+				"date.span": 1,
+				"date.at": 1,
 				distinct: 1,
 			},
 			{ unique: true }
 		)
+		.catch(console.error);
+	// Allow easy check of last computed stat for given type/dateField
+	conversationStats
+		.createIndex({
+			type: 1,
+			"date.field": 1,
+			"date.at": 1,
+		})
 		.catch(console.error);
 	abortedGenerations.createIndex({ updatedAt: 1 }, { expireAfterSeconds: 30 }).catch(console.error);
 	abortedGenerations.createIndex({ conversationId: 1 }, { unique: true }).catch(console.error);

--- a/src/lib/server/database.ts
+++ b/src/lib/server/database.ts
@@ -25,8 +25,10 @@ export const connectPromise = client.connect().catch(console.error);
 
 const db = client.db(MONGODB_DB_NAME + (import.meta.env.MODE === "test" ? "-test" : ""));
 
+export const CONVERSATION_STATS_COLLECTION = "conversations.stats";
+
 const conversations = db.collection<Conversation>("conversations");
-const conversationStats = db.collection<ConversationStats>("conversations.stats");
+const conversationStats = db.collection<ConversationStats>(CONVERSATION_STATS_COLLECTION);
 const assistants = db.collection<Assistant>("assistants");
 const reports = db.collection<Report>("reports");
 const sharedConversations = db.collection<SharedConversation>("sharedConversations");

--- a/src/lib/server/database.ts
+++ b/src/lib/server/database.ts
@@ -80,8 +80,8 @@ client.on("open", () => {
 	conversationStats
 		.createIndex(
 			{
-				"date.day": 1,
 				"date.field": 1,
+				"date.day": 1,
 				distinct: 1,
 			},
 			{ unique: true }

--- a/src/lib/types/ConversationStats.ts
+++ b/src/lib/types/ConversationStats.ts
@@ -2,9 +2,12 @@ import type { Timestamps } from "./Timestamps";
 
 export interface ConversationStats extends Timestamps {
 	date: {
-		day: Date;
+		at: Date;
+		span: "day" | "weak" | "month";
 		field: "updatedAt" | "createdAt";
 	};
+	type: "conversation" | "message";
+	/**  _id => conversationId, eg for type="message" messages will be grouped by conversation */
 	distinct: "sessionId" | "userId" | "userOrSessionId" | "_id";
 	count: number;
 }

--- a/src/lib/types/ConversationStats.ts
+++ b/src/lib/types/ConversationStats.ts
@@ -3,7 +3,7 @@ import type { Timestamps } from "./Timestamps";
 export interface ConversationStats extends Timestamps {
 	date: {
 		at: Date;
-		span: "day" | "weak" | "month";
+		span: "day" | "week" | "month";
 		field: "updatedAt" | "createdAt";
 	};
 	type: "conversation" | "message";

--- a/src/lib/types/ConversationStats.ts
+++ b/src/lib/types/ConversationStats.ts
@@ -1,0 +1,10 @@
+import type { Timestamps } from "./Timestamps";
+
+export interface ConversationStats extends Timestamps {
+	date: {
+		day: Date;
+		field: "updatedAt" | "createdAt";
+	};
+	distinct: "sessionId" | "userId" | "userOrSessionId" | "_id";
+	count: number;
+}

--- a/src/lib/types/ConversationStats.ts
+++ b/src/lib/types/ConversationStats.ts
@@ -7,7 +7,7 @@ export interface ConversationStats extends Timestamps {
 		field: "updatedAt" | "createdAt";
 	};
 	type: "conversation" | "message";
-	/**  _id => conversationId, eg for type="message" messages will be grouped by conversation */
+	/**  _id => number of conversations/messages in the month */
 	distinct: "sessionId" | "userId" | "userOrSessionId" | "_id";
 	count: number;
 }

--- a/src/routes/admin/export/+server.ts
+++ b/src/routes/admin/export/+server.ts
@@ -21,7 +21,7 @@ export async function POST({ request }) {
 	}
 
 	if (request.headers.get("Authorization") !== `Bearer ${PARQUET_EXPORT_SECRET}`) {
-		throw error(403);
+		throw error(401, "Unauthorized");
 	}
 
 	const { model } = z

--- a/src/routes/admin/export/+server.ts
+++ b/src/routes/admin/export/+server.ts
@@ -1,8 +1,4 @@
-import {
-	PARQUET_EXPORT_DATASET,
-	PARQUET_EXPORT_HF_TOKEN,
-	PARQUET_EXPORT_SECRET,
-} from "$env/static/private";
+import { PARQUET_EXPORT_DATASET, PARQUET_EXPORT_HF_TOKEN } from "$env/static/private";
 import { collections } from "$lib/server/database";
 import type { Message } from "$lib/types/Message";
 import { error } from "@sveltejs/kit";
@@ -13,15 +9,11 @@ import parquet from "parquetjs";
 import { z } from "zod";
 
 // Triger like this:
-// curl -X POST "http://localhost:5173/chat/admin/export" -H "Authorization: Bearer <PARQUET_EXPORT_SECRET>" -H "Content-Type: application/json" -d '{"model": "OpenAssistant/oasst-sft-6-llama-30b-xor"}'
+// curl -X POST "http://localhost:5173/chat/admin/export" -H "Authorization: Bearer <ADMIN_API_SECRET>" -H "Content-Type: application/json" -d '{"model": "OpenAssistant/oasst-sft-6-llama-30b-xor"}'
 
 export async function POST({ request }) {
-	if (!PARQUET_EXPORT_SECRET || !PARQUET_EXPORT_DATASET || !PARQUET_EXPORT_HF_TOKEN) {
+	if (!PARQUET_EXPORT_DATASET || !PARQUET_EXPORT_HF_TOKEN) {
 		throw error(500, "Parquet export is not configured.");
-	}
-
-	if (request.headers.get("Authorization") !== `Bearer ${PARQUET_EXPORT_SECRET}`) {
-		throw error(401, "Unauthorized");
 	}
 
 	const { model } = z

--- a/src/routes/admin/stats/compute/+server.ts
+++ b/src/routes/admin/stats/compute/+server.ts
@@ -60,6 +60,11 @@ async function computeStats(params: { dateField: ConversationStats["date"]["fiel
 										day: { $dateTrunc: { date: `$${params.dateField}`, unit: "day" } },
 										userId: "$userId",
 									},
+								},
+							},
+							{
+								$group: {
+									_id: "$_id.day",
 									count: { $sum: 1 },
 								},
 							},
@@ -67,7 +72,7 @@ async function computeStats(params: { dateField: ConversationStats["date"]["fiel
 								$project: {
 									_id: 0,
 									date: {
-										day: "$_id.day",
+										day: "$_id",
 										field: params.dateField,
 									},
 									distinct: "userId",
@@ -87,6 +92,11 @@ async function computeStats(params: { dateField: ConversationStats["date"]["fiel
 										day: { $dateTrunc: { date: `$${params.dateField}`, unit: "day" } },
 										sessionId: "$userId",
 									},
+								},
+							},
+							{
+								$group: {
+									_id: "$_id.day",
 									count: { $sum: 1 },
 								},
 							},
@@ -94,7 +104,7 @@ async function computeStats(params: { dateField: ConversationStats["date"]["fiel
 								$project: {
 									_id: 0,
 									date: {
-										day: "$_id.day",
+										day: "$_id",
 										field: params.dateField,
 									},
 									distinct: "sessionId",
@@ -109,6 +119,11 @@ async function computeStats(params: { dateField: ConversationStats["date"]["fiel
 										day: { $dateTrunc: { date: `$${params.dateField}`, unit: "day" } },
 										userOrSessionId: { $ifNull: ["$userId", "$sessionId"] },
 									},
+								},
+							},
+							{
+								$group: {
+									_id: "$_id.day",
 									count: { $sum: 1 },
 								},
 							},
@@ -116,7 +131,7 @@ async function computeStats(params: { dateField: ConversationStats["date"]["fiel
 								$project: {
 									_id: 0,
 									date: {
-										day: "$_id.day",
+										day: "$_id",
 										field: params.dateField,
 									},
 									distinct: "userOrSessionId",
@@ -127,9 +142,7 @@ async function computeStats(params: { dateField: ConversationStats["date"]["fiel
 						_id: [
 							{
 								$group: {
-									_id: {
-										day: { $dateTrunc: { date: `$${params.dateField}`, unit: "day" } },
-									},
+									_id: { $dateTrunc: { date: `$${params.dateField}`, unit: "day" } },
 									count: { $sum: 1 },
 								},
 							},
@@ -137,7 +150,7 @@ async function computeStats(params: { dateField: ConversationStats["date"]["fiel
 								$project: {
 									_id: 0,
 									date: {
-										day: "$_id.day",
+										day: "$_id",
 										field: params.dateField,
 									},
 									distinct: "_id",

--- a/src/routes/admin/stats/compute/+server.ts
+++ b/src/routes/admin/stats/compute/+server.ts
@@ -178,6 +178,7 @@ async function computeStats(params: { dateField: ConversationStats["date"]["fiel
 				{
 					$merge: {
 						into: CONVERSATION_STATS_COLLECTION,
+						on: ["date.day", "date.field", "distinct"],
 						whenMatched: "replace",
 						whenNotMatched: "insert",
 					},

--- a/src/routes/admin/stats/compute/+server.ts
+++ b/src/routes/admin/stats/compute/+server.ts
@@ -1,0 +1,171 @@
+import { ADMIN_API_SECRET } from "$env/static/private";
+import { error, json } from "@sveltejs/kit";
+import type { ConversationStats } from "$lib/types/ConversationStats";
+import { collections } from "$lib/server/database.js";
+
+export async function POST({ request }) {
+	const authorization = request.headers.get("Authorization");
+
+	if (authorization !== `Bearer ${ADMIN_API_SECRET}`) {
+		throw error(401, "Unauthorized");
+	}
+
+	computeStats({ dateField: "updatedAt" }).catch(console.error);
+	computeStats({ dateField: "createdAt" }).catch(console.error);
+
+	return json({}, { status: 202 });
+}
+
+async function computeStats(params: { dateField: ConversationStats["date"]["field"] }) {
+	const lastComputed = await collections.conversationStats.findOne(
+		{ "date.field": params.dateField },
+		{ sort: { "date.day": -1 } }
+	);
+
+	const minDay = lastComputed ? lastComputed.date.day : new Date(0);
+
+	await collections.conversationStats
+		.aggregate([
+			{
+				$match: {
+					[params.dateField]: { $gte: minDay },
+				},
+			},
+			{
+				$project: {
+					[params.dateField]: 1,
+					sessionId: 1,
+					userId: 1,
+				},
+			},
+			{
+				$sort: {
+					[params.dateField]: 1,
+				},
+			},
+			{
+				$facet: {
+					userId: [
+						{
+							$match: {
+								userId: { $exists: true },
+							},
+						},
+						{
+							$group: {
+								_id: {
+									day: { $dateTrunc: { date: `$${params.dateField}`, unit: "day" } },
+									userId: "$userId",
+								},
+								count: { $sum: 1 },
+							},
+						},
+						{
+							$project: {
+								_id: 0,
+								date: {
+									day: "$_id.day",
+									field: params.dateField,
+								},
+								distinct: "userId",
+								count: 1,
+							},
+						},
+					],
+					sessionId: [
+						{
+							$match: {
+								sessionId: { $exists: true },
+							},
+						},
+						{
+							$group: {
+								_id: {
+									day: { $dateTrunc: { date: `$${params.dateField}`, unit: "day" } },
+									sessionId: "$userId",
+								},
+								count: { $sum: 1 },
+							},
+						},
+						{
+							$project: {
+								_id: 0,
+								date: {
+									day: "$_id.day",
+									field: params.dateField,
+								},
+								distinct: "sessionId",
+								count: 1,
+							},
+						},
+					],
+					userOrSessionId: [
+						{
+							$group: {
+								_id: {
+									day: { $dateTrunc: { date: `$${params.dateField}`, unit: "day" } },
+									userOrSessionId: { $ifNull: ["$userId", "$sessionId"] },
+								},
+								count: { $sum: 1 },
+							},
+						},
+						{
+							$project: {
+								_id: 0,
+								date: {
+									day: "$_id.day",
+									field: params.dateField,
+								},
+								distinct: "userOrSessionId",
+								count: 1,
+							},
+						},
+					],
+					_id: [
+						{
+							$group: {
+								_id: {
+									day: { $dateTrunc: { date: `$${params.dateField}`, unit: "day" } },
+								},
+								count: { $sum: 1 },
+							},
+						},
+						{
+							$project: {
+								_id: 0,
+								date: {
+									day: "$_id.day",
+									field: params.dateField,
+								},
+								distinct: "_id",
+								count: 1,
+							},
+						},
+					],
+				},
+			},
+			{
+				$project: {
+					stats: {
+						$concatArrays: ["$userId", "$sessionId", "$userOrSessionId", "$_id"],
+					},
+				},
+			},
+			{
+				$unwind: "$stats",
+			},
+			{
+				$replaceRoot: {
+					newRoot: "$stats",
+				},
+			},
+			{
+				$merge: {
+					into: "conversationStats",
+					whenMatched: "replace",
+					whenNotMatched: "insert",
+				},
+			},
+		])
+		.next();
+}

--- a/src/routes/admin/stats/compute/+server.ts
+++ b/src/routes/admin/stats/compute/+server.ts
@@ -90,7 +90,7 @@ async function computeStats(params: { dateField: ConversationStats["date"]["fiel
 								$group: {
 									_id: {
 										day: { $dateTrunc: { date: `$${params.dateField}`, unit: "day" } },
-										sessionId: "$userId",
+										sessionId: "$sessionId",
 									},
 								},
 							},

--- a/src/routes/admin/stats/compute/+server.ts
+++ b/src/routes/admin/stats/compute/+server.ts
@@ -1,7 +1,7 @@
 import { ADMIN_API_SECRET } from "$env/static/private";
 import { error, json } from "@sveltejs/kit";
 import type { ConversationStats } from "$lib/types/ConversationStats";
-import { collections } from "$lib/server/database.js";
+import { CONVERSATION_STATS_COLLECTION, collections } from "$lib/server/database.js";
 
 export async function POST({ request }) {
 	const authorization = request.headers.get("Authorization");
@@ -161,7 +161,7 @@ async function computeStats(params: { dateField: ConversationStats["date"]["fiel
 			},
 			{
 				$merge: {
-					into: "conversationStats",
+					into: CONVERSATION_STATS_COLLECTION,
 					whenMatched: "replace",
 					whenNotMatched: "insert",
 				},

--- a/src/routes/admin/stats/compute/+server.ts
+++ b/src/routes/admin/stats/compute/+server.ts
@@ -26,149 +26,152 @@ async function computeStats(params: { dateField: ConversationStats["date"]["fiel
 
 	console.log("Computing stats for", params.dateField, "from", minDay);
 
-	await collections.conversationStats
-		.aggregate([
-			{
-				$match: {
-					[params.dateField]: { $gte: minDay },
-				},
-			},
-			{
-				$project: {
-					[params.dateField]: 1,
-					sessionId: 1,
-					userId: 1,
-				},
-			},
-			{
-				$sort: {
-					[params.dateField]: 1,
-				},
-			},
-			{
-				$facet: {
-					userId: [
-						{
-							$match: {
-								userId: { $exists: true },
-							},
-						},
-						{
-							$group: {
-								_id: {
-									day: { $dateTrunc: { date: `$${params.dateField}`, unit: "day" } },
-									userId: "$userId",
-								},
-								count: { $sum: 1 },
-							},
-						},
-						{
-							$project: {
-								_id: 0,
-								date: {
-									day: "$_id.day",
-									field: params.dateField,
-								},
-								distinct: "userId",
-								count: 1,
-							},
-						},
-					],
-					sessionId: [
-						{
-							$match: {
-								sessionId: { $exists: true },
-							},
-						},
-						{
-							$group: {
-								_id: {
-									day: { $dateTrunc: { date: `$${params.dateField}`, unit: "day" } },
-									sessionId: "$userId",
-								},
-								count: { $sum: 1 },
-							},
-						},
-						{
-							$project: {
-								_id: 0,
-								date: {
-									day: "$_id.day",
-									field: params.dateField,
-								},
-								distinct: "sessionId",
-								count: 1,
-							},
-						},
-					],
-					userOrSessionId: [
-						{
-							$group: {
-								_id: {
-									day: { $dateTrunc: { date: `$${params.dateField}`, unit: "day" } },
-									userOrSessionId: { $ifNull: ["$userId", "$sessionId"] },
-								},
-								count: { $sum: 1 },
-							},
-						},
-						{
-							$project: {
-								_id: 0,
-								date: {
-									day: "$_id.day",
-									field: params.dateField,
-								},
-								distinct: "userOrSessionId",
-								count: 1,
-							},
-						},
-					],
-					_id: [
-						{
-							$group: {
-								_id: {
-									day: { $dateTrunc: { date: `$${params.dateField}`, unit: "day" } },
-								},
-								count: { $sum: 1 },
-							},
-						},
-						{
-							$project: {
-								_id: 0,
-								date: {
-									day: "$_id.day",
-									field: params.dateField,
-								},
-								distinct: "_id",
-								count: 1,
-							},
-						},
-					],
-				},
-			},
-			{
-				$project: {
-					stats: {
-						$concatArrays: ["$userId", "$sessionId", "$userOrSessionId", "$_id"],
+	await collections.conversations
+		.aggregate(
+			[
+				{
+					$match: {
+						[params.dateField]: { $gte: minDay },
 					},
 				},
-			},
-			{
-				$unwind: "$stats",
-			},
-			{
-				$replaceRoot: {
-					newRoot: "$stats",
+				{
+					$project: {
+						[params.dateField]: 1,
+						sessionId: 1,
+						userId: 1,
+					},
 				},
-			},
-			{
-				$merge: {
-					into: CONVERSATION_STATS_COLLECTION,
-					whenMatched: "replace",
-					whenNotMatched: "insert",
+				{
+					$sort: {
+						[params.dateField]: 1,
+					},
 				},
-			},
-		])
+				{
+					$facet: {
+						userId: [
+							{
+								$match: {
+									userId: { $exists: true },
+								},
+							},
+							{
+								$group: {
+									_id: {
+										day: { $dateTrunc: { date: `$${params.dateField}`, unit: "day" } },
+										userId: "$userId",
+									},
+									count: { $sum: 1 },
+								},
+							},
+							{
+								$project: {
+									_id: 0,
+									date: {
+										day: "$_id.day",
+										field: params.dateField,
+									},
+									distinct: "userId",
+									count: 1,
+								},
+							},
+						],
+						sessionId: [
+							{
+								$match: {
+									sessionId: { $exists: true },
+								},
+							},
+							{
+								$group: {
+									_id: {
+										day: { $dateTrunc: { date: `$${params.dateField}`, unit: "day" } },
+										sessionId: "$userId",
+									},
+									count: { $sum: 1 },
+								},
+							},
+							{
+								$project: {
+									_id: 0,
+									date: {
+										day: "$_id.day",
+										field: params.dateField,
+									},
+									distinct: "sessionId",
+									count: 1,
+								},
+							},
+						],
+						userOrSessionId: [
+							{
+								$group: {
+									_id: {
+										day: { $dateTrunc: { date: `$${params.dateField}`, unit: "day" } },
+										userOrSessionId: { $ifNull: ["$userId", "$sessionId"] },
+									},
+									count: { $sum: 1 },
+								},
+							},
+							{
+								$project: {
+									_id: 0,
+									date: {
+										day: "$_id.day",
+										field: params.dateField,
+									},
+									distinct: "userOrSessionId",
+									count: 1,
+								},
+							},
+						],
+						_id: [
+							{
+								$group: {
+									_id: {
+										day: { $dateTrunc: { date: `$${params.dateField}`, unit: "day" } },
+									},
+									count: { $sum: 1 },
+								},
+							},
+							{
+								$project: {
+									_id: 0,
+									date: {
+										day: "$_id.day",
+										field: params.dateField,
+									},
+									distinct: "_id",
+									count: 1,
+								},
+							},
+						],
+					},
+				},
+				{
+					$project: {
+						stats: {
+							$concatArrays: ["$userId", "$sessionId", "$userOrSessionId", "$_id"],
+						},
+					},
+				},
+				{
+					$unwind: "$stats",
+				},
+				{
+					$replaceRoot: {
+						newRoot: "$stats",
+					},
+				},
+				{
+					$merge: {
+						into: CONVERSATION_STATS_COLLECTION,
+						whenMatched: "replace",
+						whenNotMatched: "insert",
+					},
+				},
+			],
+			{ allowDiskUse: true }
+		)
 		.next();
 
 	console.log("Computed stats for", params.dateField);

--- a/src/routes/admin/stats/compute/+server.ts
+++ b/src/routes/admin/stats/compute/+server.ts
@@ -1,15 +1,11 @@
-import { ADMIN_API_SECRET } from "$env/static/private";
-import { error, json } from "@sveltejs/kit";
+import { json } from "@sveltejs/kit";
 import type { ConversationStats } from "$lib/types/ConversationStats";
 import { CONVERSATION_STATS_COLLECTION, collections } from "$lib/server/database.js";
 
-export async function POST({ request }) {
-	const authorization = request.headers.get("Authorization");
+// Triger like this:
+// curl -X POST "http://localhost:5173/chat/admin/stats/compute" -H "Authorization: Bearer <ADMIN_API_SECRET>"
 
-	if (authorization !== `Bearer ${ADMIN_API_SECRET}`) {
-		throw error(401, "Unauthorized");
-	}
-
+export async function POST() {
 	for (const span of ["day", "week", "month"] as const) {
 		computeStats({ dateField: "updatedAt", type: "conversation", span }).catch(console.error);
 		computeStats({ dateField: "createdAt", type: "conversation", span }).catch(console.error);

--- a/src/routes/admin/stats/compute/+server.ts
+++ b/src/routes/admin/stats/compute/+server.ts
@@ -24,6 +24,8 @@ async function computeStats(params: { dateField: ConversationStats["date"]["fiel
 
 	const minDay = lastComputed ? lastComputed.date.day : new Date(0);
 
+	console.log("Computing stats for", params.dateField, "from", minDay);
+
 	await collections.conversationStats
 		.aggregate([
 			{
@@ -168,4 +170,6 @@ async function computeStats(params: { dateField: ConversationStats["date"]["fiel
 			},
 		])
 		.next();
+
+	console.log("Computed stats for", params.dateField);
 }


### PR DESCRIPTION
This PR adds an api call on `/admin/stats/compute`:

```console
curl -X POST -H "Authorization: Bearer {ADMIN_API_SECRET}" https://huggingface.co/chat/admin/stats/compute
```

This will return a 202 and launch the stats update in the background. The first run will be slow (all the stats to compute), and the next will be faster.

Once the first run successfully completes, the next runs should be much faster to execute. The last day of stats in DB will always be recomputed.

The stats are stored using this schema:

```ts
interface ConversationStats {
	createdAt: Date;
	updatedAt: Date;
	date: {
		at: Date;
		span: "day" | "weak" | "month";
		field: "updatedAt" | "createdAt";
	};
	type: "conversation" | "message";
	/**  _id => number of conversations/messages in the month */
	distinct: "sessionId" | "userId" | "userOrSessionId" | "_id";
	count: number;
}
```

There are 12 documents for each day, 12 for each week, 12 for each month:

- one on updatedAt / sessionId
- one on updatedAt / userId
- one on updatedAt / userOrSessionId
- one on updatedAt / _id (number of conversations updated that day)
- same 4 for createdAt
- same 4 for createdAt on messages

This allows to compute DAU as well as some stats on conversations

---

After merging, this will need a call on `/admin/stats/compute` to update the stats every few hours