### PR TITLE
Allow X-HF-Bill-To header for all deployments

### DIFF
--- a/src/lib/server/endpoints/openai/endpointOai.ts
+++ b/src/lib/server/endpoints/openai/endpointOai.ts
@@ -148,10 +148,8 @@ export async function endpointOai(
 					"ChatUI-Conversation-ID": conversationId?.toString() ?? "",
 					"X-use-cache": "false",
 					...(locals?.token ? { Authorization: `Bearer ${locals.token}` } : {}),
-					// Bill to organization if configured (HuggingChat only)
-					...(config.isHuggingChat && locals?.billingOrganization
-						? { "X-HF-Bill-To": locals.billingOrganization }
-						: {}),
+					// Bill to organization if configured
+					...(locals?.billingOrganization ? { "X-HF-Bill-To": locals.billingOrganization } : {}),
 				},
 				signal: abortSignal,
 			});
@@ -222,10 +220,8 @@ export async function endpointOai(
 							"ChatUI-Conversation-ID": conversationId?.toString() ?? "",
 							"X-use-cache": "false",
 							...(locals?.token ? { Authorization: `Bearer ${locals.token}` } : {}),
-							// Bill to organization if configured (HuggingChat only)
-							...(config.isHuggingChat && locals?.billingOrganization
-								? { "X-HF-Bill-To": locals.billingOrganization }
-								: {}),
+							// Bill to organization if configured
+							...(locals?.billingOrganization ? { "X-HF-Bill-To": locals.billingOrganization } : {}),
 						},
 						signal: abortSignal,
 					}
@@ -240,10 +236,8 @@ export async function endpointOai(
 							"ChatUI-Conversation-ID": conversationId?.toString() ?? "",
 							"X-use-cache": "false",
 							...(locals?.token ? { Authorization: `Bearer ${locals.token}` } : {}),
-							// Bill to organization if configured (HuggingChat only)
-							...(config.isHuggingChat && locals?.billingOrganization
-								? { "X-HF-Bill-To": locals.billingOrganization }
-								: {}),
+							// Bill to organization if configured
+							...(locals?.billingOrganization ? { "X-HF-Bill-To": locals.billingOrganization } : {}),
 						},
 						signal: abortSignal,
 					}

--- a/src/routes/api/transcribe/+server.ts
+++ b/src/routes/api/transcribe/+server.ts
@@ -64,10 +64,8 @@ export async function POST({ request, locals }) {
 			headers: {
 				Authorization: `Bearer ${token}`,
 				"Content-Type": contentType,
-				// Bill to organization if configured (HuggingChat only)
-				...(config.isHuggingChat && locals?.billingOrganization
-					? { "X-HF-Bill-To": locals.billingOrganization }
-					: {}),
+				// Bill to organization if configured
+				...(locals?.billingOrganization ? { "X-HF-Bill-To": locals.billingOrganization } : {}),
 			},
 			body: audioBuffer,
 			signal: controller.signal,


### PR DESCRIPTION
This enables users with local Chat-UI deployments to bill inference usage to their HuggingFace organization by removing the isHuggingChat restriction on the X-HF-Bill-To header.

Fixes #1986