### PR TITLE
fix: Ensure deterministic height adjustment in handleKeydown

### DIFF
--- a/src/lib/components/chat/ChatInput.svelte
+++ b/src/lib/components/chat/ChatInput.svelte
@@ -109,9 +109,10 @@
 			value.trim() !== ""
 		) {
 			event.preventDefault();
-			adjustTextareaHeight();
-			tick();
 			dispatch("submit");
+			tick().then(() => {
+				adjustTextareaHeight();
+			});
 		}
 	}
 


### PR DESCRIPTION
This PR improves the fix introduced in #1854 by ensuring the textarea height adjustment completes deterministically after the submit event is dispatched.

Previously, there was a race condition where the textarea height adjustment could be scheduled but not applied before submission, leading to inconsistent UI behavior.

Changes:
- Improved the existing logic by `tick().then()` in `handleKeydown` ensuring DOM updates are applied after the submit event is dispatched.

Fixes: #1854