### PR TITLE
feat: mime types on tools, show upload btn on demand

### DIFF
--- a/src/lib/components/ToolsMenu.svelte
+++ b/src/lib/components/ToolsMenu.svelte
@@ -60,10 +60,12 @@
 				<button
 					class="ml-auto text-xs underline"
 					on:click|stopPropagation={() => setAllTools(!allToolsEnabled)}
-					>{#if allToolsEnabled}
+				>
+					{#if allToolsEnabled}
 						Disable all
 					{:else}
-						Enable all{/if}
+						Enable all
+					{/if}
 				</button>
 			</div>
 			{#each $page.data.tools as tool}

--- a/src/lib/components/ToolsMenu.svelte
+++ b/src/lib/components/ToolsMenu.svelte
@@ -22,6 +22,8 @@
 			tools: Object.fromEntries($page.data.tools.map((tool: ToolFront) => [tool.name, value])),
 		});
 	}
+	$: allToolsEnabled = activeToolCount === $page.data.tools.length;
+	$: allToolsDisabled = activeToolCount === 0;
 </script>
 
 <details
@@ -57,8 +59,16 @@
 				{/if}
 			</div>
 			<div class="flex space-x-4 text-sm text-gray-500">
-				<button on:click={() => setAllTools(true)}>Enable all</button>
-				<button on:click={() => setAllTools(false)}>Disable all</button>
+				<button
+					disabled={allToolsEnabled}
+					class:opacity-50={allToolsEnabled}
+					on:click={() => setAllTools(true)}>Enable all</button
+				>
+				<button
+					disabled={allToolsDisabled}
+					class:opacity-50={allToolsDisabled}
+					on:click={() => setAllTools(false)}>Disable all</button
+				>
 			</div>
 			{#each $page.data.tools as tool}
 				{@const isChecked = $settings?.tools?.[tool.name] ?? tool.isOnByDefault}

--- a/src/lib/components/ToolsMenu.svelte
+++ b/src/lib/components/ToolsMenu.svelte
@@ -16,6 +16,12 @@
 	$: activeToolCount = $page.data.tools.filter(
 		(tool: ToolFront) => $settings?.tools?.[tool.name] ?? tool.isOnByDefault
 	).length;
+
+	function setAllTools(value: boolean) {
+		settings.instantSet({
+			tools: Object.fromEntries($page.data.tools.map((tool: ToolFront) => [tool.name, value])),
+		});
+	}
 </script>
 
 <details
@@ -39,7 +45,7 @@
 		class="absolute bottom-10 h-max w-max select-none items-center gap-1 rounded-lg border bg-white p-0.5 shadow-sm dark:border-gray-800 dark:bg-gray-900"
 	>
 		<div class="grid grid-cols-2 gap-x-6 gap-y-1 p-3">
-			<div class="col-span-2 mb-1 flex items-center gap-1.5 text-sm text-gray-500">
+			<div class="flex items-center gap-1.5 text-sm text-gray-500">
 				Available tools
 				{#if isHuggingChat}
 					<a
@@ -49,6 +55,10 @@
 						><CarbonInformation class="text-xs" /></a
 					>
 				{/if}
+			</div>
+			<div class="flex space-x-4 text-sm text-gray-500">
+				<button on:click={() => setAllTools(true)}>Enable all</button>
+				<button on:click={() => setAllTools(false)}>Disable all</button>
 			</div>
 			{#each $page.data.tools as tool}
 				{@const isChecked = $settings?.tools?.[tool.name] ?? tool.isOnByDefault}

--- a/src/lib/components/ToolsMenu.svelte
+++ b/src/lib/components/ToolsMenu.svelte
@@ -23,7 +23,6 @@
 		});
 	}
 	$: allToolsEnabled = activeToolCount === $page.data.tools.length;
-	$: allToolsDisabled = activeToolCount === 0;
 </script>
 
 <details

--- a/src/lib/components/ToolsMenu.svelte
+++ b/src/lib/components/ToolsMenu.svelte
@@ -47,7 +47,7 @@
 		class="absolute bottom-10 h-max w-max select-none items-center gap-1 rounded-lg border bg-white p-0.5 shadow-sm dark:border-gray-800 dark:bg-gray-900"
 	>
 		<div class="grid grid-cols-2 gap-x-6 gap-y-1 p-3">
