### PR TITLE
Reduce message update size returned by websearch

### DIFF
--- a/src/lib/migrations/routines/04-update-message-updates.ts
+++ b/src/lib/migrations/routines/04-update-message-updates.ts
@@ -171,7 +171,6 @@ const updateMessageUpdates: Migration = {
 					const webSearchFinishedUpdate: MessageWebSearchFinishedUpdate = {
 						type: MessageUpdateType.WebSearch,
 						subtype: MessageWebSearchUpdateType.Finished,
-						webSearch: message.webSearch,
 					};
 					updates.splice(webSearchSourcesUpdateIndex + 1, 0, webSearchFinishedUpdate);
 				}

--- a/src/lib/migrations/routines/06-trim-message-updates.ts
+++ b/src/lib/migrations/routines/06-trim-message-updates.ts
@@ -1,0 +1,80 @@
+import type { Migration } from ".";
+import { collections } from "$lib/server/database";
+import { ObjectId, type WithId } from "mongodb";
+import type { Conversation } from "$lib/types/Conversation";
+import type { WebSearch, WebSearchSource } from "$lib/types/WebSearch";
+import {
+	MessageUpdateType,
+	MessageWebSearchUpdateType,
+	type BaseMessageWebSearchUpdate,
+	type MessageUpdate,
+} from "$lib/types/MessageUpdate";
+import type { Message } from "$lib/types/Message";
+
+// -----------
+
+export interface MessageWebSearchSourcesUpdate
+	extends BaseMessageWebSearchUpdate<MessageWebSearchUpdateType.Sources> {
+	message: string;
+	sources: WebSearchSource[];
+}
+export interface MessageWebSearchFinishedUpdate
+	extends BaseMessageWebSearchUpdate<MessageWebSearchUpdateType.Finished> {
+	webSearch: WebSearch;
+}
+
+/** Converts the old message update to the new schema */
+function convertMessageUpdate(message: Message, update: MessageUpdate): MessageUpdate | null {
+	try {
+		// trim final websearch update, and sources update
+
+		if (update.type === "webSearch") {
+			if (update.subtype === MessageWebSearchUpdateType.Sources) {
+				return {
+					type: MessageUpdateType.WebSearch,
+					subtype: MessageWebSearchUpdateType.Sources,
+					message: update.message,
+					sources: update.sources.map(({ link, title }) => ({ link, title })),
+				};
+			} else if (update.subtype === MessageWebSearchUpdateType.Finished) {
+				return {
+					type: MessageUpdateType.WebSearch,
+					subtype: MessageWebSearchUpdateType.Finished,
+				};
+			}
+		}
+
+		return update;
+	} catch (error) {
+		console.error("Error converting message update during migration. Skipping it... Error:", error);
+		return null;
+	}
+}
+
+const trimMessageUpdates: Migration = {
+	_id: new ObjectId(6),
+	name: "Trim message updates to reduce stored size",
+	up: async () => {
+		const allConversations = collections.conversations.find({});
+
+		let conversation: WithId<Pick<Conversation, "messages">> | null = null;
+		while ((conversation = await allConversations.tryNext())) {
+			const messages = conversation.messages.map((message) => {
+				// Convert all of the existing updates to the new schema
+				const updates = message.updates
+					?.map((update) => convertMessageUpdate(message, update))
+					.filter((update): update is MessageUpdate => Boolean(update));
+
+				return { ...message, updates };
+			});
+
+			// Set the new messages array
+			await collections.conversations.updateOne({ _id: conversation._id }, { $set: { messages } });
+		}
+
+		return true;
+	},
+	runEveryTime: false,
+};
+
+export default trimMessageUpdates;

--- a/src/lib/migrations/routines/06-trim-message-updates.ts
+++ b/src/lib/migrations/routines/06-trim-message-updates.ts
@@ -13,12 +13,12 @@ import type { Message } from "$lib/types/Message";
 
 // -----------
 
