### PR TITLE
Add Archyve search

### DIFF
--- a/.env
+++ b/.env
@@ -20,6 +20,8 @@ SERPAPI_KEY=#your serpapi key here
 SERPSTACK_API_KEY=#your serpstack api key here
 USE_LOCAL_WEBSEARCH=#set to true to parse google results yourself, overrides other API keys
 SEARXNG_QUERY_URL=# where '<query>' will be replaced with query keywords see https://docs.searxng.org/dev/search_api.html eg https://searxng.yourdomain.com/search?q=<query>&engines=duckduckgo,google&format=json
+ARCHYVE_API_KEY=#your archyve api key here
+ARCHYVE_QUERY_URL=# where '<query>' will be replaced with query keywords eg https:/your.archyve.com/v1/search?q=<query>
 
 WEBSEARCH_ALLOWLIST=`[]` # if it's defined, allow websites from only this list.
 WEBSEARCH_BLOCKLIST=`[]` # if it's defined, block websites from this list.

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ SECRET_CONFIG
 !.env.ci
 !.env
 !.env.template
+deps/mongodb

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,9 +73,9 @@
 			},
 			"optionalDependencies": {
 				"@anthropic-ai/sdk": "^0.17.1",
+				"@google-cloud/vertexai": "^0.5.0",
 				"aws4fetch": "^1.0.17",
-				"openai": "^4.14.2",
-				"@google-cloud/vertexai": "^0.5.0"
+				"openai": "^4.14.2"
 			}
 		},
 		"node_modules/@alloc/quick-lru": {
@@ -633,6 +633,7 @@
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/@google-cloud/vertexai/-/vertexai-0.5.0.tgz",
 			"integrity": "sha512-qIFHYTXA5UCLdm9JG+Xf1suomCXxRqa1PKdYjqXuhZsCm8mn37Rb0Tf8djlhDzuRVWyWoQTmsWpsk28ZTmbqJg==",
+			"optional": true,
 			"dependencies": {
 				"google-auth-library": "^9.1.0"
 			},
@@ -2695,6 +2696,7 @@
 			"version": "9.1.2",
 			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
 			"integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==",
+			"optional": true,
 			"engines": {
 				"node": "*"
 			}
@@ -2832,7 +2834,8 @@
 		"node_modules/buffer-equal-constant-time": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+			"optional": true
 		},
 		"node_modules/bufferutil": {
 			"version": "4.0.7",
@@ -3462,6 +3465,7 @@
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
 			"integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+			"optional": true,
 			"dependencies": {
 				"safe-buffer": "^5.0.1"
 			}
@@ -3823,7 +3827,8 @@
 		"node_modules/extend": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+			"optional": true
 		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
@@ -4035,6 +4040,7 @@
 			"version": "6.3.0",
 			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.3.0.tgz",
 			"integrity": "sha512-p+ggrQw3fBwH2F5N/PAI4k/G/y1art5OxKpb2J2chwNNHM4hHuAOtivjPuirMF4KNKwTTUal/lPfL2+7h2mEcg==",
+			"optional": true,
 			"dependencies": {
 				"extend": "^3.0.2",
 				"https-proxy-agent": "^7.0.1",
@@ -4049,6 +4055,7 @@
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
 			"integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+			"optional": true,
 			"dependencies": {
 				"debug": "^4.3.4"
 			},
@@ -4060,6 +4067,7 @@
 			"version": "7.0.4",
 			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
 			"integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
+			"optional": true,
 			"dependencies": {
 				"agent-base": "^7.0.2",
 				"debug": "4"
@@ -4072,6 +4080,7 @@
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.0.tgz",
 			"integrity": "sha512-Jh/AIwwgaxan+7ZUUmRLCjtchyDiqh4KjBJ5tW3plBZb5iL/BPcso8A5DlzeD9qlw0duCamnNdpFjxwaT0KyKg==",
+			"optional": true,
 			"dependencies": {
 				"gaxios": "^6.0.0",
 				"json-bigint": "^1.0.0"
@@ -4188,6 +4197,7 @@
 			"version": "9.7.0",
 			"resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.7.0.tgz",
 			"integrity": "sha512-I/AvzBiUXDzLOy4iIZ2W+Zq33W4lcukQv1nl7C8WUA6SQwyQwUwu3waNmWNAvzds//FG8SZ+DnKnW/2k6mQS8A==",
+			"optional": true,
 			"dependencies": {
 				"base64-js": "^1.3.0",
 				"ecdsa-sig-formatter": "^1.0.11",
@@ -4222,6 +4232,7 @@
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
 			"integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+			"optional": true,
 			"dependencies": {
 				"gaxios": "^6.0.0",
 				"jws": "^4.0.0"
@@ -4575,6 +4586,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
 			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+			"devOptional": true,
 			"engines": {
 				"node": ">=8"
 			},
@@ -4708,6 +4720,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
 			"integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+			"optional": true,
 			"dependencies": {
 				"bignumber.js": "^9.0.0"
 			}
@@ -4745,6 +4758,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
 			"integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+			"optional": true,
 			"dependencies": {
 				"buffer-equal-constant-time": "1.0.1",
 				"ecdsa-sig-formatter": "1.0.11",
@@ -4755,6 +4769,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
 			"integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+			"optional": true,
 			"dependencies": {
 				"jwa": "^2.0.0",
 				"safe-buffer": "^5.0.1"
@@ -5293,6 +5308,7 @@
 			"version": "2.7.0",
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
 			"integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+			"optional": true,
 			"dependencies": {
 				"whatwg-url": "^5.0.0"
 			},
@@ -5311,17 +5327,20 @@
 		"node_modules/node-fetch/node_modules/tr46": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+			"optional": true
 		},
 		"node_modules/node-fetch/node_modules/webidl-conversions": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+			"optional": true
 		},
 		"node_modules/node-fetch/node_modules/whatwg-url": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
 			"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+			"optional": true,
 			"dependencies": {
 				"tr46": "~0.0.3",
 				"webidl-conversions": "^3.0.0"

--- a/src/lib/server/preprocessMessages.ts
+++ b/src/lib/server/preprocessMessages.ts
@@ -27,6 +27,7 @@ export async function preprocessMessages(
 				// use the WebSearch provider's message template
 				message.content = webSearch.provider.messageTemplator(
 					webSearch,
+					webSearchContext,
 					lastQuestion,
 					previousQuestions
 				);

--- a/src/lib/server/preprocessMessages.ts
+++ b/src/lib/server/preprocessMessages.ts
@@ -1,6 +1,5 @@
 import type { Conversation } from "$lib/types/Conversation";
 import type { Message } from "$lib/types/Message";
-import { format } from "date-fns";
 import { downloadFile } from "./files/downloadFile";
 
 export async function preprocessMessages(
@@ -24,15 +23,13 @@ export async function preprocessMessages(
 					.filter((el) => el.from === "user")
 					.slice(0, -1)
 					.map((el) => el.content);
-				const currentDate = format(new Date(), "MMMM d, yyyy");
 
-				message.content = `I searched the web using the query: ${webSearch.searchQuery}. 
-Today is ${currentDate} and here are the results:
-=====================
-${webSearchContext}
-=====================
-${previousQuestions.length > 0 ? `Previous questions: \n- ${previousQuestions.join("\n- ")}` : ""}
-Answer the question: ${lastQuestion}`;
+				// use the WebSearch provider's message template
+				message.content = webSearch.provider.messageTemplator(
+					webSearch,
+					lastQuestion,
+					previousQuestions
+				);
 			}
 			// handle files if model is multimodal
 			if (multimodal) {

--- a/src/lib/server/websearch/parseArchyve.ts
+++ b/src/lib/server/websearch/parseArchyve.ts
@@ -1,0 +1,24 @@
+import { ARCHYVE_API_KEY } from "$env/static/private";
+import { ARCHYVE_CLIENT_ID } from "$env/static/private";
+
+export async function parseArchyve(url: string) {
+	const abortController = new AbortController();
+	setTimeout(() => abortController.abort(), 10000);
+
+	// if we get an archyve link, just call the api and return the right attribute
+	const jsonResponse = await fetch(url, {
+		headers: {
+			Authorization: `Bearer ${ARCHYVE_API_KEY}`,
+			"X-Client-Id": ARCHYVE_CLIENT_ID,
+			Accept: "application/json",
+		},
+		signal: abortController.signal,
+	})
+		.then((response) => response.json() as Promise<{ content: string }>)
+		.catch((error) => {
+			console.error("Failed to fetch or parse JSON", error);
+			throw new Error("Failed to fetch or parse JSON");
+		});
+
+	return jsonResponse.content;
+}

--- a/src/lib/server/websearch/searchArchyve.ts
+++ b/src/lib/server/websearch/searchArchyve.ts
@@ -1,0 +1,45 @@
+import { ARCHYVE_API_KEY } from "$env/static/private";
+import { ARCHYVE_CLIENT_ID } from "$env/static/private";
+import { ARCHYVE_QUERY_URL } from "$env/static/private";
+
+export async function searchArchyve(query: string) {
+	const abortController = new AbortController();
+	setTimeout(() => abortController.abort(), 10000);
+
+	// insert the query into the URL template
+	const url = ARCHYVE_QUERY_URL.replace("<query>", query);
+
+	// search Archyve for relevant documents
+	const jsonResponse = await fetch(url, {
+		headers: {
+			Authorization: `Bearer ${ARCHYVE_API_KEY}`,
+			"X-Client-Id": ARCHYVE_CLIENT_ID,
+			Accept: "application/json",
+		},
+		signal: abortController.signal,
+	})
+		.then(
+			(response) =>
+				response.json() as Promise<{ hits: { url: string; distance: number; document: string }[] }>
+		)
+		.catch((error) => {
+			console.error("Failed to fetch or parse JSON", error);
+			throw new Error("Failed to fetch or parse JSON");
+		});
+
+	if (!jsonResponse.hits.length) {
+		throw new Error(`Response doesn't contain key "hits"`);
+	}
+	const hits = jsonResponse.hits.slice(0, 5);
+
+	interface Results {
+		link: string;
+		text: string;
+	}
+
+	const results: Results[] = hits.map((hit) => {
+		return { link: hit.url, text: hit.document };
+	});
+
+	return { organic_results: results };
+}

--- a/src/lib/server/websearch/searchArchyve.ts
+++ b/src/lib/server/websearch/searchArchyve.ts
@@ -18,10 +18,7 @@ export async function searchArchyve(query: string) {
 		},
 		signal: abortController.signal,
 	})
-		.then(
-			(response) =>
-				response.json() as Promise<{ hits: { url: string; distance: number; document: string }[] }>
-		)
+		.then((response) => response.json() as Promise<{ hits: { url: string; distance: number }[] }>)
 		.catch((error) => {
 			console.error("Failed to fetch or parse JSON", error);
 			throw new Error("Failed to fetch or parse JSON");
@@ -30,15 +27,10 @@ export async function searchArchyve(query: string) {
 	if (!jsonResponse.hits.length) {
 		throw new Error(`Response doesn't contain key "hits"`);
 	}
-	const hits = jsonResponse.hits.slice(0, 5);
+	const hits = jsonResponse.hits.slice(0, 10);
 
-	interface Results {
-		link: string;
-		text: string;
-	}
-
-	const results: Results[] = hits.map((hit) => {
-		return { link: hit.url, text: hit.document };
+	const results: { link: string }[] = hits.map((hit) => {
+		return { link: hit.url };
 	});
 
 	return { organic_results: results };

--- a/src/lib/server/websearch/searchWeb.ts
+++ b/src/lib/server/websearch/searchWeb.ts
@@ -1,5 +1,5 @@
 import type { YouWebSearch } from "../../types/WebSearch";
-import { WebSearchProvider } from "../../types/WebSearch";
+import { webSearchProviders } from "../../types/WebSearch";
 import {
 	SERPAPI_KEY,
 	SERPER_API_KEY,
@@ -7,20 +7,24 @@ import {
 	USE_LOCAL_WEBSEARCH,
 	SEARXNG_QUERY_URL,
 	YDC_API_KEY,
+	ARCHYVE_QUERY_URL,
 } from "$env/static/private";
 import { getJson } from "serpapi";
 import type { GoogleParameters } from "serpapi";
 import { searchWebLocal } from "./searchWebLocal";
 import { searchSearxng } from "./searchSearxng";
+import { searchArchyve } from "./searchArchyve";
 
 // get which SERP api is providing web results
 export function getWebSearchProvider() {
 	if (YDC_API_KEY) {
-		return WebSearchProvider.YOU;
+		return webSearchProviders.YOU;
 	} else if (SEARXNG_QUERY_URL) {
-		return WebSearchProvider.SEARXNG;
+		return webSearchProviders.SEARXNG;
+	} else if (ARCHYVE_QUERY_URL) {
+		return webSearchProviders.ARCHYVE;
 	} else {
-		return WebSearchProvider.GOOGLE;
+		return webSearchProviders.GOOGLE;
 	}
 }
 
@@ -44,7 +48,10 @@ export async function searchWeb(query: string) {
 	if (SERPSTACK_API_KEY) {
 		return await searchSerpStack(query);
 	}
-	throw new Error("No You.com or Serper.dev or SerpAPI key found");
+	if (ARCHYVE_QUERY_URL) {
+		return await searchArchyve(query);
+	}
+	throw new Error("No You.com or Serper.dev or SerpAPI or Archyve key found");
 }
 
 export async function searchWebSerper(query: string) {

--- a/src/lib/types/WebSearch.ts
+++ b/src/lib/types/WebSearch.ts
@@ -1,6 +1,7 @@
 import type { ObjectId } from "mongodb";
 import type { Conversation } from "./Conversation";
 import type { Timestamps } from "./Timestamps";
+import { format } from "date-fns";
 
 export interface WebSearch extends Timestamps {
 	_id?: ObjectId;
@@ -10,7 +11,9 @@ export interface WebSearch extends Timestamps {
 
 	searchQuery: string;
 	results: WebSearchSource[];
+	context: string;
 	contextSources: WebSearchUsedSource[];
+	provider: WebSearchProvider;
 }
 
 export interface WebSearchSource {
@@ -41,9 +44,71 @@ interface YouSearchHit {
 	snippets: string[];
 }
 
-// eslint-disable-next-line no-shadow
-export enum WebSearchProvider {
-	GOOGLE = "Google",
-	YOU = "You.com",
-	SEARXNG = "SearXNG",
+export interface WebSearchProvider {
+	name: string;
+	messageTemplator: (
+		webSearch: WebSearch,
+		lastQuestion: string,
+		previousQuestions: string[]
+	) => string;
+	generateQuery: boolean;
+	doSimilaritySearch: boolean;
 }
+
+export type WebSearchProviders = Record<string, WebSearchProvider>;
+
+function defaultTemplator(
+	webSearch: WebSearch,
+	lastQuestion: string,
+	previousQuestions: string[]
+): string {
+	return `I searched the web using the query: ${webSearch.searchQuery}.
+	Today is ${format(new Date(), "MMMM d, yyyy")} and here are the results:
+	=====================
+	${webSearch.context}
+	=====================
+	${previousQuestions.length > 0 ? `Previous questions: \n- ${previousQuestions.join("\n- ")}` : ""}
+	Answer the question: ${lastQuestion}`;
+}
+
+function archyveTemplator(
+	webSearch: WebSearch,
+	lastQuestion: string,
+	previousQuestions: string[]
+): string {
+	return `Given this context and previous questions, answer the following question:
+
+${webSearch.context}
+
+${previousQuestions.length > 0 ? `Previous questions: \n- ${previousQuestions.join("\n- ")}` : ""}
+
+Question: ${lastQuestion}
+`;
+}
+
+export const webSearchProviders: WebSearchProviders = {
+	GOOGLE: {
+		name: "Google",
+		messageTemplator: defaultTemplator,
+		generateQuery: true,
+		doSimilaritySearch: true,
+	},
+	YOU: {
+		name: "You.com",
+		messageTemplator: defaultTemplator,
+		generateQuery: true,
+		doSimilaritySearch: true,
+	},
+	SEARXNG: {
+		name: "SearXNG",
+		messageTemplator: defaultTemplator,
+		generateQuery: true,
+		doSimilaritySearch: true,
+	},
+	ARCHYVE: {
+		name: "Archyve",
+		messageTemplator: archyveTemplator,
+		generateQuery: false,
+		doSimilaritySearch: false,
+	},
+};

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -13,6 +13,7 @@ import {
 	YDC_API_KEY,
 	USE_LOCAL_WEBSEARCH,
 	SEARXNG_QUERY_URL,
+	ARCHYVE_QUERY_URL,
 	ENABLE_ASSISTANTS,
 	ENABLE_ASSISTANTS_RAG,
 } from "$env/static/private";
@@ -141,7 +142,8 @@ export const load: LayoutServerLoad = async ({ locals, depends }) => {
 				SERPSTACK_API_KEY ||
 				YDC_API_KEY ||
 				USE_LOCAL_WEBSEARCH ||
-				SEARXNG_QUERY_URL
+				SEARXNG_QUERY_URL ||
+				ARCHYVE_QUERY_URL
 			),
 			ethicsModalAccepted: !!settings?.ethicsModalAcceptedAt,
 			ethicsModalAcceptedAt: settings?.ethicsModalAcceptedAt ?? null,


### PR DESCRIPTION
Add support for using Archyve to search a document library for additional context to add to the prompt. Closes #909.

- [x] change `WebSearchProvider` enum to `WebSearchProviders` object
- [x] add info to web search provider about how to template queries and whether to generate a better search query using an LLM
- [x] call Archyve API to get document chunks
- [x] investigate skipping internal chunking and similarity search, since Archyve has already provided relevant chunks based on similarity search
- [x] ~~write tests?~~ I don't see many tests in the code, but lmk if this PR would benefit from testing a particular component
- [x] limit number/size of chunks used in context

@nsarrazin Thoughts on the general direction I'm going?

### Testing

To test, I used an actual RFP from the Government of Canada, which is about the worst PDF I can think of. I uploaded the document into Archyve and integrated ChatUI with the Archyve API. Here is the result:
<img width="972" alt="image" src="https://github.com/huggingface/chat-ui/assets/86964206/5346d06c-5eae-4a1a-9736-680d0636e99f">

the Archyve API is documented at [archyve.io](https://archyve.io).
