### PR TITLE
fix(scrape parser): Cannot read properties of 'undefined' during page parsing

### DIFF
--- a/src/lib/server/websearch/scrape/parser.ts
+++ b/src/lib/server/websearch/scrape/parser.ts
@@ -432,7 +432,7 @@ export function spatialParser() {
 		});
 
 		// if there is a dominant cluster with more than 60% text share, return that
-		const dominantCluster = clusterWithMetrics[0].percentageTextShare > 60;
+		const dominantCluster = clusterWithMetrics[0]?.percentageTextShare > 60;
 		if (dominantCluster) return [clusterWithMetrics[0].cluster];
 
 		// clusters are sorted by text share after applying a penalty for centrality
@@ -448,7 +448,7 @@ export function spatialParser() {
 		// find all clusters that are similar to the largest cluster in terms of text share
 		// and see if they are enough to cover at least 60% of the text share
 		const largeTextShareClusters = sortedClusters.filter((c) =>
-			approximatelyEqual(c.percentageTextShare, sortedClusters[0].percentageTextShare, 10)
+			approximatelyEqual(c.percentageTextShare, sortedClusters[0]?.percentageTextShare, 10)
 		);
 
 		const totalTextShareOfLargeClusters = largeTextShareClusters.reduce(


### PR DESCRIPTION
Fix of the error that occurs during parsing of the web search results

![image](https://github.com/huggingface/chat-ui/assets/35399376/76925eb1-c743-430d-af3c-4ba4f7ae0fef)
