### PR TITLE
feat: add fullscreen lightbox for images in chat messages

### DIFF
--- a/src/lib/components/chat/ChatMessage.svelte
+++ b/src/lib/components/chat/ChatMessage.svelte
@@ -21,6 +21,7 @@
 	import ToolUpdate from "./ToolUpdate.svelte";
 	import { isMessageToolUpdate } from "$lib/utils/messageUpdates";
 	import { MessageUpdateType, type MessageToolUpdate } from "$lib/types/MessageUpdate";
+	import ImageLightbox from "./ImageLightbox.svelte";
 
 	interface Props {
 		message: Message;
@@ -52,6 +53,16 @@
 	let isCopied = $state(false);
 	let messageWidth: number = $state(0);
 	let messageInfoWidth: number = $state(0);
+	let lightboxSrc: string | null = $state(null);
+
+	function handleContentClick(e: MouseEvent) {
+		const target = e.target as HTMLElement;
+		if (target.tagName === "IMG" && target instanceof HTMLImageElement) {
+			e.preventDefault();
+			e.stopPropagation();
+			lightboxSrc = target.src;
+		}
+	}
 
 	$effect(() => {
 		// referenced to appease linter for currently-unused props
@@ -257,7 +268,8 @@
 				</div>
 			{/if}
 
-			<div bind:this={contentEl} oncopy={handleCopy}>
+			<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+			<div bind:this={contentEl} oncopy={handleCopy} onclick={handleContentClick}>
 				{#if isLast && loading && blocks.length === 0}
 					<IconLoading classNames="loading inline ml-2 first:ml-0" />
 				{/if}
@@ -292,7 +304,7 @@
 									/>
 								{:else if part && part.trim().length > 0}
 									<div
-										class="prose max-w-none dark:prose-invert max-sm:prose-sm prose-headings:font-semibold prose-h1:text-lg prose-h2:text-base prose-h3:text-base prose-pre:bg-gray-800 prose-img:my-0 prose-img:rounded-lg dark:prose-pre:bg-gray-900"
+										class="prose max-w-none dark:prose-invert max-sm:prose-sm prose-headings:font-semibold prose-h1:text-lg prose-h2:text-base prose-h3:text-base prose-pre:bg-gray-800 prose-img:my-0 prose-img:cursor-pointer prose-img:rounded-lg dark:prose-pre:bg-gray-900"
 									>
 										<MarkdownRenderer content={part} loading={isLast && loading} />
 									</div>
@@ -300,7 +312,7 @@
 							{/each}
 						{:else}
 							<div
-								class="prose max-w-none dark:prose-invert max-sm:prose-sm prose-headings:font-semibold prose-h1:text-lg prose-h2:text-base prose-h3:text-base prose-pre:bg-gray-800 prose-img:my-0 prose-img:rounded-lg dark:prose-pre:bg-gray-900"
+								class="prose max-w-none dark:prose-invert max-sm:prose-sm prose-headings:font-semibold prose-h1:text-lg prose-h2:text-base prose-h3:text-base prose-pre:bg-gray-800 prose-img:my-0 prose-img:cursor-pointer prose-img:rounded-lg dark:prose-pre:bg-gray-900"
 							>
 								<MarkdownRenderer content={block.content} loading={isLast && loading} />
 							</div>
@@ -391,6 +403,9 @@
 			</div>
 		{/if}
 	</div>
+	{#if lightboxSrc}
+		<ImageLightbox src={lightboxSrc} onclose={() => (lightboxSrc = null)} />
+	{/if}
 {/if}
 {#if message.from === "user"}
 	<div

--- a/src/lib/components/chat/ImageLightbox.svelte
+++ b/src/lib/components/chat/ImageLightbox.svelte
@@ -1,0 +1,66 @@
+<script lang="ts">
+	import { onMount } from "svelte";
+	import Portal from "../Portal.svelte";
+	import CarbonClose from "~icons/carbon/close";
+
+	interface Props {
+		src: string;
+		onclose: () => void;
+	}
+
+	let { src, onclose }: Props = $props();
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === "Escape") {
+			e.preventDefault();
+			e.stopPropagation();
+			onclose();
+		}
+	}
+
+	function handleOverlayClick(e: MouseEvent) {
+		// Close when clicking the overlay (not the image)
+		if (e.target === e.currentTarget) {
+			onclose();
+		}
+	}
+
+	onMount(() => {
+		// Prevent body scroll while lightbox is open
+		const originalOverflow = document.body.style.overflow;
+		document.body.style.overflow = "hidden";
+
+		return () => {
+			document.body.style.overflow = originalOverflow;
+		};
+	});
+</script>
+
+<svelte:window onkeydown={handleKeydown} />
+
+<Portal>
+	<!-- svelte-ignore a11y_click_events_have_key_events -->
+	<!-- svelte-ignore a11y_no_static_element_interactions -->
+	<div
+		class="fixed inset-0 z-50 grid place-items-center bg-black/90 backdrop-blur-sm"
+		onclick={handleOverlayClick}
+	>
+		<!-- Close button -->
+		<button
+			class="absolute right-3 top-3 grid size-8 place-items-center rounded-full border border-white/25 bg-white/20 text-gray-300 hover:bg-white/30 sm:right-6 sm:top-6"
+			onclick={onclose}
+			aria-label="Close"
+		>
+			<CarbonClose />
+		</button>
+
+		<!-- Image with moon-landing's resize strategy -->
+		<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+		<img
+			{src}
+			alt=""
+			class="h-auto max-h-[calc(100vh-160px)] w-auto max-w-full"
+			onclick={(e) => e.stopPropagation()}
+		/>
+	</div>
+</Portal>

--- a/src/lib/components/chat/ToolUpdate.svelte
+++ b/src/lib/components/chat/ToolUpdate.svelte
@@ -235,7 +235,7 @@
 												{#each parsedOutput.images as image, imageIndex}
 													<img
 														alt={`Tool result image ${imageIndex + 1}`}
-														class="max-h-60 rounded border border-gray-200 dark:border-gray-700"
+														class="max-h-60 cursor-pointer rounded border border-gray-200 dark:border-gray-700"
 														src={`data:${image.mimeType};base64,${image.data}`}
 													/>
 												{/each}


### PR DESCRIPTION
## Summary
- Click any image in assistant messages to view it in a fullscreen lightbox overlay
- Uses moon-landing's resize strategy (`max-h-[calc(100vh-160px)]`) to constrain images while preserving aspect ratio
- Close via ESC key, close button, or clicking outside the image

## Test plan
- [ ] Send a message with an image or use a model that generates images
- [ ] Click on the image in the assistant's response
- [ ] Verify image opens in fullscreen overlay with dark background
- [ ] Verify image is properly constrained (not cropped, maintains aspect ratio)
- [ ] Click outside the image to close
- [ ] Press ESC to close
- [ ] Test with tool output images (e.g., from MCP tools)