-export interface MessageWebSearchSourcesUpdate
+interface MessageWebSearchSourcesUpdate
 	extends BaseMessageWebSearchUpdate<MessageWebSearchUpdateType.Sources> {
 	message: string;
 	sources: WebSearchSource[];
 }
-export interface MessageWebSearchFinishedUpdate
+interface MessageWebSearchFinishedUpdate
 	extends BaseMessageWebSearchUpdate<MessageWebSearchUpdateType.Finished> {
 	webSearch: WebSearch;
 }

--- a/src/lib/migrations/routines/06-trim-message-updates.ts
+++ b/src/lib/migrations/routines/06-trim-message-updates.ts
@@ -2,26 +2,14 @@ import type { Migration } from ".";
 import { collections } from "$lib/server/database";
 import { ObjectId, type WithId } from "mongodb";
 import type { Conversation } from "$lib/types/Conversation";
-import type { WebSearch, WebSearchSource } from "$lib/types/WebSearch";
 import {
 	MessageUpdateType,
 	MessageWebSearchUpdateType,
-	type BaseMessageWebSearchUpdate,
 	type MessageUpdate,
 } from "$lib/types/MessageUpdate";
 import type { Message } from "$lib/types/Message";
 
 // -----------
-
-interface MessageWebSearchSourcesUpdate
-	extends BaseMessageWebSearchUpdate<MessageWebSearchUpdateType.Sources> {
-	message: string;
-	sources: WebSearchSource[];
-}
-interface MessageWebSearchFinishedUpdate
-	extends BaseMessageWebSearchUpdate<MessageWebSearchUpdateType.Finished> {
-	webSearch: WebSearch;
-}
 
 /** Converts the old message update to the new schema */
 function convertMessageUpdate(message: Message, update: MessageUpdate): MessageUpdate | null {

--- a/src/lib/migrations/routines/index.ts
+++ b/src/lib/migrations/routines/index.ts
@@ -6,6 +6,7 @@ import type { Database } from "$lib/server/database";
 import addToolsToSettings from "./03-add-tools-in-settings";
 import updateMessageUpdates from "./04-update-message-updates";
 import updateMessageFiles from "./05-update-message-files";
+import trimMessageUpdates from "./06-trim-message-updates";
 
 export interface Migration {
 	_id: ObjectId;
@@ -23,4 +24,5 @@ export const migrations: Migration[] = [
 	addToolsToSettings,
 	updateMessageUpdates,
 	updateMessageFiles,
+	trimMessageUpdates,
 ];

--- a/src/lib/server/websearch/runWebSearch.ts
+++ b/src/lib/server/websearch/runWebSearch.ts
@@ -79,7 +79,7 @@ export async function* runWebSearch(
 			createdAt,
 			updatedAt,
 		};
-		yield makeFinalAnswerUpdate(webSearch);
+		yield makeFinalAnswerUpdate();
 		return webSearch;
 	} catch (searchError) {
 		const message = searchError instanceof Error ? searchError.message : String(searchError);
@@ -94,7 +94,7 @@ export async function* runWebSearch(
 			createdAt,
 			updatedAt,
 		};
-		yield makeFinalAnswerUpdate(webSearch);
+		yield makeFinalAnswerUpdate();
 		return webSearch;
 	}
 }

--- a/src/lib/server/websearch/update.ts
+++ b/src/lib/server/websearch/update.ts
@@ -33,14 +33,13 @@ export function makeSourcesUpdate(sources: WebSearchSource[]): MessageWebSearchS
 		type: MessageUpdateType.WebSearch,
 		subtype: MessageWebSearchUpdateType.Sources,
 		message: "sources",
-		sources,
+		sources: sources.map(({ link, title }) => ({ link, title })),
 	};
 }
 
