### PR TITLE
feat(front): autoscroll at bottom on ssr

### DIFF
--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -275,8 +275,8 @@
 			{/if}
 
 			{#if messages.length > 0}
-				<div class="flex h-max flex-col gap-8 pb-52">
-					{#each messages as message, idx (message.id)}
+				<div class="flex h-max flex-col-reverse gap-8 pb-52">
+					{#each messages.toReversed() as message, idx (message.id)}
 						<ChatMessage
 							{loading}
 							{message}


### PR DESCRIPTION
use a reverse column layout so that the default scroll position is at the bottom on ssr, which removes the annoying flash when reloading the page 