### PR TITLE
Add a simple populate script

### DIFF
--- a/README.md
+++ b/README.md
@@ -619,6 +619,9 @@ This will replace your `.env.local` file with the one that will be used in prod 
 
 ### Populate database
 
+> [!WARNING]  
+> The `MONGODB_URL` used for this script will be fetched from `.env.local`. Make sure it's correct! The command runs directly on the database.
+
 You can populate the database using faker data using the `populate` script:
 
 ```bash
@@ -628,13 +631,11 @@ npm run populate <flags here>
 At least one flag must be specified, the following flags are available:
 
 - `reset` - resets the database
+- `all` - populates all tables
 - `users` - populates the users table
 - `settings` - populates the settings table for existing users
 - `assistants` - populates the assistants table for existing users
 - `conversations` - populates the conversations table for existing users
-
-> [!WARNING]  
-> The `MONGODB_URL` used for this script will be fetched from `.env.local`. Make sure it's correct! The command runs directly on the database.
 
 For example, you could use it like so:
 

--- a/README.md
+++ b/README.md
@@ -616,3 +616,36 @@ npm run updateLocalEnv
 ```
 
 This will replace your `.env.local` file with the one that will be used in prod (simply taking `.env.template + .env.SECRET_CONFIG`).
+
+### Populate database
+
+You can populate the database using faker data using the `populate` script:
+
+```bash
+npm run populate <flags here>
+```
+
+At least one flag must be specified, the following flags are available:
+
+- `reset` - resets the database
+- `users` - populates the users table
+- `settings` - populates the settings table for existing users
+- `assistants` - populates the assistants table for existing users
+- `conversations` - populates the conversations table for existing users
+
+> [!WARNING]  
+> The `MONGODB_URL` used for this script will be fetched from `.env.local`. Make sure it's correct! The command runs directly on the database.
+
+For example, you could use it like so:
+
+```bash
+npm run populate reset
+```
+
+to clear out the database. Then login in the app to create your user and run the following command:
+
+```bash
+npm run populate users settings assistants conversations
+```
+
+to populate the database with fake data, including fake conversations and assistants for your user.

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
 				"zod": "^3.22.3"
 			},
 			"devDependencies": {
+				"@faker-js/faker": "^8.4.1",
 				"@iconify-json/carbon": "^1.1.16",
 				"@iconify-json/eos-icons": "^1.1.6",
 				"@sveltejs/adapter-node": "^1.3.1",
@@ -45,6 +46,7 @@
 				"@tailwindcss/typography": "^0.5.9",
 				"@types/jsdom": "^21.1.1",
 				"@types/marked": "^4.0.8",
+				"@types/minimist": "^1.2.5",
 				"@types/parquetjs": "^0.10.3",
 				"@typescript-eslint/eslint-plugin": "^6.x",
 				"@typescript-eslint/parser": "^6.x",
@@ -52,6 +54,7 @@
 				"eslint-config-prettier": "^8.5.0",
 				"eslint-plugin-svelte": "^2.30.0",
 				"marked-katex-extension": "^3.0.6",
+				"minimist": "^1.2.8",
 				"prettier": "^2.8.0",
 				"prettier-plugin-svelte": "^2.10.1",
 				"prettier-plugin-tailwindcss": "^0.2.7",
@@ -62,6 +65,7 @@
 				"typescript": "^5.0.0",
 				"unplugin-icons": "^0.16.1",
 				"vite": "^4.5.2",
+				"vite-node": "^1.3.1",
 				"vitest": "^0.31.0"
 			},
 			"optionalDependencies": {
@@ -144,6 +148,22 @@
 			"optional": true,
 			"dependencies": {
 				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@esbuild/aix-ppc64": {
+			"version": "0.19.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.19.12.tgz",
+			"integrity": "sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/@esbuild/android-arm": {
@@ -552,6 +572,22 @@
 			"dev": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			}
+		},
+		"node_modules/@faker-js/faker": {
+			"version": "8.4.1",
+			"resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-8.4.1.tgz",
+			"integrity": "sha512-XQ3cU+Q8Uqmrbf2e0cIC/QN43sTBSC8KF12u29Mb47tWrt2hAgBXSgpZMj4Ao8Uk0iJcU99QsOCaIL8934obCg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fakerjs"
+				}
+			],
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0",
+				"npm": ">=6.14.13"
 			}
 		},
 		"node_modules/@fastify/busboy": {
@@ -1568,6 +1604,175 @@
 				}
 			}
 		},
