### PR TITLE
fix: remove redundant apt install that fails as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,6 +90,4 @@ ENV BODY_SIZE_LIMIT=15728640
 COPY --from=builder --chown=1000 /app/build /app/build
 COPY --from=builder --chown=1000 /app/node_modules /app/node_modules
 
-RUN apt -y update && apt-get install -y curl dnsutils
-
 CMD ["/bin/bash", "-c", "/app/entrypoint.sh"]


### PR DESCRIPTION
The apt command in the final stage runs as user 1000 (non-root), causing permission denied errors. The packages (curl, dnsutils) are already installed in the base image at line 24 as root.