### PR TITLE
feat: add SKIP_LLAMA_CPP_BUILD env var to build process

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -49,6 +49,7 @@ jobs:
             APP_BASE=/chat
             PUBLIC_APP_COLOR=yellow
             PUBLIC_COMMIT_SHA=${{ env.GITHUB_SHA_SHORT }}
+            SKIP_LLAMA_CPP_BUILD=true
   deploy:
     name: Deploy on prod
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -49,4 +49,4 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Build Docker image
-        run: docker build --secret id=DOTENV_LOCAL,src=.env.ci -t chat-ui:latest .
+        run: docker build --secret id=DOTENV_LOCAL,src=.env.ci --build-arg SKIP_LLAMA_CPP_BUILD=true -t chat-ui:latest .

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,9 @@ COPY --link --chown=1000 package-lock.json package.json ./
 
 ARG APP_BASE=
 ARG PUBLIC_APP_COLOR=blue
+ARG SKIP_LLAMA_CPP_BUILD
 ENV BODY_SIZE_LIMIT=15728640
+ENV SKIP_LLAMA_CPP_BUILD=$SKIP_LLAMA_CPP_BUILD
 
 RUN --mount=type=cache,target=/app/.npm \
     npm set cache /app/.npm && \

--- a/README.md
+++ b/README.md
@@ -1098,7 +1098,7 @@ You can build the docker images locally using the following commands:
 ```bash
 docker build -t chat-ui-db:latest --build-arg INCLUDE_DB=true .
 docker build -t chat-ui:latest --build-arg INCLUDE_DB=false .
-docker build -t huggingchat:latest --build-arg INCLUDE_DB=false --build-arg APP_BASE=/chat --build-arg PUBLIC_APP_COLOR=yellow .
+docker build -t huggingchat:latest --build-arg INCLUDE_DB=false --build-arg APP_BASE=/chat --build-arg PUBLIC_APP_COLOR=yellow --build-arg SKIP_LLAMA_CPP_BUILD=true .
 ```
 
 If you want to run the images with your local .env.local you have two options

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,7 +21,9 @@ function loadTTFAsArrayBuffer() {
 	};
 }
 const isViteNode = process.argv.some((arg) => arg.includes("vite-node")) || !!process.env.VITE_NODE;
-const shouldCopyLlama = process.env.npm_lifecycle_event === "build" && !isViteNode; // Copy node-llama-cpp/llama files to build output
+const skipLlamaCppBuild = process.env.SKIP_LLAMA_CPP_BUILD === "true";
+const shouldCopyLlama =
+	process.env.npm_lifecycle_event === "build" && !isViteNode && !skipLlamaCppBuild; // Copy node-llama-cpp/llama files to build output
 
 function copyLlamaFiles() {
 	return {


### PR DESCRIPTION
allows you to skip building llama.cpp if you know you are not going to use it