### PR TITLE
fix(websearch): fix `webSearch` flag use for model with tool use

### DIFF
--- a/src/lib/server/textGeneration/index.ts
+++ b/src/lib/server/textGeneration/index.ts
@@ -62,10 +62,7 @@ async function* textGenerationWithoutTitle(
 	// - it's not continuing a previous message
 	// - AND the model doesn't support tools and websearch is selected
 	// - OR the assistant has websearch enabled (no tools for assistants for now)
-	if (
-		!isContinue &&
-		((!model.tools && webSearch && !conv.assistantId) || assistantHasWebSearch(assistant))
-	) {
+	if (!isContinue && ((webSearch && !conv.assistantId) || assistantHasWebSearch(assistant))) {
 		webSearchResult = yield* runWebSearch(conv, messages, assistant?.rag);
 	}
 

--- a/src/routes/conversation/[id]/+page.svelte
+++ b/src/routes/conversation/[id]/+page.svelte
@@ -32,6 +32,8 @@
 	let loading = false;
 	let pending = false;
 
+	$: activeModel = findCurrentModel([...data.models, ...data.oldModels], data.model);
+
 	let files: File[] = [];
 
 	async function convFromShared() {
@@ -201,7 +203,7 @@
 					messageId,
 					isRetry,
 					isContinue,
-					webSearch: !hasAssistant && $webSearchParameters.useSearch,
+					webSearch: !hasAssistant && !activeModel.tools && $webSearchParameters.useSearch,
 					tools: $settings.tools, // preference for tools
 					files: isRetry ? userMessage?.files : base64Files,
 				},


### PR DESCRIPTION
This should fix the web search toggle for llama 3.1 and command R+ on the native apps.

We were setting the toggle to false on all requests where the model had tools but since the native apps don't have tool support yet this would prevent it from working