### PR TITLE
Remove extra > in URLs

### DIFF
--- a/src/lib/components/chat/ChatMessage.svelte
+++ b/src/lib/components/chat/ChatMessage.svelte
@@ -77,6 +77,10 @@
 		return `<code>${code.replaceAll("&amp;", "&")}</code>`;
 	};
 
+	renderer.link = (href, title, text) => {
+		return `<a href="${href?.replace(/>$/, "")}" target="_blank" rel="noreferrer">${text}</a>`;
+	};
+
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	const { extensions, ...defaults } = marked.getDefaults() as marked.MarkedOptions & {
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
Apparently they are returned by the model so we can't really strip them at the source. I remove them in the renderer, which means the fix will also work for older conversations!