### PR TITLE
Fix issue with "continue" feature on llama.cpp endpoints

### DIFF
--- a/src/lib/server/endpoints/llamacpp/endpointLlamacpp.ts
+++ b/src/lib/server/endpoints/llamacpp/endpointLlamacpp.ts
@@ -110,6 +110,7 @@ export function endpointLlamacpp(
 							};
 							if (data.stop) {
 								stop = true;
+								output.token.special = true;
 								reader?.cancel();
 							}
 							yield output;


### PR DESCRIPTION
We weren't properly indicating when the generation is done.