### PR TITLE
Readme: Add instructions to build using Docker Compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -907,6 +907,8 @@ Create a `DOTENV_LOCAL` secret to your HF space with the content of your .env.lo
 
 ## Building
 
+### Local
+
 To create a production version of your app:
 
 ```bash
@@ -916,6 +918,12 @@ npm run build
 You can preview the production build with `npm run preview`.
 
 > To deploy your app, you may need to install an [adapter](https://kit.svelte.dev/docs/adapters) for your target environment.
+
+### Docker
+
+```bash
+docker compose --env-file /dev/null up --build
+```
 
 ## Config changes for HuggingChat
 

--- a/README.md
+++ b/README.md
@@ -919,7 +919,16 @@ You can preview the production build with `npm run preview`.
 
 > To deploy your app, you may need to install an [adapter](https://kit.svelte.dev/docs/adapters) for your target environment.
 
-### Docker
+### Docker Compose
+
+If `.env.local` is not present, remove the volume in `compose.yaml` as follows to avoid errors.
+
+```diff
+-     volumes:
+-      - .env.local:/app/.env.local
+```
+
+Start the app with Docker Compose:
 
 ```bash
 docker compose --env-file /dev/null up --build

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,26 @@
+services:
+  mongo:
+    image: mongo:latest
+    expose:
+      - 27017
+    networks:
+      - huggingchat-mongo
+    restart: always
+
+  huggingchat:
+    image: chat-ui:latest
+    ports:
+      - "3000:3000"
+    depends_on:
+      - mongo
+    networks:
+      - huggingchat-mongo
+    volumes:
+      - .env.local:/app/.env.local
+    environment:
+      - MONGODB_URL=mongodb://mongo:27017
+    restart: always
+
+networks:
+  huggingchat-mongo:
+    driver: bridge


### PR DESCRIPTION
Fixes #614.

# Changelog

## Add

- Add missing instructions on how to build Docker images using Docker Compose.
- Add Docker Compose file `compose.yaml` with support for `.env.local`. Current Dockerfile does not support `.env.local`.