### PR TITLE
Update Gradio library to allow version >4 spaces to be used

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"dependencies": {
 				"@aws-sdk/credential-providers": "^3.592.0",
 				"@cliqz/adblocker-playwright": "^1.27.2",
-				"@gradio/client": "^1.1.1",
+				"@gradio/client": "^1.8.0",
 				"@huggingface/hub": "^0.5.1",
 				"@huggingface/inference": "^2.7.0",
 				"@huggingface/transformers": "^3.0.0-alpha.6",
@@ -1929,9 +1929,10 @@
 			}
 		},
 		"node_modules/@gradio/client": {
-			"version": "1.5.2",
-			"resolved": "https://registry.npmjs.org/@gradio/client/-/client-1.5.2.tgz",
-			"integrity": "sha512-PJbt8n3ROxDXrR55D8oPYPIIkdmG5ksyljtgNM6Kr/FgTMTwGqiiYDdoyUIGwQSBu6g+jan2zbHoniDZePw3pg==",
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/@gradio/client/-/client-1.8.0.tgz",
+			"integrity": "sha512-0Nxi+AuEL/ICdnZ6TSxRif1yS2A0HtJnggtWhN/8sqwFxx5UAGN29/vnJONcVfe3g9nctDJCvik3uDHkzQHFGw==",
+			"license": "ISC",
 			"dependencies": {
 				"@types/eventsource": "^1.1.15",
 				"bufferutil": "^4.0.7",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
 	"dependencies": {
 		"@aws-sdk/credential-providers": "^3.592.0",
 		"@cliqz/adblocker-playwright": "^1.27.2",
-		"@gradio/client": "^1.1.1",
+		"@gradio/client": "^1.8.0",
 		"@huggingface/hub": "^0.5.1",
 		"@huggingface/inference": "^2.7.0",
 		"@huggingface/transformers": "^3.0.0-alpha.6",


### PR DESCRIPTION
Gradio Spaces higher than version 4 were causing an issue in the tool editor.
Bump Gradio client library to latest (1.8.0) solves the issue 

Space `multimodalart/logo-in-context` demonstrates this:

Before...
![image](https://github.com/user-attachments/assets/467d7788-76f3-42ab-b269-2b4df8128af1)

After...
![image](https://github.com/user-attachments/assets/19792acd-019d-4e93-b0e7-008378538853)
