### PR TITLE
Store oauth token in DB + use it when doing API calls

### DIFF
--- a/.env
+++ b/.env
@@ -8,7 +8,7 @@ OPENAI_BASE_URL=https://router.huggingface.co/v1
 
 # Canonical auth token for any OpenAI-compatible provider
 OPENAI_API_KEY=#your provider API key (works for HF router, OpenAI, LM Studio, etc.). 
-# When set to true, user token will be used for chats, internal token will still used for summarization, title, etc
+# When set to true, user token will be used for inference calls
 USE_USER_TOKEN=false
 
 ### MongoDB ###

--- a/.env
+++ b/.env
@@ -7,9 +7,9 @@
 OPENAI_BASE_URL=https://router.huggingface.co/v1
 
 # Canonical auth token for any OpenAI-compatible provider
-OPENAI_API_KEY=#your provider API key (works for HF router, OpenAI, LM Studio, etc.). Use "user-token" as a special value to use user's oauth token or API token
-# Legacy alias (still supported): if set and OPENAI_API_KEY is empty, it will be used
-# HF_TOKEN=
+OPENAI_API_KEY=#your provider API key (works for HF router, OpenAI, LM Studio, etc.). 
+# When set to true, user token will be used for chats, internal token will still used for summarization, title, etc
+USE_USER_TOKEN=false
 
 ### MongoDB ###
 MONGODB_URL=#your mongodb URL here, use chat-ui-db image if you don't want to set this

--- a/.env
+++ b/.env
@@ -7,7 +7,7 @@
 OPENAI_BASE_URL=https://router.huggingface.co/v1
 
 # Canonical auth token for any OpenAI-compatible provider
