### PR TITLE
lint & ignore ts error on old migration scripts

### DIFF
--- a/src/lib/migrations/routines/02-update-assistants-models.ts
+++ b/src/lib/migrations/routines/02-update-assistants-models.ts
@@ -7,6 +7,7 @@ const updateAssistantsModels: Migration = {
 	name: "Update deprecated models in assistants with the default model",
 	up: async () => {
 		const models = (await import("$lib/server/models")).models;
+		//@ts-expect-error the property doesn't exist anymore, keeping the script for reference
 		const oldModels = (await import("$lib/server/models")).oldModels;
 		const { assistants } = collections;
 
@@ -20,7 +21,7 @@ const updateAssistantsModels: Migration = {
 				// has an old model
 				let newModelId = defaultModelId;
 
-				const oldModel = oldModels.find((m) => m.id === assistant.modelId);
+				const oldModel = oldModels.find((m: (typeof models)[number]) => m.id === assistant.modelId);
 				if (oldModel && oldModel.transferTo && !!models.find((m) => m.id === oldModel.transferTo)) {
 					newModelId = oldModel.transferTo;
 				}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -285,7 +285,16 @@
 
 	{#if publicConfig.PUBLIC_PLAUSIBLE_SCRIPT_URL}
 		<script>
-			window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
+			(window.plausible =
+				window.plausible ||
+				function () {
+					(plausible.q = plausible.q || []).push(arguments);
+				}),
+				(plausible.init =
+					plausible.init ||
+					function (i) {
+						plausible.o = i || {};
+					});
 			plausible.init();
 		</script>
 	{/if}


### PR DESCRIPTION
make the CI green again