### PR TITLE
[Fix]: Hovering bug of close button in dark theme.

### DIFF
--- a/src/lib/components/chat/UploadedFile.svelte
+++ b/src/lib/components/chat/UploadedFile.svelte
@@ -95,7 +95,7 @@
 					</p>
 				{/if}
 				<button
-					class="absolute right-4 top-4 text-xl text-gray-500 hover:text-gray-800"
+					class="absolute right-4 top-4 text-xl text-gray-500 hover:text-gray-800 dark:text-gray-400 dark:hover:text-white"
 					onclick={() => (showModal = false)}
 				>
 					<CarbonClose class="text-xl" />


### PR DESCRIPTION
This PR fixes the hovering bug of the Close button on Pasted Content panel in dark theme.

https://github.com/user-attachments/assets/73af582a-7e8d-47bf-82e3-f96e919af458

- Closes #2033 