### PR TITLE
Add support for SearchApi API

### DIFF
--- a/.env
+++ b/.env
@@ -24,6 +24,7 @@ YDC_API_KEY=#your docs.you.com api key here
 SERPER_API_KEY=#your serper.dev api key here
 SERPAPI_KEY=#your serpapi key here
 SERPSTACK_API_KEY=#your serpstack api key here
+SEARCHAPI_KEY=#your searchapi api key here
 USE_LOCAL_WEBSEARCH=#set to true to parse google results yourself, overrides other API keys
 SEARXNG_QUERY_URL=# where '<query>' will be replaced with query keywords see https://docs.searxng.org/dev/search_api.html eg https://searxng.yourdomain.com/search?q=<query>&engines=duckduckgo,google&format=json
 

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ PUBLIC_APP_DISCLAIMER=
 
 ### Web Search config
 
-You can enable the web search through an API by adding `YDC_API_KEY` ([docs.you.com](https://docs.you.com)) or `SERPER_API_KEY` ([serper.dev](https://serper.dev/)) or `SERPAPI_KEY` ([serpapi.com](https://serpapi.com/)) or `SERPSTACK_API_KEY` ([serpstack.com](https://serpstack.com/)) to your `.env.local`.
+You can enable the web search through an API by adding `YDC_API_KEY` ([docs.you.com](https://docs.you.com)) or `SERPER_API_KEY` ([serper.dev](https://serper.dev/)) or `SERPAPI_KEY` ([serpapi.com](https://serpapi.com/)) or `SERPSTACK_API_KEY` ([serpstack.com](https://serpstack.com/)) or `SEARCHAPI_KEY` ([searchapi.io](https://www.searchapi.io/)) to your `.env.local`.
 
 You can also simply enable the local google websearch by setting `USE_LOCAL_WEBSEARCH=true` in your `.env.local` or specify a SearXNG instance by adding the query URL to `SEARXNG_QUERY_URL`.
 

--- a/docs/source/configuration/web-search.md
+++ b/docs/source/configuration/web-search.md
@@ -36,6 +36,7 @@ YDC_API_KEY=docs.you.com api key here
 SERPER_API_KEY=serper.dev api key here
 SERPAPI_KEY=serpapi key here
 SERPSTACK_API_KEY=serpstack api key here
+SEARCHAPI_KEY=searchapi api key here
 ```
 
 ## Block/Allow List

--- a/src/lib/server/websearch/search/endpoints.ts
+++ b/src/lib/server/websearch/search/endpoints.ts
@@ -6,6 +6,7 @@ import searchSerpStack from "./endpoints/serpStack";
 import searchYouApi from "./endpoints/youApi";
 import searchWebLocal from "./endpoints/webLocal";
 import searchSearxng from "./endpoints/searxng";
+import searchSearchApi from "./endpoints/searchApi";
 
 export function getWebSearchProvider() {
 	if (env.YDC_API_KEY) return WebSearchProvider.YOU;
@@ -21,7 +22,8 @@ export async function searchWeb(query: string): Promise<WebSearchSource[]> {
 	if (env.YDC_API_KEY) return searchYouApi(query);
 	if (env.SERPAPI_KEY) return searchSerpApi(query);
 	if (env.SERPSTACK_API_KEY) return searchSerpStack(query);
+	if (env.SEARCHAPI_KEY) return searchSearchApi(query);
 	throw new Error(
-		"No configuration found for web search. Please set USE_LOCAL_WEBSEARCH, SEARXNG_QUERY_URL, SERPER_API_KEY, YDC_API_KEY, or SERPSTACK_API_KEY in your environment variables."
+		"No configuration found for web search. Please set USE_LOCAL_WEBSEARCH, SEARXNG_QUERY_URL, SERPER_API_KEY, YDC_API_KEY, SERPSTACK_API_KEY, or SEARCHAPI_KEY in your environment variables."
 	);
 }

--- a/src/lib/server/websearch/search/endpoints/searchApi.ts
+++ b/src/lib/server/websearch/search/endpoints/searchApi.ts
@@ -1,0 +1,27 @@
+import { env } from "$env/dynamic/private";
+import type { WebSearchSource } from "$lib/types/WebSearch";
+import { isURL } from "$lib/utils/isUrl";
+
+export default async function search(query: string): Promise<WebSearchSource[]> {
+	const response = await fetch(
+		`https://www.searchapi.io/api/v1/search?engine=google&hl=en&gl=us&q=${query}`,
+		{
+			method: "GET",
+			headers: {
+				Authorization: `Bearer ${env.SEARCHAPI_KEY}`,
+				"Content-type": "application/json",
+			},
+		}
+	);
+
+	/* eslint-disable @typescript-eslint/no-explicit-any */
+	const data = (await response.json()) as Record<string, any>;
+
+	if (!response.ok) {
+		throw new Error(
+			data["message"] ?? `SearchApi returned error code ${response.status} - ${response.statusText}`
+		);
+	}
+
+	return data["organic_results"] ?? [];
+}

--- a/src/lib/server/websearch/search/endpoints/searchApi.ts
+++ b/src/lib/server/websearch/search/endpoints/searchApi.ts
@@ -1,6 +1,5 @@
 import { env } from "$env/dynamic/private";
 import type { WebSearchSource } from "$lib/types/WebSearch";
-import { isURL } from "$lib/utils/isUrl";
 
 export default async function search(query: string): Promise<WebSearchSource[]> {
 	const response = await fetch(

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -132,6 +132,7 @@ export const load: LayoutServerLoad = async ({ locals, depends }) => {
 				env.SERPAPI_KEY ||
 				env.SERPER_API_KEY ||
 				env.SERPSTACK_API_KEY ||
+				env.SEARCHAPI_KEY ||
 				env.YDC_API_KEY ||
 				env.USE_LOCAL_WEBSEARCH ||
 				env.SEARXNG_QUERY_URL


### PR DESCRIPTION
We have integrated a new webSearch - [SearchApi](https://www.searchapi.io/), following a similar format to the other SERP providers.

- Feel free to assign @SebastjanPrachovskij as a main reviewer for any SearchApi-related searches. We will be glad to help and support chat-ui development.