### PR TITLE
Remove gendered pronoun

### DIFF
--- a/src/lib/components/AssistantSettings.svelte
+++ b/src/lib/components/AssistantSettings.svelte
@@ -245,7 +245,7 @@
 				<textarea
 					name="description"
 					class="h-15 w-full rounded-lg border-2 border-gray-200 bg-gray-100 p-2"
-					placeholder="He knows everything about python"
+					placeholder="It knows everything about python"
 					value={assistant?.description ?? ""}
 				/>
 				<p class="text-xs text-red-500">{getError("description", form)}</p>


### PR DESCRIPTION
Multiple problems with how it was before:
- There was no need to use a gendered pronoun in the first place
- I don't think we've gotten to the point where we can refer to machine learning models with human pronouns

Another possibility if you want to use human pronouns is “they.”