### PR TITLE
Adds <s> to Phi-3-mini-4k-instruct template configuration

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -206,7 +206,7 @@ MODELS=`[
       "modelUrl": "https://huggingface.co/microsoft/Phi-3-mini-4k-instruct",
       "websiteUrl": "https://azure.microsoft.com/en-us/blog/introducing-phi-3-redefining-whats-possible-with-slms/",
       "preprompt": "",
-      "chatPromptTemplate": "{{preprompt}}{{#each messages}}{{#ifUser}}<|user|>\n{{content}}<|end|>\n<|assistant|>\n{{/ifUser}}{{#ifAssistant}}{{content}}<|end|>\n{{/ifAssistant}}{{/each}}",
+      "chatPromptTemplate": "<s>{{preprompt}}{{#each messages}}{{#ifUser}}<|user|>\n{{content}}<|end|>\n<|assistant|>\n{{/ifUser}}{{#ifAssistant}}{{content}}<|end|>\n{{/ifAssistant}}{{/each}}",
       "parameters": {
         "stop": ["<|end|>", "<|endoftext|>", "<|assistant|>"],
         "max_new_tokens": 1024,


### PR DESCRIPTION
The chat template did not account for the begin-of-sentence token during conversations through HuggingChat. It plays an important role on Phi-3-mini-4k-instruct model and must be available for producing proper generations.

Example:
```
curl https://api-inference.huggingface.co/models/microsoft/Phi-3-mini-4k-instruct \
	-X POST \
	-d '{"inputs": "<s><|user|>\nHi<|end|>\n<|assistant|>\n"}' \
	-H 'Content-Type: application/json'
```

*Without `<s>`, it starts producing unnecessary extra tokens.*