### PR TITLE
Add MongoDB read preference

### DIFF
--- a/src/lib/server/database.ts
+++ b/src/lib/server/database.ts
@@ -127,6 +127,7 @@ export class Database {
 		const tokenCaches = db.collection<TokenCache>("tokens");
 		const configCollection = db.collection<ConfigKey>("config");
 		const migrationResults = db.collection<MigrationResult>("migrationResults");
+		const sharedConversations = db.collection<SharedConversation>("sharedConversations");
 		const bucket = new GridFSBucket(db, { bucketName: "files" });
 
 		// Collections with secondaryPreferred - heavy reads, can tolerate slight replication lag
@@ -138,9 +139,6 @@ export class Database {
 			readPreference: secondaryPreferred,
 		});
 		const conversationStats = db.collection<ConversationStats>(CONVERSATION_STATS_COLLECTION, {
-			readPreference: secondaryPreferred,
-		});
-		const sharedConversations = db.collection<SharedConversation>("sharedConversations", {
 			readPreference: secondaryPreferred,
 		});
 		const reports = db.collection<Report>("reports", {


### PR DESCRIPTION
Add MongoDB `read preference` per collection to optimize read distribution across replica set. Collections like `conversations`, `users`, `sessions`, `settings`, `sharedConversations`, and `migrationResults` remain on primary to ensure read-after-write consistency. Read collections like `assistants`, `assistantStats`, `conversationStats`, `reports`, and `tools` are configured with `secondaryPreferred` to offload read traffic from primary