### PR TITLE
feat: add search query guidelines to tool prompt

### DIFF
--- a/src/lib/server/textGeneration/utils/toolPrompt.ts
+++ b/src/lib/server/textGeneration/utils/toolPrompt.ts
@@ -15,7 +15,9 @@ export function buildToolPreprompt(tools: OpenAiTool[]): string {
 		`You have access to these tools: ${names.join(", ")}.`,
 		`Today's date: ${currentDate}.`,
 		`Only use a tool if you cannot answer without it. For simple tasks like writing, editing text, or answering from your knowledge, respond directly without tools.`,
-		`If a tool generates an image, video, or audio, you can inline it using ![alt](url) or raw <video>/<audio> HTML tags. Video (.mp4, .webm) and audio (.mp3, .wav) URLs will render as playable media.`,
+		`For search queries: use few precise keywords (3-6 words), avoid redundant synonyms, use the exact terminology the source would use, prefer relative time terms like "latest" or "newest" over specific years. For complex questions, consider multiple focused searches rather than one broad query.`,
+		`When using search tools: carefully read ALL results before answering. Only state facts explicitly found in the search results—do not assume, infer, or hallucinate information not present. If results conflict, acknowledge the discrepancy. If you cannot find the information, say so clearly rather than speculating. Never fabricate URLs—only use URLs explicitly provided in tool results.`,
+		`If a tool generates an image, you can inline it directly: ![alt text](image_url).`,
 		`If a tool needs an image, set its image field ("input_image", "image", or "image_url") to a reference like "image_1", "image_2", etc. (ordered by when the user uploaded them).`,
 		`Default to image references; only use a full http(s) URL when the tool description explicitly asks for one, or reuse a URL a previous tool returned.`,
 	].join(" ");


### PR DESCRIPTION
Add instructions for crafting effective search queries (3-6 keywords,
exact terminology, relative time terms) and for handling search results
(read all results, only state explicit facts, acknowledge conflicts,
never fabricate URLs).