### PR TITLE
feat(openai): added support for o1 reasoning models

### DIFF
--- a/docs/source/configuration/models/providers/openai.md
+++ b/docs/source/configuration/models/providers/openai.md
@@ -53,6 +53,25 @@ MODELS=`[{
 }]`
 ```
 
+We also support models in the `o1` family. You need to add a few more options ot the config: Here is an example for `o1-mini`:
+
+```ini
+MODELS=`[
+  {
+      "name": "o1-mini",
+      "description": "ChatGPT o1-mini",
+      "systemRoleSupported": false,
+      "parameters": {
+        "max_new_tokens": 2048,
+      },
+      "endpoints" : [{
+        "type": "openai",
+        "useCompletionTokens": true,
+      }]
+  }
+]
+```
+
 You may also consume any model provider that provides compatible OpenAI API endpoint. For example, you may self-host [Portkey](https://github.com/Portkey-AI/gateway) gateway and experiment with Claude or GPTs offered by Azure OpenAI. Example for Claude from Anthropic:
 
 ```ini

--- a/src/lib/components/chat/MarkdownRenderer.svelte
+++ b/src/lib/components/chat/MarkdownRenderer.svelte
@@ -56,7 +56,7 @@
 			const escapedRight = right.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
 			// Create regex pattern that matches content between delimiters
-			const pattern = new RegExp(`${escapedLeft}([^]*?)${escapedRight}`, "g");
+			const pattern = new RegExp(`(?<!\\w)${escapedLeft}([^]*?)${escapedRight}(?!\\w)`, "g");
 
 			parsed = parsed.replace(pattern, (match, latex) => {
 				try {

--- a/src/lib/server/endpoints/openai/endpointOai.ts
+++ b/src/lib/server/endpoints/openai/endpointOai.ts
@@ -112,7 +112,7 @@ export const endpointOAIParametersSchema = z.object({
 		})
 		.default({}),
 	/* enable use of max_completion_tokens in place of max_tokens */
-	useCompletionTokens: z.boolean().default(true),
+	useCompletionTokens: z.boolean().default(false),
 });
 
 export async function endpointOai(
@@ -204,7 +204,10 @@ export async function endpointOai(
 
 			// if system role is not supported, convert first message to a user message.
 			if (!model.systemRoleSupported && messagesOpenAI?.[0]?.role === "system") {
-				messagesOpenAI[0].role = "user";
+				messagesOpenAI[0] = {
+					...messagesOpenAI[0],
+					role: "user",
+				};
 			}
 
 			if (toolResults && toolResults.length > 0) {

--- a/src/lib/server/endpoints/openai/endpointOai.ts
+++ b/src/lib/server/endpoints/openai/endpointOai.ts
@@ -203,7 +203,7 @@ export async function endpointOai(
 			}
 
 			// if system role is not supported, convert first message to a user message.
-			if(!model.systemRoleSupported && messagesOpenAI?.[0]?.role === "system") {
+			if (!model.systemRoleSupported && messagesOpenAI?.[0]?.role === "system") {
 				messagesOpenAI[0].role = "user";
 			}
 
@@ -249,7 +249,9 @@ export async function endpointOai(
 				model: model.id ?? model.name,
 				messages: messagesOpenAI,
 				stream: true,
-				...(useCompletionTokens) ? {max_completion_tokens: parameters?.max_new_tokens} : {max_tokens: parameters?.max_new_tokens},
+				...(useCompletionTokens
+					? { max_completion_tokens: parameters?.max_new_tokens }
+					: { max_tokens: parameters?.max_new_tokens }),
 				stop: parameters?.stop,
 				temperature: parameters?.temperature,
 				top_p: parameters?.top_p,

--- a/src/lib/server/endpoints/openai/endpointOai.ts
+++ b/src/lib/server/endpoints/openai/endpointOai.ts
@@ -199,6 +199,11 @@ export async function endpointOai(
 				messagesOpenAI[0].content = preprompt ?? "";
 			}
 
+			// if system role is not supported, convert first message to a user message.
+			if(!model.systemRoleSupported && messagesOpenAI?.[0]?.role === "system") {
+				messagesOpenAI[0].role = "user";
+			}
+
 			if (toolResults && toolResults.length > 0) {
 				const toolCallRequests: OpenAI.Chat.Completions.ChatCompletionAssistantMessageParam = {
 					role: "assistant",

--- a/src/lib/server/endpoints/openai/endpointOai.ts
+++ b/src/lib/server/endpoints/openai/endpointOai.ts
@@ -111,6 +111,8 @@ export const endpointOAIParametersSchema = z.object({
 			}),
 		})
 		.default({}),
+	/* enable use of max_completion_tokens in place of max_tokens */
+	useCompletionTokens: z.boolean().default(true),
 });
 
 export async function endpointOai(
@@ -125,6 +127,7 @@ export async function endpointOai(
 		defaultQuery,
 		multimodal,
 		extraBody,
+		useCompletionTokens,
 	} = endpointOAIParametersSchema.parse(input);
 
 	let OpenAI;
@@ -246,7 +249,7 @@ export async function endpointOai(
 				model: model.id ?? model.name,
 				messages: messagesOpenAI,
 				stream: true,
-				max_tokens: parameters?.max_new_tokens,
+				...(useCompletionTokens) ? {max_completion_tokens: parameters?.max_new_tokens} : {max_tokens: parameters?.max_new_tokens},
 				stop: parameters?.stop,
 				temperature: parameters?.temperature,
 				top_p: parameters?.top_p,


### PR DESCRIPTION
## Summary

1. Fixing a bug with `systemRoleSupported` for the OpenAI endpoint. 
2. Now using `max_completion_tokens` over `max_tokens` when querying `chat_completions` endpoint.

The bugfix is necessary as `o1-preview` and `o1-mini` models do not support "system" message types.
The token configuration change was necessary as `o1-preview` and `o1-mini` no longer support the, _now deprecated_, `max_tokens` field.

## Considerations

I added a new endpoint configuration field called `useCompletionTokens` and defaulted it to `true`. 
This would have the effect of changing the default `chat_completions` call to use `max_completion_tokens` over `max_tokens`.
There may be unintended consequences for users, as this could increase their overall token usage per query (as the default would change). 
It may be prudent to start with this field set to `false`, and later switch to `true` as part of a planned deprecate of `max_tokens` all together. 

Another consideration is that my change for system messages will leave a `"role": "user", "content": ""` entry. One thing we may want is to drop the system message entirely if content is blank  and system messages are not supported.

## Reference

For those wanting to introduce o1 reasoning models based on this PR (future readers), here is an example implementation of `o1-mini`:

```json
{
      "name": "o1-mini",
      "displayName": "o1 mini test",
      "multimodal": false,
      "description": "ChatGPT o1-mini",
      "systemRoleSupported": false,
      "parameters": {
        "max_new_tokens": 2048,
      },
      "endpoints" : [{
        "type": "openai",
      }]
}
```