-			<div class="flex items-center gap-1.5 text-sm text-gray-500">
+			<div class="col-span-2 flex items-center gap-1.5 text-sm text-gray-500">
 				Available tools
 				{#if isHuggingChat}
 					<a
@@ -57,18 +57,14 @@
 						><CarbonInformation class="text-xs" /></a
 					>
 				{/if}
-			</div>
-			<div class="flex space-x-4 text-sm text-gray-500">
 				<button
-					disabled={allToolsEnabled}
-					class:opacity-50={allToolsEnabled}
-					on:click={() => setAllTools(true)}>Enable all</button
-				>
-				<button
-					disabled={allToolsDisabled}
-					class:opacity-50={allToolsDisabled}
-					on:click={() => setAllTools(false)}>Disable all</button
-				>
+					class="ml-auto text-xs underline"
+					on:click|stopPropagation={() => setAllTools(!allToolsEnabled)}
+					>{#if allToolsEnabled}
+						Disable all
+					{:else}
+						Enable all{/if}
+				</button>
 			</div>
 			{#each $page.data.tools as tool}
 				{@const isChecked = $settings?.tools?.[tool.name] ?? tool.isOnByDefault}

--- a/src/lib/components/UploadBtn.svelte
+++ b/src/lib/components/UploadBtn.svelte
@@ -3,6 +3,7 @@
 
 	export let classNames = "";
 	export let files: File[];
+	export let mimeTypes: string[] = ["*/*"];
 
 	/**
 	 * Due to a bug with Svelte, we cannot use bind:files with multiple
@@ -22,7 +23,7 @@
 		class="absolute w-full cursor-pointer opacity-0"
 		type="file"
 		on:change={onFileChange}
-		accept="*/*"
+		accept={mimeTypes.join(",")}
 	/>
 	<CarbonUpload class="mr-2 text-xxs" /> Upload file
 </button>

--- a/src/lib/components/UploadBtn.svelte
+++ b/src/lib/components/UploadBtn.svelte
@@ -3,7 +3,7 @@
 
 	export let classNames = "";
 	export let files: File[];
-	export let mimeTypes: string[] = ["*/*"];
+	export let mimeTypes: string[];
 
 	/**
 	 * Due to a bug with Svelte, we cannot use bind:files with multiple

--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -95,7 +95,17 @@
 		const pastedFiles = Array.from(e.clipboardData.files);
 		if (pastedFiles.length !== 0) {
 			e.preventDefault();
-			files = [...files, ...pastedFiles];
+
+			// filter based on activeMimeTypes, including wildcards
+			const filteredFiles = pastedFiles.filter((file) => {
+				return activeMimeTypes.some((mimeType: string) => {
+					const [type, subtype] = mimeType.split("/");
+					const [fileType, fileSubtype] = file.type.split("/");
+					return type === fileType && (subtype === "*" || fileSubtype === subtype);
+				});
+			});
+
+			files = [...files, ...filteredFiles];
 		}
 	};
 
@@ -300,7 +310,7 @@
 					/>
 				{:else}
 					<div class="ml-auto gap-2">
-						{#if currentModel.multimodal || activeMimeTypes.length > 0}
+						{#if activeMimeTypes.length > 0}
 							<UploadBtn bind:files mimeTypes={activeMimeTypes} classNames="ml-auto" />
 						{/if}
 						{#if messages && lastMessage && lastMessage.interrupted && !isReadOnly}
@@ -327,12 +337,8 @@
 				class="relative flex w-full max-w-4xl flex-1 items-center rounded-xl border bg-gray-100 focus-within:border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:focus-within:border-gray-500
 			{isReadOnly ? 'opacity-30' : ''}"
 			>
-				{#if onDrag && (currentModel.multimodal || currentModel.tools)}
-					<FileDropzone
-						bind:files
-						bind:onDrag
-						onlyImages={currentModel.multimodal && !currentModel.tools}
-					/>
+				{#if onDrag && activeMimeTypes.length > 0}
+					<FileDropzone bind:files bind:onDrag mimeTypes={activeMimeTypes} />
 				{:else}
 					<div class="flex w-full flex-1 border-none bg-transparent">
 						{#if lastIsError}

--- a/src/lib/components/chat/FileDropzone.svelte
+++ b/src/lib/components/chat/FileDropzone.svelte
@@ -4,7 +4,7 @@
 	// import EosIconsLoading from "~icons/eos-icons/loading";
 
 	export let files: File[];
-	export let onlyImages: boolean = false;
+	export let mimeTypes: string[] = [];
 
 	let file_error_message = "";
 	let errorTimeout: ReturnType<typeof setTimeout>;
@@ -24,11 +24,19 @@
 			if (event.dataTransfer.items[0].kind === "file") {
 				const file = event.dataTransfer.items[0].getAsFile();
 				if (file) {
-					if (!event.dataTransfer.items[0].type.startsWith("image") && onlyImages) {
-						setErrorMsg("Only images are supported");
+					// check if the file matches the mimeTypes
+					if (
+						!mimeTypes.some((mimeType: string) => {
+							const [type, subtype] = mimeType.split("/");
+							const [fileType, fileSubtype] = file.type.split("/");
+							return type === fileType && (subtype === "*" || fileSubtype === subtype);
+						})
+					) {
+						setErrorMsg(`File type not supported. Only allowed: ${mimeTypes.join(", ")}`);
 						files = [];
 						return;
 					}
+
 					// if file is bigger than 10MB abort
 					if (file.size > 10 * 1024 * 1024) {
 						setErrorMsg("Image is too big. (2MB max)");
@@ -89,7 +97,7 @@
 			class="mb-3 mt-1.5 text-sm text-gray-500 dark:text-gray-400"
 			class:opacity-0={file_error_message}
 		>
-			Drag and drop <span class="font-semibold">one {onlyImages ? "image" : "file"}</span> here
+			Drag and drop <span class="font-semibold">one file</span> here
 		</p>
 	</div>
 </div>

--- a/src/lib/server/tools/documentParser.ts
+++ b/src/lib/server/tools/documentParser.ts
@@ -10,6 +10,7 @@ const documentParser: BackendTool = {
 	displayName: "Document Parser",
 	description: "Use this tool to parse any document and get its content in markdown format.",
 	isOnByDefault: true,
+	mimeTypes: ["application/*", "text/*"],
 	parameterDefinitions: {
 		fileMessageIndex: {
 			description: "Index of the message containing the document file to parse",

--- a/src/lib/server/tools/images/editing.ts
+++ b/src/lib/server/tools/images/editing.ts
@@ -18,6 +18,7 @@ const imageEditing: BackendTool = {
 	displayName: "Image Editing",
 	description: "Use this tool to edit an image from a prompt.",
 	isOnByDefault: true,
+	mimeTypes: ["image/*"],
 	parameterDefinitions: {
 		prompt: {
 			description:

--- a/src/lib/types/Tool.ts
+++ b/src/lib/types/Tool.ts
@@ -15,6 +15,8 @@ export interface Tool {
 	name: string;
 	displayName?: string;
 	description: string;
+	/** List of mime types that tool accepts */
+	mimeTypes?: string[];
 	parameterDefinitions: Record<string, ToolInput>;
 	spec?: string;
 	isOnByDefault?: true; // will it be toggled if the user hasn't tweaked it in settings ?
@@ -24,7 +26,7 @@ export interface Tool {
 
 export type ToolFront = Pick<
 	Tool,
-	"name" | "displayName" | "description" | "isOnByDefault" | "isLocked"
+	"name" | "displayName" | "description" | "isOnByDefault" | "isLocked" | "mimeTypes"
 > & { timeToUseMS?: number };
 
 export enum ToolResultStatus {

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -172,6 +172,7 @@ export const load: LayoutServerLoad = async ({ locals, depends }) => {
 				name: tool.name,
 				displayName: tool.displayName,
 				description: tool.description,
+				mimeTypes: tool.mimeTypes,
 				isOnByDefault: tool.isOnByDefault,
 				isLocked: tool.isLocked,
 				timeToUseMS:


### PR DESCRIPTION
Adds a mimetypes property on the tools used by the frontend to control the `UploadBtn`'s `accept` property. If there are no active mime types, the upload button will not be shown. Adds an enable/disable all button to the tools menu

![image](https://github.com/huggingface/chat-ui/assets/10467983/6c88bc50-fe22-4f19-9290-5bd87837c893)