### PR TITLE
feat: add DEFAULT_MAX_TOKENS env variable for global token limit

### DIFF
--- a/src/lib/server/config.ts
+++ b/src/lib/server/config.ts
@@ -160,7 +160,8 @@ type ExtraConfigKeys =
 	| "MCP_SERVERS"
 	| "MCP_FORWARD_HF_USER_TOKEN"
 	| "MCP_TOOL_TIMEOUT_MS"
-	| "EXA_API_KEY";
+	| "EXA_API_KEY"
+	| "DEFAULT_MAX_TOKENS";
 
 type ConfigProxy = ConfigManager & { [K in ConfigKey | ExtraConfigKeys]: string };
 

--- a/src/lib/server/endpoints/openai/endpointOai.ts
+++ b/src/lib/server/endpoints/openai/endpointOai.ts
@@ -130,11 +130,14 @@ export async function endpointOai(
 			});
 
 			const parameters = { ...model.parameters, ...generateSettings };
+			const parsedMaxTokens = Number(config.DEFAULT_MAX_TOKENS);
+			const defaultMaxTokens =
+				Number.isInteger(parsedMaxTokens) && parsedMaxTokens > 0 ? parsedMaxTokens : undefined;
 			const body: CompletionCreateParamsStreaming = {
 				model: model.id ?? model.name,
 				prompt,
 				stream: true,
-				max_tokens: parameters?.max_tokens,
+				max_tokens: parameters?.max_tokens ?? defaultMaxTokens,
 				stop: parameters?.stop,
 				temperature: parameters?.temperature,
 				top_p: parameters?.top_p,
@@ -195,14 +198,18 @@ export async function endpointOai(
 
 			// Combine model defaults with request-specific parameters
 			const parameters = { ...model.parameters, ...generateSettings };
+			const parsedMaxTokens = Number(config.DEFAULT_MAX_TOKENS);
+			const defaultMaxTokens =
+				Number.isInteger(parsedMaxTokens) && parsedMaxTokens > 0 ? parsedMaxTokens : undefined;
+			const effectiveMaxTokens = parameters?.max_tokens ?? defaultMaxTokens;
 			const body = {
 				model: model.id ?? model.name,
 				messages: messagesOpenAI,
 				stream: streamingSupported,
 				// Support two different ways of specifying token limits depending on the model
 				...(useCompletionTokens
-					? { max_completion_tokens: parameters?.max_tokens }
-					: { max_tokens: parameters?.max_tokens }),
+					? { max_completion_tokens: effectiveMaxTokens }
+					: { max_tokens: effectiveMaxTokens }),
 				stop: parameters?.stop,
 				temperature: parameters?.temperature,
 				top_p: parameters?.top_p,


### PR DESCRIPTION
## Summary

Add a new `DEFAULT_MAX_TOKENS` environment variable that sets a global default for `max_tokens` across all models, eliminating the need to configure `max_tokens` individually for each model in the `MODELS` env var.

## Why

When using OpenAI-compatible backends like **NVIDIA NIM**, not setting `max_tokens` can cause issues:
- NIM may use very high default values (e.g., 131072) that exceed the model's context window
- This leads to errors like `Input length + max new tokens > max sequence length`

**Before this change**, users had to configure both `OPENAI_BASE_URL` and `MODELS` just to set `max_tokens`:

```bash
OPENAI_BASE_URL=http://nim-service.namespace.svc.cluster.local/v1
MODELS='[{"id":"meta/llama-3.1-8b-instruct","name":"Llama 3.1 8B (NIM)","parameters":{"max_tokens":4096}}]'
```

**After this change**, users can simply set:

```bash
OPENAI_BASE_URL=http://nim-service.namespace.svc.cluster.local/v1
DEFAULT_MAX_TOKENS=4096
```

This is much simpler - no need to duplicate the model ID/name or use the `MODELS` config just for setting token limits.

## Changes

| File | Change |
|------|--------|
| `src/lib/server/config.ts` | Add `DEFAULT_MAX_TOKENS` to `ExtraConfigKeys` type |
| `src/lib/server/endpoints/openai/endpointOai.ts` | Use `DEFAULT_MAX_TOKENS` as fallback when model's `max_tokens` parameter is not set |

## Test plan

- [x] `npm run check` passes
- [x] Tested with NVIDIA NIM - requests now include reasonable `max_tokens` values
- [x] Verified that per-model `parameters.max_tokens` still takes priority over `DEFAULT_MAX_TOKENS`
- [x] Verified that omitting both uses undefined (existing behavior)