### PR TITLE
[fix] Assistant websearch text/markdown source

### DIFF
--- a/src/lib/server/websearch/parseWeb.ts
+++ b/src/lib/server/websearch/parseWeb.ts
@@ -32,7 +32,9 @@ export async function parseWeb(url: string) {
 		r.headers.get("content-type")?.includes("text/plain") ||
 		r.headers.get("content-type")?.includes("text/markdown")
 	) {
-		return r.text();
+		const text = await r.text();
+		// JSON.stringify is needed to turn string concatenation into a single string (ex: "Hello, " + "world!" -> "Hello, world!")
+		return JSON.stringify(text);
 	} else {
 		throw new Error("Unsupported content type");
 	}


### PR DESCRIPTION
## Description

When you combine assistant websearch with TEI, there was an error. (However, it was/is working fine with local models through transformers.js).

Although we have 

https://github.com/huggingface/chat-ui/blob/b2bee6290278fb70bba65fd2df8227508facc313/src/lib/server/embeddingEndpoints/tei/embeddingEndpoints.ts#L63, there was still an error (i.e. TEI endpoint was rejecting the input citing it as `invalid json`) when a text value was a text concat value (i.e. rather than `"Hello World"`, the actual value was `"Hello " + "World"`). Therefore, we needed to add https://github.com/huggingface/chat-ui/blob/b2bee6290278fb70bba65fd2df8227508facc313/src/lib/server/websearch/parseWeb.ts#L35-L37

### on main

![image](https://github.com/huggingface/chat-ui/assets/11827707/1b1981c9-cbfc-466a-8fda-ecfc40a56ec8)

### this PR
![Screenshot 2024-05-10 at 14 50 55](https://github.com/huggingface/chat-ui/assets/11827707/23a4ddad-b5bd-4ea7-807d-abc9644eec19)