-export function makeFinalAnswerUpdate(webSearch: WebSearch): MessageWebSearchFinishedUpdate {
+export function makeFinalAnswerUpdate(): MessageWebSearchFinishedUpdate {
 	return {
 		type: MessageUpdateType.WebSearch,
 		subtype: MessageWebSearchUpdateType.Finished,
-		webSearch,
 	};
 }

--- a/src/lib/server/websearch/update.ts
+++ b/src/lib/server/websearch/update.ts
@@ -1,4 +1,4 @@
-import type { WebSearch, WebSearchSource } from "$lib/types/WebSearch";
+import type { WebSearchSource } from "$lib/types/WebSearch";
 import {
 	MessageUpdateType,
 	MessageWebSearchUpdateType,

--- a/src/lib/types/MessageUpdate.ts
+++ b/src/lib/types/MessageUpdate.ts
@@ -1,4 +1,4 @@
-import type { WebSearch, WebSearchSource } from "$lib/types/WebSearch";
+import type { WebSearchSource } from "$lib/types/WebSearch";
 import type { ToolCall, ToolResult } from "$lib/types/Tool";
 
 export type MessageUpdate =

--- a/src/lib/types/MessageUpdate.ts
+++ b/src/lib/types/MessageUpdate.ts
@@ -58,9 +58,8 @@ export interface MessageWebSearchSourcesUpdate
 	message: string;
 	sources: WebSearchSource[];
 }
-export interface MessageWebSearchFinishedUpdate
-	extends BaseMessageWebSearchUpdate<MessageWebSearchUpdateType.Finished> {}
-
+export type MessageWebSearchFinishedUpdate =
+	BaseMessageWebSearchUpdate<MessageWebSearchUpdateType.Finished>;
 export type MessageWebSearchUpdate =
 	| MessageWebSearchErrorUpdate
 	| MessageWebSearchGeneralUpdate

--- a/src/lib/types/MessageUpdate.ts
+++ b/src/lib/types/MessageUpdate.ts
@@ -39,7 +39,7 @@ export enum MessageWebSearchUpdateType {
 	Sources = "sources",
 	Finished = "finished",
 }
-interface BaseMessageWebSearchUpdate<TSubType extends MessageWebSearchUpdateType> {
+export interface BaseMessageWebSearchUpdate<TSubType extends MessageWebSearchUpdateType> {
 	type: MessageUpdateType.WebSearch;
 	subtype: TSubType;
 }
@@ -59,9 +59,8 @@ export interface MessageWebSearchSourcesUpdate
 	sources: WebSearchSource[];
 }
 export interface MessageWebSearchFinishedUpdate
-	extends BaseMessageWebSearchUpdate<MessageWebSearchUpdateType.Finished> {
-	webSearch: WebSearch;
-}
+	extends BaseMessageWebSearchUpdate<MessageWebSearchUpdateType.Finished> {}
+
 export type MessageWebSearchUpdate =
 	| MessageWebSearchErrorUpdate
 	| MessageWebSearchGeneralUpdate

--- a/src/routes/conversation/[id]/+server.ts
+++ b/src/routes/conversation/[id]/+server.ts
@@ -331,14 +331,6 @@ export async function POST({ request, locals, params, getClientAddress }) {
 					];
 				}
 
-				// Set web search
-				else if (
-					event.type === MessageUpdateType.WebSearch &&
-					event.subtype === MessageWebSearchUpdateType.Finished
-				) {
-					messageToWriteTo.webSearch = event.webSearch;
-				}
-
 				// Append to the persistent message updates if it's not a stream update
 				if (event.type !== "stream") {
 					messageToWriteTo?.updates?.push(event);

--- a/src/routes/conversation/[id]/+server.ts
+++ b/src/routes/conversation/[id]/+server.ts
@@ -11,7 +11,6 @@ import { z } from "zod";
 import {
 	MessageUpdateStatus,
 	MessageUpdateType,
-	MessageWebSearchUpdateType,
 	type MessageUpdate,
 } from "$lib/types/MessageUpdate";
 import { uploadFile } from "$lib/server/files/uploadFile";


### PR DESCRIPTION
The websearch was returning updates which contained a lot of information we don't use in the front-end. 

This PR removes the data from the DB and remove the unnecessary data from websearch updates. 