### PR TITLE
[Privacy page] Skip disclaimer modal including `basePath`

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -166,7 +166,7 @@
 	{/if}
 </svelte:head>
 
-{#if !$settings.ethicsModalAccepted && $page.url.pathname !== "/privacy"}
+{#if !$settings.ethicsModalAccepted && $page.url.pathname !== `${base}/privacy`}
 	<DisclaimerModal />
 {/if}
 


### PR DESCRIPTION
As written https://github.com/huggingface/chat-ui/pull/808#issuecomment-1946880954, the issue persisted. Local dev setup & prod hf.co/chat behaviours differed because of base path `/chat`