### PR TITLE
fix: prevent MarkdownRenderer recreation overhead by removing {#key} wrapper

### DIFF
--- a/src/lib/components/chat/ChatMessage.svelte
+++ b/src/lib/components/chat/ChatMessage.svelte
@@ -196,9 +196,7 @@
 				<div
 					class="prose max-w-none dark:prose-invert max-sm:prose-sm prose-headings:font-semibold prose-h1:text-lg prose-h2:text-base prose-h3:text-base prose-pre:bg-gray-800 dark:prose-pre:bg-gray-900"
 				>
-					{#key message.content}
-						<MarkdownRenderer content={message.content} sources={webSearchSources} />
-					{/key}
+					<MarkdownRenderer content={message.content} sources={webSearchSources} />
 				</div>
 			</div>
 


### PR DESCRIPTION
- Remove {#key message.content} wrapper from ChatMessage component
- Allow MarkdownRenderer to handle content updates via reactive props
- Eliminate component destruction/recreation on every content change
- Improve streaming performance by reusing component instances