### PR TITLE
Use JWT email as login user

### DIFF
--- a/.env
+++ b/.env
@@ -6,6 +6,7 @@ MONGODB_DB_NAME=chat-ui
 MONGODB_DIRECT_CONNECTION=false
 
 COOKIE_NAME=hf-chat
+COOKIE_JWT_NAME=CF_Authorization
 HF_TOKEN=#hf_<token> from https://huggingface.co/settings/token
 HF_API_ROOT=https://api-inference.huggingface.co/models
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
 				"ip-address": "^9.0.5",
 				"jsdom": "^22.0.0",
 				"json5": "^2.2.3",
+				"jwt-decode": "^4.0.0",
 				"marked": "^12.0.1",
 				"marked-katex-extension": "^5.0.1",
 				"mongodb": "^5.8.0",
@@ -5413,6 +5414,14 @@
 			"dependencies": {
 				"jwa": "^2.0.0",
 				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/jwt-decode": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+			"integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/katex": {

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
 		"ip-address": "^9.0.5",
 		"jsdom": "^22.0.0",
 		"json5": "^2.2.3",
+		"jwt-decode": "^4.0.0",
 		"marked": "^12.0.1",
 		"marked-katex-extension": "^5.0.1",
 		"mongodb": "^5.8.0",

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -107,7 +107,7 @@ export const handle: Handle = async ({ event, resolve }) => {
 		secretSessionId = sessionId = email;
 
 		event.locals.user = {
-			_id: '', // Hide the "Sign Out" button
+			_id: 'jwt-user', // Special value to hide the "Sign Out" button
 			name: email,
 			email: email
 		};

--- a/src/lib/components/NavMenu.svelte
+++ b/src/lib/components/NavMenu.svelte
@@ -89,12 +89,14 @@
 				class="flex h-9 flex-none shrink items-center gap-1.5 truncate pr-2 text-gray-500 dark:text-gray-400"
 				>{user?.username || user?.email}</span
 			>
+			{#if user?.id}
 			<button
 				type="submit"
 				class="ml-auto h-6 flex-none items-center gap-1.5 rounded-md border bg-white px-2 text-gray-700 shadow-sm group-hover:flex hover:shadow-none md:hidden dark:border-gray-600 dark:bg-gray-600 dark:text-gray-400 dark:hover:text-gray-300"
 			>
 				Sign Out
 			</button>
+			{/if}
 		</form>
 	{/if}
 	{#if canLogin}

--- a/src/lib/components/NavMenu.svelte
+++ b/src/lib/components/NavMenu.svelte
@@ -89,7 +89,7 @@
 				class="flex h-9 flex-none shrink items-center gap-1.5 truncate pr-2 text-gray-500 dark:text-gray-400"
 				>{user?.username || user?.email}</span
 			>
-			{#if user?.id}
+			{#if user?.id !== 'jwt-user'}
 			<button
 				type="submit"
 				class="ml-auto h-6 flex-none items-center gap-1.5 rounded-md border bg-white px-2 text-gray-700 shadow-sm group-hover:flex hover:shadow-none md:hidden dark:border-gray-600 dark:bg-gray-600 dark:text-gray-400 dark:hover:text-gray-300"


### PR DESCRIPTION
I am hosting Chat-UI after Cloudflare Tunnel and using Cloudflare Access for SSO.

After SSO, Cloudflare will inject a cookie `CF_Authorization`. Its value is a JWT. We could use the email after decoding the JWT value as login user.

The conversation will be kept for the same login user.

Besides, I don't think it makes sense to show the "Sign Out" button while decoding login user from JWT. So, that button is hidden (with a tricky way).