### PR TITLE
Automated migration setup

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -17,6 +17,9 @@ import { findUser, refreshSessionCookie, requiresUser } from "$lib/server/auth";
 import { ERROR_MESSAGES } from "$lib/stores/errors";
 import { sha256 } from "$lib/utils/sha256";
 import { addWeeks } from "date-fns";
+import { checkAndRunMigrations } from "$lib/migrations/migrations";
+
+await checkAndRunMigrations();
 
 export const handle: Handle = async ({ event, resolve }) => {
 	if (event.url.pathname.startsWith(`${base}/api/`) && EXPOSE_API !== "true") {

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -18,8 +18,11 @@ import { ERROR_MESSAGES } from "$lib/stores/errors";
 import { sha256 } from "$lib/utils/sha256";
 import { addWeeks } from "date-fns";
 import { checkAndRunMigrations } from "$lib/migrations/migrations";
+import { building } from "$app/environment";
 
-await checkAndRunMigrations();
+if (!building) {
+	await checkAndRunMigrations();
+}
 
 export const handle: Handle = async ({ event, resolve }) => {
 	if (event.url.pathname.startsWith(`${base}/api/`) && EXPOSE_API !== "true") {

--- a/src/lib/migrations/lock.ts
+++ b/src/lib/migrations/lock.ts
@@ -1,72 +1,37 @@
 import { collections } from "$lib/server/database";
 
-// 5min time out on lock
-const LOCK_TIMEOUT = 5 * 60 * 1000;
-
-export async function createAndAcquireLock(): Promise<boolean> {
+export async function acquireLock(key = "migrations") {
 	try {
-		const upsert = await collections.semaphores.updateOne(
-			{},
-			{
-				$setOnInsert: {
-					isDBLocked: true,
-					key: "semaphore",
-					createdAt: new Date(),
-					updatedAt: new Date(),
-				},
-			},
-			{
-				upsert: true,
-			}
-		);
-		return !!upsert.upsertedCount; // true if the document was inserted
+		const insert = await collections.semaphores.insertOne({
+			key,
+			createdAt: new Date(),
+			updatedAt: new Date(),
+		});
+
+		return !!insert.acknowledged; // true if the document was inserted
 	} catch (e) {
 		// unique index violation, so there must already be a lock
 		return false;
 	}
 }
-export async function acquireLock() {
-	const res = await collections.semaphores.findOneAndUpdate(
-		{
-			isDBLocked: false,
-		},
-		{
-			$set: {
-				isDBLocked: true,
-				updatedAt: new Date(),
-			},
-		}
-	);
 
-	return !!res.ok && res.value !== null;
+export async function releaseLock(key = "migrations") {
+	await collections.semaphores.deleteOne({
+		key,
+	});
 }
 
-export async function releaseLock() {
+export async function isDBLocked(key = "migrations"): Promise<boolean> {
+	const res = await collections.semaphores.countDocuments({
+		key,
+	});
+	return res > 0;
+}
+
+export async function refreshLock(key = "migrations") {
 	await collections.semaphores.updateOne(
 		{
-			isDBLocked: true,
-		},
-		{
-			$set: {
-				isDBLocked: false,
-				updatedAt: new Date(),
-			},
-		}
-	);
-}
-
-export async function isDBLocked(): Promise<boolean> {
-	const res = await collections.semaphores.findOne({});
-	if (!res) {
-		throw new Error("No lock found");
-	}
-	return res.isDBLocked;
-}
-
-export async function refreshLock() {
-	await collections.semaphores.updateOne(
-		{
-			isDBLocked: true,
+			key,
 		},
 		{
 			$set: {
@@ -74,21 +39,4 @@ export async function refreshLock() {
 			},
 		}
 	);
-}
-
-export async function discardExpiredLock() {
-	const res = await collections.semaphores.updateOne(
-		{
-			isDBLocked: true,
-			updatedAt: { $lt: new Date(Date.now() - LOCK_TIMEOUT) },
-		},
-		{
-			$set: {
-				isDBLocked: false,
-				updatedAt: new Date(),
-			},
-		}
-	);
-
-	return res.modifiedCount > 0;
 }

--- a/src/lib/migrations/lock.ts
+++ b/src/lib/migrations/lock.ts
@@ -1,0 +1,93 @@
+import { collections } from "$lib/server/database";
+
+// 5min time out on lock
+const LOCK_TIMEOUT = 5 * 60 * 1000;
+
+export async function createAndAcquireLock(): Promise<boolean> {
+	try {
+		const upsert = await collections.semaphores.updateOne(
+			{},
+			{
+				$setOnInsert: {
+					isDBLocked: true,
+					key: "semaphore",
+					createdAt: new Date(),
+					updatedAt: new Date(),
+				},
+			},
+			{
+				upsert: true,
+			}
+		);
+		return !!upsert.upsertedCount; // true if the document was inserted
+	} catch (e) {
+		return false;
+	}
+}
+export async function acquireLock() {
+	const res = await collections.semaphores.findOneAndUpdate(
+		{
+			isDBLocked: false,
+		},
+		{
+			$set: {
+				isDBLocked: true,
+				updatedAt: new Date(),
+			},
+		}
+	);
+
+	return !!res.ok && res.value !== null;
+}
+
+export async function releaseLock() {
+	await collections.semaphores.updateOne(
+		{
+			isDBLocked: true,
+		},
+		{
+			$set: {
+				isDBLocked: false,
+				updatedAt: new Date(),
+			},
+		}
+	);
+}
+
+export async function isDBLocked(): Promise<boolean> {
+	const res = await collections.semaphores.findOne({});
+	if (!res) {
+		throw new Error("No lock found");
+	}
+	return res.isDBLocked;
+}
+
+export async function refreshLock() {
+	await collections.semaphores.updateOne(
+		{
+			isDBLocked: true,
+		},
+		{
+			$set: {
+				updatedAt: new Date(),
+			},
+		}
+	);
+}
+
+export async function discardExpiredLock() {
+	const res = await collections.semaphores.updateOne(
+		{
+			isDBLocked: true,
+			updatedAt: { $lt: new Date(Date.now() - LOCK_TIMEOUT) },
+		},
+		{
+			$set: {
+				isDBLocked: false,
+				updatedAt: new Date(),
+			},
+		}
+	);
+
+	return res.modifiedCount > 0;
+}

--- a/src/lib/migrations/lock.ts
+++ b/src/lib/migrations/lock.ts
@@ -21,6 +21,7 @@ export async function createAndAcquireLock(): Promise<boolean> {
 		);
 		return !!upsert.upsertedCount; // true if the document was inserted
 	} catch (e) {
+		// unique index violation, so there must already be a lock
 		return false;
 	}
 }

--- a/src/lib/migrations/migrations.spec.ts
+++ b/src/lib/migrations/migrations.spec.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { migrations } from "./routines";
+import {
+	acquireLock,
+	createAndAcquireLock,
+	discardExpiredLock,
+	isDBLocked,
+	refreshLock,
+	releaseLock,
+} from "./lock";
+import { collections } from "$lib/server/database";
+
+describe("migrations", () => {
+	it("should not have duplicates guid", async () => {
+		const guids = migrations.map((m) => m.guid);
+		const uniqueGuids = [...new Set(guids)];
+		expect(uniqueGuids.length).toBe(guids.length);
+	});
+
+	it("should initialize only one semaphore", async () => {
+		const results = await Promise.all(new Array(1000).fill(0).map(() => createAndAcquireLock()));
+		const locks = results.filter((r) => r);
+
+		const semaphores = await collections.semaphores.find({}).toArray();
+
+		expect(locks.length).toBe(1);
+		expect(semaphores).toBeDefined();
+		expect(semaphores[0].isDBLocked).toBe(true);
+		expect(semaphores.length).toBe(1);
+	});
+
+	it("should hold the lock when initializing the semaphore", async () => {
+		await createAndAcquireLock();
+		expect(await acquireLock()).toBe(false);
+
+		await releaseLock();
+		expect(await acquireLock()).toBe(true);
+	});
+
+	it("should acquire only one lock on DB", async () => {
+		await createAndAcquireLock();
+		await releaseLock();
+		const results = await Promise.all(new Array(1000).fill(0).map(() => acquireLock()));
+		const locks = results.filter((r) => r);
+		expect(locks.length).toBe(1);
+	});
+
+	it("should read the lock correctly", async () => {
+		expect(await createAndAcquireLock()).toBe(true);
+		expect(await isDBLocked()).toBe(true);
+		await releaseLock();
+		expect(await isDBLocked()).toBe(false);
+	});
+
+	it("should discard expired lock", async () => {
+		await createAndAcquireLock();
+
+		// set the updatedAt in the past for testing
+		await collections.semaphores.updateOne({}, { $set: { updatedAt: new Date(0) } });
+
+		expect(await isDBLocked()).toBe(true);
+		expect(await discardExpiredLock()).toBe(true);
+		expect(await isDBLocked()).toBe(false);
+	});
+
+	it("should refresh the lock", async () => {
+		await createAndAcquireLock();
+
+		// get the updatedAt time
+
+		const updatedAtInitially = (await collections.semaphores.findOne({}))?.updatedAt;
+
+		await refreshLock();
+
+		const updatedAtAfterRefresh = (await collections.semaphores.findOne({}))?.updatedAt;
+
+		expect(updatedAtInitially).toBeDefined();
+		expect(updatedAtAfterRefresh).toBeDefined();
+		expect(updatedAtInitially).not.toBe(updatedAtAfterRefresh);
+	});
+});
+
+afterEach(async () => {
+	await collections.semaphores.deleteMany({});
+	await collections.migrationResults.deleteMany({});
+});

--- a/src/lib/migrations/migrations.spec.ts
+++ b/src/lib/migrations/migrations.spec.ts
@@ -1,70 +1,36 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { migrations } from "./routines";
-import {
-	acquireLock,
-	createAndAcquireLock,
-	discardExpiredLock,
-	isDBLocked,
-	refreshLock,
-	releaseLock,
-} from "./lock";
+import { acquireLock, isDBLocked, refreshLock, releaseLock } from "./lock";
 import { collections } from "$lib/server/database";
 
 describe("migrations", () => {
 	it("should not have duplicates guid", async () => {
-		const guids = migrations.map((m) => m.guid);
+		const guids = migrations.map((m) => m._id.toString());
 		const uniqueGuids = [...new Set(guids)];
 		expect(uniqueGuids.length).toBe(guids.length);
 	});
 
-	it("should initialize only one semaphore", async () => {
-		const results = await Promise.all(new Array(1000).fill(0).map(() => createAndAcquireLock()));
+	it("should acquire only one lock on DB", async () => {
+		const results = await Promise.all(new Array(1000).fill(0).map(() => acquireLock()));
 		const locks = results.filter((r) => r);
 
 		const semaphores = await collections.semaphores.find({}).toArray();
 
 		expect(locks.length).toBe(1);
 		expect(semaphores).toBeDefined();
-		expect(semaphores[0].isDBLocked).toBe(true);
 		expect(semaphores.length).toBe(1);
-	});
-
-	it("should hold the lock when initializing the semaphore", async () => {
-		await createAndAcquireLock();
-		expect(await acquireLock()).toBe(false);
-
-		await releaseLock();
-		expect(await acquireLock()).toBe(true);
-	});
-
-	it("should acquire only one lock on DB", async () => {
-		await createAndAcquireLock();
-		await releaseLock();
-		const results = await Promise.all(new Array(1000).fill(0).map(() => acquireLock()));
-		const locks = results.filter((r) => r);
-		expect(locks.length).toBe(1);
+		expect(semaphores?.[0].key).toBe("migrations");
 	});
 
 	it("should read the lock correctly", async () => {
-		expect(await createAndAcquireLock()).toBe(true);
+		expect(await acquireLock()).toBe(true);
 		expect(await isDBLocked()).toBe(true);
 		await releaseLock();
-		expect(await isDBLocked()).toBe(false);
-	});
-
-	it("should discard expired lock", async () => {
-		await createAndAcquireLock();
-
-		// set the updatedAt in the past for testing
-		await collections.semaphores.updateOne({}, { $set: { updatedAt: new Date(0) } });
-
-		expect(await isDBLocked()).toBe(true);
-		expect(await discardExpiredLock()).toBe(true);
 		expect(await isDBLocked()).toBe(false);
 	});
 
 	it("should refresh the lock", async () => {
-		await createAndAcquireLock();
+		await acquireLock();
 
 		// get the updatedAt time
 

--- a/src/lib/migrations/migrations.spec.ts
+++ b/src/lib/migrations/migrations.spec.ts
@@ -25,6 +25,7 @@ describe("migrations", () => {
 	it("should read the lock correctly", async () => {
 		expect(await acquireLock()).toBe(true);
 		expect(await isDBLocked()).toBe(true);
+		expect(await acquireLock()).toBe(false);
 		await releaseLock();
 		expect(await isDBLocked()).toBe(false);
 	});

--- a/src/lib/migrations/migrations.ts
+++ b/src/lib/migrations/migrations.ts
@@ -1,4 +1,4 @@
-import { client, collections, getCollections } from "$lib/server/database";
+import { client, collections } from "$lib/server/database";
 import { migrations } from "./routines";
 import {
 	acquireLock,
@@ -90,7 +90,7 @@ export async function checkAndRunMigrations() {
 			// otherwise all is good and we cna run the migration
 			console.log(`[MIGRATIONS] "${migration.name}" not applied yet. Applying...`);
 
-			await getCollections(connectedClient).migrationResults.updateOne(
+			await collections.migrationResults.updateOne(
 				{ guid: migration.guid },
 				{
 					$set: {
@@ -116,7 +116,7 @@ export async function checkAndRunMigrations() {
 				await session.endSession();
 			}
 
-			await getCollections(connectedClient).migrationResults.updateOne(
+			await collections.migrationResults.updateOne(
 				{ guid: migration.guid },
 				{
 					$set: {

--- a/src/lib/migrations/migrations.ts
+++ b/src/lib/migrations/migrations.ts
@@ -6,6 +6,7 @@ import {
 	releaseLock,
 	isDBLocked,
 	discardExpiredLock,
+	refreshLock,
 } from "./lock";
 import { isHuggingChat } from "$lib/utils/isHuggingChat";
 
@@ -54,6 +55,12 @@ export async function checkAndRunMigrations() {
 		}
 		return;
 	}
+
+	// once here, we have the lock
+	// make sure to refresh it regularly while it's running
+	const refreshInterval = setInterval(async () => {
+		await refreshLock();
+	}, 60 * 1000);
 
 	// get all migration results that have already been applied
 	const migrationResults = await collections.migrationResults.find().toArray();
@@ -124,5 +131,7 @@ export async function checkAndRunMigrations() {
 	}
 
 	console.log("[MIGRATIONS] All migrations applied. Releasing lock");
+
+	clearInterval(refreshInterval);
 	releaseLock();
 }

--- a/src/lib/migrations/migrations.ts
+++ b/src/lib/migrations/migrations.ts
@@ -1,0 +1,128 @@
+import { client, collections, getCollections } from "$lib/server/database";
+import { migrations } from "./routines";
+import {
+	acquireLock,
+	createAndAcquireLock,
+	releaseLock,
+	isDBLocked,
+	discardExpiredLock,
+} from "./lock";
+import { isHuggingChat } from "$lib/utils/isHuggingChat";
+
+export async function checkAndRunMigrations() {
+	// make sure all GUIDs are unique
+	if (new Set(migrations.map((m) => m.guid)).size !== migrations.length) {
+		throw new Error("Duplicate migration GUIDs found.");
+	}
+
+	console.log("[MIGRATIONS] Begin check...");
+
+	// connect to the database
+	const connectedClient = await client.connect();
+
+	// see if semaphore needs to be created
+	let hasLock = false;
+	let isFresh = false;
+
+	const createdLock = await createAndAcquireLock();
+
+	if (createdLock) {
+		console.log("[MIGRATIONS] Created lock. Fresh install detected.");
+		// if the semaphore was created, we have the lock
+		hasLock = true;
+		isFresh = true;
+	} else {
+		// else we have to check if we can get a lock
+		hasLock = await acquireLock();
+		isFresh = false;
+	}
+
+	if (!hasLock) {
+		// another instance already has the lock, so we exit early
+		console.log(
+			"[MIGRATIONS] Another instance already has the lock. Waiting for DB to be unlocked."
+		);
+
+		// block until the lock is released
+		while (await isDBLocked()) {
+			const discarded = await discardExpiredLock();
+			if (discarded) {
+				console.log("[MIGRATIONS] Discarded expired lock. Erroring out");
+				throw new Error("Lock timed out while waiting for it to be released.");
+			}
+			await new Promise((resolve) => setTimeout(resolve, 1000));
+		}
+		return;
+	}
+
+	// get all migration results that have already been applied
+	const migrationResults = await collections.migrationResults.find().toArray();
+
+	// iterate over all migrations
+	for (const migration of migrations) {
+		// check if the migration has already been applied
+		const existingMigrationResult = migrationResults.find((m) => m.guid === migration.guid);
+
+		// check if the migration has already been applied
+		if (existingMigrationResult) {
+			console.log(`[MIGRATIONS] "${migration.name}" already applied. Skipping...`);
+		} else {
+			// check the modifiers to see if some cases match
+			if (
+				(migration.runForFreshInstall === "only" && !isFresh) ||
+				(migration.runForHuggingChat === "only" && !isHuggingChat) ||
+				(migration.runForFreshInstall === "never" && isFresh) ||
+				(migration.runForHuggingChat === "never" && isHuggingChat)
+			) {
+				console.log(
+					`[MIGRATIONS] "${migration.name}" should not be applied for this run. Skipping...`
+				);
+				continue;
+			}
+
+			// otherwise all is good and we cna run the migration
+			console.log(`[MIGRATIONS] "${migration.name}" not applied yet. Applying...`);
+
+			await getCollections(connectedClient).migrationResults.updateOne(
+				{ guid: migration.guid },
+				{
+					$set: {
+						guid: migration.guid,
+						name: migration.name,
+						status: "ongoing",
+					},
+				},
+				{ upsert: true }
+			);
+
+			const session = connectedClient.startSession();
+			let result = false;
+
+			try {
+				await session.withTransaction(async () => {
+					result = await migration.up(connectedClient);
+				});
+			} catch (e) {
+				console.log(`[MIGRATION[]  "${migration.name}" failed!`);
+				console.error(e);
+			} finally {
+				await session.endSession();
+			}
+
+			await getCollections(connectedClient).migrationResults.updateOne(
+				{ guid: migration.guid },
+				{
+					$set: {
+						guid: migration.guid,
+						name: migration.name,
+						status: result ? "success" : "failure",
+					},
+				},
+				{ upsert: true }
+			);
+		}
+	}
+
+	console.log("[MIGRATIONS] All migrations applied. Releasing lock");
+	releaseLock();
+}

--- a/src/lib/migrations/migrations.ts
+++ b/src/lib/migrations/migrations.ts
@@ -9,6 +9,17 @@ export async function checkAndRunMigrations() {
 		throw new Error("Duplicate migration GUIDs found.");
 	}
 
+	// check if all migrations have already been run
+	const migrationResults = await collections.migrationResults.find().toArray();
+
+	// if all the migrations._id are in the migrationResults, we can exit early
+	if (
+		migrations.every((m) => migrationResults.some((m2) => m2._id.toString() === m._id.toString()))
+	) {
+		console.log("[MIGRATIONS] All migrations already applied.");
+		return;
+	}
+
 	console.log("[MIGRATIONS] Begin check...");
 
 	// connect to the database
@@ -33,10 +44,7 @@ export async function checkAndRunMigrations() {
 	// make sure to refresh it regularly while it's running
 	const refreshInterval = setInterval(async () => {
 		await refreshLock();
-	}, 1000 * 30);
-
-	// get all migration results that have already been applied
-	const migrationResults = await collections.migrationResults.find().toArray();
+	}, 1000 * 10);
 
 	// iterate over all migrations
 	for (const migration of migrations) {

--- a/src/lib/migrations/routines/01-update-search-assistants.ts
+++ b/src/lib/migrations/routines/01-update-search-assistants.ts
@@ -1,10 +1,10 @@
 import type { Migration } from ".";
 import { getCollections } from "$lib/server/database";
-import type { AnyBulkWriteOperation } from "mongodb";
+import { ObjectId, type AnyBulkWriteOperation } from "mongodb";
 import type { Assistant } from "$lib/types/Assistant";
 
 const migration: Migration = {
-	guid: "78c019ad-6bac-4958-a8ad-57a880e79bbf",
+	_id: new ObjectId("5f9f3e3e3e3e3e3e3e3e3e3e"),
 	name: "Update search assistants",
 	up: async (client) => {
 		const { assistants } = getCollections(client);

--- a/src/lib/migrations/routines/01-update-search-assistants.ts
+++ b/src/lib/migrations/routines/01-update-search-assistants.ts
@@ -2,6 +2,7 @@ import type { Migration } from ".";
 import { getCollections } from "$lib/server/database";
 import { ObjectId, type AnyBulkWriteOperation } from "mongodb";
 import type { Assistant } from "$lib/types/Assistant";
+import { generateSearchTokens } from "$lib/utils/searchTokens";
 
 const migration: Migration = {
 	_id: new ObjectId("5f9f3e3e3e3e3e3e3e3e3e3e"),
@@ -20,7 +21,7 @@ const migration: Migration = {
 					},
 					update: {
 						$set: {
-							searchTokens: assistant.name.split(" ").map((el) => el.toLowerCase()),
+							searchTokens: generateSearchTokens(assistant.name),
 						},
 					},
 				},

--- a/src/lib/migrations/routines/01-update-search-assistants.ts
+++ b/src/lib/migrations/routines/01-update-search-assistants.ts
@@ -1,0 +1,49 @@
+import type { Migration } from ".";
+import { getCollections } from "$lib/server/database";
+import type { AnyBulkWriteOperation } from "mongodb";
+import type { Assistant } from "$lib/types/Assistant";
+
+const migration: Migration = {
+	guid: "78c019ad-6bac-4958-a8ad-57a880e79bbf",
+	name: "Update search assistants",
+	up: async (client) => {
+		const { assistants } = getCollections(client);
+		let ops: AnyBulkWriteOperation<Assistant>[] = [];
+
+		for await (const assistant of assistants
+			.find()
+			.project<Pick<Assistant, "_id" | "name">>({ _id: 1, name: 1 })) {
+			ops.push({
+				updateOne: {
+					filter: {
+						_id: assistant._id,
+					},
+					update: {
+						$set: {
+							searchTokens: assistant.name.split(" ").map((el) => el.toLowerCase()),
+						},
+					},
+				},
+			});
+
+			if (ops.length >= 1000) {
+				process.stdout.write(".");
+				await assistants.bulkWrite(ops, { ordered: false });
+				ops = [];
+			}
+		}
+
+		if (ops.length) {
+			await assistants.bulkWrite(ops, { ordered: false });
+		}
+
+		return true;
+	},
+	down: async (client) => {
+		const { assistants } = getCollections(client);
+		await assistants.updateMany({}, { $unset: { searchTokens: "" } });
+		return true;
+	},
+};
+
+export default migration;

--- a/src/lib/migrations/routines/index.ts
+++ b/src/lib/migrations/routines/index.ts
@@ -1,0 +1,14 @@
+import type { MongoClient } from "mongodb";
+
+import updateSearchAssistant from "./01-update-search-assistants";
+
+export interface Migration {
+	guid: ReturnType<typeof crypto.randomUUID>; // must be hardcoded randomUUID. Do not change it once pushed!
+	name: string;
+	up: (client: MongoClient) => Promise<boolean>;
+	down?: (client: MongoClient) => Promise<boolean>;
+	runForFreshInstall?: "only" | "never"; // leave unspecified to run for both
+	runForHuggingChat?: "only" | "never"; // leave unspecified to run for both
+}
+
+export const migrations: Migration[] = [updateSearchAssistant];

--- a/src/lib/migrations/routines/index.ts
+++ b/src/lib/migrations/routines/index.ts
@@ -1,9 +1,9 @@
-import type { MongoClient } from "mongodb";
+import type { MongoClient, ObjectId } from "mongodb";
 
 import updateSearchAssistant from "./01-update-search-assistants";
 
 export interface Migration {
-	guid: ReturnType<typeof crypto.randomUUID>; // must be hardcoded randomUUID. Do not change it once pushed!
+	_id: ObjectId;
 	name: string;
 	up: (client: MongoClient) => Promise<boolean>;
 	down?: (client: MongoClient) => Promise<boolean>;

--- a/src/lib/server/database.ts
+++ b/src/lib/server/database.ts
@@ -74,7 +74,6 @@ const {
 	users,
 	sessions,
 	messageEvents,
-	migrationResults,
 	semaphores,
 } = collections;
 
@@ -147,6 +146,6 @@ client.on("open", () => {
 	reports.createIndex({ createdBy: 1, assistantId: 1 }).catch(console.error);
 
 	// Unique index for semaphore and migration results
-	migrationResults.createIndex({ guid: 1 }, { unique: true }).catch(console.error);
 	semaphores.createIndex({ key: 1 }, { unique: true }).catch(console.error);
+	semaphores.createIndex({ createdAt: 1 }, { expireAfterSeconds: 300 }).catch(console.error);
 });

--- a/src/lib/server/database.ts
+++ b/src/lib/server/database.ts
@@ -147,6 +147,7 @@ client.on("open", () => {
 	collections.reports.createIndex({ assistantId: 1 }).catch(console.error);
 	collections.reports.createIndex({ createdBy: 1, assistantId: 1 }).catch(console.error);
 
-	// Unique index for semaphore
+	// Unique index for semaphore and migration results
+	collections.migrationResults.createIndex({ guid: 1 }, { unique: true }).catch(console.error);
 	collections.semaphores.createIndex({ key: 1 }, { unique: true }).catch(console.error);
 });

--- a/src/lib/server/database.ts
+++ b/src/lib/server/database.ts
@@ -147,5 +147,5 @@ client.on("open", () => {
 
 	// Unique index for semaphore and migration results
 	semaphores.createIndex({ key: 1 }, { unique: true }).catch(console.error);
-	semaphores.createIndex({ createdAt: 1 }, { expireAfterSeconds: 300 }).catch(console.error);
+	semaphores.createIndex({ createdAt: 1 }, { expireAfterSeconds: 60 }).catch(console.error);
 });

--- a/src/lib/server/database.ts
+++ b/src/lib/server/database.ts
@@ -10,11 +10,48 @@ import type { Session } from "$lib/types/Session";
 import type { Assistant } from "$lib/types/Assistant";
 import type { Report } from "$lib/types/Report";
 import type { ConversationStats } from "$lib/types/ConversationStats";
+import type { MigrationResult } from "$lib/types/MigrationResult";
+import type { Semaphore } from "$lib/types/Semaphore";
 
 if (!MONGODB_URL) {
 	throw new Error(
 		"Please specify the MONGODB_URL environment variable inside .env.local. Set it to mongodb://localhost:27017 if you are running MongoDB locally, or to a MongoDB Atlas free instance for example."
 	);
+}
+export const CONVERSATION_STATS_COLLECTION = "conversations.stats";
+
+export function getCollections(mongoClient: MongoClient) {
+	const db = mongoClient.db(MONGODB_DB_NAME + (import.meta.env.MODE === "test" ? "-test" : ""));
+
+	const conversations = db.collection<Conversation>("conversations");
+	const conversationStats = db.collection<ConversationStats>(CONVERSATION_STATS_COLLECTION);
+	const assistants = db.collection<Assistant>("assistants");
+	const reports = db.collection<Report>("reports");
+	const sharedConversations = db.collection<SharedConversation>("sharedConversations");
+	const abortedGenerations = db.collection<AbortedGeneration>("abortedGenerations");
+	const settings = db.collection<Settings>("settings");
+	const users = db.collection<User>("users");
+	const sessions = db.collection<Session>("sessions");
+	const messageEvents = db.collection<MessageEvent>("messageEvents");
+	const bucket = new GridFSBucket(db, { bucketName: "files" });
+	const migrationResults = db.collection<MigrationResult>("migrationResults");
+	const semaphores = db.collection<Semaphore>("semaphores");
+
+	return {
+		conversations,
+		conversationStats,
+		assistants,
+		reports,
+		sharedConversations,
+		abortedGenerations,
+		settings,
+		users,
+		sessions,
+		messageEvents,
+		bucket,
+		migrationResults,
+		semaphores,
+	};
 }
 
 const client = new MongoClient(MONGODB_URL, {
@@ -24,63 +61,39 @@ const client = new MongoClient(MONGODB_URL, {
 export const connectPromise = client.connect().catch(console.error);
 
 const db = client.db(MONGODB_DB_NAME + (import.meta.env.MODE === "test" ? "-test" : ""));
+const collections = getCollections(client);
 
-export const CONVERSATION_STATS_COLLECTION = "conversations.stats";
-
-const conversations = db.collection<Conversation>("conversations");
-const conversationStats = db.collection<ConversationStats>(CONVERSATION_STATS_COLLECTION);
-const assistants = db.collection<Assistant>("assistants");
-const reports = db.collection<Report>("reports");
-const sharedConversations = db.collection<SharedConversation>("sharedConversations");
-const abortedGenerations = db.collection<AbortedGeneration>("abortedGenerations");
-const settings = db.collection<Settings>("settings");
-const users = db.collection<User>("users");
-const sessions = db.collection<Session>("sessions");
-const messageEvents = db.collection<MessageEvent>("messageEvents");
-const bucket = new GridFSBucket(db, { bucketName: "files" });
-
-export { client, db };
-export const collections = {
-	conversations,
-	conversationStats,
-	assistants,
-	reports,
-	sharedConversations,
-	abortedGenerations,
-	settings,
-	users,
-	sessions,
-	messageEvents,
-	bucket,
-};
+export { client, db, collections };
 
 client.on("open", () => {
-	conversations
+	collections.conversations
 		.createIndex(
 			{ sessionId: 1, updatedAt: -1 },
 			{ partialFilterExpression: { sessionId: { $exists: true } } }
 		)
 		.catch(console.error);
-	conversations
+	collections.conversations
 		.createIndex(
 			{ userId: 1, updatedAt: -1 },
 			{ partialFilterExpression: { userId: { $exists: true } } }
 		)
 		.catch(console.error);
-	conversations
+	collections.conversations
 		.createIndex(
 			{ "message.id": 1, "message.ancestors": 1 },
 			{ partialFilterExpression: { userId: { $exists: true } } }
 		)
 		.catch(console.error);
 	// To do stats on conversations
-	conversations.createIndex({ updatedAt: 1 }).catch(console.error);
+	collections.conversations.createIndex({ updatedAt: 1 }).catch(console.error);
 	// Not strictly necessary, could use _id, but more convenient. Also for stats
-	conversations.createIndex({ createdAt: 1 }).catch(console.error);
+	collections.conversations.createIndex({ createdAt: 1 }).catch(console.error);
 	// To do stats on conversation messages
-	conversations.createIndex({ "messages.createdAt": 1 }, { sparse: true }).catch(console.error);
+	collections.conversations
+		.createIndex({ "messages.createdAt": 1 }, { sparse: true })
+		.catch(console.error);
 	// Unique index for stats
-	conversationStats
+	collections.conversationStats
 		.createIndex(
 			{
 				type: 1,
@@ -93,30 +106,47 @@ client.on("open", () => {
 		)
 		.catch(console.error);
 	// Allow easy check of last computed stat for given type/dateField
-	conversationStats
+	collections.conversationStats
 		.createIndex({
 			type: 1,
 			"date.field": 1,
 			"date.at": 1,
 		})
 		.catch(console.error);
-	abortedGenerations.createIndex({ updatedAt: 1 }, { expireAfterSeconds: 30 }).catch(console.error);
-	abortedGenerations.createIndex({ conversationId: 1 }, { unique: true }).catch(console.error);
-	sharedConversations.createIndex({ hash: 1 }, { unique: true }).catch(console.error);
-	settings.createIndex({ sessionId: 1 }, { unique: true, sparse: true }).catch(console.error);
-	settings.createIndex({ userId: 1 }, { unique: true, sparse: true }).catch(console.error);
-	settings.createIndex({ assistants: 1 }).catch(console.error);
-	users.createIndex({ hfUserId: 1 }, { unique: true }).catch(console.error);
-	users.createIndex({ sessionId: 1 }, { unique: true, sparse: true }).catch(console.error);
+	collections.abortedGenerations
+		.createIndex({ updatedAt: 1 }, { expireAfterSeconds: 30 })
+		.catch(console.error);
+	collections.abortedGenerations
+		.createIndex({ conversationId: 1 }, { unique: true })
+		.catch(console.error);
+	collections.sharedConversations.createIndex({ hash: 1 }, { unique: true }).catch(console.error);
+	collections.settings
+		.createIndex({ sessionId: 1 }, { unique: true, sparse: true })
+		.catch(console.error);
+	collections.settings
+		.createIndex({ userId: 1 }, { unique: true, sparse: true })
+		.catch(console.error);
+	collections.settings.createIndex({ assistants: 1 }).catch(console.error);
+	collections.users.createIndex({ hfUserId: 1 }, { unique: true }).catch(console.error);
+	collections.users
+		.createIndex({ sessionId: 1 }, { unique: true, sparse: true })
+		.catch(console.error);
 	// No unicity because due to renames & outdated info from oauth provider, there may be the same username on different users
-	users.createIndex({ username: 1 }).catch(console.error);
-	messageEvents.createIndex({ createdAt: 1 }, { expireAfterSeconds: 60 }).catch(console.error);
-	sessions.createIndex({ expiresAt: 1 }, { expireAfterSeconds: 0 }).catch(console.error);
-	sessions.createIndex({ sessionId: 1 }, { unique: true }).catch(console.error);
-	assistants.createIndex({ createdById: 1, userCount: -1 }).catch(console.error);
-	assistants.createIndex({ userCount: 1 }).catch(console.error);
-	assistants.createIndex({ featured: 1, userCount: -1 }).catch(console.error);
-	assistants.createIndex({ modelId: 1, userCount: -1 }).catch(console.error);
-	reports.createIndex({ assistantId: 1 }).catch(console.error);
-	reports.createIndex({ createdBy: 1, assistantId: 1 }).catch(console.error);
+	collections.users.createIndex({ username: 1 }).catch(console.error);
+	collections.messageEvents
+		.createIndex({ createdAt: 1 }, { expireAfterSeconds: 60 })
+		.catch(console.error);
+	collections.sessions
+		.createIndex({ expiresAt: 1 }, { expireAfterSeconds: 0 })
+		.catch(console.error);
+	collections.sessions.createIndex({ sessionId: 1 }, { unique: true }).catch(console.error);
+	collections.assistants.createIndex({ createdById: 1, userCount: -1 }).catch(console.error);
+	collections.assistants.createIndex({ userCount: 1 }).catch(console.error);
+	collections.assistants.createIndex({ featured: 1, userCount: -1 }).catch(console.error);
+	collections.assistants.createIndex({ modelId: 1, userCount: -1 }).catch(console.error);
+	collections.reports.createIndex({ assistantId: 1 }).catch(console.error);
+	collections.reports.createIndex({ createdBy: 1, assistantId: 1 }).catch(console.error);
+
+	// Unique index for semaphore
+	collections.semaphores.createIndex({ key: 1 }, { unique: true }).catch(console.error);
 });

--- a/src/lib/types/MigrationResult.ts
+++ b/src/lib/types/MigrationResult.ts
@@ -1,5 +1,7 @@
+import type { ObjectId } from "mongodb";
+
 export interface MigrationResult {
-	guid: ReturnType<typeof crypto.randomUUID>; // must be hardcoded randomUUID. Do not change it once pushed!
+	_id: ObjectId;
 	name: string;
 	status: "success" | "failure" | "ongoing";
 }

--- a/src/lib/types/MigrationResult.ts
+++ b/src/lib/types/MigrationResult.ts
@@ -1,0 +1,5 @@
+export interface MigrationResult {
+	guid: ReturnType<typeof crypto.randomUUID>; // must be hardcoded randomUUID. Do not change it once pushed!
+	name: string;
+	status: "success" | "failure" | "ongoing";
+}

--- a/src/lib/types/Semaphore.ts
+++ b/src/lib/types/Semaphore.ts
@@ -1,6 +1,5 @@
 import type { Timestamps } from "./Timestamps";
 
 export interface Semaphore extends Timestamps {
-	isDBLocked: boolean;
-	key: "semaphore";
+	key: string;
 }

--- a/src/lib/types/Semaphore.ts
+++ b/src/lib/types/Semaphore.ts
@@ -1,0 +1,6 @@
+import type { Timestamps } from "./Timestamps";
+
+export interface Semaphore extends Timestamps {
+	isDBLocked: boolean;
+	key: "semaphore";
+}


### PR DESCRIPTION
This PR adds a check on startup that runs migrations if needed.

## How it works

Each migration is defined by it's. `_id`  field which is unique and hardcoded. When the migration is applied we add it to the `"migrationResults"` collections, so we can check if it has already been run. Each migration is wrapped in a transaction to ensure consistency.

The migration check runs at the top-level of `hooks.server.ts` to ensure it only runs once on startup.

### DB Locks

Because we can have multiple instances of chat-ui running against a single DB we need to ensure we have a lock before running migrations. 

The code for lock related operations is under [lock.ts](https://github.com/huggingface/chat-ui/blob/f7fde32646f89ea31bcf461147e9f4da08f73c02/src/lib/migrations/lock.ts#L19) with the [associated unit-tests](https://github.com/huggingface/chat-ui/blob/20441bc103398d79bb6d916fd7e714d0e0d166ff/src/lib/migrations/migrations.spec.ts).

How it works: 
1. We have a `semaphore` collection with a [unique index on keys](https://github.com/huggingface/chat-ui/blob/f7fde32646f89ea31bcf461147e9f4da08f73c02/src/lib/server/database.ts#L152-L153) 
2. We can set the lock status by using `insertOne`, if it fails to insert then a lock must already exist (see [acquireLock](https://github.com/huggingface/chat-ui/blob/f7fde32646f89ea31bcf461147e9f4da08f73c02/src/lib/migrations/lock.ts#L28-L42))
3. the lock has an `updatedAt` field with a TTL index for mongo to discard if it times out
5. On server startup, all instances try to acquire the lock, the one that gets it can run migrations and the other will wait until the lock is released to start the rest of chat-ui.

 ### Migrations

You can find an example migration [here](https://github.com/huggingface/chat-ui/blob/f7fde32646f89ea31bcf461147e9f4da08f73c02/src/lib/migrations/routines/01-update-search-assistants.ts) 

Migrations can have both `up` (required) and `down` (optional) methods (though we don't use the `down` method for now) and optionally they can also set:
```
	runForHuggingChat?: "only" | "never"; // leave unspecified to run for both
```

We should port the migration from https://github.com/huggingface/chat-ui/pull/841 when merging this PR.