### PR TITLE
feat(tasks): use tools for tasks if available

### DIFF
--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -380,6 +380,7 @@ envVars:
       },
       {
         "name": "meta-llama/Llama-3.1-8B-Instruct",
+        "tools": true,
         "parameters": {
           "temperature": 0.6,
           "stop": ["<|endoftext|>", "<|eot_id|>"]

--- a/src/lib/server/textGeneration/tools.ts
+++ b/src/lib/server/textGeneration/tools.ts
@@ -260,7 +260,7 @@ export async function* runTools(
 	return toolResults.filter((result): result is ToolResult => result !== undefined);
 }
 
-function externalToToolCall(call: unknown, tools: Tool[]): ToolCall | undefined {
+export function externalToToolCall(call: unknown, tools: Tool[]): ToolCall | undefined {
 	// Early return if invalid input
 	if (!isValidCallObject(call)) {
 		return undefined;

--- a/src/lib/server/tools/getToolOutput.ts
+++ b/src/lib/server/tools/getToolOutput.ts
@@ -1,0 +1,64 @@
+import type { Tool } from "$lib/types/Tool";
+import { extractJson } from "./utils";
+import { externalToToolCall } from "../textGeneration/tools";
+import { logger } from "../logger";
+import type { Endpoint, EndpointMessage } from "../endpoints/endpoints";
+
+interface GetToolOutputOptions {
+	messages: EndpointMessage[];
+	tool: Tool;
+	preprompt?: string;
+	endpoint: Endpoint;
+	generateSettings?: {
+		max_new_tokens?: number;
+		[key: string]: unknown;
+	};
+}
+
+export async function getToolOutput<T = string>({
+	messages,
+	preprompt,
+	tool,
+	endpoint,
+	generateSettings = { max_new_tokens: 64 },
+}: GetToolOutputOptions): Promise<T | undefined> {
+	try {
+		const stream = await endpoint({
+			messages,
+			preprompt: preprompt + `\n\n Only use tool ${tool.name}.`,
+			tools: [tool],
+			generateSettings,
+		});
+
+		const calls = [];
+
+		for await (const output of stream) {
+			if (output.token.toolCalls) {
+				calls.push(...output.token.toolCalls);
+			}
+			if (output.generated_text) {
+				const extractedCalls = await extractJson(output.generated_text).then((calls) =>
+					calls.map((call) => externalToToolCall(call, [tool])).filter((call) => call !== undefined)
+				);
+				calls.push(...extractedCalls);
+			}
+		}
+
+		if (calls.length > 0) {
+			// Find the tool call matching our tool
+			const toolCall = calls.find((call) => call.name === tool.name);
+
+			// If we found a matching call and it has parameters
+			if (toolCall?.parameters) {
+				// Get the first parameter value since most tools have a single main parameter
+				const firstParamValue = Object.values(toolCall.parameters)[0];
+				return firstParamValue as T;
+			}
+		}
+
+		return undefined;
+	} catch (error) {
+		logger.warn(error, "Error getting tool output");
+		return undefined;
+	}
+}

--- a/src/lib/server/websearch/search/generateQuery.ts
+++ b/src/lib/server/websearch/search/generateQuery.ts
@@ -7,56 +7,67 @@ import { smallModel } from "$lib/server/models";
 import type { Tool } from "$lib/types/Tool";
 import { extractJson } from "../../tools/utils";
 import { externalToToolCall } from "$lib/server/textGeneration/tools";
+import { logger } from "$lib/server/logger";
 
 export async function generateQuery(messages: Message[]) {
 	const currentDate = format(new Date(), "MMMM d, yyyy");
 
-	if (smallModel.tools) {
-		const webSearchTool = {
-			name: "web_search",
-			description: "Search the web for information",
-			inputs: [
-				{
-					name: "query",
-					type: "str",
-					description: "The query to search the web for",
-					paramType: "required",
+	try {
+		if (smallModel.tools) {
+			const webSearchTool = {
+				name: "web_search",
+				description: "Search the web for information",
+				inputs: [
+					{
+						name: "query",
+						type: "str",
+						description: "The query to search the web for",
+						paramType: "required",
+					},
+				],
+			} as unknown as Tool; // TODO: remove the casting like this
+
+			const endpoint = await smallModel.getEndpoint();
+			const stream = await endpoint({
+				messages,
+				tools: [webSearchTool],
+				generateSettings: {
+					max_new_tokens: 64,
 				},
-			],
-		} as unknown as Tool; // TODO: remove the casting like this
+			});
 
-		const endpoint = await smallModel.getEndpoint();
-		const stream = await endpoint({
-			messages,
-			tools: [webSearchTool],
-		});
+			const calls = [];
 
-		const calls = [];
-
-		for await (const output of stream) {
-			if (output.token.toolCalls) {
-				calls.push(...output.token.toolCalls);
+			for await (const output of stream) {
+				if (output.token.toolCalls) {
+					calls.push(...output.token.toolCalls);
+				}
+				if (output.generated_text) {
+					console.log("output.generated_text", output.generated_text);
+					const extractedCalls = await extractJson(output.generated_text).then((calls) =>
+						calls
+							.map((call) => externalToToolCall(call, [webSearchTool]))
+							.filter((call) => call !== undefined)
+					);
+					calls.push(...extractedCalls);
+				}
 			}
-			if (output.generated_text) {
-				const extractedCalls = await extractJson(output.generated_text).then((calls) =>
-					calls
-						.map((call) => externalToToolCall(call, [webSearchTool]))
-						.filter((call) => call !== undefined)
-				);
-				calls.push(...extractedCalls);
-			}
-		}
 
-		if (calls.length > 0) {
-			// Find the web search tool call
-			const webSearchCall = calls.find((call) => call.name === "web_search");
+			console.log("calls", calls);
 
-			// If we found a web search call, extract the query parameter
-			if (webSearchCall && webSearchCall.parameters && "query" in webSearchCall.parameters) {
-				return webSearchCall.parameters.query.toString();
+			if (calls.length > 0) {
+				// Find the web search tool call
+				const webSearchCall = calls.find((call) => call.name === "web_search");
+
+				// If we found a web search call, extract the query parameter
+				if (webSearchCall && webSearchCall.parameters && "query" in webSearchCall.parameters) {
+					return webSearchCall.parameters.query.toString();
+				}
 			}
 		}
-	} // otherwise we fallback to the old method
+	} catch (error) {
+		logger.error("Error generating query using tools", error);
+	}
 
 	const userMessages = messages.filter(({ from }) => from === "user");
 	const previousUserMessages = userMessages.slice(0, -1);


### PR DESCRIPTION
For the following tasks:
* web query generation
* summary of titles
* summary of reasoning steps

we now use tool calling if its available on the task model, with a single tool. 

(On HuggingChat the task model is llama 3.1 8B which can do tool calling so we enable it)


The intuition here is that the smaller model will be less confused with strict tool definitions and this should reduce answers that start with "Sorry but..." or irrelevant answers such as [this](https://huggingface.co/spaces/huggingchat/chat-ui/discussions/372#67cab5133a6e3e8656d28ffc). 