### PR TITLE
Add `toolId` to ToolCall and use it in tool results

### DIFF
--- a/src/lib/server/endpoints/openai/endpointOai.ts
+++ b/src/lib/server/endpoints/openai/endpointOai.ts
@@ -227,7 +227,7 @@ export async function endpointOai(
 				const responses: Array<OpenAI.Chat.Completions.ChatCompletionToolMessageParam> = [];
 
 				for (const result of toolResults) {
-					const id = uuidv4();
+					const id = result?.call?.toolId || uuidv4();
 
 					const toolCallResult: OpenAI.Chat.Completions.ChatCompletionMessageToolCall = {
 						type: "function",

--- a/src/lib/server/endpoints/openai/openAIChatToTextGenerationStream.ts
+++ b/src/lib/server/endpoints/openai/openAIChatToTextGenerationStream.ts
@@ -115,6 +115,7 @@ export async function* openAIChatToTextGenerationStream(
 					toolCall: {
 						name: tool.function.name,
 						parameters: {},
+						toolId: tool.id,
 					},
 					parameterJsonString: "",
 				};

--- a/src/lib/types/Tool.ts
+++ b/src/lib/types/Tool.ts
@@ -178,6 +178,7 @@ export type ToolResult = ToolResultSuccess | ToolResultError;
 export interface ToolCall {
 	name: string;
 	parameters: Record<string, string | number | boolean>;
+	toolId: string;
 }
 
 export type BackendCall = (

--- a/src/lib/types/Tool.ts
+++ b/src/lib/types/Tool.ts
@@ -178,7 +178,7 @@ export type ToolResult = ToolResultSuccess | ToolResultError;
 export interface ToolCall {
 	name: string;
 	parameters: Record<string, string | number | boolean>;
-	toolId: string;
+	toolId?: string;
 }
 
 export type BackendCall = (


### PR DESCRIPTION
Add Tool id to Open ai tools calls.
Allows tools to work, especially for the Mistral AI api, via the open ai library.