### PR TITLE
feat: Add a model config option to disable system prompts

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -19,6 +19,9 @@ import { refreshConversationStats } from "$lib/jobs/refresh-conversation-stats";
 
 // TODO: move this code on a started server hook, instead of using a "building" flag
 if (!building) {
+	// Set HF_TOKEN as a process variable for Transformers.JS to see it
+	process.env.HF_TOKEN ??= env.HF_TOKEN;
+
 	logger.info("Starting server...");
 	initExitHandler();
 

--- a/src/lib/server/models.ts
+++ b/src/lib/server/models.ts
@@ -68,7 +68,7 @@ const modelConfig = z.object({
 	unlisted: z.boolean().default(false),
 	embeddingModel: validateEmbeddingModelByName(embeddingModels).optional(),
 	/** Used to enable/disable system prompt usage */
-	systemPrompt: z.boolean().default(true),
+	systemRoleSupported: z.boolean().default(true),
 });
 
 const modelsRaw = z.array(modelConfig).parse(JSON5.parse(env.MODELS));
@@ -117,7 +117,7 @@ async function getChatPromptRender(
 			role: message.from,
 		}));
 
-		if (!m.systemPrompt) {
+		if (!m.systemRoleSupported) {
 			const firstSystemMessage = formattedMessages.find((msg) => msg.role === "system");
 			formattedMessages = formattedMessages.filter((msg) => msg.role !== "system");
 
@@ -134,7 +134,7 @@ async function getChatPromptRender(
 		if (preprompt && formattedMessages[0].role !== "system") {
 			formattedMessages = [
 				{
-					role: m.systemPrompt ? "system" : "user",
+					role: m.systemRoleSupported ? "system" : "user",
 					content: preprompt,
 				},
 				...formattedMessages,
@@ -149,7 +149,7 @@ async function getChatPromptRender(
 			if (id.startsWith("CohereForAI")) {
 				formattedMessages = [
 					{
-						role: m.systemPrompt ? "system" : "user",
+						role: m.systemRoleSupported ? "system" : "user",
 						content:
 							"\n\n<results>\n" +
 							toolResults
@@ -201,7 +201,7 @@ async function getChatPromptRender(
 				formattedMessages = [
 					...formattedMessages,
 					{
-						role: m.systemPrompt ? "system" : "user",
+						role: m.systemRoleSupported ? "system" : "user",
 						content: JSON.stringify(toolResults),
 					},
 				];

--- a/src/lib/server/models.ts
+++ b/src/lib/server/models.ts
@@ -67,6 +67,8 @@ const modelConfig = z.object({
 	tools: z.boolean().default(false),
 	unlisted: z.boolean().default(false),
 	embeddingModel: validateEmbeddingModelByName(embeddingModels).optional(),
+	/** Used to enable/disable system prompt usage */
+	systemPrompt: z.boolean().default(true),
 });
 
 const modelsRaw = z.array(modelConfig).parse(JSON5.parse(env.MODELS));
@@ -115,10 +117,24 @@ async function getChatPromptRender(
 			role: message.from,
 		}));
 
+		if (!m.systemPrompt) {
+			const firstSystemMessage = formattedMessages.find((msg) => msg.role === "system");
+			formattedMessages = formattedMessages.filter((msg) => msg.role !== "system");
+
+			if (
+				firstSystemMessage &&
+				formattedMessages.length > 0 &&
+				formattedMessages[0].role === "user"
+			) {
+				formattedMessages[0].content =
+					firstSystemMessage.content + "\n" + formattedMessages[0].content;
+			}
+		}
+
 		if (preprompt && formattedMessages[0].role !== "system") {
 			formattedMessages = [
 				{
-					role: "system",
+					role: m.systemPrompt ? "system" : "user",
 					content: preprompt,
 				},
 				...formattedMessages,
@@ -133,7 +149,7 @@ async function getChatPromptRender(
 			if (id.startsWith("CohereForAI")) {
 				formattedMessages = [
 					{
-						role: "system",
+						role: m.systemPrompt ? "system" : "user",
 						content:
 							"\n\n<results>\n" +
 							toolResults
@@ -185,7 +201,7 @@ async function getChatPromptRender(
 				formattedMessages = [
 					...formattedMessages,
 					{
-						role: "system",
+						role: m.systemPrompt ? "system" : "user",
 						content: JSON.stringify(toolResults),
 					},
 				];


### PR DESCRIPTION
## Description

Closes #1432 

Some models don't support system prompts, therefore, a new `modelConfig` option has been added: `systemRoleSupported `

By default, the `systemRoleSupported ` option is `true`, where everything behaves as is. However, if the `systemRoleSupported ` option is set to `false`, all `role: "system"` messages are filtered out. And the very first `role: "system"` message encountered, will have its content preprended to the very first user message.

Brief example, let's assume the following is our `messages` array, before processing:

```json
[
    { "content": "Welcome to our service!", "role": "system" },
    { "content": "Hi, how can I help you today?", "role": "system" },
    { "content": "I need help with my account.", "role": "user" },
    { "content": "Certainly! What issue are you experiencing?", "role": "system" },
    { "content": "I forgot my password.", "role": "user" },
    { "content": "Please reset your password using the 'Forgot Password' link.", "role": "system" },
    { "content": "Thank you!", "role": "user" }
]
```

After we apply the filtering, and preprending the first `system` message's content into the first user message, we get:

```json
[
    { "content": "Welcome to our service!\nI need help with my account.", "role": "user" },
    { "content": "I forgot my password.", "role": "user" },
    { "content": "Thank you!", "role": "user" }
]
```

This keeps the existing functionality untouched, while giving the option of using a wider range of models, even those that do not support `system` role messages!

Please let me know any thoughts or suggestions that may arise!