### PR TITLE
Improve error handling when posting new messages

### DIFF
--- a/src/lib/components/chat/ChatMessage.svelte
+++ b/src/lib/components/chat/ChatMessage.svelte
@@ -106,7 +106,7 @@
 		clearTimeout(pendingTimeout);
 
 		// Add loading animation to the last message if update takes more than 600ms
-		if ((loading && isLast) || emptyLoad) {
+		if (isLast && loading && emptyLoad) {
 			pendingTimeout = setTimeout(() => {
 				if (contentEl) {
 					loadingEl = new IconLoading({

--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -86,7 +86,10 @@
 	const convTreeStore = useConvTreeStore();
 
 	$: lastMessage = browser && (messages.find((m) => m.id == $convTreeStore.leaf) as Message);
-	$: lastIsError = lastMessage && lastMessage.from === "user" && !loading;
+	$: lastIsError =
+		lastMessage &&
+		((lastMessage.from === "user" && !loading) ||
+			lastMessage.updates?.findIndex((u) => u.type === "status" && u.status === "error") !== -1);
 
 	$: sources = files.map((file) => file2base64(file));
 
@@ -242,7 +245,7 @@
 						on:click={() => {
 							if (lastMessage && lastMessage.ancestors) {
 								dispatch("retry", {
-									id: lastMessage.ancestors[lastMessage.ancestors.length - 1],
+									id: lastMessage.id,
 								});
 							}
 						}}

--- a/src/routes/conversation/[id]/+server.ts
+++ b/src/routes/conversation/[id]/+server.ts
@@ -377,6 +377,15 @@ export async function POST({ request, locals, params, getClientAddress }) {
 				}
 			} catch (e) {
 				update({ type: "status", status: "error", message: (e as Error).message });
+			} finally {
+				// check if no output was generated
+				if (messageToWriteTo.content === previousText) {
+					update({
+						type: "status",
+						status: "error",
+						message: "No output was generated. Something went wrong.",
+					});
+				}
 			}
 
 			await collections.conversations.updateOne(


### PR DESCRIPTION
* Show a "retry button" if something goes wrong
* Send an error if the endpoint terminates without streaming at least one token
* Fix the loading indicator that was spinning even if not loading