### PR TITLE
🚸 When a user signs up they're directly logged in

### DIFF
--- a/src/routes/login/callback/updateUser.ts
+++ b/src/routes/login/callback/updateUser.ts
@@ -92,9 +92,6 @@ export async function updateUser(params: {
 			ip,
 			expiresAt: addWeeks(new Date(), 2),
 		});
-
-		// refresh session cookie
-		refreshSessionCookie(cookies, secretSessionId);
 	} else {
 		// user doesn't exist yet, create a new one
 		const { insertedId } = await collections.users.insertOne({
@@ -141,6 +138,9 @@ export async function updateUser(params: {
 			});
 		}
 	}
+	
+	// refresh session cookie
+	refreshSessionCookie(cookies, secretSessionId);
 
 	// migrate pre-existing conversations
 	await collections.conversations.updateMany(

--- a/src/routes/login/callback/updateUser.ts
+++ b/src/routes/login/callback/updateUser.ts
@@ -138,7 +138,7 @@ export async function updateUser(params: {
 			});
 		}
 	}
-	
+
 	// refresh session cookie
 	refreshSessionCookie(cookies, secretSessionId);
 


### PR DESCRIPTION
Currently it seems a user, when logging in for the first time, needs to

- sign up (with "sign in with HF")
- sign in

Because the sign up doesn't send the new cookie value to the user