### PR TITLE
Generic tool error msg "Error occurred"

### DIFF
--- a/src/lib/server/textGeneration/tools.ts
+++ b/src/lib/server/textGeneration/tools.ts
@@ -92,19 +92,19 @@ async function* callTool(
 		return { ...toolResult, call } as ToolResult;
 	} catch (error) {
 		MetricsServer.getMetrics().tool.toolUseCountError.inc({ tool: call.name });
-		logger.error(error, `Failed while running tool ${call.name}`);
+		logger.error(error, `Failed while running tool ${call.name}. ${stringifyError(error)}`);
 
 		yield {
 			type: MessageUpdateType.Tool,
 			subtype: MessageToolUpdateType.Error,
 			uuid,
-			message: stringifyError(error),
+			message: "Error occurred",
 		};
 
 		return {
 			call,
 			status: ToolResultStatus.Error,
-			message: stringifyError(error),
+			message: "Error occurred",
 		};
 	}
 }


### PR DESCRIPTION
[slack context](https://huggingface.slack.com/archives/C06U2V0L0LB/p1716888678428789?thread_ts=1716884604.014799&cid=C06U2V0L0LB)

follow up to https://github.com/huggingface/chat-ui/pull/1168

When tool fails, a generic error msg "Error occurred" will be shown rather than the actual error msg for various reasons, including security concerns as it may reveal information that is not intended to the user. However, the actual error will still be logged for debugging (for admins)