### PR TITLE
Set default value for PUBLIC_APP_ASSETS environment variable

### DIFF
--- a/src/lib/utils/PublicConfig.svelte.ts
+++ b/src/lib/utils/PublicConfig.svelte.ts
@@ -39,7 +39,7 @@ class PublicConfigManager {
 			(this.#configStore.PUBLIC_ORIGIN || page.url.origin) +
 			base +
 			"/" +
-			this.#configStore.PUBLIC_APP_ASSETS
+			(this.#configStore.PUBLIC_APP_ASSETS || "chatui")
 		);
 	}
 }

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -17,6 +17,7 @@ function getCurrentCommitSHA() {
 
 process.env.PUBLIC_VERSION ??= process.env.npm_package_version;
 process.env.PUBLIC_COMMIT_SHA ??= getCurrentCommitSHA();
+process.env.PUBLIC_APP_ASSETS ??= "chatui";
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {


### PR DESCRIPTION
## Summary
This PR adds a default fallback value for the `PUBLIC_APP_ASSETS` environment variable to ensure the application has a sensible default when the variable is not explicitly configured.

## Changes
- **svelte.config.js**: Set `PUBLIC_APP_ASSETS` environment variable to default to `"chatui"` if not already defined
- **PublicConfig.svelte.ts**: Updated the assets path construction to use the default value `"chatui"` as a fallback when `PUBLIC_APP_ASSETS` is not configured

## Details
Previously, if `PUBLIC_APP_ASSETS` was not set in the environment, the application would construct an invalid assets path. Now, both the configuration initialization and the path construction include a fallback to `"chatui"`, ensuring consistent behavior across different deployment environments without requiring explicit configuration.