### PR TITLE
Make HTML preview modal fullscreen with improved close button

### DIFF
--- a/src/lib/components/HtmlPreviewModal.svelte
+++ b/src/lib/components/HtmlPreviewModal.svelte
@@ -143,11 +143,12 @@
 
 		<!-- Close button with visible container -->
 		<button
-			class="fixed right-4 top-4 z-50 flex size-10 items-center justify-center rounded-full bg-gray-900/70 shadow-lg backdrop-blur-sm transition-colors hover:bg-gray-900/90"
+			class="btn fixed right-6 top-4 z-50 flex h-7 items-center gap-1 rounded-lg border border-gray-500/60 bg-gray-800 px-2 text-xs text-white shadow-sm backdrop-blur transition-none hover:border-gray-500 hover:bg-gray-700 active:shadow-inner"
 			title="Close preview (Esc)"
 			onclick={() => onclose?.()}
 		>
-			<CarbonClose class="size-5 text-white" />
+			<CarbonClose class="size-3.5" />
+			Close preview
 		</button>
 
 		{#if errors.length > 0}


### PR DESCRIPTION
## Summary
Transforms the HTML preview modal into a fullscreen experience with a more accessible close button and improved error display positioning.

## Key Changes
- **Fullscreen layout**: Changed modal from constrained dimensions (`max-w-[90dvw]`, `h-[90dvh]`) to fullscreen (`w-[100dvw] h-[100dvh]`)
- **New close button**: Added a dedicated, always-visible close button in the top-right corner with:
  - Fixed positioning with `z-50` to stay above content
  - Semi-transparent dark background with backdrop blur for better visibility
  - Hover state for improved UX
  - Keyboard hint in title ("Esc")
- **Removed Modal's closeButton**: Eliminated the built-in close button from the Modal component since we now have an explicit one
- **Improved error button positioning**: Changed error button from `absolute` to `fixed` positioning with `z-50` to ensure it stays accessible in fullscreen
- **Cleaner iframe styling**: Removed rounded corners and border styling from iframe for true fullscreen appearance
- **Added CarbonClose icon**: Imported the close icon from Carbon icons library

## Implementation Details
- The close button uses `fixed` positioning to remain visible regardless of iframe scroll state
- Both close and error buttons use `z-50` to ensure they layer above the iframe content
- The modal now removes padding and uses the full viewport dimensions
- Maintains existing keyboard shortcut handling (Esc key) for closing

https://claude.ai/code/session_01WeASkssLKTyb1uQHeCQrxg