### PR TITLE
Ensures more consistent hyperparameters to Phi-3-mini-4k-instruct

### DIFF
--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -242,6 +242,7 @@ envVars:
           "chatPromptTemplate": "<s>{{preprompt}}{{#each messages}}{{#ifUser}}<|user|>\n{{content}}<|end|>\n<|assistant|>\n{{/ifUser}}{{#ifAssistant}}{{content}}<|end|>\n{{/ifAssistant}}{{/each}}",
           "parameters": {
             "stop": ["<|end|>", "<|endoftext|>", "<|assistant|>"],
+            "temperature": 0.7,
             "max_new_tokens": 1024,
             "truncate": 3071
           },


### PR DESCRIPTION
We are still trying to get to the root cause of the model de-railing after long conversations. We haven't been able to reproduce it locally (through scripts or chat-ui), so we are tackling some additional possibilities here.