### PR TITLE
mcp: tool results now properly rendered

### DIFF
--- a/src/lib/components/chat/ToolUpdate.svelte
+++ b/src/lib/components/chat/ToolUpdate.svelte
@@ -253,7 +253,8 @@
 					{#each parseToolOutputs(update.result.outputs) as parsedOutput}
 						<div class="space-y-2 py-2 first:pt-0 last:pb-0">
 							{#if parsedOutput.text}
-								<pre class="whitespace-pre-wrap break-all font-mono">{parsedOutput.text}</pre>
+								<!-- prettier-ignore -->
+								<pre class="whitespace-pre-wrap break-all font-mono text-xs">{parsedOutput.text}</pre>
 							{/if}
 
 							{#if parsedOutput.images.length > 0}


### PR DESCRIPTION
## Text content: `<pre>` + monospace (terminal-style)

<img width="436" height="452" alt="tool-result-text" src="https://github.com/user-attachments/assets/892ece32-b2eb-4415-93bc-c7ab06033996" />

## Image content: base64 decoded as `<img>`

<img width="464" height="452" alt="tool-result-image" src="https://github.com/user-attachments/assets/99b7fb35-f69b-47cb-ab44-03dc0a2ccfe9" />

## Conforms to MCP spec 2025-06-18