### PR TITLE
fix: double cookie refresh in server hooks

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -217,8 +217,6 @@ export const handle: Handle = async ({ event, resolve }) => {
 	];
 
 	if (event.request.method === "POST") {
-		refreshSessionCookie(event.cookies, event.locals.sessionId);
-
 		if (nativeFormContentTypes.includes(requestContentType)) {
 			const origin = event.request.headers.get("origin");
 


### PR DESCRIPTION
refreshSessionCookie() is called twice for POST requests. 
Removed the call which sends the _server_ id to the client.