### PR TITLE
fix: tools/multimodal toggles now fallback to model capability

### DIFF
--- a/src/routes/settings/(nav)/[...model]/+page.svelte
+++ b/src/routes/settings/(nav)/[...model]/+page.svelte
@@ -28,7 +28,10 @@
 	// Functional bindings for nested settings (Svelte 5):
 	// Avoid binding directly to $settings.*[modelId]; write via store update
 	function getToolsOverride() {
-		return $settings.toolsOverrides?.[page.params.model] ?? false;
+		return (
+			$settings.toolsOverrides?.[page.params.model] ??
+			Boolean((model as unknown as { supportsTools?: boolean }).supportsTools)
+		);
 	}
 	function setToolsOverride(v: boolean) {
 		settings.update((s) => ({
@@ -37,7 +40,7 @@
 		}));
 	}
 	function getMultimodalOverride() {
-		return $settings.multimodalOverrides?.[page.params.model] ?? false;
+		return $settings.multimodalOverrides?.[page.params.model] ?? Boolean(model?.multimodal);
 	}
 	function setMultimodalOverride(v: boolean) {
 		settings.update((s) => ({


### PR DESCRIPTION
## Summary
- Fixed tools and multimodal override getters to fall back to model capability instead of `false`
- Prevents stale user settings from hiding capabilities that were added after the user first visited a model

## Problem
When a user visited a model (e.g., `Qwen/Qwen3-Coder-Next`) before it had tools support, `initValue()` stored `toolsOverrides[modelId] = false`. Later, when the model gained `supports_tools: true` in the router API, the toggle still showed OFF because:

```javascript
// Before: always fell back to false
function getToolsOverride() {
    return $settings.toolsOverrides?.[page.params.model] ?? false;
}
```

## Solution
Changed the getters to fall back to model capability, matching the pattern already used in the sidebar layout and ChatWindow:

```javascript
// After: falls back to model's actual capability
function getToolsOverride() {
    return (
        $settings.toolsOverrides?.[page.params.model] ??
        Boolean((model as unknown as { supportsTools?: boolean }).supportsTools)
    );
}
```

## Test plan
- [ ] Visit a model that supports tools (e.g., `Qwen/Qwen3-Coder-Next`) - toggle should show ON
- [ ] Visit a model that doesn't support tools - toggle should show OFF
- [ ] Toggle tools OFF for a supporting model, refresh - should stay OFF (explicit override)
- [ ] Same verification for multimodal capability