### PR TITLE
[fix] Add placeholder param for sources icon

### DIFF
--- a/src/lib/components/chat/ChatMessage.svelte
+++ b/src/lib/components/chat/ChatMessage.svelte
@@ -335,7 +335,8 @@
 						>
 							<img
 								class="h-3.5 w-3.5 rounded"
-								src="https://www.google.com/s2/favicons?sz=64&domain_url={new URL(link).hostname}"
+								src="https://www.google.com/s2/favicons?sz=64&domain_url={new URL(link).hostname ||
+									'placeholder'}"
 								alt="{title} favicon"
 							/>
 							<div>{new URL(link).hostname.replace(/^www\./, "")}</div>
@@ -356,7 +357,8 @@
 						>
 							<img
 								class="h-3.5 w-3.5 rounded"
-								src="https://www.google.com/s2/favicons?sz=64&domain_url={new URL(uri).hostname}"
+								src="https://www.google.com/s2/favicons?sz=64&domain_url={new URL(uri).hostname ||
+									'placeholder'}"
 								alt="{title} favicon"
 							/>
 							<div>{title}</div>


### PR DESCRIPTION
For sources display, we use Google API (for instance `https://www.google.com/s2/favicons?sz=64&domain_url=github.com`). But when for some reason the hostname (`new URL(link).hostname`) is not well computed, we end up with a broken link `https://www.google.com/s2/favicons?sz=64&domain_url=` and the icon is replaced by the `alt` attributes, which can lead to very weird display:
![image](https://github.com/user-attachments/assets/6d0859a9-5759-49db-99fe-ddc1e2d3ad2d)

So this fix sets the hostname to `placeholder` when not well computed `https://www.google.com/s2/favicons?sz=64&domain_url=placeholder`