### PR TITLE
fix(mcp): communicate tool errors to LLM to prevent hallucinated success

### DIFF
--- a/src/lib/server/textGeneration/mcp/toolInvocation.ts
+++ b/src/lib/server/textGeneration/mcp/toolInvocation.ts
@@ -300,6 +300,9 @@ export async function* executeToolCalls({
 			toolRuns.push({ name, parameters: r.paramsClean, output });
 			// For the LLM follow-up call, we keep only the textual output
 			toolMessages.push({ role: "tool", tool_call_id: id, content: output });
+		} else {
+			// Communicate error to LLM so it doesn't hallucinate success
+			toolMessages.push({ role: "tool", tool_call_id: id, content: `Error: ${r.error}` });
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Fix bug where MCP tool errors were shown in UI but not sent to the LLM
- LLM was hallucinating success because it never received failure feedback
- Now error messages are included in `toolMessages` array

## Problem
When a tool call fails (e.g., timeout), the error appeared in the UI but the LLM received no tool response message. Without knowing the call failed, the LLM would claim success anyway.

## Solution
Add an `else` branch to include error messages in `toolMessages`:
```typescript
} else {
    toolMessages.push({ role: "tool", tool_call_id: id, content: `Error: ${r.error}` });
}
```

## Test plan
- [ ] Trigger a tool timeout (e.g., long-running video generation)
- [ ] Verify LLM acknowledges the failure instead of claiming success
- [ ] Test mixed success/failure scenarios with multiple tool calls