### PR TITLE
fix: parse ISS if returned in OIDC flow

### DIFF
--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -110,9 +110,13 @@ export async function getOIDCAuthorizationUrl(
 	});
 }
 
-export async function getOIDCUserData(settings: OIDCSettings, code: string): Promise<OIDCUserInfo> {
+export async function getOIDCUserData(
+	settings: OIDCSettings,
+	code: string,
+	iss?: string
+): Promise<OIDCUserInfo> {
 	const client = await getOIDCClient(settings);
-	const token = await client.callback(settings.redirectURI, { code });
+	const token = await client.callback(settings.redirectURI, { code, iss });
 	const userData = await client.userinfo(token);
 
 	return { token, userData };

--- a/src/routes/login/callback/+page.server.ts
+++ b/src/routes/login/callback/+page.server.ts
@@ -24,10 +24,11 @@ export async function load({ url, locals, cookies, request, getClientAddress }) 
 		throw error(400, errorName + (errorDescription ? ": " + errorDescription : ""));
 	}
 
-	const { code, state } = z
+	const { code, state, iss } = z
 		.object({
 			code: z.string(),
 			state: z.string(),
+			iss: z.string().optional(),
 		})
 		.parse(Object.fromEntries(url.searchParams.entries()));
 
@@ -39,7 +40,11 @@ export async function load({ url, locals, cookies, request, getClientAddress }) 
 		throw error(403, "Invalid or expired CSRF token");
 	}
 
-	const { userData } = await getOIDCUserData({ redirectURI: validatedToken.redirectUrl }, code);
+	const { userData } = await getOIDCUserData(
+		{ redirectURI: validatedToken.redirectUrl },
+		code,
+		iss
+	);
 
 	// Filter by allowed user emails
 	if (allowedUserEmails.length > 0) {


### PR DESCRIPTION
## Description 

This PR fixes a bug where `chat-ui` does not parse the `iss` if the OIDC provider returns it in the `url` (for example, when using `keycloak>23`). 

Let me know if you would like me to open an issue for this as well.

### Minor Changes 

1. optional parse of `iss` from `url.searchParams.entries()`
2. updated `getOIDCUserData` to pass the `iss`

Tests:
1. [x] `npm run test`
2. [x] tested with a OIDC provider that does not return `iss` (previous behavior is maintained, as `iss` is undefined, the same if condition from the `openid-client` library is evaluated.)
3. [x] tested with a OIDC provider that returns `iss` and working