### PR TITLE
feat: paste long context as plaintext files

### DIFF
--- a/src/lib/components/chat/ChatMessage.svelte
+++ b/src/lib/components/chat/ChatMessage.svelte
@@ -254,7 +254,7 @@
 			{#if message.files?.length}
 				<div class="flex h-fit flex-wrap gap-x-5 gap-y-2">
 					{#each message.files as file}
-						<UploadedFile {file} canClose={false} isPreview={false} />
+						<UploadedFile {file} canClose={false} />
 					{/each}
 				</div>
 			{/if}
@@ -382,7 +382,7 @@
 			{#if message.files?.length}
 				<div class="flex w-fit gap-4 px-5">
 					{#each message.files as file}
-						<UploadedFile {file} canClose={false} isPreview={false} />
+						<UploadedFile {file} canClose={false} />
 					{/each}
 				</div>
 			{/if}

--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -38,6 +38,9 @@
 	import type { ToolFront } from "$lib/types/Tool";
 	import ModelSwitch from "./ModelSwitch.svelte";
 
+	import { fly } from "svelte/transition";
+	import { cubicInOut } from "svelte/easing";
+
 	export let messages: Message[] = [];
 	export let loading = false;
 	export let pending = false;
@@ -360,13 +363,13 @@
 		class="dark:via-gray-80 pointer-events-none absolute inset-x-0 bottom-0 z-0 mx-auto flex w-full max-w-3xl flex-col items-center justify-center bg-gradient-to-t from-white via-white/80 to-white/0 px-3.5 py-4 dark:border-gray-800 dark:from-gray-900 dark:to-gray-900/0 max-md:border-t max-md:bg-white max-md:dark:bg-gray-900 sm:px-5 md:py-8 xl:max-w-4xl [&>*]:pointer-events-auto"
 	>
 		{#if sources?.length && !loading}
-			<div class="flex flex-row flex-wrap justify-center gap-2.5 max-md:pb-3">
-				{#each sources as source, index (source)}
+			<div
+				in:fly|local={sources.length === 1 ? { y: -20, easing: cubicInOut } : undefined}
+				class="flex flex-row flex-wrap justify-center gap-2.5 rounded-xl max-md:pb-3"
+			>
+				{#each sources as source, index}
 					{#await source then src}
 						<UploadedFile
-							shouldAnimate={!!(
-								sources.length === 1 && src.mime === "application/vnd.chatui.clipboard"
-							)}
 							file={src}
 							on:close={() => {
 								files = files.filter((_, i) => i !== index);
@@ -429,7 +432,7 @@
 					<FileDropzone bind:files bind:onDrag mimeTypes={activeMimeTypes} />
 				{:else}
 					<div
-						class="flex w-full flex-1 border-none bg-transparent"
+						class="flex w-full flex-1 rounded-xl border-none bg-transparent"
 						class:paste-glow={pastedLongContent}
 					>
 						{#if lastIsError}
@@ -534,9 +537,7 @@
 <style lang="postcss">
 	.paste-glow {
 		animation: glow 1s cubic-bezier(0.4, 0, 0.2, 1) forwards;
-		animation-iteration-count: 1;
 		will-change: box-shadow;
-		border-radius: inherit;
 	}
 
 	@keyframes glow {

--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -90,7 +90,7 @@
 
 		if (textContent && textContent.length > 256) {
 			e.preventDefault();
-			const pastedFile = new File([textContent], "Pasted Content", { type: "text/plain" });
+			const pastedFile = new File([textContent], "Pasted Content", { type: "application/vnd.chatui.clipboard" });
 
 			files = [...files, pastedFile];
 		}

--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -86,6 +86,15 @@
 	};
 
 	const onPaste = (e: ClipboardEvent) => {
+		const textContent = e.clipboardData?.getData("text");
+
+		if (textContent && textContent.length > 256) {
+			e.preventDefault();
+			const pastedFile = new File([textContent], "Pasted Content", { type: "text/plain" });
+
+			files = [...files, pastedFile];
+		}
+
 		if (!e.clipboardData) {
 			return;
 		}

--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -357,6 +357,7 @@
 				{#each sources as source, index}
 					{#await source then src}
 						<UploadedFile
+							shouldAnimate={sources.length <= 1}
 							file={src}
 							on:close={() => {
 								files = files.filter((_, i) => i !== index);

--- a/src/lib/components/chat/UploadedFile.svelte
+++ b/src/lib/components/chat/UploadedFile.svelte
@@ -47,7 +47,8 @@
 		mime === "text/csv" ||
 		mime === "text/markdown" ||
 		mime === "application/json" ||
-		mime === "application/xml";
+		mime === "application/xml" ||
+		mime === "application/vnd.chatui.clipboard";
 
 	$: isClickable = isImage(file.mime) || isPlainText(file.mime);
 </script>
@@ -87,14 +88,18 @@
 					{:then result}
 						<pre
 							class="w-full whitespace-pre-wrap break-words pt-0 text-sm"
-							class:font-sans={file.mime === "text/plain"}
-							class:font-mono={file.mime !== "text/plain"}>{result}</pre>
+							class:font-sans={file.mime === "text/plain" ||
+								file.mime === "application/vnd.chatui.clipboard"}
+							class:font-mono={file.mime !== "text/plain" &&
+								file.mime !== "application/vnd.chatui.clipboard"}>{result}</pre>
 					{/await}
 				{:else}
 					<pre
 						class="w-full whitespace-pre-wrap break-words pt-0 text-sm"
-						class:font-sans={file.mime === "text/plain"}
-						class:font-mono={file.mime !== "text/plain"}>{atob(file.value)}</pre>
+						class:font-sans={file.mime === "text/plain" ||
+							file.mime === "application/vnd.chatui.clipboard"}
+						class:font-mono={file.mime !== "text/plain" &&
+							file.mime !== "application/vnd.chatui.clipboard"}>{atob(file.value)}</pre>
 				{/if}
 			</div>
 		{/if}
@@ -151,7 +156,11 @@
 					<dd class="text-sm">
 						{truncateMiddle(file.name, 28)}
 					</dd>
-					<dt class="text-xs text-gray-400">{file.mime}</dt>
+					{#if file.mime === "application/vnd.chatui.clipboard"}
+						<dt class="text-xs text-gray-400">Clipboard source</dt>
+					{:else}
+						<dt class="text-xs text-gray-400">{file.mime}</dt>
+					{/if}
 				</dl>
 			</div>
 		{:else if file.mime === "octet-stream"}

--- a/src/lib/components/chat/UploadedFile.svelte
+++ b/src/lib/components/chat/UploadedFile.svelte
@@ -10,6 +10,9 @@
 	import AudioPlayer from "../players/AudioPlayer.svelte";
 	import EosIconsLoading from "~icons/eos-icons/loading";
 
+	import { fly } from "svelte/transition";
+	import { cubicInOut } from "svelte/easing";
+
 	export let file: MessageFile;
 	export let canClose = true;
 
@@ -97,7 +100,12 @@
 	</Modal>
 {/if}
 
-<button on:click={() => (showModal = true)} disabled={!isClickable} class:clickable={isClickable}>
+<button
+	in:fly={{ y: -20, easing: cubicInOut }}
+	on:click={() => (showModal = true)}
+	disabled={!isClickable}
+	class:clickable={isClickable}
+>
 	<div class="group relative flex items-center rounded-xl shadow-sm">
 		{#if isImage(file.mime)}
 			<div class="size-48 overflow-hidden rounded-xl">
@@ -192,7 +200,8 @@
 		<!-- add a button on top that removes the image -->
 		{#if canClose}
 			<button
-				class="invisible absolute -right-2 -top-2 z-10 grid size-6 place-items-center rounded-full border bg-black group-hover:visible dark:border-gray-700"
+				class="absolute -right-2 -top-2 z-10 grid size-6 place-items-center rounded-full border bg-black group-hover:visible dark:border-gray-700"
+				class:invisible={navigator.maxTouchPoints === 0}
 				on:click|stopPropagation|preventDefault={() => dispatch("close")}
 			>
 				<CarbonClose class=" text-xs  text-white" />

--- a/src/lib/components/chat/UploadedFile.svelte
+++ b/src/lib/components/chat/UploadedFile.svelte
@@ -10,11 +10,7 @@
 	import AudioPlayer from "../players/AudioPlayer.svelte";
 	import EosIconsLoading from "~icons/eos-icons/loading";
 
-	import { fly } from "svelte/transition";
-	import { cubicInOut } from "svelte/easing";
-
 	export let file: MessageFile;
-	export let shouldAnimate = false;
 	export let canClose = true;
 
 	$: showModal = false;
@@ -106,12 +102,7 @@
 	</Modal>
 {/if}
 
-<button
-	in:fly|local={shouldAnimate ? { y: -20, easing: cubicInOut } : undefined}
-	on:click={() => (showModal = true)}
-	disabled={!isClickable}
-	class:clickable={isClickable}
->
+<button on:click={() => (showModal = true)} disabled={!isClickable} class:clickable={isClickable}>
 	<div class="group relative flex items-center rounded-xl shadow-sm">
 		{#if isImage(file.mime)}
 			<div class="size-48 overflow-hidden rounded-xl">
@@ -146,7 +137,6 @@
 			<div
 				class="flex h-14 w-72 items-center gap-2 overflow-hidden rounded-xl border border-gray-200 bg-white p-2 dark:border-gray-800 dark:bg-gray-900"
 				class:hoverable={isClickable}
-				class:glow-on-mount={shouldAnimate}
 			>
 				<div
 					class="grid size-10 flex-none place-items-center rounded-lg bg-gray-100 dark:bg-gray-800"
@@ -224,21 +214,5 @@
 <style lang="postcss">
 	.hoverable {
 		@apply hover:bg-gray-500/10;
-	}
-
-	.glow-on-mount {
-		animation: glow 1s ease-out;
-	}
-
-	@keyframes glow {
-		0% {
-			background-color: transparent;
-		}
-		50% {
-			background-color: rgba(59, 130, 246, 0.2);
-		}
-		100% {
-			background-color: transparent;
-		}
 	}
 </style>

--- a/src/lib/components/chat/UploadedFile.svelte
+++ b/src/lib/components/chat/UploadedFile.svelte
@@ -5,13 +5,13 @@
 	import CarbonClose from "~icons/carbon/close";
 	import CarbonDocumentBlank from "~icons/carbon/document-blank";
 	import CarbonDownload from "~icons/carbon/download";
-
+	import CarbonDocument from "~icons/carbon/document";
 	import Modal from "../Modal.svelte";
 	import AudioPlayer from "../players/AudioPlayer.svelte";
+	import EosIconsLoading from "~icons/eos-icons/loading";
 
 	export let file: MessageFile;
 	export let canClose = true;
-	export let isPreview = false;
 
 	$: showModal = false;
 	$: urlNotTrailing = $page.url.pathname.replace(/\/$/, "");
@@ -38,33 +38,69 @@
 	const isVideo = (mime: string) =>
 		mime.startsWith("video/") || mime === "mp4" || mime === "x-mpeg";
 
-	$: isClickable = isImage(file.mime) && !isPreview;
+	const isPlainText = (mime: string) =>
+		mime === "text/plain" ||
+		mime === "text/csv" ||
+		mime === "text/markdown" ||
+		mime === "application/json" ||
+		mime === "application/xml";
+
+	$: isClickable = isImage(file.mime) || isPlainText(file.mime);
 </script>
 
 {#if showModal && isClickable}
 	<!-- show the image file full screen, click outside to exit -->
-	<Modal width="sm:max-w-[500px]" on:close={() => (showModal = false)}>
-		{#if file.type === "hash"}
-			<img
-				src={urlNotTrailing + "/output/" + file.value}
-				alt="input from user"
-				class="aspect-auto"
-			/>
-		{:else}
-			<!-- handle the case where this is a base64 encoded image -->
-			<img
-				src={`data:${file.mime};base64,${file.value}`}
-				alt="input from user"
-				class="aspect-auto"
-			/>
+	<Modal width="sm:max-w-[800px]" on:close={() => (showModal = false)}>
+		{#if isImage(file.mime)}
+			{#if file.type === "hash"}
+				<img
+					src={urlNotTrailing + "/output/" + file.value}
+					alt="input from user"
+					class="aspect-auto"
+				/>
+			{:else}
+				<!-- handle the case where this is a base64 encoded image -->
+				<img
+					src={`data:${file.mime};base64,${file.value}`}
+					alt="input from user"
+					class="aspect-auto"
+				/>
+			{/if}
+		{:else if isPlainText(file.mime)}
+			<div class="relative flex h-full w-full flex-col gap-4 p-4">
+				<h3 class="-mb-2 pt-2 text-xl font-bold">{file.name}</h3>
+				<button
+					class="absolute right-4 top-4 text-xl text-gray-500 hover:text-gray-800"
+					on:click={() => (showModal = false)}
+				>
+					<CarbonClose class="text-xl" />
+				</button>
+				{#if file.type === "hash"}
+					{#await fetch(urlNotTrailing + "/output/" + file.value).then((res) => res.text())}
+						<div class="flex h-full w-full items-center justify-center">
+							<EosIconsLoading class="text-xl" />
+						</div>
+					{:then result}
+						<pre
+							class="w-full whitespace-pre-wrap break-words pt-0 text-sm"
+							class:font-sans={file.mime === "text/plain"}
+							class:font-mono={file.mime !== "text/plain"}>{result}</pre>
+					{/await}
+				{:else}
+					<pre
+						class="w-full whitespace-pre-wrap break-words pt-0 text-sm"
+						class:font-sans={file.mime === "text/plain"}
+						class:font-mono={file.mime !== "text/plain"}>{atob(file.value)}</pre>
+				{/if}
+			</div>
 		{/if}
 	</Modal>
 {/if}
 
-<button on:click={() => (showModal = true)} disabled={!isClickable}>
+<button on:click={() => (showModal = true)} disabled={!isClickable} class:clickable={isClickable}>
 	<div class="group relative flex items-center rounded-xl shadow-sm">
 		{#if isImage(file.mime)}
-			<div class=" overflow-hidden rounded-xl" class:size-24={isPreview} class:size-48={!isPreview}>
+			<div class="size-48 overflow-hidden rounded-xl">
 				<img
 					src={file.type === "base64"
 						? `data:${file.mime};base64,${file.value}`
@@ -92,9 +128,27 @@
 					controls
 				/>
 			</div>
+		{:else if isPlainText(file.mime)}
+			<div
+				class="flex h-14 w-72 items-center gap-2 overflow-hidden rounded-xl border border-gray-200 bg-white p-2 dark:border-gray-800 dark:bg-gray-900"
+				class:hoverable={isClickable}
+			>
+				<div
+					class="grid size-10 flex-none place-items-center rounded-lg bg-gray-100 dark:bg-gray-800"
+				>
+					<CarbonDocument class="text-base text-gray-700 dark:text-gray-300" />
+				</div>
+				<dl class="flex flex-col items-start truncate leading-tight">
+					<dd class="text-sm">
+						{truncateMiddle(file.name, 28)}
+					</dd>
+					<dt class="text-xs text-gray-400">{file.mime}</dt>
+				</dl>
+			</div>
 		{:else if file.mime === "octet-stream"}
 			<div
 				class="flex h-14 w-72 items-center gap-2 overflow-hidden rounded-xl border border-gray-200 bg-white p-2 dark:border-gray-800 dark:bg-gray-900"
+				class:hoverable={isClickable}
 			>
 				<div
 					class="grid size-10 flex-none place-items-center rounded-lg bg-gray-100 dark:bg-gray-800"
@@ -120,13 +174,14 @@
 		{:else}
 			<div
 				class="flex h-14 w-72 items-center gap-2 overflow-hidden rounded-xl border border-gray-200 bg-white p-2 dark:border-gray-800 dark:bg-gray-900"
+				class:hoverable={isClickable}
 			>
 				<div
 					class="grid size-10 flex-none place-items-center rounded-lg bg-gray-100 dark:bg-gray-800"
 				>
 					<CarbonDocumentBlank class="text-base text-gray-700 dark:text-gray-300" />
 				</div>
-				<dl class="flex flex-col truncate leading-tight">
+				<dl class="flex flex-col items-start truncate leading-tight">
 					<dd class="text-sm">
 						{truncateMiddle(file.name, 28)}
 					</dd>
@@ -137,11 +192,17 @@
 		<!-- add a button on top that removes the image -->
 		{#if canClose}
 			<button
-				class="invisible absolute -right-2 -top-2 grid size-6 place-items-center rounded-full border bg-black group-hover:visible dark:border-gray-700"
-				on:click={() => dispatch("close")}
+				class="invisible absolute -right-2 -top-2 z-10 grid size-6 place-items-center rounded-full border bg-black group-hover:visible dark:border-gray-700"
+				on:click|stopPropagation|preventDefault={() => dispatch("close")}
 			>
 				<CarbonClose class=" text-xs  text-white" />
 			</button>
 		{/if}
 	</div>
 </button>
+
+<style lang="postcss">
+	.hoverable {
+		@apply hover:bg-gray-500/10;
+	}
+</style>

--- a/src/lib/components/chat/UploadedFile.svelte
+++ b/src/lib/components/chat/UploadedFile.svelte
@@ -146,6 +146,7 @@
 			<div
 				class="flex h-14 w-72 items-center gap-2 overflow-hidden rounded-xl border border-gray-200 bg-white p-2 dark:border-gray-800 dark:bg-gray-900"
 				class:hoverable={isClickable}
+				class:glow-on-mount={shouldAnimate}
 			>
 				<div
 					class="grid size-10 flex-none place-items-center rounded-lg bg-gray-100 dark:bg-gray-800"
@@ -223,5 +224,21 @@
 <style lang="postcss">
 	.hoverable {
 		@apply hover:bg-gray-500/10;
+	}
+
+	.glow-on-mount {
+		animation: glow 1s ease-out;
+	}
+
+	@keyframes glow {
+		0% {
+			background-color: transparent;
+		}
+		50% {
+			background-color: rgba(59, 130, 246, 0.2);
+		}
+		100% {
+			background-color: transparent;
+		}
 	}
 </style>

--- a/src/lib/components/chat/UploadedFile.svelte
+++ b/src/lib/components/chat/UploadedFile.svelte
@@ -14,6 +14,7 @@
 	import { cubicInOut } from "svelte/easing";
 
 	export let file: MessageFile;
+	export let shouldAnimate = false;
 	export let canClose = true;
 
 	$: showModal = false;
@@ -101,7 +102,7 @@
 {/if}
 
 <button
-	in:fly={{ y: -20, easing: cubicInOut }}
+	in:fly|local={shouldAnimate ? { y: -20, easing: cubicInOut } : undefined}
 	on:click={() => (showModal = true)}
 	disabled={!isClickable}
 	class:clickable={isClickable}

--- a/src/lib/server/endpoints/preprocessMessages.ts
+++ b/src/lib/server/endpoints/preprocessMessages.ts
@@ -65,6 +65,7 @@ async function injectPlaintextFiles(messages: EndpointMessage[]) {
 			return {
 				...message,
 				content: `${plaintextFiles.map((file) => file.value).join("\n\n")}\n\n${message.content}`,
+				files: message.files?.filter((file) => file.mime !== "text/plain"),
 			};
 		})
 	);


### PR DESCRIPTION
https://github.com/user-attachments/assets/66cff008-a8e9-4565-b162-e34e5d10934f

Pretty simple, if we detect a paste event with more than 256 characters, we prevent the paste and instead create a new plaintext file. 

We also add preprocessing code to inject plain text files directly into the prompt and a little modal to display the plaintext content.

We use a custom MIME type `application/vnd.chatui.clipboard`  to differentiate between uploaded plaintext files and clipboard content