### PR TITLE
Fix: tools in endpointVertex now optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -774,6 +774,7 @@ MODELS=`[
           // Optional
           "safetyThreshold": "BLOCK_MEDIUM_AND_ABOVE",
           "apiEndpoint": "", // alternative api endpoint url,
+          // Optional
           "tools": [{
             "googleSearchRetrieval": {
               "disableAttribution": true

--- a/src/lib/server/endpoints/google/endpointVertex.ts
+++ b/src/lib/server/endpoints/google/endpointVertex.ts
@@ -26,7 +26,7 @@ export const endpointVertexParametersSchema = z.object({
 			HarmBlockThreshold.BLOCK_ONLY_HIGH,
 		])
 		.optional(),
-	tools: z.array(z.any()),
+	tools: z.array(z.any()).optional(),
 });
 
 export function endpointVertex(input: z.input<typeof endpointVertexParametersSchema>): Endpoint {


### PR DESCRIPTION
The googleSearchRetrieval leads to very odd and unnatural behavior when chatting with Gemini. Making the argument optional and removing it for certain use cases fixes the issue. 

Behavior with googleSearchRetrieval:

![Gemini_Pro_with_googleSearchRetrieval](https://github.com/huggingface/chat-ui/assets/25245929/b957fcb4-91a6-4659-aad3-711cb091bec6)


