### PR TITLE
Remove unneeded QwQ System prompt

### DIFF
--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -139,7 +139,7 @@ envVars:
       },
       {
         "name": "Qwen/QwQ-32B-Preview",
-        "preprompt": "You are a helpful and harmless assistant. You are Qwen developed by Alibaba. You should think step-by-step.",
+        "preprompt": "",
         "modelUrl": "https://huggingface.co/Qwen/QwQ-32B-Preview",
         "websiteUrl": "https://qwenlm.github.io/blog/qwq-32b-preview/",
         "logoUrl": "https://huggingface.co/datasets/huggingchat/models-logo/resolve/main/qwen-logo.png",

--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -139,7 +139,6 @@ envVars:
       },
       {
         "name": "Qwen/QwQ-32B-Preview",
-        "preprompt": "",
         "modelUrl": "https://huggingface.co/Qwen/QwQ-32B-Preview",
         "websiteUrl": "https://qwenlm.github.io/blog/qwq-32b-preview/",
         "logoUrl": "https://huggingface.co/datasets/huggingchat/models-logo/resolve/main/qwen-logo.png",


### PR DESCRIPTION
Removing unneeded QwQ System prompt as HF Inference API automatically adds the default system prompt as defined in [chat_template](https://huggingface.co/Qwen/QwQ-32B-Preview/blob/main/tokenizer_config.json#L197)