### PR TITLE
Bug Fix: Json Decoder aggessively pulls json

### DIFF
--- a/src/lib/server/endpoints/llamacpp/endpointLlamacpp.ts
+++ b/src/lib/server/endpoints/llamacpp/endpointLlamacpp.ts
@@ -56,36 +56,37 @@ export function endpointLlamacpp(
 			let generatedText = "";
 			let tokenId = 0;
 			let accumulatedData = ""; // Buffer to accumulate data chunks
-		
+
 			while (!stop) {
 				// Read the stream and log the outputs to console
 				const out = (await reader?.read()) ?? { done: false, value: undefined };
-		
+
 				// If it's done, we cancel
 				if (out.done) {
 					reader?.cancel();
 					return;
 				}
-		
+
 				if (!out.value) {
 					return;
 				}
-		
+
 				// Accumulate the data chunk
 				accumulatedData += out.value;
-		
+
 				// Process each complete JSON object in the accumulated data
-				while (accumulatedData.includes("\n")) { // Assuming each JSON object ends with a newline
+				while (accumulatedData.includes("\n")) {
+					// Assuming each JSON object ends with a newline
 					const endIndex = accumulatedData.indexOf("\n");
 					let jsonString = accumulatedData.substring(0, endIndex).trim();
-		
+
 					// Remove the processed part from the buffer
 					accumulatedData = accumulatedData.substring(endIndex + 1);
-		
+
 					if (jsonString.startsWith("data: ")) {
 						jsonString = jsonString.slice(6);
 						let data = null;
-		
+
 						try {
 							data = JSON.parse(jsonString);
 						} catch (e) {
@@ -93,7 +94,7 @@ export function endpointLlamacpp(
 							console.error("Problematic JSON string:", jsonString);
 							continue; // Skip this iteration and try the next chunk
 						}
-		
+
 						// Handle the parsed data
 						if (data.content || data.stop) {
 							generatedText += data.content;

--- a/src/lib/server/endpoints/llamacpp/endpointLlamacpp.ts
+++ b/src/lib/server/endpoints/llamacpp/endpointLlamacpp.ts
@@ -111,7 +111,6 @@ export function endpointLlamacpp(
 								stop = true;
 								reader?.cancel();
 							}
-							console.log(output);
 							yield output;
 						}
 					}

--- a/src/lib/server/endpoints/llamacpp/endpointLlamacpp.ts
+++ b/src/lib/server/endpoints/llamacpp/endpointLlamacpp.ts
@@ -55,44 +55,65 @@ export function endpointLlamacpp(
 			let stop = false;
 			let generatedText = "";
 			let tokenId = 0;
+			let accumulatedData = ""; // Buffer to accumulate data chunks
+		
 			while (!stop) {
-				// read the stream and log the outputs to console
+				// Read the stream and log the outputs to console
 				const out = (await reader?.read()) ?? { done: false, value: undefined };
-				// we read, if it's done we cancel
+		
+				// If it's done, we cancel
 				if (out.done) {
 					reader?.cancel();
 					return;
 				}
-
+		
 				if (!out.value) {
 					return;
 				}
-
-				if (out.value.startsWith("data: ")) {
-					let data = null;
-					try {
-						data = JSON.parse(out.value.slice(6));
-					} catch (e) {
-						return;
-					}
-					if (data.content || data.stop) {
-						generatedText += data.content;
-						const output: TextGenerationStreamOutput = {
-							token: {
-								id: tokenId++,
-								text: data.content ?? "",
-								logprob: 0,
-								special: false,
-							},
-							generated_text: data.stop ? generatedText : null,
-							details: null,
-						};
-						if (data.stop) {
-							stop = true;
-							reader?.cancel();
+		
+				// Accumulate the data chunk
+				accumulatedData += out.value;
+		
+				// Process each complete JSON object in the accumulated data
+				while (accumulatedData.includes("\n")) { // Assuming each JSON object ends with a newline
+					const endIndex = accumulatedData.indexOf("\n");
+					let jsonString = accumulatedData.substring(0, endIndex).trim();
+		
+					// Remove the processed part from the buffer
+					accumulatedData = accumulatedData.substring(endIndex + 1);
+		
+					if (jsonString.startsWith("data: ")) {
+						jsonString = jsonString.slice(6);
+						let data = null;
+		
+						try {
+							data = JSON.parse(jsonString);
+						} catch (e) {
+							console.error("Failed to parse JSON", e);
+							console.error("Problematic JSON string:", jsonString);
+							continue; // Skip this iteration and try the next chunk
 						}
-						yield output;
-						// take the data.content value and yield it
+		
+						// Handle the parsed data
+						if (data.content || data.stop) {
+							generatedText += data.content;
+							const output: TextGenerationStreamOutput = {
+								token: {
+									id: tokenId++,
+									text: data.content ?? "",
+									logprob: 0,
+									special: false,
+								},
+								generated_text: data.stop ? generatedText : null,
+								details: null,
+							};
+							if (data.stop) {
+								stop = true;
+								reader?.cancel();
+							}
+							console.log(output);
+							yield output;
+						}
 					}
 				}
 			}


### PR DESCRIPTION
**Background**
Had this problem on 2 different setups, essentially the decoder for llamacpp would grab partially streamed json and decode it without the new line 

**Description**

Just wait until we see a new line character before trying to decode the json. if we fail to decode a token, just toss it. *may lead to tokens being thrown out but after a couple of days of running this thru the ringer it seemed to work, and dropping a word is a better UX than just crashing when it fails to decode the response