### PR TITLE
feat: add configurable MCP tool timeout via MCP_TOOL_TIMEOUT_MS

### DIFF
--- a/.env
+++ b/.env
@@ -134,6 +134,8 @@ MCP_SERVERS=
 MCP_FORWARD_HF_USER_TOKEN=
 # Exa API key for direct API calls (bypasses slow mcp.exa.ai endpoint)
 EXA_API_KEY=
+# Timeout in milliseconds for MCP tool calls (default: 120000 = 2 minutes)
+MCP_TOOL_TIMEOUT_MS=
 ENABLE_DATA_EXPORT=true
 
 ### Rate limits ### 

--- a/chart/env/dev.yaml
+++ b/chart/env/dev.yaml
@@ -73,6 +73,7 @@ envVars:
   TRANSCRIPTION_MODEL: "openai/whisper-large-v3-turbo"
   MCP_SERVERS: >
     [{"name": "Web Search (Exa)", "url": "https://mcp.exa.ai/mcp"}, {"name": "Hugging Face", "url": "https://hf.co/mcp?login"}]
+  MCP_TOOL_TIMEOUT_MS: "120000"
   PUBLIC_LLM_ROUTER_DISPLAY_NAME: "Omni"
   PUBLIC_LLM_ROUTER_LOGO_URL: "https://cdn-uploads.huggingface.co/production/uploads/5f17f0a0925b9863e28ad517/C5V0v1xZXv6M7FXsdJH9b.png"
   PUBLIC_LLM_ROUTER_ALIAS_ID: "omni"

--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -83,6 +83,7 @@ envVars:
   TRANSCRIPTION_MODEL: "openai/whisper-large-v3-turbo"
   MCP_SERVERS: >
     [{"name": "Web Search (Exa)", "url": "https://mcp.exa.ai/mcp"}, {"name": "Hugging Face", "url": "https://hf.co/mcp?login"}]
+  MCP_TOOL_TIMEOUT_MS: "120000"
   PUBLIC_LLM_ROUTER_DISPLAY_NAME: "Omni"
   PUBLIC_LLM_ROUTER_LOGO_URL: "https://cdn-uploads.huggingface.co/production/uploads/5f17f0a0925b9863e28ad517/C5V0v1xZXv6M7FXsdJH9b.png"
   PUBLIC_LLM_ROUTER_ALIAS_ID: "omni"

--- a/src/lib/server/config.ts
+++ b/src/lib/server/config.ts
@@ -159,6 +159,7 @@ type ExtraConfigKeys =
 	| "METRICS_PORT"
 	| "MCP_SERVERS"
 	| "MCP_FORWARD_HF_USER_TOKEN"
+	| "MCP_TOOL_TIMEOUT_MS"
 	| "EXA_API_KEY";
 
 type ConfigProxy = ConfigManager & { [K in ConfigKey | ExtraConfigKeys]: string };

--- a/src/lib/server/mcp/httpClient.ts
+++ b/src/lib/server/mcp/httpClient.ts
@@ -1,6 +1,7 @@
 import { Client } from "@modelcontextprotocol/sdk/client";
 import { getClient, evictFromPool } from "./clientPool";
 import { isExaServer, getExaApiKey, callExaDirectApi } from "./exaDirect";
+import { config } from "$lib/server/config";
 
 function isConnectionClosedError(err: unknown): boolean {
 	const message = err instanceof Error ? err.message : String(err);
@@ -13,7 +14,18 @@ export interface McpServerConfig {
 	headers?: Record<string, string>;
 }
 
-const DEFAULT_TIMEOUT_MS = 60_000;
+const DEFAULT_TIMEOUT_MS = 120_000;
+
+export function getMcpToolTimeoutMs(): number {
+	const envValue = config.MCP_TOOL_TIMEOUT_MS;
+	if (envValue) {
+		const parsed = parseInt(envValue, 10);
+		if (!isNaN(parsed) && parsed > 0) {
+			return parsed;
+		}
+	}
+	return DEFAULT_TIMEOUT_MS;
+}
 
 export type McpToolTextResponse = {
 	text: string;


### PR DESCRIPTION
## Summary
- Adds `MCP_TOOL_TIMEOUT_MS` environment variable to configure MCP tool call timeout
- Default remains 120 seconds (120000ms)
- Allows operators to increase timeout for slow MCP servers or decrease for faster failure

## Changes
- `src/lib/server/config.ts`: Added to ExtraConfigKeys
- `src/lib/server/mcp/httpClient.ts`: Added `getMcpToolTimeoutMs()` helper
- `src/lib/server/textGeneration/mcp/toolInvocation.ts`: Uses config-based timeout
- `chart/env/prod.yaml` & `dev.yaml`: Added env var
- `.env`: Added documentation

## Usage
```env
MCP_TOOL_TIMEOUT_MS=120000  # 2 minutes (default)
MCP_TOOL_TIMEOUT_MS=300000  # 5 minutes for slow tools
```

## Test plan
- [ ] Verify default timeout works when env var not set
- [ ] Verify custom timeout is applied when env var is set
- [ ] Verify invalid values fall back to default