### PR TITLE
Fix unresponsive page after deleting all conversations

### DIFF
--- a/src/routes/settings/(nav)/+page.svelte
+++ b/src/routes/settings/(nav)/+page.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-	import { createEventDispatcher } from "svelte";
-
 	import Modal from "$lib/components/Modal.svelte";
 	import CarbonClose from "~icons/carbon/close";
 	import CarbonTrashCan from "~icons/carbon/trash-can";
@@ -14,8 +12,6 @@
 	import { PUBLIC_APP_DATA_SHARING } from "$env/static/public";
 
 	let isConfirmingDeletion = false;
-
-	const dispatch = createEventDispatcher<{ close: void }>();
 
 	let settings = useSettingsStore();
 </script>
@@ -71,7 +67,7 @@
 		<Modal on:close={() => (isConfirmingDeletion = false)}>
 			<form
 				use:enhance={() => {
-					dispatch("close");
+					isConfirmingDeletion = false;
 				}}
 				method="post"
 				action="{base}/conversations?/delete"


### PR DESCRIPTION
The "on:close" event function is not triggered by the dispatch("close") before the page redirection (the modal is not properly removed and the page becomes unresponsive).

I removed the dispatch("close") and directly apply what is done by the "on:close" event function.

I tested it and now the page is responsive after deletion of all the conversations. It should fix #937