### PR TITLE
fix(ui): swap delete confirmation buttons for better UX (#1546)

### DIFF
--- a/src/lib/components/NavConversationItem.svelte
+++ b/src/lib/components/NavConversationItem.svelte
@@ -55,6 +55,14 @@
 		<button
 			type="button"
 			class="flex h-5 w-5 items-center justify-center rounded md:hidden md:group-hover:flex"
+			title="Cancel delete action"
+			on:click|preventDefault={() => (confirmDelete = false)}
+		>
+			<CarbonClose class="text-xs text-gray-400 hover:text-gray-500 dark:hover:text-gray-300" />
+		</button>
+		<button
+			type="button"
+			class="flex h-5 w-5 items-center justify-center rounded md:hidden md:group-hover:flex"
 			title="Confirm delete action"
 			on:click|preventDefault={() => {
 				confirmDelete = false;
@@ -62,14 +70,6 @@
 			}}
 		>
 			<CarbonCheckmark class="text-xs text-gray-400 hover:text-gray-500 dark:hover:text-gray-300" />
-		</button>
-		<button
-			type="button"
-			class="flex h-5 w-5 items-center justify-center rounded md:hidden md:group-hover:flex"
-			title="Cancel delete action"
-			on:click|preventDefault={() => (confirmDelete = false)}
-		>
-			<CarbonClose class="text-xs text-gray-400 hover:text-gray-500 dark:hover:text-gray-300" />
 		</button>
 	{:else}
 		<button


### PR DESCRIPTION
# Description
This PR improves the user experience of the conversation deletion flow by swapping the positions of the confirm and cancel buttons. After clicking the delete icon, the confirm (checkmark) button now appears closer to the original click position, reducing unnecessary mouse movement.

## Changes made:
- Reordered confirmation buttons in `NavConversationItem.svelte`
- Confirm button (✓) now appears first, followed by cancel button (×)
- Maintained all existing functionality including shift+click shortcut
- No changes to the underlying delete logic

## Screenshots
### Before:
<img width="277" alt="Screenshot 2024-10-28 at 4 05 58 PM" src="https://github.com/user-attachments/assets/2f9c5d2d-ff1b-4c26-9246-8b6aac38cc7c">
<img width="277" alt="Screenshot 2024-10-28 at 4 06 03 PM" src="https://github.com/user-attachments/assets/6cf50553-7e06-4b79-a9ca-2a2148c79554">

### After:
<img width="277" alt="Screenshot 2024-10-28 at 3 56 11 PM" src="https://github.com/user-attachments/assets/0ff53c64-59f4-4f4c-a8bb-c268d16bf9bf">
<img width="277" alt="Screenshot 2024-10-28 at 3 56 16 PM" src="https://github.com/user-attachments/assets/5230bce3-d982-4976-a9c8-cfdb652c49f5">

Fixes #1546 