### PR TITLE
Set ChatML as default chat prompt template

### DIFF
--- a/src/lib/server/models.ts
+++ b/src/lib/server/models.ts
@@ -44,7 +44,11 @@ const modelConfig = z.object({
 	datasetUrl: z.string().url().optional(),
 	preprompt: z.string().default(""),
 	prepromptUrl: z.string().url().optional(),
-	chatPromptTemplate: z.string().optional(),
+	chatPromptTemplate: z
+		.string()
+		.default(
+			"{{#if @root.preprompt}}<|im_start|>system\n{{@root.preprompt}}<|im_end|>\n{{/if}}{{#each messages}}{{#ifUser}}<|im_start|>user\n{{content}}<|im_end|>\n<|im_start|>assistant\n{{/ifUser}}{{#ifAssistant}}{{content}}<|im_end|>\n{{/ifAssistant}}{{/each}}"
+		), // ChatML
 	promptExamples: z
 		.array(
 			z.object({


### PR DESCRIPTION
Wanted to make either chatprompttemplate or tokenizer mandatory, but since some endpoints type use chat completion/messages API, they don't need a chat template as it's handled by their backend.

This PR sets a default (ChatML), so that we won't throw an error when not setting the chat template. This reverts a breaking change.

https://github.com/huggingface/chat-ui/pull/744#issuecomment-2041644232 