### PR TITLE
Improve helm chart

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -51,12 +51,19 @@ spec:
               protocol: TCP
             {{- end }}
           resources: {{ toYaml .Values.resources | nindent 12 }}
+          {{- with $.Values.extraEnv }}
+          env:
+            {{- toYaml . | nindent 14 }}
+          {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ include "name" . }}
           {{- if $.Values.externalSecrets.enabled }}
             - secretRef:
                 name: {{ $.Values.externalSecrets.secretName }}
+          {{- end }}
+          {{- with $.Values.extraEnvFrom }}
+            {{- toYaml . | nindent 14 }}
           {{- end }}
       nodeSelector: {{ toYaml .Values.nodeSelector | nindent 8 }}
       tolerations: {{ toYaml .Values.tolerations | nindent 8 }}

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -1,3 +1,4 @@
+{{- if $.Values.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -17,3 +18,4 @@ spec:
                   name: http
             path: {{ $.Values.ingress.path | default "/" }}
             pathType: Prefix
+{{- end }}

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -10,6 +10,14 @@ spec:
   {{ if $.Values.ingress.className }}
   ingressClassName: {{ .Values.ingress.className }}
   {{ end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    - hosts:
+        - {{ $.Values.domain | quote }}
+      {{- with .secretName }}
+      secretName: {{ . }}
+      {{- end }}
+  {{- end }}
   rules:
     - host: {{ .Values.domain }}
       http:

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -7,6 +7,9 @@ metadata:
   name: {{ include "name" . }}
   namespace: {{ .Release.Namespace }}
 spec:
+  {{ if $.Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{ end }}
   rules:
     - host: {{ .Values.domain }}
       http:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -13,6 +13,7 @@ service:
   annotations: { }
 
 ingress:
+  enabled: true
   path: "/"
   annotations: { }
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -17,6 +17,8 @@ ingress:
   path: "/"
   annotations: { }
   # className: "nginx"
+  tls: { }
+    # secretName: XXX
 
 resources:
   requests:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -36,6 +36,9 @@ externalSecrets:
   secretStoreName: ""
   secretName: ""
   parameters: { }
+# Allow to environment injections on top or instead of externalSecrets
+extraEnvFrom: []
+extraEnv: []
 
 autoscaling:
   enabled: false

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -16,6 +16,7 @@ ingress:
   enabled: true
   path: "/"
   annotations: { }
+  # className: "nginx"
 
 resources:
   requests:


### PR DESCRIPTION
This PR adds a bit of flexibility to facilitate the use of the chart by the community:
* Allow to disable ingress
* Allow to specify the tls block in the ingress
* Allow to specify the ingress classname
* Allow to pass extra env variable (via env or envFrom)