### PR TITLE
Simplify PRO badge styling by removing gradient background

### DIFF
--- a/src/lib/components/NavMenu.svelte
+++ b/src/lib/components/NavMenu.svelte
@@ -185,14 +185,14 @@
 					href="https://huggingface.co/subscribe/pro?from=HuggingChat"
 					target="_blank"
 					rel="noopener noreferrer"
-					class="ml-auto flex h-[20px] items-center gap-1 rounded-md bg-gradient-to-r from-pink-500/10 via-green-500/10 to-green-500/5 px-1.5 py-0.5 text-xs text-gray-500 hover:from-pink-500/20 hover:via-green-500/20 dark:from-pink-500/20 dark:via-green-500/20 dark:to-green-500/10 dark:text-gray-400 dark:hover:from-pink-500/30 dark:hover:via-green-500/30"
+					class="ml-auto flex h-[20px] items-center gap-1 px-1.5 py-0.5 text-xs text-gray-500 dark:text-gray-400"
 				>
 					<IconPro />
 					Get PRO
 				</a>
 			{:else if publicConfig.isHuggingChat && $isPro === true}
 				<span
-					class="ml-auto flex h-[20px] items-center gap-1 rounded-md bg-gradient-to-r from-pink-500/10 via-green-500/10 to-green-500/5 px-1.5 py-0.5 text-xs text-gray-500 hover:from-pink-500/20 hover:via-green-500/20 dark:from-pink-500/20 dark:via-green-500/20 dark:to-green-500/10 dark:text-gray-400 dark:hover:from-pink-500/30 dark:hover:via-green-500/30"
+					class="ml-auto flex h-[20px] items-center gap-1 px-1.5 py-0.5 text-xs text-gray-500 dark:text-gray-400"
 				>
 					<IconPro />
 					PRO


### PR DESCRIPTION
## Summary
Removed the gradient background styling from the PRO badge elements in the navigation menu, simplifying the visual design while maintaining the core functionality and text styling.

## Changes
- Removed gradient background classes (`bg-gradient-to-r from-pink-500/10 via-green-500/10 to-green-500/5`) from the "Get PRO" link
- Removed gradient background classes and hover state gradients from the PRO badge span (shown when user is already a PRO subscriber)
- Kept essential styling: layout (`flex`, `ml-auto`), spacing (`h-[20px]`, `gap-1`, `px-1.5`, `py-0.5`), and text color (`text-gray-500`, `dark:text-gray-400`)
- Removed `rounded-md` class from both elements as it's no longer needed without the background

## Details
The PRO badge now uses a minimal, flat design approach instead of the previous gradient aesthetic. This change affects both the CTA button for non-PRO users and the badge displayed for existing PRO subscribers, creating a more consistent and cleaner navigation menu appearance.