### PR TITLE
Add Qwen3-Coder-Next model to available LLM options

### DIFF
--- a/chart/env/dev.yaml
+++ b/chart/env/dev.yaml
@@ -79,6 +79,7 @@ envVars:
   PUBLIC_LLM_ROUTER_ALIAS_ID: "omni"
   MODELS: >
     [
+      { "id": "Qwen/Qwen3-Coder-Next", "description": "Ultra-sparse coding MoE for repository-scale agents with 256K context." },
       { "id": "moonshotai/Kimi-K2.5", "description": "Native multimodal agent with agent swarms for parallel tool orchestration." },
       { "id": "allenai/Molmo2-8B", "description": "Open vision-language model excelling at video understanding, pointing, and object tracking." },
       { "id": "zai-org/GLM-4.7-Flash", "description": "Fast GLM-4.7 variant optimized for lower latency coding and agents." },

--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -89,6 +89,7 @@ envVars:
   PUBLIC_LLM_ROUTER_ALIAS_ID: "omni"
   MODELS: >
     [
+      { "id": "Qwen/Qwen3-Coder-Next", "description": "Ultra-sparse coding MoE for repository-scale agents with 256K context." },
       { "id": "moonshotai/Kimi-K2.5", "description": "Native multimodal agent with agent swarms for parallel tool orchestration." },
       { "id": "allenai/Molmo2-8B", "description": "Open vision-language model excelling at video understanding, pointing, and object tracking." },
       { "id": "zai-org/GLM-4.7-Flash", "description": "Fast GLM-4.7 variant optimized for lower latency coding and agents." },


### PR DESCRIPTION
## Summary
This PR adds support for the Qwen3-Coder-Next model across both development and production environments by updating the model configuration in the Helm chart values.

## Changes
- Added `Qwen/Qwen3-Coder-Next` model to the available models list in both `chart/env/dev.yaml` and `chart/env/prod.yaml`
- Model is positioned as the first option in the models array
- Includes description: "Ultra-sparse coding MoE for repository-scale agents with 256K context."

## Details
The Qwen3-Coder-Next model is an ultra-sparse coding mixture-of-experts (MoE) model designed for repository-scale agents with an extended 256K token context window. This addition enables users to leverage this specialized coding model through the LLM router in both development and production deployments.

https://claude.ai/code/session_01VvdvpRAXPL8eEkq4S32Xfc