### PR TITLE
Add copy button to chat messages and improve tool usage guidance

### DIFF
--- a/src/lib/components/chat/ChatMessage.svelte
+++ b/src/lib/components/chat/ChatMessage.svelte
@@ -68,6 +68,20 @@
 		}
 	}
 
+	async function copyToClipboard(text: string) {
+		if (window.isSecureContext && navigator.clipboard) {
+			await navigator.clipboard.writeText(text);
+		} else {
+			const textArea = document.createElement("textarea");
+			textArea.value = text;
+			document.body.appendChild(textArea);
+			textArea.focus();
+			textArea.select();
+			document.execCommand("copy");
+			document.body.removeChild(textArea);
+		}
+	}
+
 	function handleCopy(event: ClipboardEvent) {
 		if (!contentEl) return;
 
@@ -474,7 +488,7 @@
 						title="Copy"
 						type="button"
 						onclick={() => {
-							navigator.clipboard.writeText(message.content.trim());
+							copyToClipboard(message.content.trim());
 						}}
 					>
 						<CarbonCopy />

--- a/src/lib/components/chat/ChatMessage.svelte
+++ b/src/lib/components/chat/ChatMessage.svelte
@@ -10,6 +10,7 @@
 	// import CarbonDownload from "~icons/carbon/download";
 
 	import CarbonPen from "~icons/carbon/pen";
+	import CarbonCopy from "~icons/carbon/copy";
 	import UploadedFile from "./UploadedFile.svelte";
 
 	import MarkdownRenderer from "./MarkdownRenderer.svelte";
@@ -468,6 +469,17 @@
 					/>
 				{/if}
 				{#if (alternatives.length > 1 && editMsdgId === null) || (!loading && !editMode)}
+					<button
+						class="hidden cursor-pointer items-center gap-1 rounded-md border border-gray-200 px-1.5 py-0.5 text-xs text-gray-400 group-hover:flex hover:flex hover:text-gray-500 dark:border-gray-700 dark:text-gray-400 dark:hover:text-gray-300 lg:-right-2"
+						title="Copy"
+						type="button"
+						onclick={() => {
+							navigator.clipboard.writeText(message.content.trim());
+						}}
+					>
+						<CarbonCopy />
+						Copy
+					</button>
 					<button
 						class="hidden cursor-pointer items-center gap-1 rounded-md border border-gray-200 px-1.5 py-0.5 text-xs text-gray-400 group-hover:flex hover:flex hover:text-gray-500 dark:border-gray-700 dark:text-gray-400 dark:hover:text-gray-300 lg:-right-2"
 						title="Edit"

--- a/src/lib/components/chat/ChatMessage.svelte
+++ b/src/lib/components/chat/ChatMessage.svelte
@@ -68,20 +68,6 @@
 		}
 	}
 
