### PR TITLE
Remove right margin from custom scrollbar

### DIFF
--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -235,7 +235,7 @@
 		/>
 	{/if}
 	<div
-		class="scrollbar-custom mr-1 h-full overflow-y-auto"
+		class="scrollbar-custom h-full overflow-y-auto"
 		use:snapScrollToBottom={messages.length ? [...messages] : false}
 		bind:this={chatContainer}
 	>

--- a/src/routes/assistants/+page.svelte
+++ b/src/routes/assistants/+page.svelte
@@ -114,7 +114,7 @@
 	{/if}
 </svelte:head>
 
-<div class="scrollbar-custom mr-1 h-full overflow-y-auto py-12 max-sm:pt-8 md:py-24">
+<div class="scrollbar-custom h-full overflow-y-auto py-12 max-sm:pt-8 md:py-24">
 	<div class="pt-42 mx-auto flex flex-col px-5 xl:w-[60rem] 2xl:w-[64rem]">
 		<div class="flex items-center">
 			<h1 class="text-2xl font-bold">Assistants</h1>

--- a/src/routes/models/+page.svelte
+++ b/src/routes/models/+page.svelte
@@ -23,7 +23,7 @@
 	{/if}
 </svelte:head>
 
-<div class="scrollbar-custom mr-1 h-full overflow-y-auto py-12 max-sm:pt-8 md:py-24">
+<div class="scrollbar-custom h-full overflow-y-auto py-12 max-sm:pt-8 md:py-24">
 	<div class="pt-42 mx-auto flex flex-col px-5 xl:w-[60rem] 2xl:w-[64rem]">
 		<div class="flex items-center">
 			<h1 class="text-2xl font-bold">Models</h1>

--- a/src/routes/tools/+page.svelte
+++ b/src/routes/tools/+page.svelte
@@ -98,7 +98,7 @@
 	};
 </script>
 
-<div class="scrollbar-custom mr-1 h-full overflow-y-auto py-12 max-sm:pt-8 md:py-24">
+<div class="scrollbar-custom h-full overflow-y-auto py-12 max-sm:pt-8 md:py-24">
 	<div class="pt-42 mx-auto flex flex-col px-5 xl:w-[60rem] 2xl:w-[64rem]">
 		<div class="flex items-center">
 			<h1 class="text-2xl font-bold">Tools</h1>


### PR DESCRIPTION
Here's a basic pull request for an attempt at fixing #1492

You can use it as a starting point. It's not tested (tried to run `npm run preview` locally but it failed due to lack of MongoDB, seems like getting this to work isn't trivial for me and it'd take some more time and effort than I have right now).

I simply removed the tailwind class `mr-1`, which means:

```css
.mr-1 {
  margin-right: .25rem;
}
```

From instances of `custom-scrollbar` in these source files:

`src/lib/components/chat/ChatWindow.svelte`
`src/routes/assistants/+page.svelte`
`src/routes/models/+page.svelte`
`src/routes/tools/+page.svelte`

You'll need to test it yourself to ensure it actually works.