### PR TITLE
[Trending assistants] make ui visible

### DIFF
--- a/src/routes/assistants/+page.svelte
+++ b/src/routes/assistants/+page.svelte
@@ -211,7 +211,7 @@
 			<select
 				bind:value={sortValue}
 				on:change={sortAssistants}
-				class="hidden rounded-lg border border-gray-300 bg-gray-50 px-2 py-1 text-sm text-gray-900 focus:border-blue-700 focus:ring-blue-700 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder-gray-400"
+				class="rounded-lg border border-gray-300 bg-gray-50 px-2 py-1 text-sm text-gray-900 focus:border-blue-700 focus:ring-blue-700 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder-gray-400"
 			>
 				<option value={SortKey.POPULAR}>{SortKey.POPULAR}</option>
 				<option value={SortKey.TRENDING}>{SortKey.TRENDING}</option>


### PR DESCRIPTION
![image](https://github.com/huggingface/chat-ui/assets/11827707/27bd8ee0-04ad-45f7-81f8-855fc669e199)

as written in the #938 [description](https://github.com/huggingface/chat-ui/pull/938#issue-2191919264), this PR is the last step for trending assistants

> Deployment plan
> 1. Get this PR approved
> 2. Hide the sort assistants UX/frontend while the data is being collected
> 3. Deploy
> 4. Enable/show sort assistants UX/frontend