### PR TITLE
Uses temperature 0.0 for Phi-3.

### DIFF
--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -243,7 +243,7 @@ envVars:
           "chatPromptTemplate": "<s>{{preprompt}}{{#each messages}}{{#ifUser}}<|user|>\n{{content}}<|end|>\n<|assistant|>\n{{/ifUser}}{{#ifAssistant}}{{content}}<|end|>\n{{/ifAssistant}}{{/each}}",
           "parameters": {
             "stop": ["<|end|>", "<|endoftext|>", "<|assistant|>"],
-            "temperature": 0.7,
+            "temperature": 0.0,
             "max_new_tokens": 1024,
             "truncate": 3071
           },


### PR DESCRIPTION
Sorry for sending a bunch of PRs on the same matter 😄 

We decided to set `temperature=0.0` to have a more controlled environment and attempt to fix the issue for real. One thing that we were thinking and I don't know the answer is the following:

When the truncation happen, it is done in the `left` or `right` side of the context? Is there a way to set it? I looked on the https://github.com/huggingface/chat-ui/blob/main/src/lib/server/models.ts file, but it could be somewhere else.

Thanks and best regards,
Gustavo.