### PR TITLE
fix(markdown): lazy-load DOMPurify to avoid Web Worker crash

### DIFF
--- a/src/lib/utils/marked.ts
+++ b/src/lib/utils/marked.ts
@@ -5,6 +5,7 @@ import type { Tokens, TokenizerExtension, RendererExtension } from "marked";
 
 // Lazy-load DOMPurify to avoid crashes in Web Workers (no window/DOM)
 // Web Workers have importScripts but no window
+declare const importScripts: unknown;
 const isWebWorker = typeof importScripts === "function" && typeof window === "undefined";
 const DOMPurify = isWebWorker ? null : (await import("isomorphic-dompurify")).default;
 // Simple type to replace removed WebSearchSource


### PR DESCRIPTION
## Summary
- Fix Web Worker crash caused by DOMPurify import (Web Workers don't have `window`)
- Lazy-load DOMPurify only on main thread, fall back to `escapeHTML()` in workers
- Fixes streaming appearing cut off due to `ReferenceError: window is not defined`

## Test plan
- [x] Tests pass (`npm run test -- --run src/lib/utils/marked.spec.ts`)
- [ ] Manual test: streaming works without console errors
- [ ] Video/audio tags render correctly after streaming completes