### PR TITLE
Make models endpoint accessible without authentication

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -145,10 +145,12 @@ export const handle: Handle = async ({ event, resolve }) => {
 
 	if (loginEnabled && !auth.user && !event.url.pathname.startsWith(`${base}/.well-known/`)) {
 		if (config.AUTOMATIC_LOGIN === "true") {
-			// AUTOMATIC_LOGIN: always redirect to OAuth flow (unless already on login or healthcheck pages)
+			// AUTOMATIC_LOGIN: always redirect to OAuth flow (unless already on login, healthcheck, models, or api pages)
 			if (
 				!event.url.pathname.startsWith(`${base}/login`) &&
-				!event.url.pathname.startsWith(`${base}/healthcheck`)
+				!event.url.pathname.startsWith(`${base}/healthcheck`) &&
+				!event.url.pathname.startsWith(`${base}/models`) &&
+				!event.url.pathname.startsWith(`${base}/api`)
 			) {
 				// To get the same CSRF token after callback
 				refreshSessionCookie(event.cookies, auth.secretSessionId);
@@ -164,7 +166,7 @@ export const handle: Handle = async ({ event, resolve }) => {
 				!event.url.pathname.startsWith(`${base}/healthcheck`) &&
 				!event.url.pathname.startsWith(`${base}/r/`) &&
 				!event.url.pathname.startsWith(`${base}/conversation/`) &&
-				!event.url.pathname.startsWith(`${base}/models/`) &&
+				!event.url.pathname.startsWith(`${base}/models`) &&
 				!event.url.pathname.startsWith(`${base}/api`)
 			) {
 				refreshSessionCookie(event.cookies, auth.secretSessionId);


### PR DESCRIPTION
…TIC_LOGIN is enabled

Previously, with AUTOMATIC_LOGIN=true, all routes except /login and /healthcheck would redirect to OAuth. This prevented unauthenticated access to the /models page and API endpoints like /api/models.

This aligns the AUTOMATIC_LOGIN behavior with the regular login flow, which already excludes /models and /api routes from the OAuth redirect.

Also fixes the /models/ pattern to /models (without trailing slash) so that the /models page itself is matched, not just /models/* subpages.