### PR TITLE
Set assistant prompt from URL

### DIFF
--- a/src/lib/components/chat/AssistantIntroduction.svelte
+++ b/src/lib/components/chat/AssistantIntroduction.svelte
@@ -19,10 +19,9 @@
 
 	const dispatch = createEventDispatcher<{ message: string }>();
 
-	$: hasRag =
-		assistant?.rag?.allowAllDomains ||
-		(assistant?.rag?.allowedDomains?.length ?? 0) > 0 ||
-		(assistant?.rag?.allowedLinks?.length ?? 0) > 0;
+	$: hasRag = Object.values(assistant?.rag ?? {}).some((value) =>
+		Array.isArray(value) ? value.length > 0 : !!value
+	);
 </script>
 
 <div class="flex h-full w-full flex-col content-center items-center justify-center pb-52">

--- a/src/lib/types/Assistant.ts
+++ b/src/lib/types/Assistant.ts
@@ -18,7 +18,7 @@ export interface Assistant extends Timestamps {
 		allowAllDomains: boolean;
 		allowedDomains: string[];
 		allowedLinks: string[];
-		prepromptUrl?: string
+		prepromptUrl?: string;
 	};
 	searchTokens: string[];
 }

--- a/src/lib/types/Assistant.ts
+++ b/src/lib/types/Assistant.ts
@@ -18,6 +18,7 @@ export interface Assistant extends Timestamps {
 		allowAllDomains: boolean;
 		allowedDomains: string[];
 		allowedLinks: string[];
+		prepromptUrl?: string
 	};
 	searchTokens: string[];
 }

