### PR TITLE
chore: replace isEnterprise with plan field in OAuth schema

### DIFF
--- a/src/routes/login/callback/updateUser.ts
+++ b/src/routes/login/callback/updateUser.ts
@@ -53,7 +53,7 @@ export async function updateUser(params: {
 						name: z.string(),
 						picture: z.string(),
 						preferred_username: z.string(),
-						isEnterprise: z.boolean(),
+						plan: z.string().optional(),
 					})
 				)
 				.optional(),
@@ -77,7 +77,7 @@ export async function updateUser(params: {
 			name: string;
 			picture: string;
 			preferred_username: string;
-			isEnterprise: boolean;
+			plan?: string;
 		}>;
 	} & Record<string, string>;
 


### PR DESCRIPTION
The isEnterprise field is being deprecated from the OAuth/whoami API endpoints. This replaces isEnterprise: boolean with plan?: string in the zod schema.
https://huggingface-openapi.hf.space/#tag/auth/GET/api/whoami-v2