### PR TITLE
Add Qwen3-Coder-Next-FP8 and Trinity-Mini models to dev/prod

### DIFF
--- a/chart/env/dev.yaml
+++ b/chart/env/dev.yaml
@@ -79,6 +79,8 @@ envVars:
   PUBLIC_LLM_ROUTER_ALIAS_ID: "omni"
   MODELS: >
     [
+      { "id": "Qwen/Qwen3-Coder-Next-FP8", "description": "FP8 Qwen3-Coder-Next for efficient inference with repository-scale coding agents." },
+      { "id": "arcee-ai/Trinity-Mini", "description": "Compact US-built MoE for multi-turn agents, tool use, and structured outputs." },
       { "id": "Qwen/Qwen3-Coder-Next", "description": "Ultra-sparse coding MoE for repository-scale agents with 256K context." },
       { "id": "moonshotai/Kimi-K2.5", "description": "Native multimodal agent with agent swarms for parallel tool orchestration." },
       { "id": "allenai/Molmo2-8B", "description": "Open vision-language model excelling at video understanding, pointing, and object tracking." },

--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -89,6 +89,8 @@ envVars:
   PUBLIC_LLM_ROUTER_ALIAS_ID: "omni"
   MODELS: >
     [
+      { "id": "Qwen/Qwen3-Coder-Next-FP8", "description": "FP8 Qwen3-Coder-Next for efficient inference with repository-scale coding agents." },
+      { "id": "arcee-ai/Trinity-Mini", "description": "Compact US-built MoE for multi-turn agents, tool use, and structured outputs." },
       { "id": "Qwen/Qwen3-Coder-Next", "description": "Ultra-sparse coding MoE for repository-scale agents with 256K context." },
       { "id": "moonshotai/Kimi-K2.5", "description": "Native multimodal agent with agent swarms for parallel tool orchestration." },
       { "id": "allenai/Molmo2-8B", "description": "Open vision-language model excelling at video understanding, pointing, and object tracking." },


### PR DESCRIPTION
## Summary
Add two new LLM models to both development and production environments to expand the available model options for agents.

## Changes
- Added `Qwen/Qwen3-Coder-Next-FP8`: FP8 quantized version of Qwen3-Coder-Next for efficient inference with repository-scale coding agents
- Added `arcee-ai/Trinity-Mini`: Compact US-built Mixture of Experts model optimized for multi-turn agents, tool use, and structured outputs

Both models are added to the top of the model list in:
- `chart/env/dev.yaml`
- `chart/env/prod.yaml`

## Details
These additions provide:
- A more efficient quantized alternative to the full Qwen3-Coder-Next model
- A lightweight MoE option for scenarios requiring compact model sizes with multi-turn conversation capabilities

https://claude.ai/code/session_01KDo7vKJoqh9u6xQz2X2zCm