### PR TITLE
Trim trailing comma on tool calls

### DIFF
--- a/src/lib/server/textGeneration/tools.ts
+++ b/src/lib/server/textGeneration/tools.ts
@@ -143,11 +143,14 @@ export async function* runTools(
 		// look for a code blocks of ```json and parse them
 		// if they're valid json, add them to the calls array
 		if (output.generated_text) {
-			const codeBlocks = Array.from(output.generated_text.matchAll(/```json\n(.*?)```/gs));
+			const codeBlocks = Array.from(output.generated_text.matchAll(/```json\n(.*?)```/gs))
+				.map(([, block]) => block)
+				// remove trailing comma
+				.map((block) => block.trim().replace(/,$/, ""));
 			if (codeBlocks.length === 0) continue;
 
 			// grab only the capture group from the regex match
-			for (const [, block] of codeBlocks) {
+			for (const block of codeBlocks) {
 				try {
 					calls.push(
 						...JSON5.parse(block).filter(isExternalToolCall).map(externalToToolCall).filter(Boolean)

--- a/src/lib/server/textGeneration/tools.ts
+++ b/src/lib/server/textGeneration/tools.ts
@@ -160,7 +160,7 @@ export async function* runTools(
 					yield {
 						type: MessageUpdateType.Status,
 						status: MessageUpdateStatus.Error,
-						message: stringifyError(e),
+						message: "Error while parsing tool calls, please retry",
 					};
 				}
 			}


### PR DESCRIPTION
The model likes to return trailing commas on the tool calls which JSON5 rejects. This trims the comma and adds a clearer message for the client for when tool call parsing fails