### PR TITLE
feat: change close button to list button on mobile settings view

### DIFF
--- a/src/routes/settings/(nav)/+layout.svelte
+++ b/src/routes/settings/(nav)/+layout.svelte
@@ -116,20 +116,23 @@
 			</button>
 		{/if}
 		<h2 class=" left-0 right-0 mx-auto w-fit text-center text-xl font-bold md:hidden">Settings</h2>
+		{#if showContent && browser}
+			<button
+				class="btn rounded-lg md:hidden"
+				aria-label="Back to model list"
+				onclick={() => {
+					showContent = false;
+					goto(`${base}/settings`);
+				}}
+			>
+				<IconBurger
+					classNames="text-xl text-gray-900 hover:text-black dark:text-gray-200 dark:hover:text-white"
+				/>
+			</button>
+		{/if}
 		<button
-			class="btn rounded-lg md:hidden"
-			aria-label="Back to model list"
-			onclick={() => {
-				showContent = false;
-				goto(`${base}/settings`);
-			}}
-		>
-			<IconBurger
-				classNames="text-xl text-gray-900 hover:text-black dark:text-gray-200 dark:hover:text-white"
-			/>
-		</button>
-		<button
-			class="btn hidden rounded-lg md:block"
+			class="btn rounded-lg"
+			class:max-md:hidden={showContent && browser}
 			aria-label="Close settings"
 			onclick={() => {
 				goto(previousPage);


### PR DESCRIPTION
On mobile, the close button (X) is replaced with a burger/list icon
that navigates back to the model list. Desktop shows the close button.
Uses CSS breakpoints (md:hidden / hidden md:block) for cleaner implementation.