### PR TITLE
Prepend domain filters in search query generation

### DIFF
--- a/src/lib/server/websearch/runWebSearch.ts
+++ b/src/lib/server/websearch/runWebSearch.ts
@@ -76,17 +76,19 @@ export async function runWebSearch(
 			const searchProvider = getWebSearchProvider();
 			appendUpdate(`Searching ${searchProvider}`, [webSearch.searchQuery]);
 
+			let filters = "";
 			if (ragSettings && ragSettings?.allowedDomains.length > 0) {
 				appendUpdate("Filtering on specified domains");
-				webSearch.searchQuery +=
-					" " + ragSettings.allowedDomains.map((item) => "site:" + item).join(" OR ");
+				filters += ragSettings.allowedDomains.map((item) => "site:" + item).join(" OR ");
 			}
 
 			// handle the global lists
-			webSearch.searchQuery +=
+			filters +=
 				allowList.map((item) => "site:" + item).join(" OR ") +
 				" " +
 				blockList.map((item) => "-site:" + item).join(" ");
+
+			webSearch.searchQuery = filters + " " + webSearch.searchQuery;
 
 			const results = await searchWeb(webSearch.searchQuery);
 			webSearch.results =


### PR DESCRIPTION
If the search query generation returns a long search query, the filters at the end of the query would get cut off. We can avoid this by putting the filters at the beginning of the query 