### PR TITLE
fix(modal): fix freeze after modal close

### DIFF
--- a/src/lib/components/Modal.svelte
+++ b/src/lib/components/Modal.svelte
@@ -50,7 +50,7 @@
 		tabindex="-1"
 		bind:this={backdropEl}
 		on:click|stopPropagation={handleBackdropClick}
-		transition:fade|global={{ easing: cubicOut, duration: 300 }}
+		transition:fade|local={{ easing: cubicOut, duration: 300 }}
 		class="fixed inset-0 z-40 flex items-center justify-center bg-black/80 p-8 backdrop-blur-sm dark:bg-black/50"
 	>
 		<div


### PR DESCRIPTION
Quite often, my whole interface freezes after I close the modal, but with tools, it happens to me every time.

It seems like Svelte's issue with animation: https://github.com/sveltejs/kit/issues/5434

Steps to reproduce:
- click 'globe' icon in tools
- close modal
- interface will freeze



https://github.com/user-attachments/assets/f717687a-2f45-4c17-a057-9f6df73ec793

