### PR TITLE
fix local setup instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,22 @@ llama-server --hf-repo microsoft/Phi-3-mini-4k-instruct-gguf --hf-file Phi-3-min
 
 A local LLaMA.cpp HTTP Server will start on `http://localhost:8080`. Read more [here](https://huggingface.co/docs/chat-ui/configuration/models/providers/llamacpp).
 
-**Step 2 (tell chat-ui to use local llama.cpp server):**
+**Step 3 (make sure you have MongoDb running locally):**
+
+```bash
+docker run -d -p 27017:27017 --name mongo-chatui mongo:latest
+```
+
+Read more [here](#database).
+
+**Step 4 (clone chat-ui):**
+
+```bash
+git clone https://github.com/huggingface/chat-ui
+cd chat-ui
+```
+
+**Step 5 (tell chat-ui to use local llama.cpp server):**
 
 Add the following to your `.env.local`:
 
@@ -65,7 +80,7 @@ Add the following to your `.env.local`:
 MODELS=`[
   {
     "name": "Local microsoft/Phi-3-mini-4k-instruct-gguf",
-    "tokenizer": "microsoft/Phi-3-mini-4k-instruct-gguf",
+    "tokenizer": "microsoft/Phi-3-mini-4k-instruct",
     "preprompt": "",
     "parameters": {
       "stop": ["<|end|>", "<|endoftext|>", "<|assistant|>"],
@@ -75,7 +90,8 @@ MODELS=`[
     },
     "endpoints": [{
       "type" : "llamacpp",
-      "baseURL": "http://localhost:8080"
+      "baseURL": "http://localhost:8080",
+      "accessToken": " ",
     }],
   },
 ]`
@@ -85,19 +101,9 @@ The `tokenizer` field will be used to find the appropriate chat template for the
 
 Read more [here](https://huggingface.co/docs/chat-ui/configuration/models/providers/llamacpp).
 
-**Step 3 (make sure you have MongoDb running locally):**
+**Step 6 (start chat-ui):**
 
 ```bash
-docker run -d -p 27017:27017 --name mongo-chatui mongo:latest
-```
-
-Read more [here](#database).
-
-**Step 4 (start chat-ui):**
-
-```bash
-git clone https://github.com/huggingface/chat-ui
-cd chat-ui
 npm install
 npm run dev -- --open
 ```

--- a/README.md
+++ b/README.md
@@ -90,8 +90,7 @@ MODELS=`[
     },
     "endpoints": [{
       "type" : "llamacpp",
-      "baseURL": "http://localhost:8080",
-      "accessToken": " ",
+      "baseURL": "http://localhost:8080"
     }],
   },
 ]`


### PR DESCRIPTION
This PR fixes errors that occur if you try to follow the "Local setup" section of the `README.md`.

1. Move `.env.local` to the `chat-ui` directory

The first change is that the `.env.local` file needs to be inside the `chat-ui` directory, so I have moved the creation commands to where the user has already `cd`-ed into the directory.

2. Fix tokenizer name

The second change (line 68 -> 83) fixes the startup error:

```
ERROR (89579): Failed to load tokenizer microsoft/Phi-3-mini-4k-instruct-gguf make sure the model is available on the hub and you have access to any gated models.
    err: {
      "type": "Error",
      "message": "Could not locate file: \"https://huggingface.co/microsoft/Phi-3-mini-4k-instruct-gguf/resolve/main/tokenizer_config.json\".",
      "stack":
          Error: Could not locate file: "https://huggingface.co/microsoft/Phi-3-mini-4k-instruct-gguf/resolve/main/tokenizer_config.json".
...
```

~3. Add non-empty `accessToken` placeholder~
~The third change (lines 78 -> 93-94) fixes the startup error:~

```
ERROR (91361):
    locals: {}
    url: "http://localhost:5173/"
    params: {}
    request: {}
    message: "Internal Error"
    errorId: "bcb2d18a-1c20-4fc5-aae6-3709196556ef"
    status: 500
    error: {
      "stack":
          ZodError: [
            {
              "code": "too_small",
              "minimum": 1,
              "type": "string",
              "inclusive": true,
              "exact": false,
              "message": "String must contain at least 1 character(s)",
              "path": [
                0,
                "endpoints",
                0,
                "accessToken"
              ]
            }
...
```