### PR TITLE
 Expose sampling controls in assistants (#955) 

### DIFF
--- a/src/lib/components/AssistantSettings.svelte
+++ b/src/lib/components/AssistantSettings.svelte
@@ -272,13 +272,13 @@
 					class="group/details mt-2"
 					open={Object.values(assistant?.generateSettings ?? {}).some((v) => !!v)}
 				>
-					<summary class="ml-1 cursor-pointer text-xs group-open/details:font-semibold">
+					<summary class="cursor-pointer text-xs group-open/details:font-semibold">
 						Model settings
 					</summary>
 					<p class="text-xs text-red-500">{getError("inputMessage1", form)}</p>
-					<div class="mb-2 grid grid-cols-2 grid-rows-2 gap-2">
+					<div class="my-2 grid grid-cols-2 grid-rows-2 gap-2">
 						<label for="temperature">
-							<span class="m-1 ml-0 inline-block text-nowrap text-sm">
+							<span class="m-1 ml-0 inline-block text-sm">
 								Temperature
 
 								<HoverTooltip
@@ -299,7 +299,7 @@
 							/>
 						</label>
 						<label for="top_p">
-							<span class="m-1 ml-0 inline-block text-nowrap text-sm">
+							<span class="m-1 ml-0 inline-block text-sm">
 								Top P
 								<HoverTooltip
 									align="right"
@@ -321,7 +321,7 @@
 							/>
 						</label>
 						<label for="repetition_penalty">
-							<span class="m-1 ml-0 inline-block text-nowrap text-sm">
+							<span class="m-1 ml-0 inline-block text-sm">
 								Repetition penalty
 								<HoverTooltip
 									label="Repetition penalty determines the penalty to a token's score for repeating the same token multiple times."
@@ -341,7 +341,7 @@
 							/>
 						</label>
 						<label for="top_k">
-							<span class="m-1 ml-0 inline-block text-nowrap text-sm">
+							<span class="m-1 ml-0 inline-block text-sm">
 								Top K <HoverTooltip
 									align="right"
 									label="The number of highest probability vocabulary tokens to keep for top-k-filtering."

--- a/src/lib/components/AssistantSettings.svelte
+++ b/src/lib/components/AssistantSettings.svelte
@@ -10,6 +10,7 @@
 	import CarbonPen from "~icons/carbon/pen";
 	import CarbonUpload from "~icons/carbon/upload";
 	import CarbonHelpFilled from "~icons/carbon/help";
+	import CarbonSettingsAdjust from "~icons/carbon/settings-adjust";
 
 	import { useSettingsStore } from "$lib/stores/settings";
 	import { isHuggingChat } from "$lib/utils/isHuggingChat";
@@ -36,6 +37,7 @@
 	let modelId = "";
 	let systemPrompt = assistant?.preprompt ?? "";
 	let dynamicPrompt = assistant?.dynamicPrompt ?? false;
+	let showModelSettings = Object.values(assistant?.generateSettings ?? {}).some((v) => !!v);
 
 	let compress: typeof readAndCompressImage | null = null;
 
@@ -258,33 +260,42 @@
 
 			<label>
 				<div class="mb-1 font-semibold">Model</div>
-				<select
-					name="modelId"
-					class="w-full rounded-lg border-2 border-gray-200 bg-gray-100 p-2"
-					bind:value={modelId}
+				<div class="flex gap-2">
+					<select
+						name="modelId"
+						class="w-full rounded-lg border-2 border-gray-200 bg-gray-100 p-2"
+						bind:value={modelId}
+					>
+						{#each models.filter((model) => !model.unlisted) as model}
+							<option value={model.id}>{model.displayName}</option>
+						{/each}
+						<p class="text-xs text-red-500">{getError("modelId", form)}</p>
+					</select>
+					<button
+						type="button"
+						class="flex aspect-square items-center gap-2 whitespace-nowrap rounded-lg border px-3 {showModelSettings
+							? 'border-blue-500/20 bg-blue-50 text-blue-600'
+							: ''}"
+						on:click={() => (showModelSettings = !showModelSettings)}
+						><CarbonSettingsAdjust class="text-xs" /></button
+					>
+				</div>
+				<div
+					class="mt-2 rounded-lg border border-blue-500/20 bg-blue-500/5 px-2 py-0.5"
+					class:hidden={!showModelSettings}
 				>
-					{#each models.filter((model) => !model.unlisted) as model}
-						<option value={model.id}>{model.displayName}</option>
-					{/each}
-					<p class="text-xs text-red-500">{getError("modelId", form)}</p>
-				</select>
-				<details
-					class="group/details mt-2"
-					open={Object.values(assistant?.generateSettings ?? {}).some((v) => !!v)}
-				>
-					<summary class="cursor-pointer text-xs group-open/details:font-semibold">
-						Model settings
-					</summary>
 					<p class="text-xs text-red-500">{getError("inputMessage1", form)}</p>
-					<div class="my-2 grid grid-cols-2 grid-rows-2 gap-2">
-						<label for="temperature">
-							<span class="m-1 ml-0 inline-block text-sm">
+					<div class="my-2 grid grid-cols-1 gap-2.5 sm:grid-cols-2 sm:grid-rows-2">
+						<label for="temperature" class="flex justify-between">
+							<span class="m-1 ml-0 flex items-center gap-1.5 whitespace-nowrap text-sm">
 								Temperature
 
 								<HoverTooltip
-									label="Temperature affects the distribution of tokens. A high temperature makes less probable tokens more likely to be sampled."
+									label="Temperature: Controls creativity, higher values allow more variety."
 								>
-									<CarbonHelpFilled class="inline" />
+									<CarbonHelpFilled
+										class="inline text-xxs text-gray-500 group-hover/tooltip:text-blue-600"
+									/>
 								</HoverTooltip>
 							</span>
 							<input
@@ -293,26 +304,28 @@
 								min="0.1"
 								max="2"
 								step="0.1"
-								class="w-full rounded-lg border-2 border-gray-200 bg-gray-100 p-2"
+								class="w-20 rounded-lg border-2 border-gray-200 bg-gray-100 px-2 py-1"
 								placeholder={selectedModel?.parameters?.temperature?.toString() ?? "1"}
 								value={assistant?.generateSettings?.temperature ?? ""}
 							/>
 						</label>
-						<label for="top_p">
-							<span class="m-1 ml-0 inline-block text-sm">
+						<label for="top_p" class="flex justify-between">
+							<span class="m-1 ml-0 flex items-center gap-1.5 whitespace-nowrap text-sm">
 								Top P
 								<HoverTooltip
 									align="right"
-									label="When sampling the distribution, only consider the smallest set of most probable tokens with probabilities that add up to Top P."
+									label="Top P: Sets word choice boundaries, lower values tighten focus."
 								>
-									<CarbonHelpFilled class="inline" />
+									<CarbonHelpFilled
+										class="inline text-xxs text-gray-500 group-hover/tooltip:text-blue-600"
+									/>
 								</HoverTooltip>
 							</span>
 
 							<input
 								type="number"
 								name="top_p"
-								class="w-full rounded-lg border-2 border-gray-200 bg-gray-100 p-2"
+								class="w-20 rounded-lg border-2 border-gray-200 bg-gray-100 px-2 py-1"
 								min="0.05"
 								max="1"
 								step="0.05"
@@ -320,13 +333,15 @@
 								value={assistant?.generateSettings?.top_p ?? ""}
 							/>
 						</label>
-						<label for="repetition_penalty">
-							<span class="m-1 ml-0 inline-block text-sm">
+						<label for="repetition_penalty" class="flex justify-between">
+							<span class="m-1 ml-0 flex items-center gap-1.5 whitespace-nowrap text-sm">
 								Repetition penalty
 								<HoverTooltip
-									label="Repetition penalty determines the penalty to a token's score for repeating the same token multiple times."
+									label="Repetition penalty: Prevents reuse, higher values decrease repetition."
 								>
-									<CarbonHelpFilled class="inline" />
+									<CarbonHelpFilled
+										class="inline text-xxs text-gray-500 group-hover/tooltip:text-blue-600"
+									/>
 								</HoverTooltip>
 							</span>
 							<input
@@ -334,19 +349,20 @@
 								name="repetition_penalty"
 								min="0.1"
 								max="2"
-								step="0.1"
-								class="w-full rounded-lg border-2 border-gray-200 bg-gray-100 p-2"
+								class="w-20 rounded-lg border-2 border-gray-200 bg-gray-100 px-2 py-1"
 								placeholder={selectedModel?.parameters?.repetition_penalty?.toString() ?? "1.0"}
 								value={assistant?.generateSettings?.repetition_penalty ?? ""}
 							/>
 						</label>
-						<label for="top_k">
-							<span class="m-1 ml-0 inline-block text-sm">
+						<label for="top_k" class="flex justify-between">
+							<span class="m-1 ml-0 flex items-center gap-1.5 whitespace-nowrap text-sm">
 								Top K <HoverTooltip
 									align="right"
-									label="The number of highest probability vocabulary tokens to keep for top-k-filtering."
+									label="Top K: Restricts word options, lower values for predictability."
 								>
-									<CarbonHelpFilled class="inline" />
+									<CarbonHelpFilled
+										class="inline text-xxs text-gray-500 group-hover/tooltip:text-blue-600"
+									/>
 								</HoverTooltip>
 							</span>
 							<input
@@ -355,13 +371,13 @@
 								min="5"
 								max="100"
 								step="5"
-								class="w-full rounded-lg border-2 border-gray-200 bg-gray-100 p-2"
+								class="w-20 rounded-lg border-2 border-gray-200 bg-gray-100 px-2 py-1"
 								placeholder={selectedModel?.parameters?.top_k?.toString() ?? "50"}
 								value={assistant?.generateSettings?.top_k ?? ""}
 							/>
 						</label>
 					</div>
-				</details>
+				</div>
 			</label>
 
 			<label>

--- a/src/lib/components/AssistantSettings.svelte
+++ b/src/lib/components/AssistantSettings.svelte
@@ -107,7 +107,7 @@
 
 <form
 	method="POST"
-	class="flex h-full flex-col overflow-y-auto p-4 md:p-8 relative"
+	class="relative flex h-full flex-col overflow-y-auto p-4 md:p-8"
 	enctype="multipart/form-data"
 	use:enhance={async ({ formData }) => {
 		loading = true;

--- a/src/lib/components/AssistantSettings.svelte
+++ b/src/lib/components/AssistantSettings.svelte
@@ -336,7 +336,7 @@
 							for="top_k"
 							title="The number of highest probability vocabulary tokens to keep for top-k-filtering."
 						>
-							<span class="m-1 ml-0 inline-block text-xs">
+							<span class="m-1 ml-0 inline-block text-sm">
 								Top K <CarbonHelpFilled class="inline" /></span
 							>
 							<input

--- a/src/lib/components/AssistantSettings.svelte
+++ b/src/lib/components/AssistantSettings.svelte
@@ -272,13 +272,13 @@
 					class="group/details mt-2"
 					open={Object.values(assistant?.generateSettings ?? {}).some((v) => !!v)}
 				>
-					<summary class="cursor-pointer text-xs group-open/details:font-semibold">
+					<summary class="ml-1 cursor-pointer text-xs group-open/details:font-semibold">
 						Model settings
 					</summary>
 					<p class="text-xs text-red-500">{getError("inputMessage1", form)}</p>
-					<div class="my-2 grid grid-cols-2 grid-rows-2 gap-2">
+					<div class="mb-2 grid grid-cols-2 grid-rows-2 gap-2">
 						<label for="temperature">
-							<span class="m-1 ml-0 inline-block text-sm">
+							<span class="m-1 ml-0 inline-block text-nowrap text-sm">
 								Temperature
 
 								<HoverTooltip
@@ -299,7 +299,7 @@
 							/>
 						</label>
 						<label for="top_p">
-							<span class="m-1 ml-0 inline-block text-sm">
+							<span class="m-1 ml-0 inline-block text-nowrap text-sm">
 								Top P
 								<HoverTooltip
 									align="right"
@@ -321,7 +321,7 @@
 							/>
 						</label>
 						<label for="repetition_penalty">
-							<span class="m-1 ml-0 inline-block text-sm">
+							<span class="m-1 ml-0 inline-block text-nowrap text-sm">
 								Repetition penalty
 								<HoverTooltip
 									label="Repetition penalty determines the penalty to a token's score for repeating the same token multiple times."
@@ -341,7 +341,7 @@
 							/>
 						</label>
 						<label for="top_k">
-							<span class="m-1 ml-0 inline-block text-sm">
+							<span class="m-1 ml-0 inline-block text-nowrap text-sm">
 								Top K <HoverTooltip
 									align="right"
 									label="The number of highest probability vocabulary tokens to keep for top-k-filtering."

--- a/src/lib/components/AssistantSettings.svelte
+++ b/src/lib/components/AssistantSettings.svelte
@@ -271,11 +271,10 @@
 					class="mt-2"
 					open={Object.values(assistant?.generateSettings ?? {}).some((v) => !!v)}
 				>
-					<summary class="text-xs font-semibold"> Model settings </summary>
+					<summary class="cursor-pointer text-xs font-semibold"> Model settings </summary>
 					<p class="text-xs text-red-500">{getError("inputMessage1", form)}</p>
 					<div class="my-2 grid grid-cols-2 grid-rows-2 gap-2">
 						<label
-							class="mr-1 flex-row"
 							for="temperature"
 							title="Temperature affects the distribution of tokens. A high temperature makes less probable tokens more likely to be sampled."
 						>
@@ -294,7 +293,6 @@
 							/>
 						</label>
 						<label
-							class="mr-1 flex-row"
 							for="top_p"
 							title="When sampling the distribution, only consider the smallest set of most probable tokens with probabilities that add up to Top P."
 						>
@@ -313,7 +311,6 @@
 							/>
 						</label>
 						<label
-							class="mr-1 flex-row"
 							for="repetition_penalty"
 							title="Repetition penalty determines the penalty to a token's score for repeating the same token multiple times."
 						>
@@ -332,7 +329,6 @@
 							/>
 						</label>
 						<label
-							class="mr-1 flex-row"
 							for="top_k"
 							title="The number of highest probability vocabulary tokens to keep for top-k-filtering."
 						>

--- a/src/lib/components/AssistantSettings.svelte
+++ b/src/lib/components/AssistantSettings.svelte
@@ -48,11 +48,7 @@
 		if (assistant) {
 			modelId = assistant.modelId;
 		} else {
-			if (models.map((model) => model.id).includes($settings.activeModel)) {
-				modelId = $settings.activeModel;
-			} else {
-				modelId = models[0].id;
-			}
+			modelId = models.find((model) => model.id === $settings.activeModel)?.id ?? models[0].id;
 		}
 	});
 

--- a/src/lib/components/AssistantSettings.svelte
+++ b/src/lib/components/AssistantSettings.svelte
@@ -9,12 +9,13 @@
 	import { base } from "$app/paths";
 	import CarbonPen from "~icons/carbon/pen";
 	import CarbonUpload from "~icons/carbon/upload";
+	import CarbonHelpFilled from "~icons/carbon/help";
 
 	import { useSettingsStore } from "$lib/stores/settings";
 	import { isHuggingChat } from "$lib/utils/isHuggingChat";
 	import IconInternet from "./icons/IconInternet.svelte";
 	import TokensCounter from "./TokensCounter.svelte";
-	import CarbonHelpFilled from "~icons/carbon/help";
+	import HoverTooltip from "./HoverTooltip.svelte";
 
 	type ActionData = {
 		error: boolean;
@@ -268,19 +269,24 @@
 					<p class="text-xs text-red-500">{getError("modelId", form)}</p>
 				</select>
 				<details
-					class="mt-2"
+					class="group/details mt-2"
 					open={Object.values(assistant?.generateSettings ?? {}).some((v) => !!v)}
 				>
-					<summary class="cursor-pointer text-xs font-semibold"> Model settings </summary>
+					<summary class="cursor-pointer text-xs group-open/details:font-semibold">
+						Model settings
+					</summary>
 					<p class="text-xs text-red-500">{getError("inputMessage1", form)}</p>
 					<div class="my-2 grid grid-cols-2 grid-rows-2 gap-2">
-						<label
-							for="temperature"
-							title="Temperature affects the distribution of tokens. A high temperature makes less probable tokens more likely to be sampled."
-						>
+						<label for="temperature">
 							<span class="m-1 ml-0 inline-block text-sm">
-								Temperature <CarbonHelpFilled class="inline" /></span
-							>
+								Temperature
+
+								<HoverTooltip
+									label="Temperature affects the distribution of tokens. A high temperature makes less probable tokens more likely to be sampled."
+								>
+									<CarbonHelpFilled class="inline" />
+								</HoverTooltip>
+							</span>
 							<input
 								type="number"
 								name="temperature"
@@ -292,13 +298,17 @@
 								value={assistant?.generateSettings?.temperature ?? ""}
 							/>
 						</label>
-						<label
-							for="top_p"
-							title="When sampling the distribution, only consider the smallest set of most probable tokens with probabilities that add up to Top P."
-						>
+						<label for="top_p">
 							<span class="m-1 ml-0 inline-block text-sm">
-								Top P <CarbonHelpFilled class="inline" /></span
-							>
+								Top P
+								<HoverTooltip
+									align="right"
+									label="When sampling the distribution, only consider the smallest set of most probable tokens with probabilities that add up to Top P."
+								>
+									<CarbonHelpFilled class="inline" />
+								</HoverTooltip>
+							</span>
+
 							<input
 								type="number"
 								name="top_p"
@@ -310,12 +320,14 @@
 								value={assistant?.generateSettings?.top_p ?? ""}
 							/>
 						</label>
-						<label
-							for="repetition_penalty"
-							title="Repetition penalty determines the penalty to a token's score for repeating the same token multiple times."
-						>
+						<label for="repetition_penalty">
 							<span class="m-1 ml-0 inline-block text-sm">
-								Repetition penalty <CarbonHelpFilled class="inline" />
+								Repetition penalty
+								<HoverTooltip
+									label="Repetition penalty determines the penalty to a token's score for repeating the same token multiple times."
+								>
+									<CarbonHelpFilled class="inline" />
+								</HoverTooltip>
 							</span>
 							<input
 								type="number"
@@ -328,13 +340,15 @@
 								value={assistant?.generateSettings?.repetition_penalty ?? ""}
 							/>
 						</label>
-						<label
-							for="top_k"
-							title="The number of highest probability vocabulary tokens to keep for top-k-filtering."
-						>
+						<label for="top_k">
 							<span class="m-1 ml-0 inline-block text-sm">
-								Top K <CarbonHelpFilled class="inline" /></span
-							>
+								Top K <HoverTooltip
+									align="right"
+									label="The number of highest probability vocabulary tokens to keep for top-k-filtering."
+								>
+									<CarbonHelpFilled class="inline" />
+								</HoverTooltip>
+							</span>
 							<input
 								type="number"
 								name="top_k"

--- a/src/lib/components/AssistantSettings.svelte
+++ b/src/lib/components/AssistantSettings.svelte
@@ -107,7 +107,7 @@
 
 <form
 	method="POST"
-	class="flex h-full flex-col overflow-y-auto p-4 md:p-8"
+	class="flex h-full flex-col overflow-y-auto p-4 md:p-8 relative"
 	enctype="multipart/form-data"
 	use:enhance={async ({ formData }) => {
 		loading = true;
@@ -313,7 +313,6 @@
 							<span class="m-1 ml-0 flex items-center gap-1.5 whitespace-nowrap text-sm">
 								Top P
 								<HoverTooltip
-									align="right"
 									label="Top P: Sets word choice boundaries, lower values tighten focus."
 								>
 									<CarbonHelpFilled
@@ -357,7 +356,6 @@
 						<label for="top_k" class="flex justify-between">
 							<span class="m-1 ml-0 flex items-center gap-1.5 whitespace-nowrap text-sm">
 								Top K <HoverTooltip
-									align="right"
 									label="Top K: Restricts word options, lower values for predictability."
 								>
 									<CarbonHelpFilled

--- a/src/lib/components/HoverTooltip.svelte
+++ b/src/lib/components/HoverTooltip.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+	export let label = "";
+	export let align: "left" | "right" = "left";
+</script>
+
+<div class="group relative inline-block">
+	<slot />
+	<span
+		class="invisible absolute
+		z-10 w-max max-w-md
+		items-center overflow-clip rounded-md bg-black p-1
+		text-center
+		text-white
+		group-hover:visible
+		group-active:visible
+		max-sm:top-5 max-sm:w-48 md:top-5"
+		class:max-sm:left-0={align === "left"}
+		class:max-sm:right-0={align === "right"}
+	>
+		{label}
+	</span>
+</div>

--- a/src/lib/components/HoverTooltip.svelte
+++ b/src/lib/components/HoverTooltip.svelte
@@ -3,20 +3,13 @@
 	export let align: "left" | "right" = "left";
 </script>
 
-<div class="group relative inline-block">
+<div class="group/tooltip relative">
 	<slot />
-	<span
-		class="invisible absolute
-		z-10 w-max max-w-md
-		items-center overflow-clip rounded-md bg-black p-1
-		text-center
-		text-white
-		group-hover:visible
-		group-active:visible
-		max-sm:top-5 max-sm:w-48 md:top-5"
+	<div
+		class="invisible absolute z-10 w-64 items-center whitespace-normal rounded-md bg-black p-2 text-center text-white group-hover/tooltip:visible group-active/tooltip:visible max-sm:top-5 md:top-5"
 		class:max-sm:left-0={align === "left"}
 		class:max-sm:right-0={align === "right"}
 	>
 		{label}
-	</span>
+	</div>
 </div>

--- a/src/lib/components/HoverTooltip.svelte
+++ b/src/lib/components/HoverTooltip.svelte
@@ -1,14 +1,11 @@
 <script lang="ts">
 	export let label = "";
-	export let align: "left" | "right" = "left";
 </script>
 
-<div class="group/tooltip relative">
+<div class="group/tooltip md:relative">
 	<slot />
 	<div
-		class="invisible absolute z-10 w-64 items-center whitespace-normal rounded-md bg-black p-2 text-center text-white group-hover/tooltip:visible group-active/tooltip:visible max-sm:top-5 md:top-5"
-		class:max-sm:left-0={align === "left"}
-		class:max-sm:right-0={align === "right"}
+		class="invisible absolute z-10 w-64 whitespace-normal rounded-md bg-black p-2 text-center text-white group-hover/tooltip:visible group-active/tooltip:visible max-sm:left-1/2 max-sm:-translate-x-1/2"
 	>
 		{label}
 	</div>

--- a/src/lib/components/HoverTooltip.svelte
+++ b/src/lib/components/HoverTooltip.svelte
@@ -7,8 +7,9 @@
 	<slot />
 	<span
 		class="invisible absolute
-		z-10 w-max max-w-md
-		items-center overflow-clip rounded-md bg-black p-1
+		z-10
+		w-max max-w-md items-center
+		overflow-clip text-wrap rounded-md bg-black p-1
 		text-center
 		text-white
 		group-hover:visible

--- a/src/lib/components/HoverTooltip.svelte
+++ b/src/lib/components/HoverTooltip.svelte
@@ -7,9 +7,8 @@
 	<slot />
 	<span
 		class="invisible absolute
-		z-10
-		w-max max-w-md items-center
-		overflow-clip text-wrap rounded-md bg-black p-1
+		z-10 w-max max-w-md
+		items-center overflow-clip rounded-md bg-black p-1
 		text-center
 		text-white
 		group-hover:visible

--- a/src/lib/server/endpoints/anthropic/endpointAnthropic.ts
+++ b/src/lib/server/endpoints/anthropic/endpointAnthropic.ts
@@ -32,7 +32,7 @@ export async function endpointAnthropic(
 		defaultQuery,
 	});
 
-	return async ({ messages, preprompt }) => {
+	return async ({ messages, preprompt, generateSettings }) => {
 		let system = preprompt;
 		if (messages?.[0]?.from === "system") {
 			system = messages[0].content;
@@ -49,15 +49,18 @@ export async function endpointAnthropic(
 		}[];
 
 		let tokenId = 0;
+
+		const parameters = { ...model.parameters, ...generateSettings };
+
 		return (async function* () {
 			const stream = anthropic.messages.stream({
 				model: model.id ?? model.name,
 				messages: messagesFormatted,
-				max_tokens: model.parameters?.max_new_tokens,
-				temperature: model.parameters?.temperature,
-				top_p: model.parameters?.top_p,
-				top_k: model.parameters?.top_k,
-				stop_sequences: model.parameters?.stop,
+				max_tokens: parameters?.max_new_tokens,
+				temperature: parameters?.temperature,
+				top_p: parameters?.top_p,
+				top_k: parameters?.top_k,
+				stop_sequences: parameters?.stop,
 				system,
 			});
 			while (true) {

--- a/src/lib/server/endpoints/aws/endpointAws.ts
+++ b/src/lib/server/endpoints/aws/endpointAws.ts
@@ -36,7 +36,7 @@ export async function endpointAws(
 		region,
 	});
 
-	return async ({ messages, preprompt, continueMessage }) => {
+	return async ({ messages, preprompt, continueMessage, generateSettings }) => {
 		const prompt = await buildPrompt({
 			messages,
 			continueMessage,
@@ -46,7 +46,7 @@ export async function endpointAws(
 
 		return textGenerationStream(
 			{
-				parameters: { ...model.parameters, return_full_text: false },
+				parameters: { ...model.parameters, ...generateSettings, return_full_text: false },
 				model: url,
 				inputs: prompt,
 			},

--- a/src/lib/server/endpoints/endpoints.ts
+++ b/src/lib/server/endpoints/endpoints.ts
@@ -10,12 +10,14 @@ import {
 	endpointAnthropic,
 	endpointAnthropicParametersSchema,
 } from "./anthropic/endpointAnthropic";
+import type { Model } from "$lib/types/Model";
 
 // parameters passed when generating text
 export interface EndpointParameters {
 	messages: Omit<Conversation["messages"][0], "id">[];
 	preprompt?: Conversation["preprompt"];
 	continueMessage?: boolean; // used to signal that the last message will be extended
+	generateSettings?: Partial<Model["parameters"]>;
 }
 
 interface CommonEndpoint {

--- a/src/lib/server/endpoints/llamacpp/endpointLlamacpp.ts
+++ b/src/lib/server/endpoints/llamacpp/endpointLlamacpp.ts
@@ -19,13 +19,15 @@ export function endpointLlamacpp(
 	input: z.input<typeof endpointLlamacppParametersSchema>
 ): Endpoint {
 	const { url, model } = endpointLlamacppParametersSchema.parse(input);
-	return async ({ messages, preprompt, continueMessage }) => {
+	return async ({ messages, preprompt, continueMessage, generateSettings }) => {
 		const prompt = await buildPrompt({
 			messages,
 			continueMessage,
 			preprompt,
 			model,
 		});
+
+		const parameters = { ...model.parameters, ...generateSettings };
 
 		const r = await fetch(`${url}/completion`, {
 			method: "POST",
@@ -35,12 +37,12 @@ export function endpointLlamacpp(
 			body: JSON.stringify({
 				prompt,
 				stream: true,
-				temperature: model.parameters.temperature,
-				top_p: model.parameters.top_p,
-				top_k: model.parameters.top_k,
-				stop: model.parameters.stop,
-				repeat_penalty: model.parameters.repetition_penalty,
-				n_predict: model.parameters.max_new_tokens,
+				temperature: parameters.temperature,
+				top_p: parameters.top_p,
+				top_k: parameters.top_k,
+				stop: parameters.stop,
+				repeat_penalty: parameters.repetition_penalty,
+				n_predict: parameters.max_new_tokens,
 				cache_prompt: true,
 			}),
 		});

--- a/src/lib/server/endpoints/ollama/endpointOllama.ts
+++ b/src/lib/server/endpoints/ollama/endpointOllama.ts
@@ -14,13 +14,15 @@ export const endpointOllamaParametersSchema = z.object({
 export function endpointOllama(input: z.input<typeof endpointOllamaParametersSchema>): Endpoint {
 	const { url, model, ollamaName } = endpointOllamaParametersSchema.parse(input);
 
-	return async ({ messages, preprompt, continueMessage }) => {
+	return async ({ messages, preprompt, continueMessage, generateSettings }) => {
 		const prompt = await buildPrompt({
 			messages,
 			continueMessage,
 			preprompt,
 			model,
 		});
+
+		const parameters = { ...model.parameters, ...generateSettings };
 
 		const r = await fetch(`${url}/api/generate`, {
 			method: "POST",
@@ -32,12 +34,12 @@ export function endpointOllama(input: z.input<typeof endpointOllamaParametersSch
 				model: ollamaName ?? model.name,
 				raw: true,
 				options: {
-					top_p: model.parameters.top_p,
-					top_k: model.parameters.top_k,
-					temperature: model.parameters.temperature,
-					repeat_penalty: model.parameters.repetition_penalty,
-					stop: model.parameters.stop,
-					num_predict: model.parameters.max_new_tokens,
+					top_p: parameters.top_p,
+					top_k: parameters.top_k,
+					temperature: parameters.temperature,
+					repeat_penalty: parameters.repetition_penalty,
+					stop: parameters.stop,
+					num_predict: parameters.max_new_tokens,
 				},
 			}),
 		});

--- a/src/lib/server/endpoints/openai/endpointOai.ts
+++ b/src/lib/server/endpoints/openai/endpointOai.ts
@@ -38,7 +38,7 @@ export async function endpointOai(
 	});
 
 	if (completion === "completions") {
-		return async ({ messages, preprompt, continueMessage }) => {
+		return async ({ messages, preprompt, continueMessage, generateSettings }) => {
 			const prompt = await buildPrompt({
 				messages,
 				continueMessage,
@@ -46,21 +46,23 @@ export async function endpointOai(
 				model,
 			});
 
+			const parameters = { ...model.parameters, ...generateSettings };
+
 			return openAICompletionToTextGenerationStream(
 				await openai.completions.create({
 					model: model.id ?? model.name,
 					prompt,
 					stream: true,
-					max_tokens: model.parameters?.max_new_tokens,
-					stop: model.parameters?.stop,
-					temperature: model.parameters?.temperature,
-					top_p: model.parameters?.top_p,
-					frequency_penalty: model.parameters?.repetition_penalty,
+					max_tokens: parameters?.max_new_tokens,
+					stop: parameters?.stop,
+					temperature: parameters?.temperature,
+					top_p: parameters?.top_p,
+					frequency_penalty: parameters?.repetition_penalty,
 				})
 			);
 		};
 	} else if (completion === "chat_completions") {
-		return async ({ messages, preprompt }) => {
+		return async ({ messages, preprompt, generateSettings }) => {
 			let messagesOpenAI = messages.map((message) => ({
 				role: message.from,
 				content: message.content,
@@ -74,16 +76,18 @@ export async function endpointOai(
 				messagesOpenAI[0].content = preprompt ?? "";
 			}
 
+			const parameters = { ...model.parameters, ...generateSettings };
+
 			return openAIChatToTextGenerationStream(
 				await openai.chat.completions.create({
 					model: model.id ?? model.name,
 					messages: messagesOpenAI,
 					stream: true,
-					max_tokens: model.parameters?.max_new_tokens,
-					stop: model.parameters?.stop,
-					temperature: model.parameters?.temperature,
-					top_p: model.parameters?.top_p,
-					frequency_penalty: model.parameters?.repetition_penalty,
+					max_tokens: parameters?.max_new_tokens,
+					stop: parameters?.stop,
+					temperature: parameters?.temperature,
+					top_p: parameters?.top_p,
+					frequency_penalty: parameters?.repetition_penalty,
 				})
 			);
 		};

--- a/src/lib/server/endpoints/tgi/endpointTgi.ts
+++ b/src/lib/server/endpoints/tgi/endpointTgi.ts
@@ -16,7 +16,7 @@ export const endpointTgiParametersSchema = z.object({
 export function endpointTgi(input: z.input<typeof endpointTgiParametersSchema>): Endpoint {
 	const { url, accessToken, model, authorization } = endpointTgiParametersSchema.parse(input);
 
-	return async ({ messages, preprompt, continueMessage }) => {
+	return async ({ messages, preprompt, continueMessage, generateSettings }) => {
 		const prompt = await buildPrompt({
 			messages,
 			preprompt,
@@ -26,7 +26,7 @@ export function endpointTgi(input: z.input<typeof endpointTgiParametersSchema>):
 
 		return textGenerationStream(
 			{
-				parameters: { ...model.parameters, return_full_text: false },
+				parameters: { ...model.parameters, ...generateSettings, return_full_text: false },
 				model: url,
 				inputs: prompt,
 				accessToken,

--- a/src/lib/types/Assistant.ts
+++ b/src/lib/types/Assistant.ts
@@ -19,6 +19,12 @@ export interface Assistant extends Timestamps {
 		allowedDomains: string[];
 		allowedLinks: string[];
 	};
+	generateSettings?: {
+		temperature?: number;
+		top_p?: number;
+		repetition_penalty?: number;
+		top_k?: number;
+	};
 	dynamicPrompt?: boolean;
 	searchTokens: string[];
 }

--- a/src/routes/conversation/[id]/+server.ts
+++ b/src/routes/conversation/[id]/+server.ts
@@ -338,8 +338,11 @@ export async function POST({ request, locals, params, getClientAddress }) {
 
 			// check if assistant has a rag
 			const assistant = await collections.assistants.findOne<
-				Pick<Assistant, "rag" | "dynamicPrompt">
-			>({ _id: conv.assistantId }, { projection: { rag: 1, dynamicPrompt: 1 } });
+				Pick<Assistant, "rag" | "dynamicPrompt" | "generateSettings">
+			>(
+				{ _id: conv.assistantId },
+				{ projection: { rag: 1, dynamicPrompt: 1, generateSettings: 1 } }
+			);
 
 			const assistantHasRAG =
 				ENABLE_ASSISTANTS_RAG === "true" &&
@@ -403,12 +406,15 @@ export async function POST({ request, locals, params, getClientAddress }) {
 
 			const previousText = messageToWriteTo.content;
 
+			let hasError = false;
+
 			try {
 				const endpoint = await model.getEndpoint();
 				for await (const output of await endpoint({
 					messages: processedMessages,
 					preprompt,
 					continueMessage: isContinue,
+					generateSettings: assistant?.generateSettings,
 				})) {
 					// if not generated_text is here it means the generation is not done
 					if (!output.generated_text) {
@@ -448,10 +454,11 @@ export async function POST({ request, locals, params, getClientAddress }) {
 					}
 				}
 			} catch (e) {
+				hasError = true;
 				update({ type: "status", status: "error", message: (e as Error).message });
 			} finally {
 				// check if no output was generated
-				if (messageToWriteTo.content === previousText) {
+				if (!hasError && messageToWriteTo.content === previousText) {
 					update({
 						type: "status",
 						status: "error",

--- a/src/routes/settings/(nav)/assistants/[assistantId]/edit/+page.server.ts
+++ b/src/routes/settings/(nav)/assistants/[assistantId]/edit/+page.server.ts
@@ -25,6 +25,20 @@ const newAsssistantSchema = z.object({
 	ragDomainList: z.preprocess(parseStringToList, z.string().array()),
 	ragAllowAll: z.preprocess((v) => v === "true", z.boolean()),
 	dynamicPrompt: z.preprocess((v) => v === "on", z.boolean()),
+	temperature: z
+		.union([z.literal(""), z.coerce.number().min(0.1).max(2)])
+		.transform((v) => (v === "" ? undefined : v)),
+	top_p: z
+		.union([z.literal(""), z.coerce.number().min(0.05).max(1)])
+		.transform((v) => (v === "" ? undefined : v)),
+
+	repetition_penalty: z
+		.union([z.literal(""), z.coerce.number().min(0.1).max(2)])
+		.transform((v) => (v === "" ? undefined : v)),
+
+	top_k: z
+		.union([z.literal(""), z.coerce.number().min(5).max(100)])
+		.transform((v) => (v === "" ? undefined : v)),
 });
 
 const uploadAvatar = async (avatar: File, assistantId: ObjectId): Promise<string> => {
@@ -143,6 +157,12 @@ export const actions: Actions = {
 					},
 					dynamicPrompt: parse.data.dynamicPrompt,
 					searchTokens: generateSearchTokens(parse.data.name),
+					generateSettings: {
+						temperature: parse.data.temperature,
+						top_p: parse.data.top_p,
+						repetition_penalty: parse.data.repetition_penalty,
+						top_k: parse.data.top_k,
+					},
 				},
 			}
 		);

--- a/src/routes/settings/(nav)/assistants/new/+page.server.ts
+++ b/src/routes/settings/(nav)/assistants/new/+page.server.ts
@@ -25,6 +25,20 @@ const newAsssistantSchema = z.object({
 	ragDomainList: z.preprocess(parseStringToList, z.string().array()),
 	ragAllowAll: z.preprocess((v) => v === "true", z.boolean()),
 	dynamicPrompt: z.preprocess((v) => v === "on", z.boolean()),
+	temperature: z
+		.union([z.literal(""), z.coerce.number().min(0.1).max(2)])
+		.transform((v) => (v === "" ? undefined : v)),
+	top_p: z
+		.union([z.literal(""), z.coerce.number().min(0.05).max(1)])
+		.transform((v) => (v === "" ? undefined : v)),
+
+	repetition_penalty: z
+		.union([z.literal(""), z.coerce.number().min(0.1).max(2)])
+		.transform((v) => (v === "" ? undefined : v)),
+
+	top_k: z
+		.union([z.literal(""), z.coerce.number().min(5).max(100)])
+		.transform((v) => (v === "" ? undefined : v)),
 });
 
 const uploadAvatar = async (avatar: File, assistantId: ObjectId): Promise<string> => {
@@ -125,6 +139,12 @@ export const actions: Actions = {
 			},
 			dynamicPrompt: parse.data.dynamicPrompt,
 			searchTokens: generateSearchTokens(parse.data.name),
+			generateSettings: {
+				temperature: parse.data.temperature,
+				top_p: parse.data.top_p,
+				repetition_penalty: parse.data.repetition_penalty,
+				top_k: parse.data.top_k,
+			},
 		});
 
 		// add insertedId to user settings


### PR DESCRIPTION
| <img width="1186" alt="Screenshot 2024-03-27 at 13 31 03" src="https://github.com/huggingface/chat-ui/assets/25119303/f90846f1-70f5-4e49-a40e-5ab687b6a93c"> | <img width="324" alt="Screenshot 2024-03-27 at 13 29 59" src="https://github.com/huggingface/chat-ui/assets/25119303/a2793221-e5aa-4eaa-b82d-f2a7dde78e85"> |
| ------- | ------- | 


It opens by default if values are prefilled. I updated the endpoint code so it should work with every endpoint type. There's a tooltip for each field that works on mobile & desktop.

Had to deviate a bit from the design in #955, it was hard to fit the label and the field horizontally (only looked good on big screen at full width) so I ended up putting the label above the field. 

Also used the native html details/summary elements instead of a button, and added a border around the content, otherwise it was easy to confuse with the user start messages below.