### PR TITLE
Standardize llama.cpp endpoint with `baseURL`

### DIFF
--- a/src/lib/server/endpoints/llamacpp/endpointLlamacpp.ts
+++ b/src/lib/server/endpoints/llamacpp/endpointLlamacpp.ts
@@ -5,27 +5,22 @@ import type { Endpoint } from "../endpoints";
 import { z } from "zod";
 import { logger } from "$lib/server/logger";
 
-export const endpointLlamacppParametersSchema = z
-	.object({
-		weight: z.number().int().positive().default(1),
-		model: z.any(),
-		type: z.literal("llamacpp"),
-		url: z.string().url().default("http://127.0.0.1:8080"), // legacy, feel free to remove in breaking change update
-		baseURL: z.string().url().optional(),
-		accessToken: z
-			.string()
-			.min(1)
-			.default(env.HF_TOKEN ?? env.HF_ACCESS_TOKEN),
-	})
-	.transform((params) => ({
-		...params,
-		baseURL: params.baseURL ?? params.url,
-	}));
+export const endpointLlamacppParametersSchema = z.object({
+	weight: z.number().int().positive().default(1),
+	model: z.any(),
+	type: z.literal("llamacpp"),
+	url: z.string().url().default("http://127.0.0.1:8080"), // legacy, feel free to remove in breaking change update
+	baseURL: z.string().url().optional(),
+	accessToken: z
+		.string()
+		.min(1)
+		.default(env.HF_TOKEN ?? env.HF_ACCESS_TOKEN),
+});
 
 export function endpointLlamacpp(
 	input: z.input<typeof endpointLlamacppParametersSchema>
 ): Endpoint {
-	const { baseURL, model } = endpointLlamacppParametersSchema.parse(input);
+	const { baseURL, url, model } = endpointLlamacppParametersSchema.parse(input);
 	return async ({ messages, preprompt, continueMessage, generateSettings }) => {
 		const prompt = await buildPrompt({
 			messages,
@@ -36,7 +31,7 @@ export function endpointLlamacpp(
 
 		const parameters = { ...model.parameters, ...generateSettings };
 
-		const r = await fetch(`${baseURL}/completion`, {
+		const r = await fetch(`${baseURL ?? url}/completion`, {
 			method: "POST",
 			headers: {
 				"Content-Type": "application/json",


### PR DESCRIPTION
llamacpp endpoint was using an `url` param instead of `baseURL` like everyone else