### PR TITLE
Fix error logging

### DIFF
--- a/src/lib/migrations/routines/03-add-tools-in-settings.ts
+++ b/src/lib/migrations/routines/03-add-tools-in-settings.ts
@@ -19,7 +19,7 @@ const addToolsToSettings: Migration = {
 
 		settings
 			.createIndex({ tools: 1 })
-			.catch((e) => logger.error("Error creating index during tools migration", e));
+			.catch((e) => logger.error(e, "Error creating index during tools migration"));
 
 		return true;
 	},

--- a/src/lib/server/database.ts
+++ b/src/lib/server/database.ts
@@ -35,7 +35,7 @@ export class Database {
 		});
 
 		this.client.connect().catch((err) => {
-			logger.error("Connection error", err);
+			logger.error(err, "Connection error");
 			process.exit(1);
 		});
 		this.client.db(env.MONGODB_DB_NAME + (import.meta.env.MODE === "test" ? "-test" : ""));

--- a/src/lib/server/embeddingEndpoints/hfApi/embeddingHfApi.ts
+++ b/src/lib/server/embeddingEndpoints/hfApi/embeddingHfApi.ts
@@ -42,7 +42,7 @@ export async function embeddingEndpointHfApi(
 
 				if (!response.ok) {
 					logger.error(await response.text());
-					logger.error("Failed to get embeddings from Hugging Face API", response);
+					logger.error(response, "Failed to get embeddings from Hugging Face API");
 					return [];
 				}
 

--- a/src/lib/server/endpoints/cloudflare/endpointCloudflare.ts
+++ b/src/lib/server/endpoints/cloudflare/endpointCloudflare.ts
@@ -105,7 +105,7 @@ export async function endpointCloudflare(
 						try {
 							data = JSON.parse(jsonString);
 						} catch (e) {
-							logger.error("Failed to parse JSON", e);
+							logger.error(e, "Failed to parse JSON");
 							logger.error("Problematic JSON string:", jsonString);
 							continue; // Skip this iteration and try the next chunk
 						}

--- a/src/lib/server/endpoints/langserve/endpointLangserve.ts
+++ b/src/lib/server/endpoints/langserve/endpointLangserve.ts
@@ -100,7 +100,7 @@ export function endpointLangserve(
 						try {
 							data = JSON.parse(jsonString);
 						} catch (e) {
-							logger.error("Failed to parse JSON", e);
+							logger.error(e, "Failed to parse JSON");
 							logger.error("Problematic JSON string:", jsonString);
 							continue; // Skip this iteration and try the next chunk
 						}

--- a/src/lib/server/endpoints/llamacpp/endpointLlamacpp.ts
+++ b/src/lib/server/endpoints/llamacpp/endpointLlamacpp.ts
@@ -94,7 +94,7 @@ export function endpointLlamacpp(
 						try {
 							data = JSON.parse(jsonString);
 						} catch (e) {
-							logger.error("Failed to parse JSON", e);
+							logger.error(e, "Failed to parse JSON");
 							logger.error("Problematic JSON string:", jsonString);
 							continue; // Skip this iteration and try the next chunk
 						}

--- a/src/lib/server/websearch/search/endpoints/searxng.ts
+++ b/src/lib/server/websearch/search/endpoints/searxng.ts
@@ -21,7 +21,7 @@ export default async function searchSearxng(query: string): Promise<WebSearchSou
 	})
 		.then((response) => response.json() as Promise<{ results: { url: string }[] }>)
 		.catch((error) => {
-			logger.error("Failed to fetch or parse JSON", error);
+			logger.error(error, "Failed to fetch or parse JSON");
 			throw new Error("Failed to fetch or parse JSON", { cause: error });
 		});
 


### PR DESCRIPTION
Logging for chat-ui was switched to Pino in https://github.com/huggingface/chat-ui/pull/1086. For error logging, Pino wants the object first, and then the string message. Otherwise you don't get the information from the error object. For example see this thread: https://github.com/pinojs/pino/issues/673

There's already one example in the repo of correct usage: https://github.com/huggingface/chat-ui/blob/main/src/lib/server/textGeneration/tools.ts#L95