### PR TITLE
Do not clear system prompt if messages[0].content is empty

### DIFF
--- a/src/lib/server/endpoints/anthropic/endpointAnthropic.ts
+++ b/src/lib/server/endpoints/anthropic/endpointAnthropic.ts
@@ -37,7 +37,7 @@ export async function endpointAnthropic(
 		if (messages?.[0]?.from === "system" && messages[0].content) {
 			system = messages[0].content;
 		} else {
-			messages[0].content = system || '';
+			messages[0].content = system || "";
 		}
 
 		const messagesFormatted = messages

--- a/src/lib/server/endpoints/anthropic/endpointAnthropic.ts
+++ b/src/lib/server/endpoints/anthropic/endpointAnthropic.ts
@@ -34,8 +34,10 @@ export async function endpointAnthropic(
 
 	return async ({ messages, preprompt, generateSettings }) => {
 		let system = preprompt;
-		if (messages?.[0]?.from === "system") {
+		if (messages?.[0]?.from === "system" && messages[0].content) {
 			system = messages[0].content;
+		} else {
+			messages[0].content = system || '';
 		}
 
 		const messagesFormatted = messages

--- a/src/lib/server/endpoints/cohere/endpointCohere.ts
+++ b/src/lib/server/endpoints/cohere/endpointCohere.ts
@@ -33,7 +33,7 @@ export async function endpointCohere(
 		if (messages?.[0]?.from === "system" && messages[0].content) {
 			system = messages[0].content;
 		} else {
-			messages[0].content = system || '';
+			messages[0].content = system || "";
 		}
 
 		const parameters = { ...model.parameters, ...generateSettings };

--- a/src/lib/server/endpoints/cohere/endpointCohere.ts
+++ b/src/lib/server/endpoints/cohere/endpointCohere.ts
@@ -30,8 +30,10 @@ export async function endpointCohere(
 
 	return async ({ messages, preprompt, generateSettings, continueMessage }) => {
 		let system = preprompt;
-		if (messages?.[0]?.from === "system") {
+		if (messages?.[0]?.from === "system" && messages[0].content) {
 			system = messages[0].content;
+		} else {
+			messages[0].content = system || '';
 		}
 
 		const parameters = { ...model.parameters, ...generateSettings };


### PR DESCRIPTION
System prompt was being cleared because messages[0].content was always an empty string, causing assistants to not work on Anthropic and Cohere endpoints.

Not sure if the preprompt should be copied to messages[0].content, but it doesn't seem to hurt.

This fixes #1005 
