### PR TITLE
🎨 Add color for copy icon

### DIFF
--- a/src/lib/components/CopyToClipBoardBtn.svelte
+++ b/src/lib/components/CopyToClipBoardBtn.svelte
@@ -43,7 +43,7 @@
 >
 	<div class="relative">
 		<slot>
-			<IconCopy />
+			<IconCopy classNames="dark:text-gray-700 text-gray-200" />
 		</slot>
 
 		<Tooltip classNames={isSuccess ? "opacity-100" : "opacity-0"} />


### PR DESCRIPTION
Right now, the copy button is not easy to see it, I have put the same colour as the border to make it easier to see.
Now:
https://github.com/huggingface/chat-ui/assets/7398909/c98ab65e-02ec-4d15-80b1-7a9f01d4bfed

After:
https://github.com/huggingface/chat-ui/assets/7398909/dd65045d-a34b-4104-b330-8067e65c8377