+		"node_modules/@rollup/rollup-android-arm-eabi": {
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.12.0.tgz",
+			"integrity": "sha512-+ac02NL/2TCKRrJu2wffk1kZ+RyqxVUlbjSagNgPm94frxtr+XDL12E5Ll1enWskLrtrZ2r8L3wED1orIibV/w==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/@rollup/rollup-android-arm64": {
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.12.0.tgz",
+			"integrity": "sha512-OBqcX2BMe6nvjQ0Nyp7cC90cnumt8PXmO7Dp3gfAju/6YwG0Tj74z1vKrfRz7qAv23nBcYM8BCbhrsWqO7PzQQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/@rollup/rollup-darwin-arm64": {
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.12.0.tgz",
+			"integrity": "sha512-X64tZd8dRE/QTrBIEs63kaOBG0b5GVEd3ccoLtyf6IdXtHdh8h+I56C2yC3PtC9Ucnv0CpNFJLqKFVgCYe0lOQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@rollup/rollup-darwin-x64": {
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.12.0.tgz",
+			"integrity": "sha512-cc71KUZoVbUJmGP2cOuiZ9HSOP14AzBAThn3OU+9LcA1+IUqswJyR1cAJj3Mg55HbjZP6OLAIscbQsQLrpgTOg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.12.0.tgz",
+			"integrity": "sha512-a6w/Y3hyyO6GlpKL2xJ4IOh/7d+APaqLYdMf86xnczU3nurFTaVN9s9jOXQg97BE4nYm/7Ga51rjec5nfRdrvA==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm64-gnu": {
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.12.0.tgz",
+			"integrity": "sha512-0fZBq27b+D7Ar5CQMofVN8sggOVhEtzFUwOwPppQt0k+VR+7UHMZZY4y+64WJ06XOhBTKXtQB/Sv0NwQMXyNAA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm64-musl": {
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.12.0.tgz",
+			"integrity": "sha512-eTvzUS3hhhlgeAv6bfigekzWZjaEX9xP9HhxB0Dvrdbkk5w/b+1Sxct2ZuDxNJKzsRStSq1EaEkVSEe7A7ipgQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.12.0.tgz",
+			"integrity": "sha512-ix+qAB9qmrCRiaO71VFfY8rkiAZJL8zQRXveS27HS+pKdjwUfEhqo2+YF2oI+H/22Xsiski+qqwIBxVewLK7sw==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-x64-gnu": {
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.12.0.tgz",
+			"integrity": "sha512-TenQhZVOtw/3qKOPa7d+QgkeM6xY0LtwzR8OplmyL5LrgTWIXpTQg2Q2ycBf8jm+SFW2Wt/DTn1gf7nFp3ssVA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-x64-musl": {
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.12.0.tgz",
+			"integrity": "sha512-LfFdRhNnW0zdMvdCb5FNuWlls2WbbSridJvxOvYWgSBOYZtgBfW9UGNJG//rwMqTX1xQE9BAodvMH9tAusKDUw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-arm64-msvc": {
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.12.0.tgz",
+			"integrity": "sha512-JPDxovheWNp6d7AHCgsUlkuCKvtu3RB55iNEkaQcf0ttsDU/JZF+iQnYcQJSk/7PtT4mjjVG8N1kpwnI9SLYaw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-ia32-msvc": {
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.12.0.tgz",
+			"integrity": "sha512-fjtuvMWRGJn1oZacG8IPnzIV6GF2/XG+h71FKn76OYFqySXInJtseAqdprVTDTyqPxQOG9Exak5/E9Z3+EJ8ZA==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-x64-msvc": {
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.12.0.tgz",
+			"integrity": "sha512-ZYmr5mS2wd4Dew/JjT0Fqi2NPB/ZhZ2VvPp7SmvPZb4Y1CG/LRcS6tcRo2cYU7zLK5A7cdbhWnnWmUjoI4qapg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
 		"node_modules/@shuding/opentype.js": {
 			"version": "1.4.0-beta.0",
 			"resolved": "https://registry.npmjs.org/@shuding/opentype.js/-/opentype.js-1.4.0-beta.0.tgz",
@@ -1751,9 +1956,9 @@
 			"dev": true
 		},
 		"node_modules/@types/estree": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.2.tgz",
-			"integrity": "sha512-VeiPZ9MMwXjO32/Xu7+OwflfmeoRwkE/qzndw42gGtgJwZopBnzy2gD//NN1+go1mADzkDcqf/KnFRSjTJ8xJA==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+			"integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
 			"dev": true
 		},
 		"node_modules/@types/jsdom": {
@@ -1788,6 +1993,12 @@
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/@types/marked/-/marked-4.0.8.tgz",
 			"integrity": "sha512-HVNzMT5QlWCOdeuBsgXP8EZzKUf0+AXzN+sLmjvaB3ZlLqO+e4u0uXrdw9ub69wBKFs+c6/pA4r9sy6cCDvImw==",
+			"dev": true
+		},
+		"node_modules/@types/minimist": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.5.tgz",
+			"integrity": "sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==",
 			"dev": true
 		},
 		"node_modules/@types/node": {
@@ -2198,9 +2409,9 @@
 			}
 		},
 		"node_modules/acorn": {
-			"version": "8.10.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
-			"integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+			"version": "8.11.3",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
+			"integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
 			"devOptional": true,
 			"bin": {
 				"acorn": "bin/acorn"
@@ -3726,9 +3937,9 @@
 			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
 		},
 		"node_modules/fsevents": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
 			"hasInstallScript": true,
 			"optional": true,
 			"os": [
@@ -4367,9 +4578,9 @@
 			}
 		},
 		"node_modules/jsonc-parser": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
-			"integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.1.tgz",
+			"integrity": "sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==",
 			"dev": true
 		},
 		"node_modules/katex": {
@@ -4740,15 +4951,15 @@
 			"integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
 		},
 		"node_modules/mlly": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/mlly/-/mlly-1.2.1.tgz",
-			"integrity": "sha512-1aMEByaWgBPEbWV2BOPEMySRrzl7rIHXmQxam4DM8jVjalTQDjpN2ZKOLUrwyhfZQO7IXHml2StcHMhooDeEEQ==",
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/mlly/-/mlly-1.6.1.tgz",
+			"integrity": "sha512-vLgaHvaeunuOXHSmEbZ9izxPx3USsk8KCQ8iC+aTlp5sKRSoZvwhHh5L9VbKSaVC6sJDqbyohIS76E2VmHIPAA==",
 			"dev": true,
 			"dependencies": {
-				"acorn": "^8.8.2",
-				"pathe": "^1.1.0",
+				"acorn": "^8.11.3",
+				"pathe": "^1.1.2",
 				"pkg-types": "^1.0.3",
-				"ufo": "^1.1.2"
+				"ufo": "^1.3.2"
 			}
 		},
 		"node_modules/mongodb": {
@@ -5297,9 +5508,9 @@
 			}
 		},
 		"node_modules/pathe": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.0.tgz",
-			"integrity": "sha512-ODbEPR0KKHqECXW1GoxdDb+AZvULmXjVPy4rt+pGo2+TnjJTIPJQSVS6N63n8T2Ip+syHhbn52OewKicV0373w==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+			"integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
 			"dev": true
 		},
 		"node_modules/pathval": {
@@ -5389,9 +5600,9 @@
 			"integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg=="
 		},
 		"node_modules/postcss": {
-			"version": "8.4.31",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-			"integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+			"version": "8.4.35",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.35.tgz",
+			"integrity": "sha512-u5U8qYpBCpN13BsiEB0CbR1Hhh4Gc0zLFuedrHJKMctHCHAGrMdG0PRM/KErzAL3CU6/eckEtmHNB3x6e3c0vA==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -5407,7 +5618,7 @@
 				}
 			],
 			"dependencies": {
-				"nanoid": "^3.3.6",
+				"nanoid": "^3.3.7",
 				"picocolors": "^1.0.0",
 				"source-map-js": "^1.0.2"
 			},
@@ -5556,9 +5767,9 @@
 			"integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
 		},
 		"node_modules/postcss/node_modules/nanoid": {
-			"version": "3.3.6",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-			"integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+			"version": "3.3.7",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+			"integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
 			"funding": [
 				{
 					"type": "github",
@@ -7101,9 +7312,9 @@
 			}
 		},
 		"node_modules/ufo": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/ufo/-/ufo-1.1.2.tgz",
-			"integrity": "sha512-TrY6DsjTQQgyS3E3dBaOXf0TpPD8u9FVrVYmKVegJuFw51n/YB9XPt+U6ydzFG5ZIN7+DIjPbNmXoBj9esYhgQ==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/ufo/-/ufo-1.4.0.tgz",
+			"integrity": "sha512-Hhy+BhRBleFjpJ2vchUNN40qgkh0366FWJGqVLYBHev0vpHTrXSA0ryT+74UiW6KWsldNurQMKGqCm1M2zBciQ==",
 			"dev": true
 		},
 		"node_modules/uglify-js": {
@@ -7316,26 +7527,502 @@
 			}
 		},
 		"node_modules/vite-node": {
-			"version": "0.31.0",
-			"resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.31.0.tgz",
-			"integrity": "sha512-8x1x1LNuPvE2vIvkSB7c1mApX5oqlgsxzHQesYF7l5n1gKrEmrClIiZuOFbFDQcjLsmcWSwwmrWrcGWm9Fxc/g==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.3.1.tgz",
+			"integrity": "sha512-azbRrqRxlWTJEVbzInZCTchx0X69M/XPTCz4H+TLvlTcR/xH/3hkRqhOakT41fMJCMzXTu4UvegkZiEoJAWvng==",
 			"dev": true,
 			"dependencies": {
 				"cac": "^6.7.14",
 				"debug": "^4.3.4",
-				"mlly": "^1.2.0",
-				"pathe": "^1.1.0",
+				"pathe": "^1.1.1",
 				"picocolors": "^1.0.0",
-				"vite": "^3.0.0 || ^4.0.0"
+				"vite": "^5.0.0"
 			},
 			"bin": {
 				"vite-node": "vite-node.mjs"
 			},
 			"engines": {
-				"node": ">=v14.18.0"
+				"node": "^18.0.0 || >=20.0.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/vite-node/node_modules/@esbuild/android-arm": {
+			"version": "0.19.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.12.tgz",
+			"integrity": "sha512-qg/Lj1mu3CdQlDEEiWrlC4eaPZ1KztwGJ9B6J+/6G+/4ewxJg7gqj8eVYWvao1bXrqGiW2rsBZFSX3q2lcW05w==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite-node/node_modules/@esbuild/android-arm64": {
+			"version": "0.19.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.12.tgz",
+			"integrity": "sha512-P0UVNGIienjZv3f5zq0DP3Nt2IE/3plFzuaS96vihvD0Hd6H/q4WXUGpCxD/E8YrSXfNyRPbpTq+T8ZQioSuPA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite-node/node_modules/@esbuild/android-x64": {
+			"version": "0.19.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.12.tgz",
+			"integrity": "sha512-3k7ZoUW6Q6YqhdhIaq/WZ7HwBpnFBlW905Fa4s4qWJyiNOgT1dOqDiVAQFwBH7gBRZr17gLrlFCRzF6jFh7Kew==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite-node/node_modules/@esbuild/darwin-arm64": {
+			"version": "0.19.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.12.tgz",
+			"integrity": "sha512-B6IeSgZgtEzGC42jsI+YYu9Z3HKRxp8ZT3cqhvliEHovq8HSX2YX8lNocDn79gCKJXOSaEot9MVYky7AKjCs8g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite-node/node_modules/@esbuild/darwin-x64": {
+			"version": "0.19.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.12.tgz",
+			"integrity": "sha512-hKoVkKzFiToTgn+41qGhsUJXFlIjxI/jSYeZf3ugemDYZldIXIxhvwN6erJGlX4t5h417iFuheZ7l+YVn05N3A==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite-node/node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.19.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.12.tgz",
+			"integrity": "sha512-4aRvFIXmwAcDBw9AueDQ2YnGmz5L6obe5kmPT8Vd+/+x/JMVKCgdcRwH6APrbpNXsPz+K653Qg8HB/oXvXVukA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite-node/node_modules/@esbuild/freebsd-x64": {
+			"version": "0.19.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.12.tgz",
+			"integrity": "sha512-EYoXZ4d8xtBoVN7CEwWY2IN4ho76xjYXqSXMNccFSx2lgqOG/1TBPW0yPx1bJZk94qu3tX0fycJeeQsKovA8gg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite-node/node_modules/@esbuild/linux-arm": {
+			"version": "0.19.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.12.tgz",
+			"integrity": "sha512-J5jPms//KhSNv+LO1S1TX1UWp1ucM6N6XuL6ITdKWElCu8wXP72l9MM0zDTzzeikVyqFE6U8YAV9/tFyj0ti+w==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite-node/node_modules/@esbuild/linux-arm64": {
+			"version": "0.19.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.12.tgz",
+			"integrity": "sha512-EoTjyYyLuVPfdPLsGVVVC8a0p1BFFvtpQDB/YLEhaXyf/5bczaGeN15QkR+O4S5LeJ92Tqotve7i1jn35qwvdA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite-node/node_modules/@esbuild/linux-ia32": {
+			"version": "0.19.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.12.tgz",
+			"integrity": "sha512-Thsa42rrP1+UIGaWz47uydHSBOgTUnwBwNq59khgIwktK6x60Hivfbux9iNR0eHCHzOLjLMLfUMLCypBkZXMHA==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite-node/node_modules/@esbuild/linux-loong64": {
+			"version": "0.19.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.12.tgz",
+			"integrity": "sha512-LiXdXA0s3IqRRjm6rV6XaWATScKAXjI4R4LoDlvO7+yQqFdlr1Bax62sRwkVvRIrwXxvtYEHHI4dm50jAXkuAA==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite-node/node_modules/@esbuild/linux-mips64el": {
+			"version": "0.19.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.12.tgz",
+			"integrity": "sha512-fEnAuj5VGTanfJ07ff0gOA6IPsvrVHLVb6Lyd1g2/ed67oU1eFzL0r9WL7ZzscD+/N6i3dWumGE1Un4f7Amf+w==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite-node/node_modules/@esbuild/linux-ppc64": {
+			"version": "0.19.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.12.tgz",
+			"integrity": "sha512-nYJA2/QPimDQOh1rKWedNOe3Gfc8PabU7HT3iXWtNUbRzXS9+vgB0Fjaqr//XNbd82mCxHzik2qotuI89cfixg==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite-node/node_modules/@esbuild/linux-riscv64": {
+			"version": "0.19.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.12.tgz",
+			"integrity": "sha512-2MueBrlPQCw5dVJJpQdUYgeqIzDQgw3QtiAHUC4RBz9FXPrskyyU3VI1hw7C0BSKB9OduwSJ79FTCqtGMWqJHg==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite-node/node_modules/@esbuild/linux-s390x": {
+			"version": "0.19.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.12.tgz",
+			"integrity": "sha512-+Pil1Nv3Umes4m3AZKqA2anfhJiVmNCYkPchwFJNEJN5QxmTs1uzyy4TvmDrCRNT2ApwSari7ZIgrPeUx4UZDg==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite-node/node_modules/@esbuild/linux-x64": {
+			"version": "0.19.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.12.tgz",
+			"integrity": "sha512-B71g1QpxfwBvNrfyJdVDexenDIt1CiDN1TIXLbhOw0KhJzE78KIFGX6OJ9MrtC0oOqMWf+0xop4qEU8JrJTwCg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite-node/node_modules/@esbuild/netbsd-x64": {
+			"version": "0.19.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.12.tgz",
+			"integrity": "sha512-3ltjQ7n1owJgFbuC61Oj++XhtzmymoCihNFgT84UAmJnxJfm4sYCiSLTXZtE00VWYpPMYc+ZQmB6xbSdVh0JWA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite-node/node_modules/@esbuild/openbsd-x64": {
+			"version": "0.19.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.12.tgz",
+			"integrity": "sha512-RbrfTB9SWsr0kWmb9srfF+L933uMDdu9BIzdA7os2t0TXhCRjrQyCeOt6wVxr79CKD4c+p+YhCj31HBkYcXebw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite-node/node_modules/@esbuild/sunos-x64": {
+			"version": "0.19.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.12.tgz",
+			"integrity": "sha512-HKjJwRrW8uWtCQnQOz9qcU3mUZhTUQvi56Q8DPTLLB+DawoiQdjsYq+j+D3s9I8VFtDr+F9CjgXKKC4ss89IeA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite-node/node_modules/@esbuild/win32-arm64": {
+			"version": "0.19.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.12.tgz",
+			"integrity": "sha512-URgtR1dJnmGvX864pn1B2YUYNzjmXkuJOIqG2HdU62MVS4EHpU2946OZoTMnRUHklGtJdJZ33QfzdjGACXhn1A==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite-node/node_modules/@esbuild/win32-ia32": {
+			"version": "0.19.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.12.tgz",
+			"integrity": "sha512-+ZOE6pUkMOJfmxmBZElNOx72NKpIa/HFOMGzu8fqzQJ5kgf6aTGrcJaFsNiVMH4JKpMipyK+7k0n2UXN7a8YKQ==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite-node/node_modules/@esbuild/win32-x64": {
+			"version": "0.19.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.12.tgz",
+			"integrity": "sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite-node/node_modules/esbuild": {
+			"version": "0.19.12",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.12.tgz",
+			"integrity": "sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg==",
+			"dev": true,
+			"hasInstallScript": true,
+			"bin": {
+				"esbuild": "bin/esbuild"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"optionalDependencies": {
+				"@esbuild/aix-ppc64": "0.19.12",
+				"@esbuild/android-arm": "0.19.12",
+				"@esbuild/android-arm64": "0.19.12",
+				"@esbuild/android-x64": "0.19.12",
+				"@esbuild/darwin-arm64": "0.19.12",
+				"@esbuild/darwin-x64": "0.19.12",
+				"@esbuild/freebsd-arm64": "0.19.12",
+				"@esbuild/freebsd-x64": "0.19.12",
+				"@esbuild/linux-arm": "0.19.12",
+				"@esbuild/linux-arm64": "0.19.12",
+				"@esbuild/linux-ia32": "0.19.12",
+				"@esbuild/linux-loong64": "0.19.12",
+				"@esbuild/linux-mips64el": "0.19.12",
+				"@esbuild/linux-ppc64": "0.19.12",
+				"@esbuild/linux-riscv64": "0.19.12",
+				"@esbuild/linux-s390x": "0.19.12",
+				"@esbuild/linux-x64": "0.19.12",
+				"@esbuild/netbsd-x64": "0.19.12",
+				"@esbuild/openbsd-x64": "0.19.12",
+				"@esbuild/sunos-x64": "0.19.12",
+				"@esbuild/win32-arm64": "0.19.12",
+				"@esbuild/win32-ia32": "0.19.12",
+				"@esbuild/win32-x64": "0.19.12"
+			}
+		},
+		"node_modules/vite-node/node_modules/rollup": {
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.12.0.tgz",
+			"integrity": "sha512-wz66wn4t1OHIJw3+XU7mJJQV/2NAfw5OAk6G6Hoo3zcvz/XOfQ52Vgi+AN4Uxoxi0KBBwk2g8zPrTDA4btSB/Q==",
+			"dev": true,
+			"dependencies": {
+				"@types/estree": "1.0.5"
+			},
+			"bin": {
+				"rollup": "dist/bin/rollup"
+			},
+			"engines": {
+				"node": ">=18.0.0",
+				"npm": ">=8.0.0"
+			},
+			"optionalDependencies": {
+				"@rollup/rollup-android-arm-eabi": "4.12.0",
+				"@rollup/rollup-android-arm64": "4.12.0",
+				"@rollup/rollup-darwin-arm64": "4.12.0",
+				"@rollup/rollup-darwin-x64": "4.12.0",
+				"@rollup/rollup-linux-arm-gnueabihf": "4.12.0",
+				"@rollup/rollup-linux-arm64-gnu": "4.12.0",
+				"@rollup/rollup-linux-arm64-musl": "4.12.0",
+				"@rollup/rollup-linux-riscv64-gnu": "4.12.0",
+				"@rollup/rollup-linux-x64-gnu": "4.12.0",
+				"@rollup/rollup-linux-x64-musl": "4.12.0",
+				"@rollup/rollup-win32-arm64-msvc": "4.12.0",
+				"@rollup/rollup-win32-ia32-msvc": "4.12.0",
+				"@rollup/rollup-win32-x64-msvc": "4.12.0",
+				"fsevents": "~2.3.2"
+			}
+		},
+		"node_modules/vite-node/node_modules/vite": {
+			"version": "5.1.4",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-5.1.4.tgz",
+			"integrity": "sha512-n+MPqzq+d9nMVTKyewqw6kSt+R3CkvF9QAKY8obiQn8g1fwTscKxyfaYnC632HtBXAQGc1Yjomphwn1dtwGAHg==",
+			"dev": true,
+			"dependencies": {
+				"esbuild": "^0.19.3",
+				"postcss": "^8.4.35",
+				"rollup": "^4.2.0"
+			},
+			"bin": {
+				"vite": "bin/vite.js"
+			},
+			"engines": {
+				"node": "^18.0.0 || >=20.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/vitejs/vite?sponsor=1"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.3"
+			},
+			"peerDependencies": {
+				"@types/node": "^18.0.0 || >=20.0.0",
+				"less": "*",
+				"lightningcss": "^1.21.0",
+				"sass": "*",
+				"stylus": "*",
+				"sugarss": "*",
+				"terser": "^5.4.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				},
+				"less": {
+					"optional": true
+				},
+				"lightningcss": {
+					"optional": true
+				},
+				"sass": {
+					"optional": true
+				},
+				"stylus": {
+					"optional": true
+				},
+				"sugarss": {
+					"optional": true
+				},
+				"terser": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/vitefu": {
@@ -7428,6 +8115,29 @@
 				"webdriverio": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/vitest/node_modules/vite-node": {
+			"version": "0.31.0",
+			"resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.31.0.tgz",
+			"integrity": "sha512-8x1x1LNuPvE2vIvkSB7c1mApX5oqlgsxzHQesYF7l5n1gKrEmrClIiZuOFbFDQcjLsmcWSwwmrWrcGWm9Fxc/g==",
+			"dev": true,
+			"dependencies": {
+				"cac": "^6.7.14",
+				"debug": "^4.3.4",
+				"mlly": "^1.2.0",
+				"pathe": "^1.1.0",
+				"picocolors": "^1.0.0",
+				"vite": "^3.0.0 || ^4.0.0"
+			},
+			"bin": {
+				"vite-node": "vite-node.mjs"
+			},
+			"engines": {
+				"node": ">=v14.18.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
 			}
 		},
 		"node_modules/w3c-xmlserializer": {

--- a/package.json
+++ b/package.json
@@ -13,9 +13,11 @@
 		"format": "prettier --plugin-search-dir . --write .",
 		"test": "MONGODB_URL=mongodb://127.0.0.1:27017/ vitest",
 		"updateLocalEnv": "node --loader ts-node/esm scripts/updateLocalEnv.ts",
-		"updateProdEnv": "node --loader ts-node/esm scripts/updateProdEnv.ts"
+		"updateProdEnv": "node --loader ts-node/esm scripts/updateProdEnv.ts",
+		"populate": "vite-node --options.transformMode.ssr='/.*/' scripts/populate.ts"
 	},
 	"devDependencies": {
+		"@faker-js/faker": "^8.4.1",
 		"@iconify-json/carbon": "^1.1.16",
 		"@iconify-json/eos-icons": "^1.1.6",
 		"@sveltejs/adapter-node": "^1.3.1",
@@ -23,6 +25,7 @@
 		"@tailwindcss/typography": "^0.5.9",
 		"@types/jsdom": "^21.1.1",
 		"@types/marked": "^4.0.8",
+		"@types/minimist": "^1.2.5",
 		"@types/parquetjs": "^0.10.3",
 		"@typescript-eslint/eslint-plugin": "^6.x",
 		"@typescript-eslint/parser": "^6.x",
@@ -30,6 +33,7 @@
 		"eslint-config-prettier": "^8.5.0",
 		"eslint-plugin-svelte": "^2.30.0",
 		"marked-katex-extension": "^3.0.6",
+		"minimist": "^1.2.8",
 		"prettier": "^2.8.0",
 		"prettier-plugin-svelte": "^2.10.1",
 		"prettier-plugin-tailwindcss": "^0.2.7",
@@ -40,6 +44,7 @@
 		"typescript": "^5.0.0",
 		"unplugin-icons": "^0.16.1",
 		"vite": "^4.5.2",
+		"vite-node": "^1.3.1",
 		"vitest": "^0.31.0"
 	},
 	"type": "module",

--- a/scripts/populate.ts
+++ b/scripts/populate.ts
@@ -27,7 +27,7 @@ rl.on("close", function () {
 	process.exit(0);
 });
 
-const possibleFlags = ["reset", "users", "settings", "assistants", "conversations"];
+const possibleFlags = ["reset", "all", "users", "settings", "assistants", "conversations"];
 const argv = minimist(process.argv.slice(2));
 const flags = argv["_"].filter((flag) => possibleFlags.includes(flag));
 
@@ -113,7 +113,7 @@ async function seed() {
 		console.log("Reset done");
 	}
 
-	if (flags.includes("users")) {
+	if (flags.includes("users") || flags.includes("all")) {
 		const newUsers: User[] = Array.from({ length: 100 }, () => ({
 			_id: new ObjectId(),
 			createdAt: faker.date.recent({ days: 30 }),
@@ -127,7 +127,7 @@ async function seed() {
 		await collections.users.insertMany(newUsers);
 	}
 	const users = await collections.users.find().toArray();
-	if (flags.includes("settings")) {
+	if (flags.includes("settings") || flags.includes("all")) {
 		users.forEach(async (user) => {
 			const settings: Settings = {
 				userId: user._id,
@@ -148,7 +148,7 @@ async function seed() {
 		});
 	}
 
-	if (flags.includes("assistants")) {
+	if (flags.includes("assistants") || flags.includes("all")) {
 		await Promise.all(
 			users.map(async (user) => {
 				const assistants = faker.helpers.multiple<Assistant>(
@@ -180,7 +180,7 @@ async function seed() {
 		);
 	}
 
-	if (flags.includes("conversations")) {
+	if (flags.includes("conversations") || flags.includes("all")) {
 		await Promise.all(
 			users.map(async (user) => {
 				const conversations = faker.helpers.multiple(

--- a/scripts/populate.ts
+++ b/scripts/populate.ts
@@ -1,0 +1,253 @@
+import readline from "readline";
+import minimist from "minimist";
+
+// @ts-expect-error: vite-node makes the var available but the typescript compiler doesn't see them
+import { MONGODB_URL } from "$env/static/private";
+
+import { faker } from "@faker-js/faker";
+import { ObjectId } from "mongodb";
+
+import { collections } from "../src/lib/server/database.ts";
+import { models } from "../src/lib/server/models.ts";
+import type { User } from "../src/lib/types/User";
+import type { Assistant } from "../src/lib/types/Assistant";
+import type { Conversation } from "../src/lib/types/Conversation";
+import type { Settings } from "../src/lib/types/Settings";
+import { defaultEmbeddingModel } from "../src/lib/server/embeddingModels.ts";
+import { Message } from "../src/lib/types/Message.ts";
+
+import { addChildren } from "../src/lib/utils/tree/addChildren.ts";
+
+const rl = readline.createInterface({
+	input: process.stdin,
+	output: process.stdout,
+});
+
+rl.on("close", function () {
+	process.exit(0);
+});
+
+const possibleFlags = ["reset", "users", "settings", "assistants", "conversations"];
+const argv = minimist(process.argv.slice(2));
+const flags = argv["_"].filter((flag) => possibleFlags.includes(flag));
+
+async function generateMessages(preprompt?: string): Promise<Message[]> {
+	const isLinear = faker.datatype.boolean(0.5);
+	const isInterrupted = faker.datatype.boolean(0.05);
+
+	const messages: Message[] = [];
+
+	messages.push({
+		id: crypto.randomUUID(),
+		from: "system",
+		content: preprompt ?? "",
+		createdAt: faker.date.recent({ days: 30 }),
+		updatedAt: faker.date.recent({ days: 30 }),
+	});
+
+	let isUser = true;
+	let lastId = messages[0].id;
+	if (isLinear) {
+		const convLength = faker.number.int({ min: 1, max: 25 }) * 2; // must always be even
+
+		for (let i = 0; i < convLength; i++) {
+			lastId = addChildren(
+				{
+					messages,
+					rootMessageId: messages[0].id,
+				},
+				{
+					from: isUser ? "user" : "assistant",
+					content: faker.lorem.sentence({
+						min: 10,
+						max: isUser ? 50 : 200,
+					}),
+					createdAt: faker.date.recent({ days: 30 }),
+					updatedAt: faker.date.recent({ days: 30 }),
+					interrupted: i === convLength - 1 && isInterrupted,
+				},
+				lastId
+			);
+			isUser = !isUser;
+		}
+	} else {
+		const convLength = faker.number.int({ min: 2, max: 200 });
+
+		for (let i = 0; i < convLength; i++) {
+			addChildren(
+				{
+					messages,
+					rootMessageId: messages[0].id,
+				},
+				{
+					from: isUser ? "user" : "assistant",
+					content: faker.lorem.sentence({
+						min: 10,
+						max: isUser ? 50 : 200,
+					}),
+					createdAt: faker.date.recent({ days: 30 }),
+					updatedAt: faker.date.recent({ days: 30 }),
+					interrupted: i === convLength - 1 && isInterrupted,
+				},
+				faker.helpers.arrayElement([
+					messages[0].id,
+					...messages.filter((m) => m.from === (isUser ? "assistant" : "user")).map((m) => m.id),
+				])
+			);
+
+			isUser = !isUser;
+		}
+	}
+	return messages;
+}
+
+async function seed() {
+	console.log("Seeding...");
+	const modelIds = models.map((model) => model.id);
+
+	if (flags.includes("reset")) {
+		await collections.users.deleteMany({});
+		await collections.settings.deleteMany({});
+		await collections.assistants.deleteMany({});
+		await collections.conversations.deleteMany({});
+		console.log("Reset done");
+	}
+
+	if (flags.includes("users")) {
+		const newUsers: User[] = Array.from({ length: 100 }, () => ({
+			_id: new ObjectId(),
+			createdAt: faker.date.recent({ days: 30 }),
+			updatedAt: faker.date.recent({ days: 30 }),
+			username: faker.internet.userName(),
+			name: faker.person.fullName(),
+			hfUserId: faker.string.alphanumeric(24),
+			avatarUrl: faker.image.avatar(),
+		}));
+
+		await collections.users.insertMany(newUsers);
+	}
+	const users = await collections.users.find().toArray();
+	if (flags.includes("settings")) {
+		users.forEach(async (user) => {
+			const settings: Settings = {
+				userId: user._id,
+				shareConversationsWithModelAuthors: faker.datatype.boolean(0.25),
+				hideEmojiOnSidebar: faker.datatype.boolean(0.25),
+				ethicsModalAcceptedAt: faker.date.recent({ days: 30 }),
+				activeModel: faker.helpers.arrayElement(modelIds),
+				createdAt: faker.date.recent({ days: 30 }),
+				updatedAt: faker.date.recent({ days: 30 }),
+				customPrompts: {},
+				assistants: [],
+			};
+			await collections.settings.updateOne(
+				{ userId: user._id },
+				{ $set: { ...settings } },
+				{ upsert: true }
+			);
+		});
+	}
+
+	if (flags.includes("assistants")) {
+		await Promise.all(
+			users.map(async (user) => {
+				const assistants = faker.helpers.multiple<Assistant>(
+					() => ({
+						_id: new ObjectId(),
+						name: faker.animal.insect(),
+						createdById: user._id,
+						createdByName: user.username,
+						createdAt: faker.date.recent({ days: 30 }),
+						updatedAt: faker.date.recent({ days: 30 }),
+						userCount: faker.number.int({ min: 1, max: 100000 }),
+						featured: faker.datatype.boolean(0.25),
+						modelId: faker.helpers.arrayElement(modelIds),
+						description: faker.lorem.sentence(),
+						preprompt: faker.hacker.phrase(),
+						exampleInputs: faker.helpers.multiple(() => faker.lorem.sentence(), {
+							count: faker.number.int({ min: 0, max: 4 }),
+						}),
+					}),
+					{ count: faker.number.int({ min: 3, max: 10 }) }
+				);
+				await collections.assistants.insertMany(assistants);
+				await collections.settings.updateOne(
+					{ userId: user._id },
+					{ $set: { assistants: assistants.map((a) => a._id.toString()) } },
+					{ upsert: true }
+				);
+			})
+		);
+	}
+
+	if (flags.includes("conversations")) {
+		await Promise.all(
+			users.map(async (user) => {
+				const conversations = faker.helpers.multiple(
+					async () => {
+						const settings = await collections.settings.findOne<Settings>({ userId: user._id });
+
+						const assistantId =
+							settings?.assistants && settings.assistants.length > 0 && faker.datatype.boolean(0.1)
+								? faker.helpers.arrayElement<ObjectId>(settings.assistants)
+								: undefined;
+
+						const preprompt =
+							(assistantId
+								? await collections.assistants
+										.findOne({ _id: assistantId })
+										.then((assistant: Assistant) => assistant?.preprompt ?? "")
+								: faker.helpers.maybe(() => faker.hacker.phrase(), { probability: 0.5 })) ?? "";
+
+						const messages = await generateMessages(preprompt);
+
+						const conv = {
+							_id: new ObjectId(),
+							userId: user._id,
+							assistantId,
+							preprompt,
+							createdAt: faker.date.recent({ days: 145 }),
+							updatedAt: faker.date.recent({ days: 145 }),
+							model: faker.helpers.arrayElement(modelIds),
+							title: faker.internet.emoji() + " " + faker.hacker.phrase(),
+							embeddingModel: defaultEmbeddingModel.id,
+							messages,
+							rootMessageId: messages[0].id,
+						} satisfies Conversation;
+
+						return conv;
+					},
+					{ count: faker.number.int({ min: 10, max: 200 }) }
+				);
+
+				await collections.conversations.insertMany(await Promise.all(conversations));
+			})
+		);
+	}
+}
+
+// run seed
+(async () => {
+	try {
+		rl.question(
+			"You're about to run a seeding script on the following MONGODB_URL: \x1b[31m" +
+				MONGODB_URL +
+				"\x1b[0m\n\n With the following flags: \x1b[31m" +
+				flags.join("\x1b[0m , \x1b[31m") +
+				"\x1b[0m\n \n\n Are you sure you want to continue? (yes/no): ",
+			async (confirm) => {
+				if (confirm !== "yes") {
+					console.log("Not 'yes', exiting.");
+					rl.close();
+					process.exit(0);
+				}
+				console.log("Starting seeding...");
+				await seed();
+				rl.close();
+			}
+		);
+	} catch (e) {
+		console.error(e);
+		process.exit(1);
+	}
+})();

--- a/scripts/populate.ts
+++ b/scripts/populate.ts
@@ -106,6 +106,7 @@ async function seed() {
 	const modelIds = models.map((model) => model.id);
 
 	if (flags.includes("reset")) {
+		console.log("Starting reset of DB");
 		await collections.users.deleteMany({});
 		await collections.settings.deleteMany({});
 		await collections.assistants.deleteMany({});
@@ -114,6 +115,7 @@ async function seed() {
 	}
 
 	if (flags.includes("users") || flags.includes("all")) {
+		console.log("Creating 100 new users");
 		const newUsers: User[] = Array.from({ length: 100 }, () => ({
 			_id: new ObjectId(),
 			createdAt: faker.date.recent({ days: 30 }),
@@ -125,9 +127,12 @@ async function seed() {
 		}));
 
 		await collections.users.insertMany(newUsers);
+		console.log("Done creating users.");
 	}
+
 	const users = await collections.users.find().toArray();
 	if (flags.includes("settings") || flags.includes("all")) {
+		console.log("Updating settings for all users");
 		users.forEach(async (user) => {
 			const settings: Settings = {
 				userId: user._id,
@@ -146,9 +151,11 @@ async function seed() {
 				{ upsert: true }
 			);
 		});
+		console.log("Done updating settings.");
 	}
 
 	if (flags.includes("assistants") || flags.includes("all")) {
+		console.log("Creating assistants for all users");
 		await Promise.all(
 			users.map(async (user) => {
 				const assistants = faker.helpers.multiple<Assistant>(
@@ -178,9 +185,11 @@ async function seed() {
 				);
 			})
 		);
+		console.log("Done creating assistants.");
 	}
 
 	if (flags.includes("conversations") || flags.includes("all")) {
+		console.log("Creating conversations for all users");
 		await Promise.all(
 			users.map(async (user) => {
 				const conversations = faker.helpers.multiple(
@@ -223,6 +232,7 @@ async function seed() {
 				await collections.conversations.insertMany(await Promise.all(conversations));
 			})
 		);
+		console.log("Done creating conversations.");
 	}
 }
 
@@ -243,6 +253,7 @@ async function seed() {
 				}
 				console.log("Starting seeding...");
 				await seed();
+				console.log("Seeding done.");
 				rl.close();
 			}
 		);


### PR DESCRIPTION
### Why

When testing changes I found myself often having to generate a bunch of data manually to get started testing. This PR adds a script that we can run to create users, assistants and conversations. 

### How to use
You can populate the database using faker data using the `populate` script:

```bash
npm run populate <flags here>
```

At least one flag must be specified, the following flags are available:

- `reset` - resets the database
- `users` - populates the users table
- `settings` - populates the settings table for users in the db
- `assistants` - populates the assistants table for users in the db
- `conversations` - populates the conversations table for users in the db

> [!WARNING]  
> The `MONGODB_URL` used for this script will be fetched from `.env.local`. Make sure it's correct! The command runs directly on the database.

For example, you could use it like so:

```bash
npm run populate reset
```

to clear out the database. Then login in the app to create your user in the DB, and run the following command:

```bash
npm run populate users settings assistants conversations
```

to populate the database with fake data, including fake conversations and assistants for your user.


### Mock data

| ![image](https://github.com/huggingface/chat-ui/assets/25119303/8ced9506-622d-4373-9152-5eb348d8ff3e)  | ![image](https://github.com/huggingface/chat-ui/assets/25119303/1ed95b6f-5bce-463f-bb83-19f80cf1c456) |
| ------------- | ------------- |




### Missing stuff 
(Not a prio to add, unless we need it for testing)
- websearch messages
- Support for non-logged in users (we can have settings and conversations linked to anonymous sessions)
- Avatar for assistants


