### PR TITLE
Fix system message handling to preserve user-configured system prompts

### DIFF
--- a/src/lib/server/endpoints/openai/endpointOai.ts
+++ b/src/lib/server/endpoints/openai/endpointOai.ts
@@ -198,25 +198,37 @@ export async function endpointOai(
 			toolResults,
 			conversationId,
 		}) => {
+			// Format messages for the chat API, handling multimodal content if supported
 			let messagesOpenAI: OpenAI.Chat.Completions.ChatCompletionMessageParam[] =
 				await prepareMessages(messages, imageProcessor, !model.tools && model.multimodal);
 
-			if (messagesOpenAI?.[0]?.role !== "system") {
-				messagesOpenAI = [{ role: "system", content: "" }, ...messagesOpenAI];
+			// Check if a system message already exists as the first message
+			const hasSystemMessage = messagesOpenAI.length > 0 && messagesOpenAI[0]?.role === "system";
+
+			if (hasSystemMessage) {
+				// System message exists - preserve user configuration
+				if (preprompt !== undefined) {
+					// Prepend preprompt to existing system message if preprompt exists
+					const userSystemPrompt = messagesOpenAI[0].content || "";
+					messagesOpenAI[0].content = preprompt + (userSystemPrompt ? "\n\n" + userSystemPrompt : "");
+				}
+				// If no preprompt, user's system message remains unchanged
+			} else {
+				// No system message exists - create a new one with preprompt or empty string
+				messagesOpenAI = [{ role: "system", content: preprompt ?? "" }, ...messagesOpenAI];
 			}
 
-			if (messagesOpenAI?.[0]) {
-				messagesOpenAI[0].content = preprompt ?? "";
-			}
-
-			// if system role is not supported, convert first message to a user message.
-			if (!model.systemRoleSupported && messagesOpenAI?.[0]?.role === "system") {
+			// Handle models that don't support system role by converting to user message
+			// This maintains compatibility with older or non-standard models
+			if (!model.systemRoleSupported && messagesOpenAI.length > 0 && messagesOpenAI[0]?.role === "system") {
 				messagesOpenAI[0] = {
 					...messagesOpenAI[0],
 					role: "user",
 				};
 			}
 
+			// Format tool results for the API to provide context for follow-up tool calls
+			// This creates the full conversation flow needed for multi-step tool interactions
 			if (toolResults && toolResults.length > 0) {
 				const toolCallRequests: OpenAI.Chat.Completions.ChatCompletionAssistantMessageParam = {
 					role: "assistant",
@@ -227,6 +239,7 @@ export async function endpointOai(
 				const responses: Array<OpenAI.Chat.Completions.ChatCompletionToolMessageParam> = [];
 
 				for (const result of toolResults) {
+					// Generate unique IDs to correlate tool calls with their responses
 					const id = uuidv4();
 
 					const toolCallResult: OpenAI.Chat.Completions.ChatCompletionMessageToolCall = {
@@ -253,12 +266,14 @@ export async function endpointOai(
 				messagesOpenAI.push(...responses);
 			}
 
+			// Combine model defaults with request-specific parameters
 			const parameters = { ...model.parameters, ...generateSettings };
 			const toolCallChoices = createChatCompletionToolsArray(tools);
 			const body = {
 				model: model.id ?? model.name,
 				messages: messagesOpenAI,
 				stream: streamingSupported,
+				// Support two different ways of specifying token limits depending on the model
 				...(useCompletionTokens
 					? { max_completion_tokens: parameters?.max_new_tokens }
 					: { max_tokens: parameters?.max_new_tokens }),
@@ -267,9 +282,11 @@ export async function endpointOai(
 				top_p: parameters?.top_p,
 				frequency_penalty: parameters?.repetition_penalty,
 				presence_penalty: parameters?.presence_penalty,
+				// Only include tool configuration if tools are provided
 				...(toolCallChoices.length > 0 ? { tools: toolCallChoices, tool_choice: "auto" } : {}),
 			};
 
+			// Handle both streaming and non-streaming responses with appropriate processors
 			if (streamingSupported) {
 				const openChatAICompletion = await openai.chat.completions.create(
 					body as ChatCompletionCreateParamsStreaming,


### PR DESCRIPTION
## Problem
Previously, when a preprompt was provided, it would completely replace any user-configured system message instead of being prepended to it.

## Solution
- Added explicit detection of existing system messages
- When a system message exists and preprompt is defined, prepend preprompt to the existing content
- When a system message exists and no preprompt is defined, preserve the user's message unchanged
- When no system message exists, create one with either preprompt or empty string
- Maintained handling for models that don't support system roles

## Testing
| Scenario | User System Prompt | Preprompt | Result |
|----------|-------------------|-----------|--------|
| 1 | ❌ No | ❌ No | System message with empty content is created |
| 2 | ❌ No | ✅ Yes | System message with preprompt content is created |
| 3 | ✅ Yes | ❌ No | User's system prompt is preserved unchanged |
| 4 | ✅ Yes | ✅ Yes | Preprompt + "\n\n" + User's system prompt |

## Breaking Changes
None - this change preserves all existing functionality while fixing the prompt handling logic.