### PR TITLE
Update HuggingFace API link and button label

### DIFF
--- a/src/routes/settings/(nav)/[...model]/+page.svelte
+++ b/src/routes/settings/(nav)/[...model]/+page.svelte
@@ -201,13 +201,13 @@
 		{#if publicConfig.isHuggingChat}
 			{#if !model?.isRouter}
 				<a
-					href={"https://huggingface.co/playground?modelId=" + model.name}
+					href={"https://huggingface.co/" + model.name + "?inference_api=true"}
 					target="_blank"
 					rel="noreferrer"
 					class="inline-flex items-center rounded-full border border-gray-200 px-2.5 py-1 text-sm hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700/60"
 				>
 					<CarbonCode class="mr-1.5 shrink-0 text-xs" />
-					API Playground
+					Use via API
 				</a>
 				<a
 					href={"https://huggingface.co/" + model.name}


### PR DESCRIPTION
## Summary
Updated the HuggingFace API access link and button label to direct users to the model's inference API page instead of the playground.

## Changes
- Changed the API link from `https://huggingface.co/playground?modelId={model.name}` to `https://huggingface.co/{model.name}?inference_api=true`
- Updated button label from "API Playground" to "Use via API" for better clarity on the action's purpose

## Details
This change redirects users to the model's direct inference API page on HuggingFace rather than the generic playground, providing a more direct path to programmatic API usage. The updated button label better reflects this intent.

https://claude.ai/code/session_01BnftBy2jk9z28gWQ4cbK1M