### PR TITLE
Add limits on API endpoints

### DIFF
--- a/.env
+++ b/.env
@@ -113,7 +113,7 @@ ADMIN_API_SECRET=# secret to admin API calls, like computing usage stats or expo
 
 PARQUET_EXPORT_SECRET=#DEPRECATED, use ADMIN_API_SECRET instead
 
-RATE_LIMIT= # requests per minute
+RATE_LIMIT= # /!\ Legacy definition of messages per minute. Use RATE_LIMITS.messagesPerMinute instead
 MESSAGES_BEFORE_LOGIN=# how many messages a user can send in a conversation before having to login. set to 0 to force login right away
 
 APP_BASE="" # base path of the app, e.g. /chat, left blank as default
@@ -141,3 +141,5 @@ ALTERNATIVE_REDIRECT_URLS=`[]` #valide alternative redirect URL for OAuth
 WEBHOOK_URL_REPORT_ASSISTANT=#provide webhook url to get notified when an assistant gets reported
 
 ALLOWED_USER_EMAILS=`[]` # if it's defined, only these emails will be allowed to use the app
+
+RATE_LIMITS=`{}`

--- a/.env.template
+++ b/.env.template
@@ -269,7 +269,6 @@ PUBLIC_APP_DISCLAIMER_MESSAGE="Disclaimer: AI is an area of active research with
 PUBLIC_APP_DATA_SHARING=1
 PUBLIC_APP_DISCLAIMER=1
 
-RATE_LIMIT=16
 MESSAGES_BEFORE_LOGIN=5# how many messages a user can send in a conversation before having to login. set to 0 to force login right away
 
 PUBLIC_GOOGLE_ANALYTICS_ID=G-8Q63TH4CSL
@@ -285,3 +284,10 @@ EXPOSE_API=true
 ALTERNATIVE_REDIRECT_URLS=`[
   huggingchat://login/callback
 ]`
+
+RATE_LIMITS=`{
+  "conversations" : 3000, // max number of conversations per user
+  "messages" : 500, // max messages per conversation, both user and assistants are counted
+  "assistants" : 100, // max number of assistants per user
+  "messagesPerMinute" : 16, // max messages per minute per user
+}`

--- a/src/lib/server/rateLimits.ts
+++ b/src/lib/server/rateLimits.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+import { RATE_LIMITS, RATE_LIMIT } from "$env/static/private";
+import JSON5 from "json5";
+
+// RATE_LIMIT is the legacy way to define messages per minute limit
+export const rateLimitsSchema = z
+	.object({
+		conversations: z.coerce.number().optional(), // how many conversations
+		messages: z.coerce.number().optional(), // how many messages in a conversation
+		assistants: z.coerce.number().optional(), // how many assistants
+		messagesPerMinute: z
+			.preprocess((val) => {
+				if (val === undefined) {
+					return RATE_LIMIT;
+				}
+				return val;
+			}, z.coerce.number().optional())
+			.optional(), // how many messages per minute
+	})
+	.optional();
+
+export const RateLimits = rateLimitsSchema.parse(JSON5.parse(RATE_LIMITS));

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -47,8 +47,9 @@
 			});
 
 			if (!res.ok) {
-				error.set("Error while creating conversation, try again.");
-				console.error("Error while creating conversation: " + (await res.text()));
+				const errorMessage = (await res.json()).message || ERROR_MESSAGES.default;
+				error.set(errorMessage);
+				console.error("Error while creating conversation: ", errorMessage);
 				return;
 			}
 
@@ -63,7 +64,7 @@
 			// invalidateAll to update list of conversations
 			await goto(`${base}/conversation/${conversationId}`, { invalidateAll: true });
 		} catch (err) {
-			error.set(ERROR_MESSAGES.default);
+			error.set((err as Error).message || ERROR_MESSAGES.default);
 			console.error(err);
 		} finally {
 			loading = false;

--- a/src/routes/conversation/+server.ts
+++ b/src/routes/conversation/+server.ts
@@ -8,6 +8,8 @@ import type { Message } from "$lib/types/Message";
 import { models, validateModel } from "$lib/server/models";
 import { defaultEmbeddingModel } from "$lib/server/embeddingModels";
 import { v4 } from "uuid";
+import { authCondition } from "$lib/server/auth";
+import { RateLimits } from "$lib/server/rateLimits";
 
 export const POST: RequestHandler = async ({ locals, request }) => {
 	const body = await request.text();
@@ -22,6 +24,15 @@ export const POST: RequestHandler = async ({ locals, request }) => {
 			preprompt: z.string().optional(),
 		})
 		.parse(JSON.parse(body));
+
+	const convCount = await collections.conversations.countDocuments(authCondition(locals));
+
+	if (RateLimits?.conversations && convCount > RateLimits?.conversations) {
+		throw error(
+			429,
+			"You have reached the maximum number of conversations. Delete some to continue."
+		);
+	}
 
 	let messages: Message[] = [
 		{

--- a/src/routes/conversation/[id]/+page.svelte
+++ b/src/routes/conversation/[id]/+page.svelte
@@ -43,7 +43,7 @@
 			});
 
 			if (!res.ok) {
-				error.set("Error while creating conversation, try again.");
+				error.set(await res.text());
 				console.error("Error while creating conversation: " + (await res.text()));
 				return;
 			}


### PR DESCRIPTION
This PR adds a new env var `RATE_LIMITS` which can contain limits for conversations, messages depth, assistants and messages per minute.

For HuggingChat the defauls are set as follow:

```
RATE_LIMITS=`{
  "conversations" : 3000, // max number of conversations per user
  "messages" : 500, // max messages per conversation, both user and assistants are counted
  "assistants" : 100, // max number of assistants per user
  "messagesPerMinute" : 16, // max messages per minute per user
}`
```

though we could tweak them in the future.