### PR TITLE
Add message trimming for router prompt construction

### DIFF
--- a/.env
+++ b/.env
@@ -62,6 +62,10 @@ LLM_ROUTER_OTHER_ROUTE=casual_conversation
 LLM_ROUTER_FALLBACK_MODEL=
 # Arch selection timeout in milliseconds (default 10000)
 LLM_ROUTER_ARCH_TIMEOUT_MS=10000
+# Maximum length (in characters) for assistant messages sent to router for route selection (default 500)
+LLM_ROUTER_MAX_ASSISTANT_LENGTH=500
+# Maximum length (in characters) for previous user messages sent to router (latest user message not trimmed, default 400)
+LLM_ROUTER_MAX_PREV_USER_LENGTH=400
 
 # Enable router multimodal fallback (set to true to allow image inputs via router)
 LLM_ROUTER_ENABLE_MULTIMODAL=false


### PR DESCRIPTION
Introduces configurable maximum lengths for assistant and previous user messages in the router prompt via new .env variables. Implements a trimMiddle function to keep the start and end of long messages, improving prompt efficiency and latency while preserving relevant context for route selection.