-OPENAI_API_KEY=#your provider API key (works for HF router, OpenAI, LM Studio, etc.)
+OPENAI_API_KEY=#your provider API key (works for HF router, OpenAI, LM Studio, etc.). Use "user-token" as a special value to use user's oauth token or API token
 # Legacy alias (still supported): if set and OPENAI_API_KEY is empty, it will be used
 # HF_TOKEN=
 

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -12,6 +12,7 @@ declare global {
 			sessionId: string;
 			user?: User & { logoutDisabled?: boolean };
 			isAdmin: boolean;
+			token?: string;
 		}
 
 		interface Error {

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -128,6 +128,7 @@ export const handle: Handle = async ({ event, resolve }) => {
 
 	event.locals.user = auth.user || undefined;
 	event.locals.sessionId = auth.sessionId;
+	event.locals.token = auth.token;
 
 	event.locals.isAdmin =
 		event.locals.user?.isAdmin || adminTokenManager.isAdmin(event.locals.sessionId);

--- a/src/lib/server/apiToken.ts
+++ b/src/lib/server/apiToken.ts
@@ -1,0 +1,11 @@
+import { config } from "$lib/server/config";
+
+export function getApiToken(locals: App.Locals | undefined) {
+	if (config.USE_USER_TOKEN === "true") {
+		if (!locals?.token) {
+			throw new Error("User token not found");
+		}
+		return locals.token;
+	}
+	return config.OPENAI_API_KEY || config.HF_TOKEN;
+}

--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -18,6 +18,7 @@ import { ObjectId } from "mongodb";
 import type { Cookie } from "elysia";
 import { adminTokenManager } from "./adminToken";
 import type { User } from "$lib/types/User";
+import type { Session } from "$lib/types/Session";
 
 export interface OIDCSettings {
 	redirectURI: string;
@@ -79,6 +80,7 @@ export async function findUser(
 ): Promise<{
 	user: User | null;
 	invalidateSession: boolean;
+	oauth?: Session["oauth"];
 }> {
 	const session = await collections.sessions.findOne({ sessionId });
 
@@ -93,6 +95,7 @@ export async function findUser(
 	return {
 		user: await collections.users.findOne({ _id: session.userId }),
 		invalidateSession: false,
+		oauth: session.oauth,
 	};
 }
 export const authCondition = (locals: App.Locals) => {
@@ -283,6 +286,7 @@ export async function authenticateRequest(
 
 		return {
 			user: result.user ?? undefined,
+			token: result.oauth?.token?.value,
 			sessionId,
 			secretSessionId,
 			isAdmin: result.user?.isAdmin || adminTokenManager.isAdmin(sessionId),
@@ -308,6 +312,7 @@ export async function authenticateRequest(
 				return {
 					user,
 					sessionId,
+					token,
 					secretSessionId,
 					isAdmin: user.isAdmin || adminTokenManager.isAdmin(sessionId),
 				};
@@ -338,6 +343,7 @@ export async function authenticateRequest(
 				user,
 				sessionId,
 				secretSessionId,
+				token,
 				isAdmin: user.isAdmin || adminTokenManager.isAdmin(sessionId),
 			};
 		}

--- a/src/lib/server/config.ts
+++ b/src/lib/server/config.ts
@@ -10,8 +10,6 @@ export type PublicConfigKey = keyof typeof publicEnv;
 const keysFromEnv = { ...publicEnv, ...serverEnv };
 export type ConfigKey = keyof typeof keysFromEnv;
 
-export const USE_USER_TOKEN = "user-token";
-
 class ConfigManager {
 	private keysFromDB: Partial<Record<ConfigKey, string>> = {};
 	private isInitialized = false;

--- a/src/lib/server/config.ts
+++ b/src/lib/server/config.ts
@@ -10,6 +10,8 @@ export type PublicConfigKey = keyof typeof publicEnv;
 const keysFromEnv = { ...publicEnv, ...serverEnv };
 export type ConfigKey = keyof typeof keysFromEnv;
 
+export const USE_USER_TOKEN = "user-token";
+
 class ConfigManager {
 	private keysFromDB: Partial<Record<ConfigKey, string>> = {};
 	private isInitialized = false;

--- a/src/lib/server/endpoints/endpoints.ts
+++ b/src/lib/server/endpoints/endpoints.ts
@@ -16,6 +16,7 @@ export interface EndpointParameters {
 	generateSettings?: Partial<Model["parameters"]>;
 	isMultimodal?: boolean;
 	conversationId?: ObjectId;
+	locals: App.Locals | undefined;
 }
 
 export type TextGenerationStreamOutputSimplified = TextGenerationStreamOutput & {

--- a/src/lib/server/generateFromDefaultEndpoint.ts
+++ b/src/lib/server/generateFromDefaultEndpoint.ts
@@ -7,18 +7,20 @@ export async function* generateFromDefaultEndpoint({
 	preprompt,
 	generateSettings,
 	modelId,
+	locals,
 }: {
 	messages: EndpointMessage[];
 	preprompt?: string;
 	generateSettings?: Record<string, unknown>;
 	/** Optional: use this model instead of the default task model */
 	modelId?: string;
+	locals: App.Locals | undefined;
 }): AsyncGenerator<MessageUpdate, string, undefined> {
 	try {
 		// Choose endpoint based on provided modelId, else fall back to taskModel
 		const model = modelId ? (models.find((m) => m.id === modelId) ?? taskModel) : taskModel;
 		const endpoint = await model.getEndpoint();
-		const tokenStream = await endpoint({ messages, preprompt, generateSettings });
+		const tokenStream = await endpoint({ messages, preprompt, generateSettings, locals });
 
 		for await (const output of tokenStream) {
 			// if not generated_text is here it means the generation is not done

--- a/src/lib/server/models.ts
+++ b/src/lib/server/models.ts
@@ -1,4 +1,4 @@
-import { config } from "$lib/server/config";
+import { config, USE_USER_TOKEN } from "$lib/server/config";
 import type { ChatTemplateInput } from "$lib/types/Template";
 import { z } from "zod";
 import endpoints, { endpointSchema, type Endpoint } from "./endpoints/endpoints";
@@ -109,7 +109,10 @@ if (openaiBaseUrl) {
 		logger.info({ baseURL }, "[models] Using OpenAI-compatible base URL");
 
 		// Canonical auth token is OPENAI_API_KEY; keep HF_TOKEN as legacy alias
-		const authToken = config.OPENAI_API_KEY || config.HF_TOKEN || "";
+		let authToken = config.OPENAI_API_KEY || config.HF_TOKEN;
+		if (authToken === USE_USER_TOKEN) {
+			authToken = "";
+		}
 
 		// Try unauthenticated request first (many model lists are public, e.g. HF router)
 		let response = await fetch(`${baseURL}/models`);

--- a/src/lib/server/models.ts
+++ b/src/lib/server/models.ts
@@ -1,4 +1,4 @@
-import { config, USE_USER_TOKEN } from "$lib/server/config";
+import { config } from "$lib/server/config";
 import type { ChatTemplateInput } from "$lib/types/Template";
 import { z } from "zod";
 import endpoints, { endpointSchema, type Endpoint } from "./endpoints/endpoints";
@@ -109,10 +109,7 @@ if (openaiBaseUrl) {
 		logger.info({ baseURL }, "[models] Using OpenAI-compatible base URL");
 
 		// Canonical auth token is OPENAI_API_KEY; keep HF_TOKEN as legacy alias
-		let authToken = config.OPENAI_API_KEY || config.HF_TOKEN;
-		if (authToken === USE_USER_TOKEN) {
-			authToken = "";
-		}
+		const authToken = config.OPENAI_API_KEY || config.HF_TOKEN;
 
 		// Try unauthenticated request first (many model lists are public, e.g. HF router)
 		let response = await fetch(`${baseURL}/models`);

--- a/src/lib/server/router/arch.ts
+++ b/src/lib/server/router/arch.ts
@@ -3,6 +3,7 @@ import { logger } from "$lib/server/logger";
 import type { EndpointMessage } from "../endpoints/endpoints";
 import type { Route, RouteConfig } from "./types";
 import { getRoutes } from "./policy";
+import { getApiToken } from "$lib/server/apiToken";
 
 const DEFAULT_LAST_TURNS = 16;
 const PROMPT_TEMPLATE = `
@@ -68,7 +69,8 @@ function parseRouteName(text: string): string | undefined {
 
 export async function archSelectRoute(
 	messages: EndpointMessage[],
-	traceId?: string
+	traceId: string | undefined,
+	locals: App.Locals | undefined
 ): Promise<{ routeName: string }> {
 	const routes = await getRoutes();
 	const prompt = toRouterPrompt(messages, routes);
@@ -82,7 +84,7 @@ export async function archSelectRoute(
 	}
 
 	const headers: HeadersInit = {
-		Authorization: `Bearer ${config.OPENAI_API_KEY || config.HF_TOKEN}`,
+		Authorization: `Bearer ${getApiToken(locals)}`,
 		"Content-Type": "application/json",
 	};
 	const body = {

--- a/src/lib/server/router/endpoint.ts
+++ b/src/lib/server/router/endpoint.ts
@@ -10,6 +10,7 @@ import { config } from "$lib/server/config";
 import { logger } from "$lib/server/logger";
 import { archSelectRoute } from "./arch";
 import { getRoutes, resolveRouteModels } from "./policy";
+import { getApiToken } from "$lib/server/apiToken";
 
 const REASONING_BLOCK_REGEX = /<think>[\s\S]*?(?:<\/think>|$)/g;
 
@@ -72,7 +73,7 @@ export async function makeRouterEndpoint(routerModel: ProcessedModel): Promise<E
 			return endpoints.openai({
 				type: "openai",
 				baseURL: (config.OPENAI_BASE_URL || "https://router.huggingface.co/v1").replace(/\/$/, ""),
-				apiKey: config.OPENAI_API_KEY || config.HF_TOKEN || "sk-",
+				apiKey: getApiToken(params.locals),
 				model: modelForCall,
 				// Ensure streaming path is used
 				streamingSupported: true,
@@ -133,7 +134,7 @@ export async function makeRouterEndpoint(routerModel: ProcessedModel): Promise<E
 			}
 		}
 
-		const { routeName } = await archSelectRoute(sanitizedMessages);
+		const { routeName } = await archSelectRoute(sanitizedMessages, undefined, params.locals);
 
 		const fallbackModel = config.LLM_ROUTER_FALLBACK_MODEL || routerModel.id;
 		const { candidates } = resolveRouteModels(routeName, routes, fallbackModel);

--- a/src/lib/server/textGeneration/generate.ts
+++ b/src/lib/server/textGeneration/generate.ts
@@ -116,6 +116,7 @@ Do not use prefixes such as Response: or Answer: when answering to the user.`,
 							max_tokens: 1024,
 						},
 						modelId: model.id,
+						locals,
 					});
 					finalAnswer = summary;
 					yield {
@@ -226,7 +227,7 @@ Do not use prefixes such as Response: or Answer: when answering to the user.`,
 			) {
 				lastReasoningUpdate = new Date();
 				try {
-					generateSummaryOfReasoning(reasoningBuffer, model.id).then((summary) => {
+					generateSummaryOfReasoning(reasoningBuffer, model.id, locals).then((summary) => {
 						status = summary;
 					});
 				} catch (e) {

--- a/src/lib/server/textGeneration/generate.ts
+++ b/src/lib/server/textGeneration/generate.ts
@@ -23,6 +23,7 @@ export async function* generate(
 		isContinue,
 		promptedAt,
 		forceMultimodal,
+		locals,
 	}: GenerateContext,
 	preprompt?: string
 ): AsyncIterable<MessageUpdate> {
@@ -57,6 +58,7 @@ export async function* generate(
 		// Allow user-level override to force multimodal
 		isMultimodal: (forceMultimodal ?? false) || model.multimodal,
 		conversationId: conv._id,
+		locals,
 	})) {
 		// Check if this output contains router metadata
 		if (

--- a/src/lib/server/textGeneration/index.ts
+++ b/src/lib/server/textGeneration/index.ts
@@ -23,7 +23,7 @@ async function* keepAlive(done: AbortSignal): AsyncGenerator<MessageUpdate, unde
 export async function* textGeneration(ctx: TextGenerationContext) {
 	const done = new AbortController();
 
-	const titleGen = generateTitleForConversation(ctx.conv);
+	const titleGen = generateTitleForConversation(ctx.conv, ctx.locals);
 	const textGen = textGenerationWithoutTitle(ctx, done);
 	const keepAliveGen = keepAlive(done.signal);
 

--- a/src/lib/server/textGeneration/reasoning.ts
+++ b/src/lib/server/textGeneration/reasoning.ts
@@ -3,7 +3,8 @@ import { getReturnFromGenerator } from "$lib/utils/getReturnFromGenerator";
 
 export async function generateSummaryOfReasoning(
 	buffer: string,
-	modelId?: string
+	modelId: string | undefined,
+	locals: App.Locals | undefined
 ): Promise<string> {
 	let summary: string | undefined;
 
@@ -25,6 +26,7 @@ export async function generateSummaryOfReasoning(
 					max_tokens: 50,
 				},
 				modelId,
+				locals,
 			})
 		);
 	}

--- a/src/lib/server/textGeneration/types.ts
+++ b/src/lib/server/textGeneration/types.ts
@@ -16,4 +16,5 @@ export interface TextGenerationContext {
 	username?: string;
 	/** Force-enable multimodal handling for endpoints that support it */
 	forceMultimodal?: boolean;
+	locals: App.Locals | undefined;
 }

--- a/src/lib/types/Session.ts
+++ b/src/lib/types/Session.ts
@@ -11,4 +11,12 @@ export interface Session extends Timestamps {
 	expiresAt: Date;
 	admin?: boolean;
 	coupledCookieHash?: string;
+
+	oauth?: {
+		token: {
+			value: string;
+			expiresAt: Date;
+		};
+		refreshToken?: string;
+	};
 }

--- a/src/routes/conversation/[id]/+server.ts
+++ b/src/routes/conversation/[id]/+server.ts
@@ -459,6 +459,7 @@ export async function POST({ request, locals, params, getClientAddress }) {
 							model.id
 						]
 					),
+					locals,
 				};
 				// run the text generation and send updates to the client
 				for await (const event of textGeneration(ctx)) await update(event);

--- a/src/routes/login/callback/+server.ts
+++ b/src/routes/login/callback/+server.ts
@@ -52,7 +52,7 @@ export async function GET({ url, locals, cookies, request, getClientAddress }) {
 		throw error(403, "Invalid or expired CSRF token");
 	}
 
-	const { userData } = await getOIDCUserData(
+	const { userData, token } = await getOIDCUserData(
 		{ redirectURI: validatedToken.redirectUrl },
 		code,
 		iss
@@ -79,6 +79,7 @@ export async function GET({ url, locals, cookies, request, getClientAddress }) {
 
 	await updateUser({
 		userData,
+		token,
 		locals,
 		cookies,
 		userAgent: request.headers.get("user-agent") ?? undefined,

--- a/src/routes/login/callback/updateUser.spec.ts
+++ b/src/routes/login/callback/updateUser.spec.ts
@@ -6,6 +6,7 @@ import { ObjectId } from "mongodb";
 import { DEFAULT_SETTINGS } from "$lib/types/Settings";
 import { defaultModel } from "$lib/server/models";
 import { findUser } from "$lib/server/auth";
+import type { TokenSet } from "openid-client";
 
 const userData = {
 	preferred_username: "new-username",
@@ -20,6 +21,13 @@ const locals = {
 	sessionId: "1234567890",
 	isAdmin: false,
 };
+
+const token = {
+	access_token: "access_token",
+	refresh_token: "refresh_token",
+	expires_at: 1717334400,
+	expires_in: 3600,
+} as TokenSet;
 
 // @ts-expect-error SvelteKit cookies dumb mock
 const cookiesMock: Cookies = {
@@ -61,7 +69,7 @@ describe("login", () => {
 	it("should update user if existing", async () => {
 		await insertRandomUser();
 
-		await updateUser({ userData, locals, cookies: cookiesMock });
+		await updateUser({ userData, locals, cookies: cookiesMock, token });
 
 		const existingUser = await collections.users.findOne({ hfUserId: userData.sub });
 
@@ -75,7 +83,7 @@ describe("login", () => {
 
 		await insertRandomConversations(2);
 
-		await updateUser({ userData, locals, cookies: cookiesMock });
+		await updateUser({ userData, locals, cookies: cookiesMock, token });
 
 		const conversationCount = await collections.conversations.countDocuments({
 			userId: insertedId,
@@ -88,7 +96,7 @@ describe("login", () => {
 	});
 
 	it("should create default settings for new user", async () => {
-		await updateUser({ userData, locals, cookies: cookiesMock });
+		await updateUser({ userData, locals, cookies: cookiesMock, token });
 
 		const user = (await findUser(locals.sessionId)).user;
 
@@ -115,7 +123,7 @@ describe("login", () => {
 			shareConversationsWithModelAuthors: false,
 		});
 
-		await updateUser({ userData, locals, cookies: cookiesMock });
+		await updateUser({ userData, locals, cookies: cookiesMock, token });
 
 		const settings = await collections.settings.findOne({
 			_id: insertedId,


### PR DESCRIPTION
Need `USE_USER_TOKEN="true"` in env to sue the user token

Still need to:

- refresh oauth token when it expires
- otherwise force oauth login to always have a oauth fresh token

and, separate:

- automatically login via oauth if a param is set

cc @gary149 