### PR TITLE
Add support for allowing users based on their domain

### DIFF
--- a/.env
+++ b/.env
@@ -71,6 +71,8 @@ OPENID_CONFIG=
 MESSAGES_BEFORE_LOGIN=# how many messages a user can send in a conversation before having to login. set to 0 to force login right away
 # if it's defined, only these emails will be allowed to use login
 ALLOWED_USER_EMAILS=`[]` 
+# If it's defined, users with emails matching these domains will also be allowed to use login
+ALLOWED_USER_DOMAINS=`[]`
 # valid alternative redirect URLs for OAuth, used for HuggingChat apps
 ALTERNATIVE_REDIRECT_URLS=`[]` 
 ### Cookies


### PR DESCRIPTION
e.g.
  ALLOWED_USER_DOMAINS=`["example.com"]`
  will allow both foo@example.com and bar@example.com

A user can log in if one of the conditions is true:
  - ALLOWED_USER_DOMAINS and ALLOWED_USER_EMAILS are empty
  - their email is in ALLOWED_USER_EMAILS
  - their email domain ALLOWED_USER_DOMAINS

Fixes #1650