### PR TITLE
Fix auto-scroll issue with message streaming in Svelte 5

### DIFF
--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -248,7 +248,7 @@
 <div class="relative min-h-0 min-w-0">
 	<div
 		class="scrollbar-custom h-full overflow-y-auto"
-		use:snapScrollToBottom={messages.map(message => message.content)}
+		use:snapScrollToBottom={messages.map((message) => message.content)}
 		bind:this={chatContainer}
 	>
 		<div

--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -248,7 +248,7 @@
 <div class="relative min-h-0 min-w-0">
 	<div
 		class="scrollbar-custom h-full overflow-y-auto"
-		use:snapScrollToBottom={messages.length ? [...messages] : false}
+		use:snapScrollToBottom={messages.map(message => message.content)}
 		bind:this={chatContainer}
 	>
 		<div


### PR DESCRIPTION
In Svelte 5, actions only update when the bound value changes by reference. Previously, snapScrollToBottom was bound to `messages`, which didn't trigger updates when only the content of a message changed during streaming.

Updated binding to `messages.map(message => message.content)` to ensure the action reacts to content changes, restoring expected scroll behavior.

Fix #1766 