### PR TITLE
fix: move FinalAnswer outside of reasoning processing blocks

### DIFF
--- a/src/lib/server/textGeneration/generate.ts
+++ b/src/lib/server/textGeneration/generate.ts
@@ -119,15 +119,15 @@ Do not use prefixes such as Response: or Answer: when answering to the user.`,
 					finalAnswer =
 						text.slice(0, beginIndex) + text.slice(endIndex + model.reasoning.endToken.length);
 				}
-
-				yield {
-					type: MessageUpdateType.FinalAnswer,
-					text: finalAnswer,
-					interrupted,
-					webSources: output.webSources,
-				};
-				continue;
 			}
+
+			yield {
+				type: MessageUpdateType.FinalAnswer,
+				text: finalAnswer,
+				interrupted,
+				webSources: output.webSources,
+			};
+			continue;
 		}
 
 		if (model.reasoning && model.reasoning.type === "tokens") {


### PR DESCRIPTION
moving final answer outside of reasoning block so the ui displays all tokens for non reasoning models