### PR TITLE
Fix MongoDB regex issue

### DIFF
--- a/src/routes/conversation/[id]/share/+server.ts
+++ b/src/routes/conversation/[id]/share/+server.ts
@@ -45,7 +45,7 @@ export async function POST({ params, locals }) {
 
 	// copy files from `${conversation._id}-` to `${shared._id}-`
 	const files = await collections.bucket
-		.find({ filename: { $regex: `${conversation._id}-` } })
+		.find({ filename: { $regex: `^${conversation._id}-` } })
 		.toArray();
 
 	await Promise.all(


### PR DESCRIPTION
Add `^` anchor to regex query on files.files collection to enable efficient index prefix search. Without the anchor, MongoDB scans the entire filename index (`~116K keys`) for each query, taking 600-850ms. With the anchor, MongoDB can use the index as a prefix lookup and find matching documents in a few index operations, reducing query time


