### PR TITLE
Group tokens randomly

### DIFF
--- a/src/routes/conversation/[id]/+server.ts
+++ b/src/routes/conversation/[id]/+server.ts
@@ -474,6 +474,13 @@ export async function POST({ request, locals, params, getClientAddress }) {
 						message: "No output was generated. Something went wrong.",
 					});
 				}
+
+				if (buffer) {
+					update({
+						type: "stream",
+						token: buffer,
+					});
+				}
 			}
 
 			await collections.conversations.updateOne(

--- a/src/routes/conversation/[id]/+server.ts
+++ b/src/routes/conversation/[id]/+server.ts
@@ -421,7 +421,6 @@ export async function POST({ request, locals, params, getClientAddress }) {
 				})) {
 					// if not generated_text is here it means the generation is not done
 					if (!output.generated_text) {
-						// else we get the next token
 						if (!output.token.special) {
 							// 33% chance to send the stream update, with a max buffer size of 30 chars
 							buffer += output.token.text;


### PR DESCRIPTION
To avoid sending packets which have the exact size of the tokens, we group them together at random