### PR TITLE
[vertex] Add PDF/plein texts support

### DIFF
--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -213,7 +213,7 @@
 		...(!$page.data?.assistant && currentModel.tools
 			? activeTools.flatMap((tool: ToolFront) => tool.mimeTypes ?? [])
 			: []),
-		...(currentModel.multimodal ? ["image/*"] : []),
+		...(currentModel.multimodal ? currentModel.multimodalAcceptedMimetypes ?? ["image/*"] : []),
 	];
 
 	$: isFileUploadEnabled = activeMimeTypes.length > 0;

--- a/src/lib/server/endpoints/document.ts
+++ b/src/lib/server/endpoints/document.ts
@@ -1,0 +1,75 @@
+import type { MessageFile } from "$lib/types/Message";
+import { z, type util } from "zod";
+
+export interface FileProcessorOptions<TMimeType extends string = string> {
+	supportedMimeTypes: TMimeType[];
+	preferredMimeType: TMimeType;
+	maxSizeInMB: number;
+}
+
+export type ImageProcessor<TMimeType extends string = string> = (file: MessageFile) => Promise<{
+	file: Buffer;
+	mime: TMimeType;
+}>;
+
+export const createDocumentProcessorOptionsValidator = <TMimeType extends string = string>(
+	defaults: FileProcessorOptions<TMimeType>
+) => {
+	return z
+		.object({
+			supportedMimeTypes: z
+				.array(
+					z.enum<string, [TMimeType, ...TMimeType[]]>([
+						defaults.supportedMimeTypes[0],
+						...defaults.supportedMimeTypes.slice(1),
+					])
+				)
+				.default(defaults.supportedMimeTypes),
+			preferredMimeType: z
+				.enum([defaults.supportedMimeTypes[0], ...defaults.supportedMimeTypes.slice(1)])
+				.default(defaults.preferredMimeType as util.noUndefined<TMimeType>),
+			maxSizeInMB: z.number().positive().default(defaults.maxSizeInMB),
+		})
+		.default(defaults);
+};
+
+export type DocumentProcessor<TMimeType extends string = string> = (file: MessageFile) => {
+	file: Buffer;
+	mime: TMimeType;
+};
+
+export function makeDocumentProcessor<TMimeType extends string = string>(
+	options: FileProcessorOptions<TMimeType>
+): DocumentProcessor<TMimeType> {
+	return (file) => {
+		const { supportedMimeTypes, preferredMimeType, maxSizeInMB } = options;
+		const { mime, value } = file;
+
+		const buffer = Buffer.from(value, "base64");
+
+		const tooLargeInBytes = buffer.byteLength > maxSizeInMB * 1000 * 1000;
+
+		if (tooLargeInBytes) {
+			throw Error("Document is too large");
+		}
+
+		const outputMime = validateMimeType(supportedMimeTypes, preferredMimeType, mime);
+
+		return { file: buffer, mime: outputMime };
+	};
+}
+
+const validateMimeType = <T extends readonly string[]>(
+	supportedMimes: T,
+	preferredMime: string,
+	mime: string
+): T[number] => {
+	if (!supportedMimes.includes(preferredMime)) {
+		const supportedMimesStr = supportedMimes.join(", ");
+		throw Error(
+			`Preferred format "${preferredMime}" not found in supported mimes: ${supportedMimesStr}`
+		);
+	}
+
+	return mime;
+};

--- a/src/lib/server/endpoints/google/endpointVertex.ts
+++ b/src/lib/server/endpoints/google/endpointVertex.ts
@@ -48,8 +48,7 @@ export const endpointVertexParametersSchema = z.object({
 				maxHeight: 4096,
 			}),
 			document: createDocumentProcessorOptionsValidator({
-				supportedMimeTypes: ["application/pdf"],
-				preferredMimeType: "application/pdf",
+				supportedMimeTypes: ["application/pdf", "text/plain"],
 				maxSizeInMB: 20,
 			}),
 		})
@@ -126,7 +125,7 @@ export function endpointVertex(input: z.input<typeof endpointVertexParametersSch
 										const { image, mime } = await imageProcessor(file);
 
 										return { file: image, mime };
-									} else if (file.mime === "application/pdf") {
+									} else if (file.mime === "application/pdf" || file.mime === "text/plain") {
 										return documentProcessor(file);
 									}
 

