### PR TITLE
set `sameSite` to `lax` when allowing insecure cookies

### DIFF
--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -55,7 +55,7 @@ export function refreshSessionCookie(cookies: Cookies, sessionId: string) {
 	cookies.set(COOKIE_NAME, sessionId, {
 		path: "/",
 		// So that it works inside the space's iframe
-		sameSite: dev ? "lax" : "none",
+		sameSite: dev || ALLOW_INSECURE_COOKIES === "true" ? "lax" : "none",
 		secure: !dev && !(ALLOW_INSECURE_COOKIES === "true"),
 		httpOnly: true,
 		expires: addWeeks(new Date(), 2),

--- a/src/routes/logout/+page.server.ts
+++ b/src/routes/logout/+page.server.ts
@@ -11,7 +11,7 @@ export const actions = {
 		cookies.delete(COOKIE_NAME, {
 			path: "/",
 			// So that it works inside the space's iframe
-			sameSite: dev ? "lax" : "none",
+			sameSite: dev || ALLOW_INSECURE_COOKIES === "true" ? "lax" : "none",
 			secure: !dev && !(ALLOW_INSECURE_COOKIES === "true"),
 			httpOnly: true,
 		});


### PR DESCRIPTION
The `ALLOW_INSECURE_COOKIES` flag wasn't working properly since we had strict `sameSite` policy. 

Now when you `ALLOW_INSECURE_COOKIES=true` you get `secure:false` and `sameSIte: "lax"`