### PR TITLE
Automatic login

### DIFF
--- a/.env
+++ b/.env
@@ -10,6 +10,8 @@ OPENAI_BASE_URL=https://router.huggingface.co/v1
 OPENAI_API_KEY=#your provider API key (works for HF router, OpenAI, LM Studio, etc.). 
 # When set to true, user token will be used for inference calls
 USE_USER_TOKEN=false
+# Automatically redirect to oauth login page if user is not logged in, when set to "true"
+AUTOMATIC_LOGIN=false
 
 ### MongoDB ###
 MONGODB_URL=#your mongodb URL here, use chat-ui-db image if you don't want to set this

--- a/src/lib/server/adminToken.ts
+++ b/src/lib/server/adminToken.ts
@@ -37,9 +37,11 @@ class AdminTokenManager {
 		// if admin token is set, don't display it
 		if (!this.enabled || config.ADMIN_TOKEN) return;
 
-		let port = process.argv.includes("--port")
-			? parseInt(process.argv[process.argv.indexOf("--port") + 1])
-			: undefined;
+		let port = process.env.PORT
+			? parseInt(process.env.PORT)
+			: process.argv.includes("--port")
+				? parseInt(process.argv[process.argv.indexOf("--port") + 1])
+				: undefined;
 
 		if (!port) {
 			const mode = process.argv.find((arg) => arg === "preview" || arg === "dev");

--- a/src/lib/server/endpoints/openai/endpointOai.ts
+++ b/src/lib/server/endpoints/openai/endpointOai.ts
@@ -106,7 +106,14 @@ export async function endpointOai(
 	const imageProcessor = makeImageProcessor(multimodal.image);
 
 	if (completion === "completions") {
-		return async ({ messages, preprompt, continueMessage, generateSettings, conversationId }) => {
+		return async ({
+			messages,
+			preprompt,
+			continueMessage,
+			generateSettings,
+			conversationId,
+			locals,
+		}) => {
 			const prompt = await buildPrompt({
 				messages,
 				continueMessage,
@@ -132,13 +139,21 @@ export async function endpointOai(
 				headers: {
 					"ChatUI-Conversation-ID": conversationId?.toString() ?? "",
 					"X-use-cache": "false",
+					...(locals?.token ? { Authorization: `Bearer ${locals.token}` } : {}),
 				},
 			});
 
 			return openAICompletionToTextGenerationStream(openAICompletion);
 		};
 	} else if (completion === "chat_completions") {
-		return async ({ messages, preprompt, generateSettings, conversationId, isMultimodal }) => {
+		return async ({
+			messages,
+			preprompt,
+			generateSettings,
+			conversationId,
+			isMultimodal,
+			locals,
+		}) => {
 			// Format messages for the chat API, handling multimodal content if supported
 			let messagesOpenAI: OpenAI.Chat.Completions.ChatCompletionMessageParam[] =
 				await prepareMessages(messages, imageProcessor, isMultimodal ?? model.multimodal);
@@ -186,6 +201,7 @@ export async function endpointOai(
 						headers: {
 							"ChatUI-Conversation-ID": conversationId?.toString() ?? "",
 							"X-use-cache": "false",
+							...(locals?.token ? { Authorization: `Bearer ${locals.token}` } : {}),
 						},
 					}
 				);
@@ -198,6 +214,7 @@ export async function endpointOai(
 						headers: {
 							"ChatUI-Conversation-ID": conversationId?.toString() ?? "",
 							"X-use-cache": "false",
+							...(locals?.token ? { Authorization: `Bearer ${locals.token}` } : {}),
 						},
 					}
 				);

--- a/src/routes/login/+server.ts
+++ b/src/routes/login/+server.ts
@@ -1,29 +1,5 @@
-import { getOIDCAuthorizationUrl } from "$lib/server/auth";
-import { base } from "$app/paths";
-import { config } from "$lib/server/config";
+import { triggerOauthFlow } from "$lib/server/auth";
 
 export async function GET({ request, url, locals }) {
-	const referer = request.headers.get("referer");
-	let redirectURI = `${(referer ? new URL(referer) : url).origin}${base}/login/callback`;
-
-	// TODO: Handle errors if provider is not responding
-
-	if (url.searchParams.has("callback")) {
-		const callback = url.searchParams.get("callback") || redirectURI;
-		if (config.ALTERNATIVE_REDIRECT_URLS.includes(callback)) {
-			redirectURI = callback;
-		}
-	}
-
-	const authorizationUrl = await getOIDCAuthorizationUrl(
-		{ redirectURI },
-		{ sessionId: locals.sessionId }
-	);
-
-	return new Response(null, {
-		status: 302,
-		headers: {
-			Location: authorizationUrl,
-		},
-	});
+	return await triggerOauthFlow({ request, url, locals });
 }


### PR DESCRIPTION
Env to test things:

```
#.env.local
OPENID_CLIENT_ID=8f1a1d63-479b-46c8-84cb-521fe9f3222f
OPENID_CLIENT_SECRET=...
OPENID_SCOPES="openid profile inference-api"
USE_USER_TOKEN=true
AUTOMATIC_LOGIN=true
```

This PR forces a login when user is not logged in. We could tweak it that on failure, for the same session, it doesn't retry (currently it always retries)

We can also add a "prompt=none" in the oauth param (via another env var) and tweak the backend to automatically authorize the oauth app, if we want something 100% seamless. Currently the consent screen shows.

Still need to:

-   refresh oauth token when it expires
-   otherwise force oauth login to always have a oauth fresh token