--- a/src/lib/server/endpoints/google/endpointVertex.ts
+++ b/src/lib/server/endpoints/google/endpointVertex.ts
@@ -51,7 +51,7 @@ export const endpointVertexParametersSchema = z.object({
 				supportedMimeTypes: ["application/pdf"],
 				preferredMimeType: "application/pdf",
 				maxSizeInMB: 20,
-			})
+			}),
 		})
 		.default({}),
 });

--- a/src/lib/server/endpoints/google/endpointVertex.ts
+++ b/src/lib/server/endpoints/google/endpointVertex.ts
@@ -10,6 +10,7 @@ import { z } from "zod";
 import type { Message } from "$lib/types/Message";
 import type { TextGenerationStreamOutput } from "@huggingface/inference";
 import { createImageProcessorOptionsValidator, makeImageProcessor } from "../images";
+import { createDocumentProcessorOptionsValidator, makeDocumentProcessor } from "../document";
 
 export const endpointVertexParametersSchema = z.object({
 	weight: z.number().int().positive().default(1),
@@ -39,12 +40,18 @@ export const endpointVertexParametersSchema = z.object({
 					"image/avif",
 					"image/tiff",
 					"image/gif",
+					"application/pdf",
 				],
 				preferredMimeType: "image/webp",
-				maxSizeInMB: Infinity,
+				maxSizeInMB: 20,
 				maxWidth: 4096,
 				maxHeight: 4096,
 			}),
+			document: createDocumentProcessorOptionsValidator({
+				supportedMimeTypes: ["application/pdf"],
+				preferredMimeType: "application/pdf",
+				maxSizeInMB: 20,
+			})
 		})
 		.default({}),
 });
@@ -109,17 +116,33 @@ export function endpointVertex(input: z.input<typeof endpointVertexParametersSch
 		const vertexMessages = await Promise.all(
 			messages.map(async ({ from, content, files }: Omit<Message, "id">): Promise<Content> => {
 				const imageProcessor = makeImageProcessor(multimodal.image);
-				const processedFiles =
+				const documentProcessor = makeDocumentProcessor(multimodal.document);
+
+				const processedFilesWithNull =
 					files && files.length > 0
-						? await Promise.all(files.map(async (file) => imageProcessor(file)))
+						? await Promise.all(
+								files.map(async (file) => {
+									if (file.mime.includes("image")) {
+										const { image, mime } = await imageProcessor(file);
+
+										return { file: image, mime };
+									} else if (file.mime === "application/pdf") {
+										return documentProcessor(file);
+									}
+
+									return null;
+								})
+						  )
 						: [];
+
+				const processedFiles = processedFilesWithNull.filter((file) => file !== null);
 
 				return {
 					role: from === "user" ? "user" : "model",
 					parts: [
 						...processedFiles.map((processedFile) => ({
 							inlineData: {
-								data: processedFile.image.toString("base64"),
+								data: processedFile.file.toString("base64"),
 								mimeType: processedFile.mime,
 							},
 						})),

--- a/src/lib/server/models.ts
+++ b/src/lib/server/models.ts
@@ -63,6 +63,7 @@ const modelConfig = z.object({
 		.passthrough()
 		.optional(),
 	multimodal: z.boolean().default(false),
+	multimodalAcceptedMimetypes: z.array(z.string()).optional(),
 	tools: z.boolean().default(false),
 	unlisted: z.boolean().default(false),
 	embeddingModel: validateEmbeddingModelByName(embeddingModels).optional(),

--- a/src/lib/types/Model.ts
+++ b/src/lib/types/Model.ts
@@ -16,6 +16,7 @@ export type Model = Pick<
 	| "datasetUrl"
 	| "preprompt"
 	| "multimodal"
+	| "multimodalAcceptedMimetypes"
 	| "unlisted"
 	| "tools"
 	| "hasInferenceAPI"

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -190,6 +190,7 @@ export const load: LayoutServerLoad = async ({ locals, depends, request }) => {
 			parameters: model.parameters,
 			preprompt: model.preprompt,
 			multimodal: model.multimodal,
+			multimodalAcceptedMimetypes: model.multimodalAcceptedMimetypes,
 			tools:
 				model.tools &&
 				// disable tools on huggingchat android app


### PR DESCRIPTION
Following this issue https://github.com/huggingface/chat-ui/issues/1505, adding PDF and plain text support to Vertex.

The basis has also been setup for other endpoints that would support inline documents.

**DEMO**

https://github.com/user-attachments/assets/a417bfbb-7212-439f-a562-1f984544ff69

<img width="1510" alt="Capture d’écran 2024-10-15 à 09 54 56" src="https://github.com/user-attachments/assets/8a242797-3f1c-4593-8a17-f18776e4e987">