--- a/src/routes/assistants/+page.svelte
+++ b/src/routes/assistants/+page.svelte
@@ -202,10 +202,9 @@
 
 		<div class="mt-8 grid grid-cols-2 gap-3 sm:gap-5 md:grid-cols-3 lg:grid-cols-4">
 			{#each data.assistants as assistant (assistant._id)}
-				{@const hasRag =
-					assistant?.rag?.allowAllDomains ||
-					!!assistant?.rag?.allowedDomains?.length ||
-					!!assistant?.rag?.allowedLinks?.length}
+				{@const hasRag = Object.values(assistant?.rag ?? {}).some((value) =>
+					Array.isArray(value) ? value.length > 0 : !!value
+				)}
 
 				<button
 					class="relative flex flex-col items-center justify-center overflow-hidden text-balance rounded-xl border bg-gray-50/50 px-4 py-6 text-center shadow hover:bg-gray-50 hover:shadow-inner max-sm:px-4 sm:h-64 sm:pb-4 xl:pt-8 dark:border-gray-800/70 dark:bg-gray-950/20 dark:hover:bg-gray-950/40"

--- a/src/routes/conversation/+server.ts
+++ b/src/routes/conversation/+server.ts
@@ -53,7 +53,6 @@ export const POST: RequestHandler = async ({ locals, request }) => {
 	});
 
 	if (assistant) {
-		console.log(assistant?.rag?.prepromptUrl);
 		// if the assistant has a preprompt Url and it's not local, try to fetch it
 		if (assistant.rag?.prepromptUrl && !(await isURLLocal(new URL(assistant.rag.prepromptUrl)))) {
 			try {

--- a/src/routes/conversation/[id]/+server.ts
+++ b/src/routes/conversation/[id]/+server.ts
@@ -346,10 +346,13 @@ export async function POST({ request, locals, params, getClientAddress }) {
 			const assistantHasRAG =
 				ENABLE_ASSISTANTS_RAG === "true" &&
 				rag &&
-				(rag.allowedLinks.length > 0 || rag.allowedDomains.length > 0 || rag.allowAllDomains);
+				Object.values(rag).some((value) => (Array.isArray(value) ? value.length > 0 : !!value));
 
 			// perform websearch if needed
-			if (!isContinue && ((webSearch && !conv.assistantId) || assistantHasRAG)) {
+			if (
+				!isContinue &&
+				((webSearch && !conv.assistantId) || (assistantHasRAG && !rag.prepromptUrl))
+			) {
 				messageToWriteTo.webSearch = await runWebSearch(conv, messagesForPrompt, update, rag);
 			}
 

--- a/src/routes/settings/(nav)/assistants/[assistantId]/+page.svelte
+++ b/src/routes/settings/(nav)/assistants/[assistantId]/+page.svelte
@@ -29,10 +29,9 @@
 
 	let displayReportModal = false;
 
-	$: hasRag =
-		assistant?.rag?.allowAllDomains ||
-		!!assistant?.rag?.allowedDomains?.length ||
-		!!assistant?.rag?.allowedLinks?.length;
+	$: hasRag = Object.values(assistant?.rag ?? {}).some((value) =>
+		Array.isArray(value) ? value.length > 0 : !!value
+	);
 </script>
 
 {#if displayReportModal}
@@ -164,14 +163,35 @@
 
 	<!-- two columns for big screen, single column for small screen -->
 	<div class="mb-12 mt-3">
-		<h2 class="mb-2 font-semibold">System Instructions</h2>
-		<textarea
-			disabled
-			class="box-border h-full min-h-[8lh] w-full rounded-lg border-2 border-gray-200 bg-gray-100 p-2 disabled:cursor-not-allowed"
-			>{assistant?.preprompt}</textarea
-		>
+		<h2 class="mb-2 font-semibold">
+			System Instructions
+			{#if assistant?.rag?.prepromptUrl}
+				<span
+					class="inline-grid size-5 place-items-center rounded-full bg-blue-500/10"
+					title="This assistant gets its instructions from the internet.."
+				>
+					<IconInternet classNames="text-sm text-blue-600" />
+				</span>
+			{/if}
+		</h2>
+		{#if assistant?.rag?.prepromptUrl}
+			<p class="pb-3 text-sm text-gray-500">
+				This Assistant gets its instructions from the following URL:
+			</p>
+			<a
+				target="_blank"
+				class="break-all rounded-lg border border-gray-200 bg-gray-100 px-2 py-1.5 leading-tight underline decoration-gray-400"
+				href={assistant?.rag?.prepromptUrl}>{assistant?.rag?.prepromptUrl}</a
+			>
+		{:else}
+			<textarea
+				disabled
+				class="box-border h-full min-h-[8lh] w-full rounded-lg border-2 border-gray-200 bg-gray-100 p-2 disabled:cursor-not-allowed"
+				>{assistant?.preprompt}</textarea
+			>
+		{/if}
 
-		{#if hasRag}
+		{#if hasRag && !assistant?.rag?.prepromptUrl}
 			<div class="mt-4">
 				<h2 class=" font-semibold">Internet Access</h2>
 				{#if assistant?.rag?.allowAllDomains}

--- a/src/routes/settings/(nav)/assistants/[assistantId]/+page.svelte
+++ b/src/routes/settings/(nav)/assistants/[assistantId]/+page.svelte
@@ -176,7 +176,7 @@
 		</h2>
 		{#if assistant?.rag?.prepromptUrl}
 			<p class="pb-3 text-sm text-gray-500">
-				This Assistant gets its instructions from the following URL:
+				This assistant loads system instructions from the following URL:
 			</p>
 			<a
 				target="_blank"

--- a/src/routes/settings/(nav)/assistants/[assistantId]/edit/+page.server.ts
+++ b/src/routes/settings/(nav)/assistants/[assistantId]/edit/+page.server.ts
@@ -24,6 +24,7 @@ const newAsssistantSchema = z.object({
 	ragLinkList: z.preprocess(parseStringToList, z.string().url().array().max(10)),
 	ragDomainList: z.preprocess(parseStringToList, z.string().array()),
 	ragAllowAll: z.preprocess((v) => v === "true", z.boolean()),
+	ragPrepromptUrl: z.union([z.literal(""), z.string().trim().url()]),
 });
 
 const uploadAvatar = async (avatar: File, assistantId: ObjectId): Promise<string> => {
@@ -139,6 +140,7 @@ export const actions: Actions = {
 						allowedLinks: parse.data.ragLinkList,
 						allowedDomains: parse.data.ragDomainList,
 						allowAllDomains: parse.data.ragAllowAll,
+						prepromptUrl: parse.data.ragPrepromptUrl,
 					},
 					searchTokens: generateSearchTokens(parse.data.name),
 				},

--- a/src/routes/settings/(nav)/assistants/new/+page.server.ts
+++ b/src/routes/settings/(nav)/assistants/new/+page.server.ts
@@ -24,6 +24,7 @@ const newAsssistantSchema = z.object({
 	ragLinkList: z.preprocess(parseStringToList, z.string().url().array().max(10)),
 	ragDomainList: z.preprocess(parseStringToList, z.string().array()),
 	ragAllowAll: z.preprocess((v) => v === "true", z.boolean()),
+	ragPrepromptUrl: z.union([z.literal(""), z.string().trim().url()]),
 });
 
 const uploadAvatar = async (avatar: File, assistantId: ObjectId): Promise<string> => {
@@ -121,6 +122,7 @@ export const actions: Actions = {
 				allowedLinks: parse.data.ragLinkList,
 				allowedDomains: parse.data.ragDomainList,
 				allowAllDomains: parse.data.ragAllowAll,
+				prepromptUrl: parse.data.ragPrepromptUrl,
 			},
 			searchTokens: generateSearchTokens(parse.data.name),
 		});


### PR DESCRIPTION
### Assistant view
![image](https://github.com/huggingface/chat-ui/assets/25119303/c9b50977-8ce9-43e1-a028-490947ea979e)
### Settings edit/new
![image](https://github.com/huggingface/chat-ui/assets/25119303/0958fef9-4144-425a-8645-0c1f51622113)


This uses the same `parseWeb` method we use in the web search, but instead of chunking and generating embeddings we just add the resulting text to the system prompt. 