### PR TITLE
Fix max upload size in huggingchat

### DIFF
--- a/src/lib/utils/messageUpdates.ts
+++ b/src/lib/utils/messageUpdates.ts
@@ -59,18 +59,28 @@ export async function fetchMessageUpdates(
 	const abortController = new AbortController();
 	abortSignal.addEventListener("abort", () => abortController.abort());
 
+	const form = new FormData();
+
+	const optsJSON = JSON.stringify({
+		inputs: opts.inputs,
+		id: opts.messageId,
+		is_retry: opts.isRetry,
+		is_continue: opts.isContinue,
+		web_search: opts.webSearch,
+		tools: opts.tools,
+	});
+
+	opts.files?.forEach((file) => {
+		const name = file.type + ";" + file.name;
+
+		form.append("files", new File([file.value], name, { type: file.mime }));
+	});
+
+	form.append("data", optsJSON);
+
 	const response = await fetch(`${opts.base}/conversation/${conversationId}`, {
 		method: "POST",
-		headers: { "Content-Type": "application/json" },
-		body: JSON.stringify({
-			inputs: opts.inputs,
-			id: opts.messageId,
-			is_retry: opts.isRetry,
-			is_continue: opts.isContinue,
-			web_search: opts.webSearch,
-			tools: opts.tools,
-			files: opts.files,
-		}),
+		body: form,
 		signal: abortController.signal,
 	});
 


### PR DESCRIPTION
We were running into issues with the file upload mechanism. The old way was to encode the file as a `base64` string and POST a request with a JSON body, including the files. This worked OK locally but the body got too big in prod and the request would get denied with a 413. 

So I switched to using `FormData` instead (like we do for the assistant avatar since that seemed to work ok).

 In order to keep the PR simple, everything except the files is still a stringified JSON inside of `form.get('data')` but I moved the files to `form.getAll("files")` 