### PR TITLE
Fix prompt caching on llama.cpp endpoints

### DIFF
--- a/src/lib/server/endpoints/llamacpp/endpointLlamacpp.ts
+++ b/src/lib/server/endpoints/llamacpp/endpointLlamacpp.ts
@@ -41,6 +41,7 @@ export function endpointLlamacpp(
 				stop: model.parameters.stop,
 				repeat_penalty: model.parameters.repetition_penalty,
 				n_predict: model.parameters.max_new_tokens,
+				cache_prompt: true,
 			}),
 		});
 


### PR DESCRIPTION
In versions of llama.cpp since [3677](https://github.com/ggerganov/llama.cpp/pull/3677), the prompt cache is dropped by the [server](https://github.com/ggerganov/llama.cpp/blob/master/examples/server/README.md?plain=1#L260) unless `cache_prompt: true` is included in the request. 

This change reduces prompt processing times in long chat threads: local inference with large models can have 10s of seconds of processing time for chats with 1000s of context tokens, this massively improves the responsiveness.