### PR TITLE
Add page title to model detail page

### DIFF
--- a/src/routes/models/[...model]/+page.svelte
+++ b/src/routes/models/[...model]/+page.svelte
@@ -122,6 +122,7 @@
 </script>
 
 <svelte:head>
+	<title>{modelId} - {publicConfig.PUBLIC_APP_NAME}</title>
 	<meta property="og:title" content={modelId + " - " + publicConfig.PUBLIC_APP_NAME} />
 	<meta property="og:type" content="link" />
 	<meta property="og:description" content={`Use ${modelId} with ${publicConfig.PUBLIC_APP_NAME}`} />


### PR DESCRIPTION
## Summary
Added the `<title>` tag to the model detail page's `<svelte:head>` section to improve SEO and browser tab visibility.

## Changes
- Added `<title>` element to the model page header that displays the model ID and app name
- The title follows the same format as the existing Open Graph title meta tag for consistency

## Details
The page now properly sets the browser tab title when viewing a model detail page, displaying the model name alongside the application name (e.g., "gpt-4 - MyApp"). This improves user experience by making it easier to identify the page when multiple tabs are open, and also benefits SEO by providing a proper page title.

https://claude.ai/code/session_014tSRcK9EoKEV6B5RFzide2