### PR TITLE
fix(continue): fix continue feature 

### DIFF
--- a/src/lib/buildPrompt.ts
+++ b/src/lib/buildPrompt.ts
@@ -28,6 +28,7 @@ export async function buildPrompt({
 			preprompt,
 			tools,
 			toolResults,
+			continueMessage,
 		})
 		// Not super precise, but it's truncated in the model's backend anyway
 		.split(" ")

--- a/src/lib/buildPrompt.ts
+++ b/src/lib/buildPrompt.ts
@@ -35,12 +35,20 @@ export async function buildPrompt({
 		.join(" ");
 
 	if (continueMessage && model.parameters?.stop) {
-		prompt = model.parameters.stop.reduce((acc: string, curr: string) => {
-			if (acc.endsWith(curr)) {
-				return acc.slice(0, acc.length - curr.length);
+		let trimmedPrompt = prompt.trimEnd();
+		let hasRemovedStop = true;
+		while (hasRemovedStop) {
+			hasRemovedStop = false;
+			for (const stopToken of model.parameters.stop) {
+				if (trimmedPrompt.endsWith(stopToken)) {
+					trimmedPrompt = trimmedPrompt.slice(0, -stopToken.length);
+					hasRemovedStop = true;
+					break;
+				}
 			}
-			return acc;
-		}, prompt.trimEnd());
+			trimmedPrompt = trimmedPrompt.trimEnd();
+		}
+		prompt = trimmedPrompt;
 	}
 
 	return prompt;

--- a/src/lib/server/models.ts
+++ b/src/lib/server/models.ts
@@ -94,7 +94,13 @@ async function getChatPromptRender(
 		process.exit();
 	}
 
-	const renderTemplate = ({ messages, preprompt, tools, toolResults }: ChatTemplateInput) => {
+	const renderTemplate = ({
+		messages,
+		preprompt,
+		tools,
+		toolResults,
+		continueMessage,
+	}: ChatTemplateInput) => {
 		let formattedMessages: { role: string; content: string }[] = messages.map((message) => ({
 			content: message.content,
 			role: message.from,
@@ -222,10 +228,8 @@ async function getChatPromptRender(
 
 		const output = tokenizer.apply_chat_template(formattedMessages, {
 			tokenize: false,
-			add_generation_prompt: true,
+			add_generation_prompt: !continueMessage,
 			chat_template: chatTemplate,
-			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-			// @ts-ignore
 			tools: mappedTools,
 			documents,
 		});

--- a/src/lib/types/Template.ts
+++ b/src/lib/types/Template.ts
@@ -6,4 +6,5 @@ export type ChatTemplateInput = {
 	preprompt?: string;
 	tools?: Tool[];
 	toolResults?: ToolResult[];
+	continueMessage?: boolean;
 };


### PR DESCRIPTION
Made the end token stripping code more robust

Also made sure to set `add_generation_prompt: false` for continue mode

Paired with fixes to the chat prompt template for llama 3.1 70b: https://huggingface.co/nsarrazin/llama3.1-tokenizer/commit/9bf7a8ffd049a7f43d6c93b327cc5ab7f0e17c4b


should fix continue mode