### PR TITLE
Include last chunk in websearch context

### DIFF
--- a/src/lib/server/sentenceSimilarity.ts
+++ b/src/lib/server/sentenceSimilarity.ts
@@ -22,7 +22,7 @@ export async function findSimilarSentences(
 	const output = await embeddingEndpoint({ inputs });
 
 	const queryEmbedding: Embedding = output[0];
-	const sentencesEmbeddings: Embedding[] = output.slice(1, inputs.length - 1);
+	const sentencesEmbeddings: Embedding[] = output.slice(1);
 
 	const distancesFromQuery: { distance: number; index: number }[] = [...sentencesEmbeddings].map(
 		(sentenceEmbedding: Embedding, index: number) => {


### PR DESCRIPTION
While working on RAG for assistants, I noticed that the last chunk was always missing from the websearch context. In my case it was quite important because my context only had one chunk 😆 