### PR TITLE
filter out transcription returning ellipsis dots

### DIFF
--- a/src/routes/api/transcribe/+server.ts
+++ b/src/routes/api/transcribe/+server.ts
@@ -85,7 +85,10 @@ export async function POST({ request, locals }) {
 		const result = await response.json();
 
 		// Whisper API returns { text: "transcribed text" }
-		return json({ text: result.text || "" });
+		// Filter out responses that only contain dots (e.g. "..." returned for silence/unclear audio)
+		const text = (result.text || "").trim();
+		const isOnlyDots = /^\.+$/.test(text);
+		return json({ text: isOnlyDots ? "" : text });
 	} catch (err) {
 		if (err instanceof Error && err.name === "AbortError") {
 			logger.error({ model: transcriptionModel }, "Transcription timeout");


### PR DESCRIPTION
Whisper model returns "..." (or similar dot patterns) when audio is too short, silent, or unclear. Filter out responses that only contain dots server-side to prevent them from being inserted into the draft message or triggering auto-send on mobile.