### PR TITLE
Fix incorrect touchscreen detection

### DIFF
--- a/src/lib/components/chat/ChatInput.svelte
+++ b/src/lib/components/chat/ChatInput.svelte
@@ -89,7 +89,7 @@
 		if (!browser) return false;
 
 		// Check for touch capability
-		if (navigator.maxTouchPoints > 0) return true;
+		if (navigator.maxTouchPoints > 0 && screen.width <= 768) return true;
 
 		// Check for touch events
 		if ("ontouchstart" in window) return true;


### PR DESCRIPTION
The UI erroneously detects a touchscreen laptop as a phone and assumes it has a virtual keyboard, which makes the Enter button not send a message but rather start a new line. This was mentioned in #1767.