### PR TITLE
Reset MCP timeout on Progress Notifications

### DIFF
--- a/src/lib/server/mcp/httpClient.ts
+++ b/src/lib/server/mcp/httpClient.ts
@@ -40,7 +40,13 @@ export async function callMcpTool(
 	const response = await activeClient.callTool(
 		{ name: tool, arguments: normalizedArgs },
 		undefined,
-		{ signal, timeout: timeoutMs }
+		{
+			signal,
+			timeout: timeoutMs,
+			// Enable progress tokens so long-running tools keep extending the timeout.
+			onprogress: () => {},
+			resetTimeoutOnProgress: true,
+		}
 	);
 
 	const parts = Array.isArray(response?.content) ? (response.content as Array<unknown>) : [];


### PR DESCRIPTION
Allow Tool Calls >30s as long as they send updates... progress info not surfaced to UX.