### PR TITLE
fix: add tick() to prevent textarea height adjustment failures

### DIFF
--- a/src/lib/components/chat/ChatInput.svelte
+++ b/src/lib/components/chat/ChatInput.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createEventDispatcher, onMount } from "svelte";
+	import { createEventDispatcher, onMount, tick } from "svelte";
 
 	import HoverTooltip from "$lib/components/HoverTooltip.svelte";
 	import IconInternet from "$lib/components/icons/IconInternet.svelte";
@@ -110,6 +110,7 @@
 		) {
 			event.preventDefault();
 			adjustTextareaHeight();
+			tick();
 			dispatch("submit");
 		}
 	}


### PR DESCRIPTION
- Add tick() after adjustTextareaHeight() in handleKeydown to ensure DOM updates are completed before the submit event is dispatched.

Without this fix, textarea height adjustment occasionally fails to complete before the submit event fires. This inconsistent behavior creates a race condition where the UI may appear broken when pressing Enter, as the height adjustment is scheduled but not guaranteed to be applied in time.

The fix targets specifically the handleKeydown function to maintain performance while ensuring the textarea always renders with the correct height in all cases before submission.