### PR TITLE
Add upn as an allowable name claim

### DIFF
--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -40,7 +40,7 @@ export const OIDConfig = z
 		PROVIDER_URL: stringWithDefault(OPENID_PROVIDER_URL),
 		SCOPES: stringWithDefault(OPENID_SCOPES),
 		NAME_CLAIM: stringWithDefault(OPENID_NAME_CLAIM).refine(
-			(el) => !["preferred_username", "email", "picture", "sub"].includes(el),
+			(el) => !["preferred_username", "email", "picture", "sub", "upn"].includes(el),
 			{ message: "nameClaim cannot be one of the restricted keys." }
 		),
 		TOLERANCE: stringWithDefault(OPENID_TOLERANCE),


### PR DESCRIPTION
Provided in Microsoft Entra v1 tokens (which don't have preferred_username or email).

UPN is UserPrincipleName.