### PR TITLE
Only paste or drop the allowed MIME types

### DIFF
--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -310,7 +310,7 @@
 					/>
 				{:else}
 					<div class="ml-auto gap-2">
-						{#if currentModel.multimodal || activeMimeTypes.length > 0}
+						{#if activeMimeTypes.length > 0}
 							<UploadBtn bind:files mimeTypes={activeMimeTypes} classNames="ml-auto" />
 						{/if}
 						{#if messages && lastMessage && lastMessage.interrupted && !isReadOnly}

--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -95,7 +95,17 @@
 		const pastedFiles = Array.from(e.clipboardData.files);
 		if (pastedFiles.length !== 0) {
 			e.preventDefault();
-			files = [...files, ...pastedFiles];
+
+			// filter based on activeMimeTypes, including wildcards
+			const filteredFiles = pastedFiles.filter((file) => {
+				return activeMimeTypes.some((mimeType: string) => {
+					const [type, subtype] = mimeType.split("/");
+					const [fileType, fileSubtype] = file.type.split("/");
+					return type === fileType && (subtype === "*" || fileSubtype === subtype);
+				});
+			});
+
+			files = [...files, ...filteredFiles];
 		}
 	};
 
@@ -426,7 +436,7 @@
 							<CarbonCheckmark class="text-[.6rem] sm:mr-1.5 sm:text-green-600" />
 							<div class="text-green-600 max-sm:hidden">Link copied to clipboard</div>
 						{:else}
-							<CarbonExport class="sm:text-primary-500 text-[.6rem] sm:mr-1.5" />
+							<CarbonExport class="text-[.6rem] sm:mr-1.5 sm:text-primary-500" />
 							<div class="max-sm:hidden">Share this conversation</div>
 						{/if}
 					</button>

--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -436,7 +436,7 @@
 							<CarbonCheckmark class="text-[.6rem] sm:mr-1.5 sm:text-green-600" />
 							<div class="text-green-600 max-sm:hidden">Link copied to clipboard</div>
 						{:else}
-							<CarbonExport class="text-[.6rem] sm:mr-1.5 sm:text-primary-500" />
+							<CarbonExport class="sm:text-primary-500 text-[.6rem] sm:mr-1.5" />
 							<div class="max-sm:hidden">Share this conversation</div>
 						{/if}
 					</button>

--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -337,12 +337,8 @@
 				class="relative flex w-full max-w-4xl flex-1 items-center rounded-xl border bg-gray-100 focus-within:border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:focus-within:border-gray-500
 			{isReadOnly ? 'opacity-30' : ''}"
 			>
-				{#if onDrag && (currentModel.multimodal || currentModel.tools)}
-					<FileDropzone
-						bind:files
-						bind:onDrag
-						onlyImages={currentModel.multimodal && !currentModel.tools}
-					/>
+				{#if onDrag && activeMimeTypes.length > 0}
+					<FileDropzone bind:files bind:onDrag mimeTypes={activeMimeTypes} />
 				{:else}
 					<div class="flex w-full flex-1 border-none bg-transparent">
 						{#if lastIsError}

--- a/src/lib/components/chat/FileDropzone.svelte
+++ b/src/lib/components/chat/FileDropzone.svelte
@@ -4,7 +4,7 @@
 	// import EosIconsLoading from "~icons/eos-icons/loading";
 
 	export let files: File[];
-	export let onlyImages: boolean = false;
+	export let mimeTypes: string[] = [];
 
 	let file_error_message = "";
 	let errorTimeout: ReturnType<typeof setTimeout>;
@@ -24,11 +24,19 @@
 			if (event.dataTransfer.items[0].kind === "file") {
 				const file = event.dataTransfer.items[0].getAsFile();
 				if (file) {
-					if (!event.dataTransfer.items[0].type.startsWith("image") && onlyImages) {
-						setErrorMsg("Only images are supported");
+					// check if the file matches the mimeTypes
+					if (
+						!mimeTypes.some((mimeType: string) => {
+							const [type, subtype] = mimeType.split("/");
+							const [fileType, fileSubtype] = file.type.split("/");
+							return type === fileType && (subtype === "*" || fileSubtype === subtype);
+						})
+					) {
+						setErrorMsg(`File type not supported. Only ${mimeTypes.join(", ")} allowed`);
 						files = [];
 						return;
 					}
+
 					// if file is bigger than 10MB abort
 					if (file.size > 10 * 1024 * 1024) {
 						setErrorMsg("Image is too big. (2MB max)");
@@ -89,7 +97,7 @@
 			class="mb-3 mt-1.5 text-sm text-gray-500 dark:text-gray-400"
 			class:opacity-0={file_error_message}
 		>
-			Drag and drop <span class="font-semibold">one {onlyImages ? "image" : "file"}</span> here
+			Drag and drop <span class="font-semibold">one file</span> here
 		</p>
 	</div>
 </div>

--- a/src/lib/components/chat/FileDropzone.svelte
+++ b/src/lib/components/chat/FileDropzone.svelte
@@ -32,7 +32,7 @@
 							return type === fileType && (subtype === "*" || fileSubtype === subtype);
 						})
 					) {
-						setErrorMsg(`File type not supported. Only ${mimeTypes.join(", ")} allowed`);
+						setErrorMsg(`File type not supported. Only allowed: ${mimeTypes.join(", ")}`);
 						files = [];
 						return;
 					}


### PR DESCRIPTION
Since #1204 adds MIME types, I extended their use to the `onPaste` handler as well as the `FileDropzone` component