### PR TITLE
Removed mistralai/Mistral-7B-Instruct-v0.1 from HuggingChat

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -165,39 +165,8 @@ MODELS=`[
         "stop": ["<|im_end|>"]
       }
     },
-    {
-      "name": "mistralai/Mistral-7B-Instruct-v0.1",
-      "displayName": "mistralai/Mistral-7B-Instruct-v0.1",
-      "description": "Mistral 7B is a new Apache 2.0 model, released by Mistral AI that outperforms Llama2 13B in benchmarks.",
-      "logoUrl": "https://huggingface.co/datasets/huggingchat/models-logo/resolve/main/mistral-logo.png",
-      "websiteUrl": "https://mistral.ai/news/announcing-mistral-7b/",
-      "modelUrl": "https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.1",
-      "tokenizer": "mistralai/Mistral-7B-Instruct-v0.1",
-      "preprompt": "",
-      "chatPromptTemplate" : "<s>{{#each messages}}{{#ifUser}}[INST] {{#if @first}}{{#if @root.preprompt}}{{@root.preprompt}}\n{{/if}}{{/if}}{{content}} [/INST]{{/ifUser}}{{#ifAssistant}}{{content}}</s>{{/ifAssistant}}{{/each}}",
-      "parameters": {
-        "temperature": 0.1,
-        "top_p": 0.95,
-        "repetition_penalty": 1.2,
-        "top_k": 50,
-        "truncate": 3072,
-        "max_new_tokens": 1024,
-        "stop": ["</s>"]
-      },
-      "promptExamples": [
-        {
-          "title": "Write an email from bullet list",
-          "prompt": "As a restaurant owner, write a professional email to the supplier to get these products every week: \n\n- Wine (x10)\n- Eggs (x24)\n- Bread (x12)"
-        }, {
-          "title": "Code a snake game",
-          "prompt": "Code a basic snake game in python, give explanations for each step."
-        }, {
-          "title": "Assist in a task",
-          "prompt": "How do I make a delicious lemon cheesecake?"
-        }
-      ],
-      "unlisted": true
-    },
+
+
         {
       "name": "mistralai/Mistral-7B-Instruct-v0.2",
       "displayName": "mistralai/Mistral-7B-Instruct-v0.2",
@@ -244,6 +213,8 @@ OLD_MODELS=`[
   {"name": "meta-llama/Llama-2-70b-chat-hf"},
   {"name": "codellama/CodeLlama-70b-Instruct-hf"},
   {"name": "openchat/openchat-3.5-0106"}
+  {"name": "mistralai/Mistral-7B-Instruct-v0.1"}
+
 ]`
 
 TASK_MODEL='meta-llama/Meta-Llama-3-70B-Instruct'


### PR DESCRIPTION
The mistralai/Mistral-7B-Instruct-v0.1 was removed due to it being unnecessary. Since it was eliminated from the task model, there was no further use for that Model, leading to its removal.