### PR TITLE
Add Poe as a provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ MONGODB_URL=
 | llama.cpp server (`llama.cpp --server --api`) | `http://127.0.0.1:8080/v1`         | `OPENAI_API_KEY=sk-local-demo` (any string works; llama.cpp ignores it) |
 | Ollama (with OpenAI-compatible bridge)        | `http://127.0.0.1:11434/v1`        | `OPENAI_API_KEY=ollama`                                                 |
 | OpenRouter                                    | `https://openrouter.ai/api/v1`     | `OPENAI_API_KEY=sk-or-v1-...`                                           |
+| Poe                                           | `https://api.poe.com/v1`           | `OPENAI_API_KEY=pk_...`                                                 |
 
 Check the root [`.env` template](./.env) for the full list of optional variables you can override.
 


### PR DESCRIPTION
## Description

This pull request adds [Poe](https://poe.com/) as a supported OpenAI-compatible provider within the chat-ui configuration.

- Endpoint: https://api.poe.com/v1
- Environment variable: OPENAI_API_KEY=pk_...

Enables developers to connect Poe models directly through the same OpenAI API interface used for other providers (e.g., OpenRouter, Ollama, llama.cpp).

## Why

Expands the set of compatible backends for developers using chat-ui, providing a lightweight path to access models hosted on Poe without additional adapters. This also expands support of Chat-UI to include image, video, audio models. 

## Changes

Added Poe to the provider list in README.md.

Verified endpoint and key usage match the OpenAI spec.

Example
OPENAI_API_BASE=https://api.poe.com/v1
OPENAI_API_KEY=pk_yourkey