### PR TITLE
Clear playwright singleton on close

### DIFF
--- a/src/lib/server/websearch/scrape/playwright.ts
+++ b/src/lib/server/websearch/scrape/playwright.ts
@@ -43,7 +43,7 @@ async function initPlaywrightService() {
 		return mostBlocked;
 	});
 
-	// Clera the singleton when the context closes
+	// Clear the singleton when the context closes
 	ctx.on("close", () => {
 		playwrightService = undefined;
 	});

--- a/src/lib/server/websearch/scrape/playwright.ts
+++ b/src/lib/server/websearch/scrape/playwright.ts
@@ -10,7 +10,7 @@ import { PlaywrightBlocker } from "@cliqz/adblocker-playwright";
 import { env } from "$env/dynamic/private";
 
 // Singleton initialized by initPlaywrightService
-let playwrightService: Promise<{ ctx: BrowserContext; blocker: PlaywrightBlocker }>;
+let playwrightService: Promise<{ ctx: BrowserContext; blocker: PlaywrightBlocker }> | undefined;
 
 async function initPlaywrightService() {
 	if (playwrightService) return playwrightService;
@@ -42,6 +42,12 @@ async function initPlaywrightService() {
 		if (env.WEBSEARCH_JAVASCRIPT === "false") return mostBlocked.blockScripts();
 		return mostBlocked;
 	});
+
+	// Clera the singleton when the context closes
+	ctx.on("close", () => {
+		playwrightService = undefined;
+	});
+
 	return Object.freeze({ ctx, blocker });
 }
 


### PR DESCRIPTION
Fixes an issue where the playwright context will remain closed because we don't attempt to recreate it after it closes. This solves it by clearing the singleton on close.