### PR TITLE
Add support for `?q` query parameter to start a conversation

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,12 +1,14 @@
 <script lang="ts">
 	import { goto } from "$app/navigation";
 	import { base } from "$app/paths";
+	import { page } from "$app/stores";
 	import { env as envPublic } from "$env/dynamic/public";
 	import ChatWindow from "$lib/components/chat/ChatWindow.svelte";
 	import { ERROR_MESSAGES, error } from "$lib/stores/errors";
 	import { pendingMessage } from "$lib/stores/pendingMessage";
 	import { useSettingsStore } from "$lib/stores/settings.js";
 	import { findCurrentModel } from "$lib/utils/models";
+	import { onMount } from "svelte";
 
 	export let data;
 	let loading = false;
@@ -70,6 +72,12 @@
 			loading = false;
 		}
 	}
+
+	onMount(() => {
+		// check if there's a ?q query param with a message
+		const query = $page.url.searchParams.get("q");
+		if (query) createConversation(query);
+	});
 </script>
 
 <svelte:head>

--- a/src/routes/models/[...model]/+page.svelte
+++ b/src/routes/models/[...model]/+page.svelte
@@ -76,6 +76,9 @@
 		settings.instantSet({
 			activeModel: modelId,
 		});
+
+		const query = $page.url.searchParams.get("q");
+		if (query) createConversation(query);
 	});
 </script>
 


### PR DESCRIPTION
Very simple PR you can just do

http://localhost:5173/chat/?q=test

To start a conversation with the prompt `test`


Also works on model specific landing pages

http://localhost:5173/chat/models/mistralai/Mixtral-8x7B-Instruct-v0.1?q=hello