### PR TITLE
Reduce unnecessary tool calls in model

### DIFF
--- a/src/lib/server/textGeneration/utils/toolPrompt.ts
+++ b/src/lib/server/textGeneration/utils/toolPrompt.ts
@@ -12,8 +12,9 @@ export function buildToolPreprompt(tools: OpenAiTool[]): string {
 		day: "numeric",
 	});
 	return [
-		`You can use the following tools if helpful: ${names.join(", ")}.`,
+		`You have access to these tools: ${names.join(", ")}.`,
 		`Today's date: ${currentDate}.`,
+		`Only use a tool if you cannot answer without it. For simple tasks like writing, editing text, or answering from your knowledge, respond directly without tools.`,
 		`If a tool generates an image, video, or audio, you can inline it using ![alt](url) or raw <video>/<audio> HTML tags. Video (.mp4, .webm) and audio (.mp3, .wav) URLs will render as playable media.`,
 		`If a tool needs an image, set its image field ("input_image", "image", or "image_url") to a reference like "image_1", "image_2", etc. (ordered by when the user uploaded them).`,
 		`Default to image references; only use a full http(s) URL when the tool description explicitly asks for one, or reuse a URL a previous tool returned.`,


### PR DESCRIPTION
Change tool preprompt from permissive "if helpful" to explicit instruction to only use tools when the model cannot answer without them. This prevents the model from calling tools for simple tasks like text editing or spelling corrections that don't require external tool assistance.