### PR TITLE
Move Google GenAI API key to env file instead

### DIFF
--- a/.env
+++ b/.env
@@ -16,6 +16,7 @@ ANTHROPIC_API_KEY=#your anthropic api key here
 CLOUDFLARE_ACCOUNT_ID=#your cloudflare account id here
 CLOUDFLARE_API_TOKEN=#your cloudflare api token here
 COHERE_API_TOKEN=#your cohere api token here
+GOOGLE_GENAI_API_KEY=#your google genai api token here
 
 HF_ACCESS_TOKEN=#LEGACY! Use HF_TOKEN instead
 

--- a/docs/source/configuration/models/providers/google.md
+++ b/docs/source/configuration/models/providers/google.md
@@ -52,7 +52,11 @@ MODELS=`[
 
 Or use the Gemini API API provider [from](https://github.com/google-gemini/generative-ai-js#readme):
 
-> Make sure that you have an API key from Google Cloud Platform. To get an API key, follow the instructions [here](https://cloud.google.com/docs/authentication/api-keys).
+Make sure that you have an API key from Google Cloud Platform. To get an API key, follow the instructions [here](https://ai.google.dev/gemini-api/docs/api-key).
+
+You can either specify them directly in your `.env.local` using the `GOOGLE_GENAI_API_KEY` variables, or you can set them directly in the endpoint config.
+
+You can find the list of models available [here](https://ai.google.dev/gemini-api/docs/models/gemini), and experimental models available [here](https://ai.google.dev/gemini-api/docs/models/experimental-models).
 
 ```ini
 MODELS=`[
@@ -63,12 +67,12 @@ MODELS=`[
     "endpoints": [
       {
         "type": "genai",
+
+        // Optional
         "apiKey": "abc...xyz"
+        "safetyThreshold": "BLOCK_MEDIUM_AND_ABOVE",
       }
     ]
-
-    // Optional
-    "safetyThreshold": "BLOCK_MEDIUM_AND_ABOVE",
   },
   {
     "name": "gemini-1.5-pro",
@@ -77,6 +81,8 @@ MODELS=`[
     "endpoints": [
       {
         "type": "genai",
+
+        // Optional
         "apiKey": "abc...xyz"
       }
     ]


### PR DESCRIPTION
- Updated the documentation with the latest links from Google AI Studio
- Fixed the incorrect documentation on `safetyThreshold`
- Fixed the `safetySettings` to exclude unspecified category, as it is not considered as a valid input category in Google's API