### PR TITLE
Send `ollama pull` request if model is not available locally

### DIFF
--- a/src/lib/server/endpoints/ollama/endpointOllama.ts
+++ b/src/lib/server/endpoints/ollama/endpointOllama.ts
@@ -24,6 +24,31 @@ export function endpointOllama(input: z.input<typeof endpointOllamaParametersSch
 
 		const parameters = { ...model.parameters, ...generateSettings };
 
+		const requestInfo = await fetch(`${url}/api/tags`, {
+			method: "GET",
+			headers: {
+				"Content-Type": "application/json",
+			},
+		});
+
+		const tags = await requestInfo.json();
+
+		if (!tags.models.some((m: { name: string }) => m.name === ollamaName)) {
+			// if its not in the tags, pull but dont wait for the answer
+			fetch(`${url}/api/pull`, {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify({
+					name: ollamaName ?? model.name,
+					stream: false,
+				}),
+			});
+
+			throw new Error("Currently pulling model from Ollama, please try again later.");
+		}
+
 		const r = await fetch(`${url}/api/generate`, {
 			method: "POST",
 			headers: {


### PR DESCRIPTION
Before you had to `ollama pull [whatevermodel]` manually in ollama. I wanted a single deployment with ollama+chat-ui where I didn't have to run any commands. 

This PR handles the downloading of the model directly from the endpoint if needed.