-	async function copyToClipboard(text: string) {
-		if (window.isSecureContext && navigator.clipboard) {
-			await navigator.clipboard.writeText(text);
-		} else {
-			const textArea = document.createElement("textarea");
-			textArea.value = text;
-			document.body.appendChild(textArea);
-			textArea.focus();
-			textArea.select();
-			document.execCommand("copy");
-			document.body.removeChild(textArea);
-		}
-	}
-
 	function handleCopy(event: ClipboardEvent) {
 		if (!contentEl) return;
 
@@ -483,17 +469,16 @@
 					/>
 				{/if}
 				{#if (alternatives.length > 1 && editMsdgId === null) || (!loading && !editMode)}
-					<button
-						class="hidden cursor-pointer items-center gap-1 rounded-md border border-gray-200 px-1.5 py-0.5 text-xs text-gray-400 group-hover:flex hover:flex hover:text-gray-500 dark:border-gray-700 dark:text-gray-400 dark:hover:text-gray-300 lg:-right-2"
-						title="Copy"
-						type="button"
-						onclick={() => {
-							copyToClipboard(message.content.trim());
-						}}
+					<CopyToClipBoardBtn
+						classNames="hidden cursor-pointer items-center gap-1 rounded-md border border-gray-200 px-1.5 py-0.5 text-xs text-gray-400 group-hover:flex hover:flex hover:text-gray-500 dark:border-gray-700 dark:text-gray-400 dark:hover:text-gray-300 lg:-right-2"
+						value={message.content.trim()}
+						showTooltip={false}
 					>
-						<CarbonCopy />
-						Copy
-					</button>
+						{#snippet children()}
+							<CarbonCopy />
+							Copy
+						{/snippet}
+					</CopyToClipBoardBtn>
 					<button
 						class="hidden cursor-pointer items-center gap-1 rounded-md border border-gray-200 px-1.5 py-0.5 text-xs text-gray-400 group-hover:flex hover:flex hover:text-gray-500 dark:border-gray-700 dark:text-gray-400 dark:hover:text-gray-300 lg:-right-2"
 						title="Edit"

--- a/src/lib/server/textGeneration/utils/toolPrompt.ts
+++ b/src/lib/server/textGeneration/utils/toolPrompt.ts
@@ -1,100 +1,22 @@
 import type { OpenAiTool } from "$lib/server/mcp/tools";
 
-/**
- * Categorize tools by their purpose to provide better guidance.
- */
-function categorizeTools(tools: OpenAiTool[]): {
-	generative: string[];
-	search: string[];
-	other: string[];
-} {
-	const generative: string[] = [];
-	const search: string[] = [];
-	const other: string[] = [];
-
-	for (const tool of tools) {
-		const name = tool?.function?.name ?? "";
-		const desc = (tool?.function?.description ?? "").toLowerCase();
-		if (!name) continue;
-
-		// Detect generative tools (image/video/audio generation)
-		if (
-			desc.includes("generate") ||
-			desc.includes("create image") ||
-			desc.includes("create video") ||
-			desc.includes("text-to-image") ||
-			desc.includes("image generation") ||
-			name.toLowerCase().includes("generate") ||
-			name.toLowerCase().includes("_gen")
-		) {
-			generative.push(name);
-		}
-		// Detect search/retrieval tools
-		else if (
-			desc.includes("search") ||
-			desc.includes("find") ||
-			desc.includes("lookup") ||
-			desc.includes("retrieve") ||
-			desc.includes("fetch") ||
-			name.toLowerCase().includes("search") ||
-			name.toLowerCase().includes("lookup")
-		) {
-			search.push(name);
-		} else {
-			other.push(name);
-		}
-	}
-
-	return { generative, search, other };
-}
-
 export function buildToolPreprompt(tools: OpenAiTool[]): string {
 	if (!Array.isArray(tools) || tools.length === 0) return "";
 	const names = tools
 		.map((t) => (t?.function?.name ? String(t.function.name) : ""))
 		.filter((s) => s.length > 0);
 	if (names.length === 0) return "";
-
 	const currentDate = new Date().toLocaleDateString("en-US", {
 		year: "numeric",
 		month: "long",
 		day: "numeric",
 	});
-
-	const { generative, search } = categorizeTools(tools);
-
-	const lines: string[] = [
-		`You have access to tools: ${names.join(", ")}.`,
+	return [
+		`You have access to these tools: ${names.join(", ")}.`,
 		`Today's date: ${currentDate}.`,
-		"",
-		"IMPORTANT - Tool Usage Guidelines:",
-		"- ALWAYS prefer answering directly if you can. Only use tools when you genuinely need external information or capabilities.",
-		"- For simple questions, text edits, spelling checks, or tasks you can do yourself: respond directly WITHOUT calling any tools.",
-		"- When you have enough information from tool results, respond directly without making additional tool calls.",
-		"- Do NOT use multiple tools in parallel for simple requests.",
-	];
-
-	// Add specific guidance for generative tools
-	if (generative.length > 0) {
-		lines.push(
-			`- Generative tools (${generative.join(", ")}): ONLY use these when the user EXPLICITLY asks to generate/create something new. Do NOT use for editing text or prompts.`
-		);
-	}
-
-	// Add specific guidance for search tools
-	if (search.length > 0) {
-		lines.push(
-			`- Search tools (${search.join(", ")}): ONLY use when you need factual information you don't already know. Do NOT search for things you can answer from your training.`
-		);
-	}
-
-	lines.push(
-		"",
-		"Image handling:",
-		"- If a tool generates an image, inline it: ![alt text](image_url).",
-		`- If a tool needs an image, use references like "image_1", "image_2" (ordered by user upload).`,
-		"- Only use full http(s) URLs when the tool explicitly requires one, or reuse a URL from a previous tool result."
-	);
-
-	return lines.join("\n");
+		`Only use a tool if you cannot answer without it. For simple tasks like writing, editing text, or answering from your knowledge, respond directly without tools.`,
+		`If a tool generates an image, you can inline it directly: ![alt text](image_url).`,
+		`If a tool needs an image, set its image field ("input_image", "image", or "image_url") to a reference like "image_1", "image_2", etc. (ordered by when the user uploaded them).`,
+		`Default to image references; only use a full http(s) URL when the tool description explicitly asks for one, or reuse a URL a previous tool returned.`,
+	].join(" ");
 }

--- a/src/lib/server/textGeneration/utils/toolPrompt.ts
+++ b/src/lib/server/textGeneration/utils/toolPrompt.ts
@@ -1,21 +1,100 @@
 import type { OpenAiTool } from "$lib/server/mcp/tools";
 
+/**
+ * Categorize tools by their purpose to provide better guidance.
+ */
+function categorizeTools(tools: OpenAiTool[]): {
+	generative: string[];
+	search: string[];
+	other: string[];
+} {
+	const generative: string[] = [];
+	const search: string[] = [];
+	const other: string[] = [];
+
+	for (const tool of tools) {
+		const name = tool?.function?.name ?? "";
+		const desc = (tool?.function?.description ?? "").toLowerCase();
+		if (!name) continue;
+
+		// Detect generative tools (image/video/audio generation)
+		if (
+			desc.includes("generate") ||
+			desc.includes("create image") ||
+			desc.includes("create video") ||
+			desc.includes("text-to-image") ||
+			desc.includes("image generation") ||
+			name.toLowerCase().includes("generate") ||
+			name.toLowerCase().includes("_gen")
+		) {
+			generative.push(name);
+		}
+		// Detect search/retrieval tools
+		else if (
+			desc.includes("search") ||
+			desc.includes("find") ||
+			desc.includes("lookup") ||
+			desc.includes("retrieve") ||
+			desc.includes("fetch") ||
+			name.toLowerCase().includes("search") ||
+			name.toLowerCase().includes("lookup")
+		) {
+			search.push(name);
+		} else {
+			other.push(name);
+		}
+	}
+
+	return { generative, search, other };
+}
+
 export function buildToolPreprompt(tools: OpenAiTool[]): string {
 	if (!Array.isArray(tools) || tools.length === 0) return "";
 	const names = tools
 		.map((t) => (t?.function?.name ? String(t.function.name) : ""))
 		.filter((s) => s.length > 0);
 	if (names.length === 0) return "";
+
 	const currentDate = new Date().toLocaleDateString("en-US", {
 		year: "numeric",
 		month: "long",
 		day: "numeric",
 	});
-	return [
-		`You can use the following tools if helpful: ${names.join(", ")}.`,
+
+	const { generative, search } = categorizeTools(tools);
+
+	const lines: string[] = [
+		`You have access to tools: ${names.join(", ")}.`,
 		`Today's date: ${currentDate}.`,
-		`If a tool generates an image, you can inline it directly: ![alt text](image_url).`,
-		`If a tool needs an image, set its image field ("input_image", "image", or "image_url") to a reference like "image_1", "image_2", etc. (ordered by when the user uploaded them).`,
-		`Default to image references; only use a full http(s) URL when the tool description explicitly asks for one, or reuse a URL a previous tool returned.`,
-	].join(" ");
+		"",
+		"IMPORTANT - Tool Usage Guidelines:",
+		"- ALWAYS prefer answering directly if you can. Only use tools when you genuinely need external information or capabilities.",
+		"- For simple questions, text edits, spelling checks, or tasks you can do yourself: respond directly WITHOUT calling any tools.",
+		"- When you have enough information from tool results, respond directly without making additional tool calls.",
+		"- Do NOT use multiple tools in parallel for simple requests.",
+	];
+
+	// Add specific guidance for generative tools
+	if (generative.length > 0) {
+		lines.push(
+			`- Generative tools (${generative.join(", ")}): ONLY use these when the user EXPLICITLY asks to generate/create something new. Do NOT use for editing text or prompts.`
+		);
+	}
+
+	// Add specific guidance for search tools
+	if (search.length > 0) {
+		lines.push(
+			`- Search tools (${search.join(", ")}): ONLY use when you need factual information you don't already know. Do NOT search for things you can answer from your training.`
+		);
+	}
+
+	lines.push(
+		"",
+		"Image handling:",
+		"- If a tool generates an image, inline it: ![alt text](image_url).",
+		`- If a tool needs an image, use references like "image_1", "image_2" (ordered by user upload).`,
+		"- Only use full http(s) URLs when the tool explicitly requires one, or reuse a URL from a previous tool result."
+	);
+
+	return lines.join("\n");
 }


### PR DESCRIPTION
## Summary
This PR enhances the chat interface with a copy-to-clipboard feature for messages and refines the AI's tool usage behavior by providing clearer guidance on when to use available tools.

## Key Changes

- **Chat Message Copy Button**: Added a "Copy" button to chat messages that appears on hover, allowing users to easily copy message content to their clipboard. The button uses the Carbon copy icon and matches the styling of existing message action buttons.

- **Tool Usage Guidance**: Updated the tool prompt instructions to:
  - Reword the tool availability message for clarity ("You have access to these tools" instead of "You can use the following tools if helpful")
  - Add explicit guidance to discourage unnecessary tool usage for simple tasks like writing, editing, or knowledge-based questions
  - Encourage direct responses when tools aren't needed

## Implementation Details

- The copy button is conditionally rendered alongside the edit button with the same visibility logic (hidden by default, shown on group/element hover)
- Uses the native `navigator.clipboard.writeText()` API for copying
- Message content is trimmed before copying to remove excess whitespace
- Tool prompt changes are minimal and focused on improving AI decision-making around tool selection