### PR TITLE
Add `ALLOW_INSECURE_COOKIES` feature flag

### DIFF
--- a/.env
+++ b/.env
@@ -153,3 +153,4 @@ WEBHOOK_URL_REPORT_ASSISTANT=#provide webhook url to get notified when an assist
 ALLOWED_USER_EMAILS=`[]` # if it's defined, only these emails will be allowed to use the app
 
 USAGE_LIMITS=`{}`
+ALLOW_INSECURE_COOKIES=false # recommended to keep this to false but set to true if you need to run over http without tls

--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ A chat interface using open source models, eg OpenAssistant or Llama. It is a Sv
 3. [Web Search](#web-search)
 4. [Text Embedding Models](#text-embedding-models)
 5. [Extra parameters](#extra-parameters)
-6. [Deploying to a HF Space](#deploying-to-a-hf-space)
-7. [Building](#building)
+6. [Common issues](#common-issues)
+7. [Deploying to a HF Space](#deploying-to-a-hf-space)
+8. [Building](#building)
 
 ## No Setup Deploy
 
@@ -734,6 +735,14 @@ MODELS=`[
   }
 ]`
 ```
+
+## Common issues
+
+### 403：You don't have access to this conversation
+
+Most likely you are running chat-ui over HTTP. The recommended option is to setup something like NGINX to handle HTTPS and proxy the requests to chat-ui. If you really need to run over HTTP you can add `ALLOW_INSECURE_COOKIES=true` to your `.env.local`.
+
+Make sure to set your `PUBLIC_ORIGIN` in your `.env.local` to the correct URL as well.
 
 ## Deploying to a HF Space
 

--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -10,6 +10,7 @@ import {
 	OPENID_TOLERANCE,
 	OPENID_RESOURCE,
 	OPENID_CONFIG,
+	ALLOW_INSECURE_COOKIES,
 } from "$env/static/private";
 import { sha256 } from "$lib/utils/sha256";
 import { z } from "zod";
@@ -55,7 +56,7 @@ export function refreshSessionCookie(cookies: Cookies, sessionId: string) {
 		path: "/",
 		// So that it works inside the space's iframe
 		sameSite: dev ? "lax" : "none",
-		secure: !dev,
+		secure: !dev && !(ALLOW_INSECURE_COOKIES === "true"),
 		httpOnly: true,
 		expires: addWeeks(new Date(), 2),
 	});

--- a/src/routes/logout/+page.server.ts
+++ b/src/routes/logout/+page.server.ts
@@ -1,6 +1,6 @@
 import { dev } from "$app/environment";
 import { base } from "$app/paths";
-import { COOKIE_NAME } from "$env/static/private";
+import { COOKIE_NAME, ALLOW_INSECURE_COOKIES } from "$env/static/private";
 import { collections } from "$lib/server/database";
 import { redirect } from "@sveltejs/kit";
 
@@ -12,7 +12,7 @@ export const actions = {
 			path: "/",
 			// So that it works inside the space's iframe
 			sameSite: dev ? "lax" : "none",
-			secure: !dev,
+			secure: !dev && !(ALLOW_INSECURE_COOKIES === "true"),
 			httpOnly: true,
 		});
 		throw redirect(303, `${base}/`);


### PR DESCRIPTION
We require a secure cookie for huggingchat, however some users might want to run `chat-ui` over http. While not recommended, we shouldn't be blocking users from doing so.

This PR adds `ALLOW_INSECURE_COOKIES` as an env variable which will allow insecure cookies if set to`ALLOW_INSECURE_COOKIES=true`.

Closes #877 
Closes #1057 
Closes #658 
Closes #364 
Closes #330 

This is a fairly common issue so I added a section in the readme about it.