### PR TITLE
Fix XSS vulnerability in href attribute injection

### DIFF
--- a/src/lib/utils/marked.ts
+++ b/src/lib/utils/marked.ts
@@ -194,7 +194,7 @@ function addInlineCitations(md: string, webSearchSources: SimpleSource[] = []): 
 				if (index === 0) return false;
 				const source = webSearchSources[index - 1];
 				if (source) {
-					return `<a href="${source.link}" target="_blank" rel="noreferrer" style="${linkStyle}">${index}</a>`;
+					return `<a href="${escapeHTML(source.link)}" target="_blank" rel="noreferrer" style="${linkStyle}">${index}</a>`;
 				}
 				return "";
 			})
@@ -235,7 +235,7 @@ function createMarkedInstance(sources: SimpleSource[]): Marked {
 			link: (href, title, text) => {
 				const safeHref = sanitizeHref(href);
 				return safeHref
-					? `<a href="${safeHref}" target="_blank" rel="noreferrer">${text}</a>`
+					? `<a href="${escapeHTML(safeHref)}" target="_blank" rel="noreferrer">${text}</a>`
 					: `<span>${escapeHTML(text ?? "")}</span>`;
 			},
 			html: (html) => escapeHTML(html),


### PR DESCRIPTION
## Summary
- Fixes critical XSS vulnerability allowing JavaScript execution via crafted URLs
- Escapes HTML special characters in href attributes using existing `escapeHTML()` function
- Prevents attribute injection attacks like `https://a.com"onmouseover="alert()"`

## Root Cause
URLs placed in `href` attributes were not being escaped, allowing attackers to break out of the attribute with a double quote and inject event handlers.

**Vulnerable code:**
```typescript
return `<a href="${source.link}" ...>`;  // source.link not escaped
```

**Attack payload:** `https://a.com"onmouseover="alert(document.cookie);"`

**Rendered HTML (before fix):**
```html
<a href="https://a.com"onmouseover="alert(document.cookie);"" ...>
```

## Fix
Apply `escapeHTML()` to href values:
- Line 197: `addInlineCitations()` - citation source links  
- Line 238: Link renderer - markdown links

## Regression Source
The vulnerability was re-introduced in e0ebf461 (Nov 20, 2025, PR #1989) which removed the `escapeAttribute` function during refactoring.

## Test plan
- [ ] Verify payload `https://a.com"onmouseover="alert()"` renders as escaped URL, not executable JS
- [ ] Verify normal URLs still work correctly
- [ ] Verify shared chat links don't execute injected scripts