### PR TITLE
Kill app on tokenizer load fail

### DIFF
--- a/src/lib/server/models.ts
+++ b/src/lib/server/models.ts
@@ -91,12 +91,13 @@ async function getChatPromptRender(
 	try {
 		tokenizer = await getTokenizer(m.tokenizer);
 	} catch (e) {
-		throw Error(
+		console.error(
 			"Failed to load tokenizer for model " +
 				m.name +
 				" consider setting chatPromptTemplate manually or making sure the model is available on the hub. Error: " +
 				(e as Error).message
 		);
+		process.exit();
 	}
 
 	const renderTemplate = ({ messages, preprompt }: ChatTemplateInput) => {


### PR DESCRIPTION
We have an issue where the app will show a 500 error when it fails to load the tokenizer but won't properly crash. This is a temp fix, let's find a better solution later