### PR TITLE
feat: Update featured workflow to allow user to submit featured requests

### DIFF
--- a/scripts/populate.ts
+++ b/scripts/populate.ts
@@ -20,6 +20,7 @@ import { Message } from "../src/lib/types/Message.ts";
 
 import { addChildren } from "../src/lib/utils/tree/addChildren.ts";
 import { generateSearchTokens } from "../src/lib/utils/searchTokens.ts";
+import { ReviewStatus } from "../src/lib/types/Review.ts";
 
 const rl = readline.createInterface({
 	input: process.stdin,
@@ -148,6 +149,7 @@ async function seed() {
 				updatedAt: faker.date.recent({ days: 30 }),
 				customPrompts: {},
 				assistants: [],
+				disableStream: faker.datatype.boolean(0.25),
 			};
 			await collections.settings.updateOne(
 				{ userId: user._id },
@@ -172,7 +174,7 @@ async function seed() {
 						createdAt: faker.date.recent({ days: 30 }),
 						updatedAt: faker.date.recent({ days: 30 }),
 						userCount: faker.number.int({ min: 1, max: 100000 }),
-						featured: faker.datatype.boolean(0.25),
+						review: faker.helpers.enumValue(ReviewStatus),
 						modelId: faker.helpers.arrayElement(modelIds),
 						description: faker.lorem.sentence(),
 						preprompt: faker.hacker.phrase(),
@@ -304,7 +306,9 @@ async function seed() {
 						createdAt: faker.date.recent({ days: 30 }),
 						updatedAt: faker.date.recent({ days: 30 }),
 						searchTokens: generateSearchTokens(displayName),
-						featured: faker.datatype.boolean(),
+						review: faker.helpers.enumValue(ReviewStatus),
+						outputComponent: null,
+						outputComponentIdx: null,
 					};
 				},
 				{ count: faker.number.int({ min: 10, max: 200 }) }

--- a/src/lib/migrations/routines/06-trim-message-updates.ts
+++ b/src/lib/migrations/routines/06-trim-message-updates.ts
@@ -41,7 +41,7 @@ function convertMessageUpdate(message: Message, update: MessageUpdate): MessageU
 }
 
 const trimMessageUpdates: Migration = {
-	_id: new ObjectId("000000000006"),
+	_id: new ObjectId("000000000000000000000006"),
 	name: "Trim message updates to reduce stored size",
 	up: async () => {
 		const allConversations = collections.conversations.find({});

--- a/src/lib/migrations/routines/07-reset-tools-in-settings.ts
+++ b/src/lib/migrations/routines/07-reset-tools-in-settings.ts
@@ -3,7 +3,7 @@ import { collections } from "$lib/server/database";
 import { ObjectId } from "mongodb";
 
 const resetTools: Migration = {
-	_id: new ObjectId("000000000007"),
+	_id: new ObjectId("000000000000000000000007"),
 	name: "Reset tools to empty",
 	up: async () => {
 		const { settings } = collections;

--- a/src/lib/migrations/routines/08-update-featured-to-review.ts
+++ b/src/lib/migrations/routines/08-update-featured-to-review.ts
@@ -1,0 +1,32 @@
+import type { Migration } from ".";
+import { collections } from "$lib/server/database";
+import { ObjectId } from "mongodb";
+import { ReviewStatus } from "$lib/types/Review";
+
+const updateFeaturedToReview: Migration = {
+	_id: new ObjectId("000000000000000000000008"),
+	name: "Update featured to review",
+	up: async () => {
+		const { assistants, tools } = collections;
+
+		// Update assistants
+		await assistants.updateMany({ featured: true }, { $set: { review: ReviewStatus.APPROVED } });
+		await assistants.updateMany(
+			{ featured: { $ne: true } },
+			{ $set: { review: ReviewStatus.PRIVATE } }
+		);
+
+		await assistants.updateMany({}, { $unset: { featured: "" } });
+
+		// Update tools
+		await tools.updateMany({ featured: true }, { $set: { review: ReviewStatus.APPROVED } });
+		await tools.updateMany({ featured: { $ne: true } }, { $set: { review: ReviewStatus.PRIVATE } });
+
+		await tools.updateMany({}, { $unset: { featured: "" } });
+
+		return true;
+	},
+	runEveryTime: false,
+};
+
+export default updateFeaturedToReview;

--- a/src/lib/migrations/routines/index.ts
+++ b/src/lib/migrations/routines/index.ts
@@ -8,6 +8,7 @@ import updateMessageUpdates from "./04-update-message-updates";
 import updateMessageFiles from "./05-update-message-files";
 import trimMessageUpdates from "./06-trim-message-updates";
 import resetTools from "./07-reset-tools-in-settings";
+import updateFeaturedToReview from "./08-update-featured-to-review";
 
 export interface Migration {
 	_id: ObjectId;
@@ -27,4 +28,5 @@ export const migrations: Migration[] = [
 	updateMessageFiles,
 	trimMessageUpdates,
 	resetTools,
+	updateFeaturedToReview,
 ];

--- a/src/lib/server/database.ts
+++ b/src/lib/server/database.ts
@@ -202,7 +202,7 @@ export class Database {
 		sessions.createIndex({ sessionId: 1 }, { unique: true }).catch((e) => logger.error(e));
 		assistants.createIndex({ createdById: 1, userCount: -1 }).catch((e) => logger.error(e));
 		assistants.createIndex({ userCount: 1 }).catch((e) => logger.error(e));
-		assistants.createIndex({ featured: 1, userCount: -1 }).catch((e) => logger.error(e));
+		assistants.createIndex({ review: 1, userCount: -1 }).catch((e) => logger.error(e));
 		assistants.createIndex({ modelId: 1, userCount: -1 }).catch((e) => logger.error(e));
 		assistants.createIndex({ searchTokens: 1 }).catch((e) => logger.error(e));
 		assistants.createIndex({ last24HoursCount: 1 }).catch((e) => logger.error(e));

--- a/src/lib/server/sendSlack.ts
+++ b/src/lib/server/sendSlack.ts
@@ -1,0 +1,23 @@
+import { env } from "$env/dynamic/private";
+import { logger } from "$lib/server/logger";
+
+export async function sendSlack(text: string) {
+	if (!env.WEBHOOK_URL_REPORT_ASSISTANT) {
+		logger.warn("WEBHOOK_URL_REPORT_ASSISTANT is not set, tried to send a slack message.");
+		return;
+	}
+
+	const res = await fetch(env.WEBHOOK_URL_REPORT_ASSISTANT, {
+		method: "POST",
+		headers: {
+			"Content-type": "application/json",
+		},
+		body: JSON.stringify({
+			text,
+		}),
+	});
+
+	if (!res.ok) {
+		logger.error(`Webhook message failed. ${res.statusText} ${res.text}`);
+	}
+}

--- a/src/lib/types/Assistant.ts
+++ b/src/lib/types/Assistant.ts
@@ -1,6 +1,7 @@
 import type { ObjectId } from "mongodb";
 import type { User } from "./User";
 import type { Timestamps } from "./Timestamps";
+import type { ReviewStatus } from "./Review";
 
 export interface Assistant extends Timestamps {
 	_id: ObjectId;
@@ -13,7 +14,7 @@ export interface Assistant extends Timestamps {
 	exampleInputs: string[];
 	preprompt: string;
 	userCount?: number;
-	featured?: boolean;
+	review: ReviewStatus;
 	rag?: {
 		allowAllDomains: boolean;
 		allowedDomains: string[];

--- a/src/lib/types/Review.ts
+++ b/src/lib/types/Review.ts
@@ -1,0 +1,6 @@
+export enum ReviewStatus {
+	PRIVATE = "PRIVATE",
+	PENDING = "PENDING",
+	APPROVED = "APPROVED",
+	DENIED = "DENIED",
+}

--- a/src/lib/types/Tool.ts
+++ b/src/lib/types/Tool.ts
@@ -4,6 +4,7 @@ import type { Timestamps } from "./Timestamps";
 import type { BackendToolContext } from "$lib/server/tools";
 import type { MessageUpdate } from "./MessageUpdate";
 import { z } from "zod";
+import type { ReviewStatus } from "./Review";
 
 export const ToolColor = z.union([
 	z.literal("purple"),
@@ -122,7 +123,7 @@ export interface CommunityTool extends BaseTool, Timestamps {
 	useCount: number;
 	last24HoursUseCount: number;
 
-	featured: boolean;
+	review: ReviewStatus;
 	searchTokens: string[];
 }
 
@@ -136,7 +137,7 @@ export type CommunityToolEditable = Omit<
 	| "last24HoursUseCount"
 	| "createdById"
 	| "createdByName"
-	| "featured"
+	| "review"
 	| "searchTokens"
 	| "type"
 	| "createdAt"

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -11,6 +11,7 @@ import type { ConvSidebar } from "$lib/types/ConvSidebar";
 import { toolFromConfigs } from "$lib/server/tools";
 import { MetricsServer } from "$lib/server/metrics";
 import type { ToolFront, ToolInputFile } from "$lib/types/Tool";
+import { ReviewStatus } from "$lib/types/Review";
 
 export const load: LayoutServerLoad = async ({ locals, depends, request }) => {
 	depends(UrlDependency.ConversationList);
@@ -221,7 +222,7 @@ export const load: LayoutServerLoad = async ({ locals, depends, request }) => {
 			),
 		communityToolCount: await collections.tools.countDocuments({
 			type: "community",
-			featured: true,
+			review: ReviewStatus.APPROVED,
 		}),
 		assistants: assistants
 			.filter((el) => userAssistantsSet.has(el._id.toString()))

--- a/src/routes/api/assistants/+server.ts
+++ b/src/routes/api/assistants/+server.ts
@@ -4,6 +4,7 @@ import type { User } from "$lib/types/User";
 import { generateQueryTokens } from "$lib/utils/searchTokens.js";
 import type { Filter } from "mongodb";
 import { env } from "$env/dynamic/private";
+import { ReviewStatus } from "$lib/types/Review";
 
 const NUM_PER_PAGE = 24;
 
@@ -27,7 +28,7 @@ export async function GET({ url, locals }) {
 
 	// if there is no user, we show community assistants, so only show featured assistants
 	const shouldBeFeatured =
-		env.REQUIRE_FEATURED_ASSISTANTS === "true" && !user ? { featured: true } : {};
+		env.REQUIRE_FEATURED_ASSISTANTS === "true" && !user ? { review: ReviewStatus.APPROVED } : {};
 
 	// if the user queried is not the current user, only show "public" assistants that have been shared before
 	const shouldHaveBeenShared =

--- a/src/routes/api/tools/[toolId]/+server.ts
+++ b/src/routes/api/tools/[toolId]/+server.ts
@@ -1,6 +1,7 @@
 import { env } from "$env/dynamic/private";
 import { collections } from "$lib/server/database.js";
 import { toolFromConfigs } from "$lib/server/tools/index.js";
+import { ReviewStatus } from "$lib/types/Review";
 import type { CommunityToolDB } from "$lib/types/Tool.js";
 import { ObjectId } from "mongodb";
 
@@ -33,12 +34,12 @@ export async function GET({ params }) {
 								color: tool.color,
 								icon: tool.icon,
 								createdByName: tool.createdByName,
-								featured: tool.featured,
+								review: tool.review,
 						  }
 						: undefined
 				);
 
-			if (!tool || !tool.featured) {
+			if (!tool || tool.review !== ReviewStatus.APPROVED) {
 				return new Response(`Tool "${toolId}" not found`, { status: 404 });
 			}
 

--- a/src/routes/api/tools/search/+server.ts
+++ b/src/routes/api/tools/search/+server.ts
@@ -4,7 +4,7 @@ import { toolFromConfigs } from "$lib/server/tools/index.js";
 import type { BaseTool, CommunityToolDB } from "$lib/types/Tool.js";
 import { generateQueryTokens, generateSearchTokens } from "$lib/utils/searchTokens.js";
 import type { Filter } from "mongodb";
-
+import { ReviewStatus } from "$lib/types/Review";
 export async function GET({ url }) {
 	if (env.COMMUNITY_TOOLS !== "true") {
 		return new Response("Community tools are not enabled", { status: 403 });
@@ -15,7 +15,7 @@ export async function GET({ url }) {
 
 	const filter: Filter<CommunityToolDB> = {
 		...(queryTokens && { searchTokens: { $all: queryTokens } }),
-		featured: true,
+		review: ReviewStatus.APPROVED,
 	};
 
 	const matchingCommunityTools = await collections.tools

--- a/src/routes/assistants/+page.server.ts
+++ b/src/routes/assistants/+page.server.ts
@@ -6,7 +6,7 @@ import type { User } from "$lib/types/User";
 import { generateQueryTokens } from "$lib/utils/searchTokens.js";
 import { error, redirect } from "@sveltejs/kit";
 import type { Filter } from "mongodb";
-
+import { ReviewStatus } from "$lib/types/Review";
 const NUM_PER_PAGE = 24;
 
 export const load = async ({ url, locals }) => {
@@ -36,7 +36,7 @@ export const load = async ({ url, locals }) => {
 	// if there is no user, we show community assistants, so only show featured assistants
 	const shouldBeFeatured =
 		env.REQUIRE_FEATURED_ASSISTANTS === "true" && !user && !(locals.user?.isAdmin && showUnfeatured)
-			? { featured: true }
+			? { review: ReviewStatus.APPROVED }
 			: {};
 
 	// if the user queried is not the current user, only show "public" assistants that have been shared before

--- a/src/routes/assistants/+page.svelte
+++ b/src/routes/assistants/+page.svelte
@@ -25,6 +25,7 @@
 	import IconInternet from "$lib/components/icons/IconInternet.svelte";
 	import { isDesktop } from "$lib/utils/isDesktop";
 	import { SortKey } from "$lib/types/Assistant";
+	import { ReviewStatus } from "$lib/types/Review";
 
 	export let data: PageData;
 
@@ -245,7 +246,7 @@
 
 				<button
 					class="relative flex flex-col items-center justify-center overflow-hidden text-balance rounded-xl border bg-gray-50/50 px-4 py-6 text-center shadow hover:bg-gray-50 hover:shadow-inner dark:border-gray-800/70 dark:bg-gray-950/20 dark:hover:bg-gray-950/40 max-sm:px-4 sm:h-64 sm:pb-4 xl:pt-8
-					{!assistant.featured && !createdByMe ? 'border !border-red-500/30' : ''}"
+					{!(assistant.review === ReviewStatus.APPROVED) && !createdByMe ? 'border !border-red-500/30' : ''}"
 					on:click={() => {
 						if (data.settings.assistants.includes(assistant._id.toString())) {
 							settings.instantSet({ activeModel: assistant._id.toString() });

--- a/src/routes/settings/(nav)/assistants/[assistantId]/+page.svelte
+++ b/src/routes/settings/(nav)/assistants/[assistantId]/+page.svelte
@@ -15,11 +15,13 @@
 	import CarbonChat from "~icons/carbon/chat";
 	import CarbonStar from "~icons/carbon/star";
 	import CarbonTools from "~icons/carbon/tools";
+	import CarbonLock from "~icons/carbon/locked";
 
 	import CopyToClipBoardBtn from "$lib/components/CopyToClipBoardBtn.svelte";
 	import ReportModal from "./ReportModal.svelte";
 	import IconInternet from "$lib/components/icons/IconInternet.svelte";
 	import ToolBadge from "$lib/components/ToolBadge.svelte";
+	import { ReviewStatus } from "$lib/types/Review";
 
 	export let data: PageData;
 
@@ -151,24 +153,51 @@
 					{/if}
 				{/if}
 				{#if data?.user?.isAdmin}
-					<form method="POST" action="?/delete" use:enhance>
-						<button type="submit" class="flex items-center text-red-600 underline">
-							<CarbonTrash class="mr-1.5 inline text-xs" />Delete</button
-						>
-					</form>
-					{#if assistant?.featured}
-						<form method="POST" action="?/unfeature" use:enhance>
+					{#if !assistant?.createdByMe}
+						<form method="POST" action="?/delete" use:enhance>
 							<button type="submit" class="flex items-center text-red-600 underline">
-								<CarbonTrash class="mr-1.5 inline text-xs" />Un-feature</button
-							>
-						</form>
-					{:else}
-						<form method="POST" action="?/feature" use:enhance>
-							<button type="submit" class="flex items-center text-green-600 underline">
-								<CarbonStar class="mr-1.5 inline text-xs" />Feature</button
+								<CarbonTrash class="mr-1.5 inline text-xs" />Delete</button
 							>
 						</form>
 					{/if}
+					{#if assistant?.review === ReviewStatus.PENDING}
+						<form method="POST" action="?/approve" use:enhance>
+							<button type="submit" class="flex items-center text-green-600 underline">
+								<CarbonStar class="mr-1.5 inline text-xs" />Approve</button
+							>
+						</form>
+						<form method="POST" action="?/deny" use:enhance>
+							<button type="submit" class="flex items-center text-red-600">
+								<span class="mr-1.5 font-light no-underline">X</span>
+								<span class="underline">Deny</span>
+							</button>
+						</form>
+					{/if}
+					{#if assistant?.review === ReviewStatus.APPROVED || assistant?.review === ReviewStatus.DENIED}
+						<form method="POST" action="?/unrequest" use:enhance>
+							<button type="submit" class="flex items-center text-red-600 underline">
+								<CarbonLock class="mr-1.5 inline text-xs " />Make private</button
+							>
+						</form>
+					{/if}
+				{/if}
+				{#if assistant?.createdByMe && assistant?.review === ReviewStatus.PRIVATE}
+					<form
+						method="POST"
+						action="?/request"
+						use:enhance={async ({ cancel }) => {
+							const confirmed = confirm(
+								"Are you sure you want to request this assistant to be featured? Make sure you have tried the assistant and that it works as expected. "
+							);
+							if (!confirmed) {
+								cancel();
+							}
+						}}
+					>
+						<button type="submit" class="text-grey-600 flex items-center underline">
+							<CarbonStar class="mr-1.5 inline text-xs" />Request to be featured</button
+						>
+					</form>
 				{/if}
 			</div>
 		</div>

--- a/src/routes/settings/(nav)/assistants/[assistantId]/+page.svelte
+++ b/src/routes/settings/(nav)/assistants/[assistantId]/+page.svelte
@@ -194,7 +194,7 @@
 							}
 						}}
 					>
-						<button type="submit" class="text-grey-600 flex items-center underline">
+						<button type="submit" class="flex items-center underline">
 							<CarbonStar class="mr-1.5 inline text-xs" />Request to be featured</button
 						>
 					</form>

--- a/src/routes/settings/(nav)/assistants/new/+page.server.ts
+++ b/src/routes/settings/(nav)/assistants/new/+page.server.ts
@@ -11,6 +11,7 @@ import { parseStringToList } from "$lib/utils/parseStringToList";
 import { usageLimits } from "$lib/server/usageLimits";
 import { generateSearchTokens } from "$lib/utils/searchTokens";
 import { toolFromConfigs } from "$lib/server/tools";
+import { ReviewStatus } from "$lib/types/Review";
 
 const newAsssistantSchema = z.object({
 	name: z.string().min(1),
@@ -148,7 +149,7 @@ export const actions: Actions = {
 			createdAt: new Date(),
 			updatedAt: new Date(),
 			userCount: 1,
-			featured: false,
+			review: ReviewStatus.PRIVATE,
 			rag: {
 				allowedLinks: parse.data.ragLinkList,
 				allowedDomains: parse.data.ragDomainList,

--- a/src/routes/tools/+page.server.ts
+++ b/src/routes/tools/+page.server.ts
@@ -3,6 +3,7 @@ import { authCondition } from "$lib/server/auth.js";
 import { Database, collections } from "$lib/server/database.js";
 import { toolFromConfigs } from "$lib/server/tools/index.js";
 import { SortKey } from "$lib/types/Assistant.js";
+import { ReviewStatus } from "$lib/types/Review";
 import type { CommunityToolDB } from "$lib/types/Tool.js";
 import type { User } from "$lib/types/User.js";
 import { generateQueryTokens, generateSearchTokens } from "$lib/utils/searchTokens.js";
@@ -47,7 +48,7 @@ export const load = async ({ url, locals }) => {
 	const filter: Filter<CommunityToolDB> = {
 		...(!createdByCurrentUser &&
 			!activeOnly &&
-			!(locals.user?.isAdmin && showUnfeatured) && { featured: true }),
+			!(locals.user?.isAdmin && showUnfeatured) && { review: ReviewStatus.APPROVED }),
 		...(user && { createdById: user._id }),
 		...(queryTokens && { searchTokens: { $all: queryTokens } }),
 		...(activeOnly && {

--- a/src/routes/tools/+page.svelte
+++ b/src/routes/tools/+page.svelte
@@ -19,6 +19,7 @@
 	import { isDesktop } from "$lib/utils/isDesktop";
 	import { SortKey } from "$lib/types/Assistant";
 	import ToolLogo from "$lib/components/ToolLogo.svelte";
+	import { ReviewStatus } from "$lib/types/Review";
 
 	export let data: PageData;
 
@@ -233,8 +234,9 @@
 				{@const isOfficial = !tool.createdByName}
 				<a
 					href="{base}/tools/{tool._id.toString()}"
-					class="relative flex flex-row items-center gap-4 overflow-hidden text-balance rounded-xl border bg-gray-50/50 px-4 text-center shadow hover:bg-gray-50 hover:shadow-inner dark:bg-gray-950/20 dark:hover:bg-gray-950/40 max-sm:px-4 sm:h-24 {!tool.featured &&
-					!isOfficial
+					class="relative flex flex-row items-center gap-4 overflow-hidden text-balance rounded-xl border bg-gray-50/50 px-4 text-center shadow hover:bg-gray-50 hover:shadow-inner dark:bg-gray-950/20 dark:hover:bg-gray-950/40 max-sm:px-4 sm:h-24 {!(
+						tool.review === ReviewStatus.APPROVED
+					) && !isOfficial
 						? ' border-red-500/30'
 						: 'dark:border-gray-800/70'}"
 					class:!border-blue-600={isActive}

--- a/src/routes/tools/[toolId]/+layout.server.ts
+++ b/src/routes/tools/[toolId]/+layout.server.ts
@@ -1,6 +1,7 @@
 import { base } from "$app/paths";
 import { collections } from "$lib/server/database.js";
 import { toolFromConfigs } from "$lib/server/tools/index.js";
+import { ReviewStatus } from "$lib/types/Review.js";
 import { redirect } from "@sveltejs/kit";
 import { ObjectId } from "mongodb";
 
@@ -21,7 +22,7 @@ export const load = async ({ params, locals }) => {
 				createdByName: null,
 				createdByMe: false,
 				reported: false,
-				featured: false,
+				review: ReviewStatus.APPROVED,
 			},
 		};
 	}

--- a/src/routes/tools/[toolId]/+page.svelte
+++ b/src/routes/tools/[toolId]/+page.svelte
@@ -207,7 +207,7 @@
 									}
 								}}
 							>
-								<button type="submit" class="text-grey-600 flex items-center underline">
+								<button type="submit" class="flex items-center underline">
 									<CarbonStar class="mr-1.5 inline text-xs" />Request to be featured</button
 								>
 							</form>

--- a/src/routes/tools/[toolId]/+page.svelte
+++ b/src/routes/tools/[toolId]/+page.svelte
@@ -6,6 +6,7 @@
 	import ToolLogo from "$lib/components/ToolLogo.svelte";
 	import { env as envPublic } from "$env/dynamic/public";
 	import { useSettingsStore } from "$lib/stores/settings";
+	import { ReviewStatus } from "$lib/types/Review";
 
 	import ReportModal from "../../settings/(nav)/assistants/[assistantId]/ReportModal.svelte";
 	import { applyAction, enhance } from "$app/forms";
@@ -17,6 +18,7 @@
 	import CarbonFlag from "~icons/carbon/flag";
 	import CarbonLink from "~icons/carbon/link";
 	import CarbonStar from "~icons/carbon/star";
+	import CarbonLock from "~icons/carbon/locked";
 
 	export let data;
 
@@ -99,7 +101,7 @@
 							<button
 								class="{isActive
 									? 'bg-gray-100 text-gray-800'
-									: 'bg-black !text-white'} mx-auto my-2 flex w-full w-min items-center justify-center rounded-full px-3 py-1 text-base"
+									: 'bg-black !text-white'} mx-auto my-2 flex w-min items-center justify-center rounded-full px-3 py-1 text-base"
 								name="Activate model"
 								on:click|stopPropagation={() => {
 									if (isActive) {
@@ -164,24 +166,51 @@
 							{/if}
 						{/if}
 						{#if data?.user?.isAdmin}
-							<form method="POST" action="?/delete" use:enhance>
-								<button type="submit" class="flex items-center text-red-600 underline">
-									<CarbonTrash class="mr-1.5 inline text-xs" />Delete</button
-								>
-							</form>
-							{#if data.tool?.featured}
-								<form method="POST" action="?/unfeature" use:enhance>
+							{#if !data.tool?.createdByMe}
+								<form method="POST" action="?/delete" use:enhance>
 									<button type="submit" class="flex items-center text-red-600 underline">
-										<CarbonTrash class="mr-1.5 inline text-xs" />Un-feature</button
-									>
-								</form>
-							{:else}
-								<form method="POST" action="?/feature" use:enhance>
-									<button type="submit" class="flex items-center text-green-600 underline">
-										<CarbonStar class="mr-1.5 inline text-xs" />Feature</button
+										<CarbonTrash class="mr-1.5 inline text-xs" />Delete</button
 									>
 								</form>
 							{/if}
+							{#if data.tool?.review === ReviewStatus.PENDING}
+								<form method="POST" action="?/approve" use:enhance>
+									<button type="submit" class="flex items-center text-green-600 underline">
+										<CarbonStar class="mr-1.5 inline text-xs" />Approve</button
+									>
+								</form>
+								<form method="POST" action="?/deny" use:enhance>
+									<button type="submit" class="flex items-center text-red-600">
+										<span class="mr-1.5 font-light no-underline">X</span>
+										<span class="underline">Deny</span>
+									</button>
+								</form>
+							{/if}
+							{#if data.tool?.review === ReviewStatus.APPROVED || data.tool?.review === ReviewStatus.DENIED}
+								<form method="POST" action="?/unrequest" use:enhance>
+									<button type="submit" class="flex items-center text-red-600 underline">
+										<CarbonLock class="mr-1.5 inline text-xs " />Make private</button
+									>
+								</form>
+							{/if}
+						{/if}
+						{#if data.tool?.createdByMe && data.tool?.review === ReviewStatus.PRIVATE}
+							<form
+								method="POST"
+								action="?/request"
+								use:enhance={async ({ cancel }) => {
+									const confirmed = confirm(
+										"Are you sure you want to request this tool to be featured? Make sure you have tried the tool and that it works as expected. We will review your request once submitted."
+									);
+									if (!confirmed) {
+										cancel();
+									}
+								}}
+							>
+								<button type="submit" class="text-grey-600 flex items-center underline">
+									<CarbonStar class="mr-1.5 inline text-xs" />Request to be featured</button
+								>
+							</form>
 						{/if}
 					</div>
 				</div>

--- a/src/routes/tools/new/+page.server.ts
+++ b/src/routes/tools/new/+page.server.ts
@@ -3,6 +3,7 @@ import { authCondition, requiresUser } from "$lib/server/auth.js";
 import { collections } from "$lib/server/database.js";
 import { editableToolSchema } from "$lib/server/tools/index.js";
 import { usageLimits } from "$lib/server/usageLimits.js";
+import { ReviewStatus } from "$lib/types/Review";
 import { generateSearchTokens } from "$lib/utils/searchTokens.js";
 import { error, fail } from "@sveltejs/kit";
 import { ObjectId } from "mongodb";
@@ -66,7 +67,7 @@ export const actions = {
 			updatedAt: new Date(),
 			last24HoursUseCount: 0,
 			useCount: 0,
-			featured: locals.user?.isAdmin ?? false, // admin tools are featured by default
+			review: ReviewStatus.PRIVATE,
 			searchTokens: generateSearchTokens(parse.data.displayName),
 		});
 


### PR DESCRIPTION
## Why

Currently we review all tools & assistants without checking if the user wants it to be reviewed. This means that we waste a lot of time on private stuff, tools that don't work, etc.


With this, the user can now ask to be featured, which will set a flag on the assistant and trigger a slack notification. Then the admin has two buttons to approve or deny a request. Once a request is denied the user won't be able to retrigger the flow. Admins can at any time reset an assistant or a tool to private (to un-feature something).

[(slack link)](https://huggingface.slack.com/archives/C052EKHD1U0/p1728468364907289?thread_ts=1728464686.106719&cid=C052EKHD1U0)

## How

The  `featured: boolean` flag was replaced by `review: "PRIVATE"|"PENDING"|"APPROVED"|"DENIED"`, with the appropriate migrations for tools & assistants. 

Buttons were added for admins to deny/approve and reset featured status. A button was added for user to request to be featured, with a confirm native modal to avoid misclicks.

Slack notifications were added for featured requests.


## Screenshots

### user
![image](https://github.com/user-attachments/assets/f5b27453-3842-4c32-875f-0fc6f9ba353f)
![image](https://github.com/user-attachments/assets/6385488d-57de-4bed-8363-b2c164e2bf96)

### admin

![image](https://github.com/user-attachments/assets/171cc50f-557f-4d6c-bac7-1e01bad17240)

