### PR TITLE
Auto-growing input for editing existing messages

### DIFF
--- a/src/lib/components/chat/ChatInput.svelte
+++ b/src/lib/components/chat/ChatInput.svelte
@@ -47,7 +47,7 @@
 		enterkeyhint="send"
 		tabindex="0"
 		rows="1"
-		class="scrollbar-custom absolute top-0 m-0 h-full w-full resize-none scroll-p-3 overflow-x-hidden overflow-y-scroll border-0 bg-transparent p-3 outline-none focus:ring-0 focus-visible:ring-0"
+		class="scrollbar-custom absolute top-0 m-0 h-full w-full resize-none scroll-p-3 overflow-y-auto overflow-x-hidden border-0 bg-transparent p-3 outline-none focus:ring-0 focus-visible:ring-0"
 		class:text-gray-400={disabled}
 		bind:value
 		bind:this={textareaElement}

--- a/src/lib/components/chat/ChatMessage.svelte
+++ b/src/lib/components/chat/ChatMessage.svelte
@@ -198,7 +198,7 @@
 	$: if (editMode) {
 		tick();
 		if (editContentEl) {
-			editContentEl.innerText = message.content;
+			editContentEl.textContent = message.content;
 			editContentEl?.focus();
 		}
 	}

--- a/src/lib/components/chat/ChatMessage.svelte
+++ b/src/lib/components/chat/ChatMessage.svelte
@@ -192,13 +192,13 @@
 	}
 
 	$: editMode = $convTreeStore.editing === message.id;
-	let editContentEl: HTMLTextAreaElement;
+	let editContentEl: HTMLSpanElement;
 	let editFormEl: HTMLFormElement;
 
 	$: if (editMode) {
 		tick();
 		if (editContentEl) {
-			editContentEl.value = message.content;
+			editContentEl.innerText = message.content;
 			editContentEl?.focus();
 		}
 	}
@@ -485,29 +485,25 @@
 			{/if}
 
 			<div class="flex w-full flex-row flex-nowrap">
-				{#if !editMode}
-					<p
-						class="disabled w-full appearance-none whitespace-break-spaces text-wrap break-words bg-inherit px-5 py-3.5 text-gray-500 dark:text-gray-400"
+				<form
+					class="flex w-full flex-col"
+					bind:this={editFormEl}
+					on:submit|preventDefault={() => {
+						dispatch("retry", { content: editContentEl.innerText, id: message.id });
+						$convTreeStore.editing = null;
+					}}
+				>
+					<span
+						role="textbox"
+						tabindex={1}
+						class="w-full whitespace-break-spaces text-wrap break-words break-words rounded-xl px-5 py-3.5 text-gray-500 outline-none *:h-max dark:text-gray-400"
+						class:bg-gray-100={editMode}
+						class:dark:bg-gray-800={editMode}
+						bind:this={editContentEl}
+						on:keydown={handleKeyDown}
+						contenteditable={editMode}>{message.content.trim()}</span
 					>
-						{message.content.trim()}
-					</p>
-				{:else}
-					<form
-						class="flex w-full flex-col"
-						bind:this={editFormEl}
-						on:submit|preventDefault={() => {
-							dispatch("retry", { content: editContentEl.value, id: message.id });
-							$convTreeStore.editing = null;
-						}}
-					>
-						<textarea
-							class="w-full whitespace-break-spaces break-words rounded-xl bg-gray-100 px-5 py-3.5 text-gray-500 *:h-max dark:bg-gray-800 dark:text-gray-400"
-							rows="5"
-							bind:this={editContentEl}
-							value={message.content.trim()}
-							on:keydown={handleKeyDown}
-							required
-						/>
+					{#if editMode}
 						<div class="flex w-full flex-row flex-nowrap items-center justify-center gap-2 pt-2">
 							<button
 								type="submit"
@@ -530,8 +526,8 @@
 								Cancel
 							</button>
 						</div>
-					</form>
-				{/if}
+					{/if}
+				</form>
 				{#if !loading && !editMode}
 					<div
 						class="

--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -319,7 +319,7 @@
 										loginModalOpen = true;
 									}
 								}}
-								maxRows={6}
+								maxRows={16}
 								disabled={isReadOnly || lastIsError}
 							/>
 						{/if}


### PR DESCRIPTION
![image](https://github.com/huggingface/chat-ui/assets/10467983/c5cf2bf3-edc1-4de0-9dc7-e46b4eec6229)

Changes the message input to use a `<span>` with `contenteditable` and `role="textarea` (for accessibility). This allows the textarea to auto-expand to the content and avoids relayout on edit. I've found it improves the UX for editing larger prompts