### PR TITLE
Fix: Cohere Endpoint - Add Support for Tools

### DIFF
--- a/src/lib/server/endpoints/cohere/endpointCohere.ts
+++ b/src/lib/server/endpoints/cohere/endpointCohere.ts
@@ -62,7 +62,7 @@ export async function endpointCohere(
 				});
 
 				stream = await cohere.chatStream({
-					force_single_step: true,
+					forceSingleStep: true,
 					message: prompt,
 					rawPrompting: true,
 					model: model.id ?? model.name,
@@ -83,7 +83,7 @@ export async function endpointCohere(
 
 				stream = await cohere
 					.chatStream({
-						force_single_step: true,
+						forceSingleStep: true,
 						model: model.id ?? model.name,
 						chatHistory: formattedMessages.slice(0, -1),
 						message: formattedMessages[formattedMessages.length - 1].message,

--- a/src/lib/server/endpoints/cohere/endpointCohere.ts
+++ b/src/lib/server/endpoints/cohere/endpointCohere.ts
@@ -62,6 +62,7 @@ export async function endpointCohere(
 				});
 
 				stream = await cohere.chatStream({
+					force_single_step: true,
 					message: prompt,
 					rawPrompting: true,
 					model: model.id ?? model.name,
@@ -82,6 +83,7 @@ export async function endpointCohere(
 
 				stream = await cohere
 					.chatStream({
+						force_single_step: true,
 						model: model.id ?? model.name,
 						chatHistory: formattedMessages.slice(0, -1),
 						message: formattedMessages[formattedMessages.length - 1].message,


### PR DESCRIPTION
This pull request addresses the issue described in https://github.com/huggingface/chat-ui/issues/1404#issue-2460503883, where attempting to use tools with the Cohere endpoint results in the following error: `cannot specify both message and tool_results in multistep mode`.

Since the Chat UI project handles the tool usage process, the multistep feature provided by the Cohere endpoint is unnecessary in this context. Therefore, I've modified the implementation to enforce a single API call, which resolves the issue.

**Tested on:**
- **OS**: Ubuntu 22.04 
- **Node.js Version**: v22.9.0
