### PR TITLE
Fix double-click issue in navigation bar

### DIFF
--- a/src/lib/components/NavConversationItem.svelte
+++ b/src/lib/components/NavConversationItem.svelte
@@ -26,6 +26,7 @@
 
 <a
 	data-sveltekit-noscroll
+	data-sveltekit-preload-data="tap"
 	onmouseleave={() => {
 		confirmDelete = false;
 	}}


### PR DESCRIPTION
Change preload behavior for conversation links from "hover" to "tap".

The issue was caused by SvelteKit's data preloading on hover combined with production network conditions. When hovering over a conversation link, preloading would start but could be slow or fail due to network latency. Clicking while a preload was pending/failed would cause the first click to be ineffective.

By using data-sveltekit-preload-data="tap", the preload only starts when the user clicks, eliminating the race condition between hover preload and click navigation.