### PR TITLE
Fix: show all web search sources when multiple searches run in one message

### DIFF
--- a/src/lib/components/chat/ChatMessage.svelte
+++ b/src/lib/components/chat/ChatMessage.svelte
@@ -101,11 +101,13 @@
 	);
 	let urlNotTrailing = $derived(page.url.pathname.replace(/\/$/, ""));
 	let downloadLink = $derived(urlNotTrailing + `/message/${message.id}/prompt`);
-	let webSearchSources = $derived(
-		searchUpdates?.find(
-			(update): update is MessageWebSearchSourcesUpdate =>
-				update.subtype === MessageWebSearchUpdateType.Sources
-		)?.sources
+    let webSearchSources = $derived(
+		searchUpdates
+			?.filter(
+				(update): update is MessageWebSearchSourcesUpdate =>
+					update.subtype === MessageWebSearchUpdateType.Sources
+			)
+			?.flatMap(update => update.sources)
 	);
 
 	$effect(() => {


### PR DESCRIPTION
## Problem
When a single assistant message triggers multiple web searches in parallel
(e.g., “Compare the current weather in Paris and London, and also tell me about recent Apple tech news”),
the UI only showed sources from one of the searches. This happened because the code used `.find(...)?.sources`.

## What’s changed
- Replace `.find` with `.filter(...).flatMap(...)` over `MessageWebSearchUpdateType.Sources` updates.
- Result: the “Sources” chips now include links from **all** searches that contributed to the message.

## Before
Only a single search’s sources appeared under the message.

## After
All contributing searches’ sources appear.