### PR TITLE
Limit number of fetched conversations in the API

### DIFF
--- a/src/routes/api/conversations/+server.ts
+++ b/src/routes/api/conversations/+server.ts
@@ -2,7 +2,9 @@ import { collections } from "$lib/server/database";
 import { authCondition } from "$lib/server/auth";
 import type { Conversation } from "$lib/types/Conversation";
 
-export async function GET({ locals }) {
+export async function GET({ locals, url }) {
+	const p = parseInt(url.searchParams.get("p") ?? "0");
+
 	if (locals.user?._id || locals.sessionId) {
 		const convs = await collections.conversations
 			.find({
@@ -14,6 +16,7 @@ export async function GET({ locals }) {
 				model: 1,
 			})
 			.sort({ updatedAt: -1 })
+			.skip(300 * p)
 			.limit(300)
 			.toArray();
 

--- a/src/routes/api/conversations/+server.ts
+++ b/src/routes/api/conversations/+server.ts
@@ -14,6 +14,7 @@ export async function GET({ locals }) {
 				model: 1,
 			})
 			.sort({ updatedAt: -1 })
+			.limit(300)
 			.toArray();
 
 		const res = convs.map((conv) => ({

--- a/src/routes/api/conversations/+server.ts
+++ b/src/routes/api/conversations/+server.ts
@@ -2,6 +2,8 @@ import { collections } from "$lib/server/database";
 import { authCondition } from "$lib/server/auth";
 import type { Conversation } from "$lib/types/Conversation";
 
+const NUM_PER_PAGE = 300;
+
 export async function GET({ locals, url }) {
 	const p = parseInt(url.searchParams.get("p") ?? "0");
 
@@ -16,8 +18,8 @@ export async function GET({ locals, url }) {
 				model: 1,
 			})
 			.sort({ updatedAt: -1 })
-			.skip(300 * p)
-			.limit(300)
+			.skip(p * NUM_PER_PAGE)
+			.limit(NUM_PER_PAGE)
 			.toArray();
 
 		const res = convs.map((conv) => ({


### PR DESCRIPTION
We were missing the same limit that we use in the load function of the web app.