### PR TITLE
[tool] hugging face docs tool

### DIFF
--- a/src/lib/server/tools/hfDocs.ts
+++ b/src/lib/server/tools/hfDocs.ts
@@ -1,0 +1,47 @@
+import type { BackendTool } from ".";
+import { callSpace, getIpToken } from "./utils";
+
+const hfDocs: BackendTool = {
+	name: "hf_docs",
+	displayName: "Hugging Face Docs",
+	description:
+		"Use this tool to get relevant docs snippets regarding Hugging Face open source libraries (transformers, diffusers, accelerate, huggingface_hub) and Hugging Face hf.co platform.",
+	isOnByDefault: true,
+	parameterDefinitions: {
+		query: {
+			required: true,
+			type: "string",
+			description:
+				"A search query which will be used to fetch the most relevant docs snippets regarding the user's query",
+		},
+	},
+	async *call({ query }, { messages, ip, username }) {
+		const ipToken = await getIpToken(ip, username);
+
+		const userMessages = messages.filter(({ from }) => from === "user");
+		const previousUserMessages = userMessages.slice(0, -1);
+
+		const queryWithPreviousMsgs =
+			(previousUserMessages.length
+				? `Previous questions: \n${previousUserMessages
+						.map(({ content }) => `- ${content}`)
+						.join("\n")}`
+				: "") +
+			"\n\nCurrent Question: " +
+			String(query);
+
+		const outputs = await callSpace<string[], string[]>(
+			"huggingchat/hf-docs",
+			"/predict",
+			[queryWithPreviousMsgs, "RAG-friendly"],
+			ipToken
+		);
+
+		return {
+			outputs: [{ hfDocs: outputs[0] }],
+			display: false,
+		};
+	},
+};
+
+export default hfDocs;

--- a/src/lib/server/tools/index.ts
+++ b/src/lib/server/tools/index.ts
@@ -2,6 +2,7 @@ import type { MessageUpdate } from "$lib/types/MessageUpdate";
 import type { Tool, ToolResultSuccess } from "$lib/types/Tool";
 
 import calculator from "./calculator";
+import hfDocs from "./hfDocs";
 import directlyAnswer from "./directlyAnswer";
 import imageEditing from "./images/editing";
 import imageGeneration from "./images/generation";
@@ -30,4 +31,5 @@ export const allTools: BackendTool[] = [
 	imageEditing,
 	documentParser,
 	calculator,
+	hfDocs,
 ];


### PR DESCRIPTION
### Addition of new `hfDocs` tool

Given a user query about hugging face libraries usage, this tool will call space [huggingchat/hf-docs](https://huggingface.co/spaces/huggingchat/hf-docs) to get relevant docs snippets so that LLM can answer more accurately.

Related to https://github.com/huggingface/doc-builder/pull/506

<img width="700" alt="image" src="https://github.com/huggingface/chat-ui/assets/11827707/aa3cf9b9-95af-4041-9f9e-dc4d430aab0b">
