### PR TITLE
Fix message update migration not applying

### DIFF
--- a/src/lib/migrations/routines/04-update-message-updates.ts
+++ b/src/lib/migrations/routines/04-update-message-updates.ts
@@ -150,7 +150,7 @@ const updateMessageUpdates: Migration = {
 	_id: new ObjectId("5f9f4f4f4f4f4f4f4f4f4f4f"),
 	name: "Convert message updates to the new schema",
 	up: async () => {
-		const allConversations = collections.conversations.find({}, { projection: { messages: 1 } });
+		const allConversations = collections.conversations.find({});
 
 		let conversation: WithId<Pick<Conversation, "messages">> | null = null;
 		while ((conversation = await allConversations.tryNext())) {

--- a/src/lib/migrations/routines/04-update-message-updates.ts
+++ b/src/lib/migrations/routines/04-update-message-updates.ts
@@ -147,7 +147,7 @@ function convertMessageUpdate(message: Message, update: OldMessageUpdate): Messa
 }
 
 const updateMessageUpdates: Migration = {
-	_id: new ObjectId("5f9f4f4f4f4f4f4f4f4f4f4f"),
+	_id: new ObjectId("5f9f7f7f7f7f7f7f7f7f7f7f"),
 	name: "Convert message updates to the new schema",
 	up: async () => {
 		const allConversations = collections.conversations.find({});


### PR DESCRIPTION
Fixes the message update migrations needed as part of #996 not applying to the tools objects.