### PR TITLE
Add missing indexes for createdAt/updatedAt on conversations collection

### DIFF
--- a/src/lib/server/database.ts
+++ b/src/lib/server/database.ts
@@ -350,6 +350,14 @@ export class Database {
 				logger.error(e, "Error creating index for conversations by userId and sessionId")
 			);
 
+		// For stats aggregation jobs that filter by createdAt/updatedAt alone
+		conversations
+			.createIndex({ createdAt: 1 })
+			.catch((e) => logger.error(e, "Error creating index for conversations by createdAt"));
+		conversations
+			.createIndex({ updatedAt: 1 })
+			.catch((e) => logger.error(e, "Error creating index for conversations by updatedAt"));
+
 		config
 			.createIndex({ key: 1 }, { unique: true })
 			.catch((e) => logger.error(e, "Error creating index for config by key"));


### PR DESCRIPTION
The refresh-conversation-stats job filters conversations by createdAt or updatedAt alone, but existing compound indexes require userId or `sessionId` `first`. This causes full collection scans taking 2+ minutes each, scanning `293K` documents.
<img width="1418" height="156" alt="image" src="https://github.com/user-attachments/assets/f5d1edac-db20-4cce-bf12-7a4e88a4e3ea" />

Added two indexes: { createdAt: 1 } and { updatedAt: 1 }.

From slow query log: 6 COLLSCAN queries on conversations with 120+ seconds duration and ~40GB disk read. After this fix, queries will use IXSCAN and complete in milliseconds.
more info:
https://huggingface-mongodb-logs-reports.static.hf.space/hugging-chat-prod/huggingchat-prod-shard-00-01.josxbb.mongodb.net/2026-01-26/03-45-01/index-report.html