### PR TITLE
Add super basic admin feature

### DIFF
--- a/src/lib/types/User.ts
+++ b/src/lib/types/User.ts
@@ -9,4 +9,5 @@ export interface User extends Timestamps {
 	email?: string;
 	avatarUrl: string | undefined;
 	hfUserId: string;
+	isAdmin?: boolean;
 }

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -193,6 +193,7 @@ export const load: LayoutServerLoad = async ({ locals, depends }) => {
 			avatarUrl: locals.user.avatarUrl,
 			email: locals.user.email,
 			logoutDisabled: locals.user.logoutDisabled,
+			isAdmin: locals.user.isAdmin ?? false,
 		},
 		assistant,
 		enableAssistants,

--- a/src/routes/settings/(nav)/assistants/[assistantId]/+page.svelte
+++ b/src/routes/settings/(nav)/assistants/[assistantId]/+page.svelte
@@ -142,6 +142,20 @@
 						>
 					{/if}
 				{/if}
+				{#if data?.user?.isAdmin}
+					<form method="POST" action="?/delete" use:enhance>
+						<button type="submit" class="flex items-center text-red-600 underline">
+							<CarbonTrash class="mr-1.5 inline text-xs" />Delete</button
+						>
+					</form>
+					{#if assistant?.featured}
+						<form method="POST" action="?/unfeature" use:enhance>
+							<button type="submit" class="flex items-center text-red-600 underline">
+								<CarbonTrash class="mr-1.5 inline text-xs" />Un-feature</button
+							>
+						</form>
+					{/if}
+				{/if}
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
Only lets you unfeature/delete assistants for now.

Was needed because deleting assistants requires deleting it from every user's settings which was impossible to do manually

![Screenshot from 2024-05-29 11-49-05](https://github.com/huggingface/chat-ui/assets/25119303/e24176ac-62b5-48b5-9cdf-210ebb5664b4)


Currently admins are created by setting `isAdmin` manually on the user document in the DB