### PR TITLE
feat: Enhance toast display to improve user experience (#1689)

### DIFF
--- a/src/lib/components/Toast.svelte
+++ b/src/lib/components/Toast.svelte
@@ -14,6 +14,6 @@
 		class="pointer-events-auto flex items-center rounded-full bg-white/90 px-3 py-1 shadow-sm dark:bg-gray-900/80"
 	>
 		<IconDazzled classNames="text-2xl mr-2" />
-		<h2 class="font-semibold">{message}</h2>
+		<h2 class="max-w-2xl font-semibold">{message}</h2>
 	</div>
 </div>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -43,7 +43,7 @@
 		errorToastTimeout = setTimeout(() => {
 			$error = null;
 			currentError = null;
-		}, 3000);
+		}, 10000);
 	}
 
 	async function deleteConversation(id: string) {


### PR DESCRIPTION
1. Updated the Toast component to add a maximum width for the message to prevent it from stretching across the full screen.
2. Increased the timeout duration for error toasts from 3 seconds to 10 seconds to ensure long messages are readable.