### PR TITLE
Remove trim on user input

### DIFF
--- a/src/routes/conversation/[id]/+server.ts
+++ b/src/routes/conversation/[id]/+server.ts
@@ -141,7 +141,6 @@ export async function POST({ request, locals, params, getClientAddress }) {
 			inputs: z.optional(
 				z
 					.string()
-					.trim()
 					.min(1)
 					.transform((s) => s.replace(/\r\n/g, "\n"))
 			),


### PR DESCRIPTION
We shouldn't trim user inputs, as it can mess with tokenization if the user wants to do something specific.

And this also closes #1117 