### PR TITLE
fix: remove quotes from search query to prevent exact match search

### DIFF
--- a/src/lib/server/websearch/search/generateQuery.ts
+++ b/src/lib/server/websearch/search/generateQuery.ts
@@ -66,5 +66,5 @@ export async function generateQuery(messages: Message[]) {
 		})
 	);
 
-	return webQuery.trim();
+	return webQuery.trim().replace(/^"|"$/g, "");
 }


### PR DESCRIPTION
Remove quotes from search query to prevent exact match search. This issue only happens when running locally.