### PR TITLE
Rm redundant if check

### DIFF
--- a/src/lib/components/chat/ChatMessage.svelte
+++ b/src/lib/components/chat/ChatMessage.svelte
@@ -428,17 +428,15 @@
 							: ''}"
 					>
 						<div class="mx-auto flex flex-row flex-nowrap gap-2">
-							{#if downloadLink}
-								<a
-									class="rounded-lg border border-gray-100 bg-gray-100 p-1 text-xs text-gray-400 group-hover:block hover:text-gray-500 dark:border-gray-800 dark:bg-gray-800 dark:text-gray-400 dark:hover:text-gray-300 max-sm:!hidden md:hidden"
-									title="Download prompt and parameters"
-									type="button"
-									target="_blank"
-									href={downloadLink}
-								>
-									<CarbonDownload />
-								</a>
-							{/if}
+							<a
+								class="rounded-lg border border-gray-100 bg-gray-100 p-1 text-xs text-gray-400 group-hover:block hover:text-gray-500 dark:border-gray-800 dark:bg-gray-800 dark:text-gray-400 dark:hover:text-gray-300 max-sm:!hidden md:hidden"
+								title="Download prompt and parameters"
+								type="button"
+								target="_blank"
+								href={downloadLink}
+							>
+								<CarbonDownload />
+							</a>
 							{#if !readOnly}
 								<button
 									class="cursor-pointer rounded-lg border border-gray-100 bg-gray-100 p-1 text-xs text-gray-400 group-hover:block hover:text-gray-500 dark:border-gray-800 dark:bg-gray-800 dark:text-gray-400 dark:hover:text-gray-300 md:hidden lg:-right-2"


### PR DESCRIPTION
var `downloadLink` seem to be always defined

hide the whitespace diff

<img width="500" alt="image" src="https://github.com/user-attachments/assets/96ea705e-fee9-48d7-a983-c67a9b616d34" />
