### PR TITLE
Npm: Remove updateProdEnv from script from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
 		"format": "prettier --plugin-search-dir . --write .",
 		"test": "MONGODB_URL=mongodb://127.0.0.1:27017/ vitest",
 		"updateLocalEnv": "node --loader ts-node/esm scripts/updateLocalEnv.ts",
-		"updateProdEnv": "node --loader ts-node/esm scripts/updateProdEnv.ts",
 		"populate": "vite-node --options.transformMode.ssr='/.*/' scripts/populate.ts"
 	},
 	"devDependencies": {


### PR DESCRIPTION
The script itself and the documentation about it were deleted in https://github.com/huggingface/chat-ui/pull/1107 already.

## Changelog

### Removed

- Script `updateProdEnv` from `package.json`