### PR TITLE
feat: allow strings in `MODELS` env var

### DIFF
--- a/src/lib/server/models.ts
+++ b/src/lib/server/models.ts
@@ -116,19 +116,22 @@ const ggufModelsConfig = await Promise.all(
 const turnStringIntoLocalModel = z.preprocess((obj: unknown) => {
 	if (typeof obj !== "string") return obj;
 
+	const name = obj.startsWith("hf:") ? obj.split(":")[1] : obj;
 	const displayName = obj.startsWith("hf:")
 		? obj.split(":")[1].split("/").slice(0, 2).join("/")
 		: obj.endsWith(".gguf")
 			? obj.replace(".gguf", "")
 			: obj;
 
+	const modelPath = obj.includes("/") && !obj.startsWith("hf:") ? `hf:${obj}` : obj;
+
 	return {
-		name: obj,
+		name,
 		displayName,
 		endpoints: [
 			{
 				type: "local",
-				modelPath: obj,
+				modelPath,
 			},
 		],
 	} satisfies z.input<typeof modelConfig>;

--- a/src/lib/server/models.ts
+++ b/src/lib/server/models.ts
@@ -113,7 +113,28 @@ const ggufModelsConfig = await Promise.all(
 		})
 );
 
-let modelsRaw = z.array(modelConfig).parse(JSON5.parse(env.MODELS ?? "[]"));
+const turnStringIntoLocalModel = z.preprocess((obj: unknown) => {
+	if (typeof obj !== "string") return obj;
+
+	const displayName = obj.startsWith("hf:")
+		? obj.split(":")[1].split("/").slice(0, 2).join("/")
+		: obj.endsWith(".gguf")
+			? obj.replace(".gguf", "")
+			: obj;
+
+	return {
+		name: obj,
+		displayName,
+		endpoints: [
+			{
+				type: "local",
+				modelPath: obj,
+			},
+		],
+	} satisfies z.input<typeof modelConfig>;
+}, modelConfig);
+
+let modelsRaw = z.array(turnStringIntoLocalModel).parse(JSON5.parse(env.MODELS ?? "[]"));
 
 if (env.LOAD_GGUF_MODELS === "true" || modelsRaw.length === 0) {
 	const parsedGgufModels = z.array(modelConfig).parse(ggufModelsConfig);


### PR DESCRIPTION
This feature lets you simplify your `MODELS` env var by just specifying a bunch of model names on the hub and letting chat-ui deal with the rest.

For example

```
MODELS=['HuggingFaceTB/SmolLM2-1.7B-Instruct-GGUF']
```

would automatically download the relevant file and serve it locally with `node-llama-cpp`


The goal of this is to keep simplifying the setup experience of chat-ui for most users. #1774 