### PR TITLE
fix: Improve error handling in generateFromDefaultEndpoint

### DIFF
--- a/src/lib/server/generateFromDefaultEndpoint.ts
+++ b/src/lib/server/generateFromDefaultEndpoint.ts
@@ -11,11 +11,10 @@ export async function* generateFromDefaultEndpoint({
 	preprompt?: string;
 	generateSettings?: Record<string, unknown>;
 }): AsyncGenerator<MessageUpdate, string, undefined> {
-	const endpoint = await taskModel.getEndpoint();
-
-	const tokenStream = await endpoint({ messages, preprompt, generateSettings });
-
 	try {
+		const endpoint = await taskModel.getEndpoint();
+		const tokenStream = await endpoint({ messages, preprompt, generateSettings });
+
 		for await (const output of tokenStream) {
 			// if not generated_text is here it means the generation is not done
 			if (output.generated_text) {


### PR DESCRIPTION
- Refactor error handling in the generateFromDefaultEndpoint function to prevent the Node.js process from crashing when an AbortError occurs.
- Wrapped the getEndpoint and endpoint calls within a try...catch block to ensure that exceptions are caught and the process remains stable.


### Error Log
```
AbortError: This operation was aborted
    at node:internal/deps/undici/undici:13510:13
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async file:///app/build/server/chunks/models-BZWchM1f.js:9918:17
    at async generateFromDefaultEndpoint (file:///app/build/server/chunks/_server.ts-DQzfZKIq.js:380:23)\n    at async getReturnFromGenerator (file:///app/build/server/chunks/_server.ts-DQzfZKIq.js:405:14)
    at async generateTitle (file:///app/build/server/chunks/_server.ts-DQzfZKIq.js:2022:10)
    at async generateTitleForConversation (file:///app/build/server/chunks/_server.ts-DQzfZKIq.js:1978:19)
```