### PR TITLE
Simplify tool error handling

### DIFF
--- a/src/lib/server/tools/calculator.ts
+++ b/src/lib/server/tools/calculator.ts
@@ -22,14 +22,10 @@ const calculator: BackendTool = {
 			const query = blocks[blocks.length - 1].replace(/[^-()\d/*+.]/g, "");
 
 			return {
-				status: ToolResultStatus.Success,
 				outputs: [{ calculator: `${query} = ${vm.runInNewContext(query)}` }],
 			};
-		} catch (e) {
-			return {
-				status: ToolResultStatus.Error,
-				message: "Invalid expression",
-			};
+		} catch (cause) {
+			throw Error("Invalid expression", { cause });
 		}
 	},
 };

--- a/src/lib/server/tools/calculator.ts
+++ b/src/lib/server/tools/calculator.ts
@@ -1,4 +1,3 @@
-import { ToolResultStatus } from "$lib/types/Tool";
 import type { BackendTool } from ".";
 import vm from "node:vm";
 

--- a/src/lib/server/tools/directlyAnswer.ts
+++ b/src/lib/server/tools/directlyAnswer.ts
@@ -1,4 +1,3 @@
-import { ToolResultStatus } from "$lib/types/Tool";
 import type { BackendTool } from ".";
 
 const directlyAnswer: BackendTool = {
@@ -10,7 +9,6 @@ const directlyAnswer: BackendTool = {
 	parameterDefinitions: {},
 	async *call() {
 		return {
-			status: ToolResultStatus.Success,
 			outputs: [],
 			display: false,
 		};

--- a/src/lib/server/tools/documentParser.ts
+++ b/src/lib/server/tools/documentParser.ts
@@ -1,5 +1,4 @@
 import type { BackendTool } from ".";
-import { ToolResultStatus } from "$lib/types/Tool";
 import { callSpace, getIpToken } from "./utils";
 import { downloadFile } from "$lib/server/files/downloadFile";
 

--- a/src/lib/server/tools/documentParser.ts
+++ b/src/lib/server/tools/documentParser.ts
@@ -29,18 +29,8 @@ const documentParser: BackendTool = {
 
 		const message = messages[fileMessageIndex];
 		const files = message?.files ?? [];
-		if (!files || files.length === 0) {
-			return {
-				status: ToolResultStatus.Error,
-				message: "User did not provide a pdf to parse",
-			};
-		}
-		if (fileIndex >= files.length) {
-			return {
-				status: ToolResultStatus.Error,
-				message: "Model provided an invalid file index",
-			};
-		}
+		if (!files || files.length === 0) throw Error("User did not provide a pdf to parse");
+		if (fileIndex >= files.length) throw Error("Model provided an invalid file index");
 
 		const file = files[fileIndex];
 		const fileBlob = await downloadFile(files[fileIndex].value, conv._id)
@@ -62,7 +52,6 @@ const documentParser: BackendTool = {
 			documentMarkdown = documentMarkdown.slice(0, 30_000) + "\n\n... (truncated)";
 		}
 		return {
-			status: ToolResultStatus.Success,
 			outputs: [{ [file.name]: documentMarkdown }],
 			display: false,
 		};

--- a/src/lib/server/tools/images/editing.ts
+++ b/src/lib/server/tools/images/editing.ts
@@ -44,23 +44,10 @@ const imageEditing: BackendTool = {
 
 		const message = messages[fileMessageIndex];
 		const images = message?.files ?? [];
-		if (!images || images.length === 0) {
-			return {
-				status: ToolResultStatus.Error,
-				message: "User did not provide an image to edit.",
-			};
-		}
-		if (fileIndex >= images.length) {
-			return {
-				status: ToolResultStatus.Error,
-				message: "Model provided an invalid file index",
-			};
-		}
+		if (!images || images.length === 0) throw Error("User did not provide an image to edit");
+		if (fileIndex >= images.length) throw Error("Model provided an invalid file index");
 		if (!images[fileIndex].mime.startsWith("image/")) {
-			return {
-				status: ToolResultStatus.Error,
-				message: "Model provided a file indx which is not an image",
-			};
+			throw Error("Model provided a file idex which is not an image");
 		}
 
 		// todo: should handle multiple images
@@ -96,7 +83,6 @@ const imageEditing: BackendTool = {
 		};
 
 		return {
-			status: ToolResultStatus.Success,
 			outputs: [
 				{
 					imageEditing: `An image has been generated for the following prompt: "${prompt}". Answer as if the user can already see the image. Do not try to insert the image or to add space for it. The user can already see the image. Do not try to describe the image as you the model cannot see it.`,

--- a/src/lib/server/tools/images/editing.ts
+++ b/src/lib/server/tools/images/editing.ts
@@ -1,6 +1,5 @@
 import type { BackendTool } from "..";
 import { uploadFile } from "../../files/uploadFile";
-import { ToolResultStatus } from "$lib/types/Tool";
 import { MessageUpdateType } from "$lib/types/MessageUpdate";
 import { callSpace, getIpToken, type GradioImage } from "../utils";
 import { downloadFile } from "$lib/server/files/downloadFile";

--- a/src/lib/server/tools/images/generation.ts
+++ b/src/lib/server/tools/images/generation.ts
@@ -81,7 +81,6 @@ const imageGeneration: BackendTool = {
 		}
 
 		return {
-			status: ToolResultStatus.Success,
 			outputs: [
 				{
 					imageGeneration: `An image has been generated for the following prompt: "${prompt}". Answer as if the user can already see the image. Do not try to insert the image or to add space for it. The user can already see the image. Do not try to describe the image as you the model cannot see it.`,

--- a/src/lib/server/tools/images/generation.ts
+++ b/src/lib/server/tools/images/generation.ts
@@ -1,6 +1,5 @@
 import type { BackendTool } from "..";
 import { uploadFile } from "../../files/uploadFile";
-import { ToolResultStatus } from "$lib/types/Tool";
 import { MessageUpdateType } from "$lib/types/MessageUpdate";
 import { callSpace, getIpToken, type GradioImage } from "../utils";
 

--- a/src/lib/server/tools/index.ts
+++ b/src/lib/server/tools/index.ts
@@ -1,5 +1,5 @@
 import type { MessageUpdate } from "$lib/types/MessageUpdate";
-import type { Tool, ToolResultError, ToolResultSuccess } from "$lib/types/Tool";
+import type { Tool, ToolResultSuccess } from "$lib/types/Tool";
 
 import calculator from "./calculator";
 import directlyAnswer from "./directlyAnswer";
@@ -19,7 +19,7 @@ export interface BackendTool extends Tool {
 	call(
 		params: Record<string, string | number | boolean>,
 		context: BackendToolContext
-	): AsyncGenerator<MessageUpdate, Omit<ToolResultSuccess, "call" | "type">, undefined>;
+	): AsyncGenerator<MessageUpdate, Omit<ToolResultSuccess, "status" | "call" | "type">, undefined>;
 }
 
 export const allTools: BackendTool[] = [

--- a/src/lib/server/tools/index.ts
+++ b/src/lib/server/tools/index.ts
@@ -15,17 +15,11 @@ export type BackendToolContext = Pick<
 	"conv" | "messages" | "assistant" | "ip" | "username"
 > & { preprompt?: string };
 
-// typescript can't narrow a discriminated union after applying a generic like Omit to it
-// so we have to define the omitted types and create a new union
-type ToolResultSuccessOmitted = Omit<ToolResultSuccess, "call">;
-type ToolResultErrorOmitted = Omit<ToolResultError, "call">;
-type ToolResultOmitted = ToolResultSuccessOmitted | ToolResultErrorOmitted;
-
 export interface BackendTool extends Tool {
 	call(
 		params: Record<string, string | number | boolean>,
 		context: BackendToolContext
-	): AsyncGenerator<MessageUpdate, ToolResultOmitted, undefined>;
+	): AsyncGenerator<MessageUpdate, Omit<ToolResultSuccess, "call" | "type">, undefined>;
 }
 
 export const allTools: BackendTool[] = [

--- a/src/lib/server/tools/web/search.ts
+++ b/src/lib/server/tools/web/search.ts
@@ -23,7 +23,6 @@ const websearch: BackendTool = {
 			.join("\n------------\n");
 
 		return {
-			status: ToolResultStatus.Success,
 			outputs: [{ websearch: chunks }],
 			display: false,
 		};

--- a/src/lib/server/tools/web/search.ts
+++ b/src/lib/server/tools/web/search.ts
@@ -1,4 +1,3 @@
-import { ToolResultStatus } from "$lib/types/Tool";
 import type { BackendTool } from "..";
 import { runWebSearch } from "../../websearch/runWebSearch";
 

--- a/src/lib/server/tools/web/url.ts
+++ b/src/lib/server/tools/web/url.ts
@@ -22,7 +22,6 @@ const fetchUrl: BackendTool = {
 		const { title, markdownTree } = await scrapeUrl(url, Infinity);
 
 		return {
-			status: ToolResultStatus.Success,
 			outputs: [{ title, text: stringifyMarkdownElementTree(markdownTree) }],
 			display: false,
 		};

--- a/src/lib/server/tools/web/url.ts
+++ b/src/lib/server/tools/web/url.ts
@@ -1,6 +1,5 @@
 import { stringifyMarkdownElementTree } from "$lib/server/websearch/markdown/utils/stringify";
 import { scrapeUrl } from "$lib/server/websearch/scrape/scrape";
-import { ToolResultStatus } from "$lib/types/Tool";
 import type { BackendTool } from "..";
 
 const fetchUrl: BackendTool = {

--- a/src/lib/utils/stringifyError.ts
+++ b/src/lib/utils/stringifyError.ts
@@ -1,0 +1,12 @@
+/** Takes an unknown error and attempts to convert it to a string */
+export function stringifyError(error: unknown): string {
+	if (error instanceof Error) return error.message;
+	if (typeof error === "string") return error;
+	if (typeof error === "object" && error !== null) {
+		// try a few common properties
+		if ("message" in error && typeof error.message === "string") return error.message;
+		if ("body" in error && typeof error.body === "string") return error.body;
+		if ("name" in error && typeof error.name === "string") return error.name;
+	}
+	return "Unknown error";
+}


### PR DESCRIPTION
Continues #1163 by having tools simplify throw errors rather than returning an explicit error or success status. Also introduced a util for stringifying unknown errors so we'll hopefully find less `[Object object]` errors downstream from libraries which don't use the native `Error` object