### PR TITLE
Add five new LLM models to dev and prod environments

### DIFF
--- a/chart/env/dev.yaml
+++ b/chart/env/dev.yaml
@@ -79,6 +79,11 @@ envVars:
   PUBLIC_LLM_ROUTER_ALIAS_ID: "omni"
   MODELS: >
     [
+      { "id": "zai-org/GLM-5", "description": "Flagship 745B MoE for agentic reasoning, coding, and creative writing." },
+      { "id": "Qwen/Qwen3-VL-235B-A22B-Instruct", "description": "Flagship Qwen3 vision-language MoE for visual agents, documents, and GUI automation." },
+      { "id": "google/gemma-3n-E4B-it", "description": "Mobile-first multimodal Gemma handling text, images, video, and audio on-device." },
+      { "id": "nvidia/NVIDIA-Nemotron-Nano-9B-v2", "description": "Hybrid Mamba-Transformer with 128K context and controllable reasoning budget." },
+      { "id": "mistralai/Mistral-7B-Instruct-v0.2", "description": "Efficient 7B instruction model with 32K context for dialogue and coding." },
       { "id": "Qwen/Qwen3-Coder-Next-FP8", "description": "FP8 Qwen3-Coder-Next for efficient inference with repository-scale coding agents." },
       { "id": "arcee-ai/Trinity-Mini", "description": "Compact US-built MoE for multi-turn agents, tool use, and structured outputs." },
       { "id": "Qwen/Qwen3-Coder-Next", "description": "Ultra-sparse coding MoE for repository-scale agents with 256K context." },

--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -89,6 +89,11 @@ envVars:
   PUBLIC_LLM_ROUTER_ALIAS_ID: "omni"
   MODELS: >
     [
+      { "id": "zai-org/GLM-5", "description": "Flagship 745B MoE for agentic reasoning, coding, and creative writing." },
+      { "id": "Qwen/Qwen3-VL-235B-A22B-Instruct", "description": "Flagship Qwen3 vision-language MoE for visual agents, documents, and GUI automation." },
+      { "id": "google/gemma-3n-E4B-it", "description": "Mobile-first multimodal Gemma handling text, images, video, and audio on-device." },
+      { "id": "nvidia/NVIDIA-Nemotron-Nano-9B-v2", "description": "Hybrid Mamba-Transformer with 128K context and controllable reasoning budget." },
+      { "id": "mistralai/Mistral-7B-Instruct-v0.2", "description": "Efficient 7B instruction model with 32K context for dialogue and coding." },
       { "id": "Qwen/Qwen3-Coder-Next-FP8", "description": "FP8 Qwen3-Coder-Next for efficient inference with repository-scale coding agents." },
       { "id": "arcee-ai/Trinity-Mini", "description": "Compact US-built MoE for multi-turn agents, tool use, and structured outputs." },
       { "id": "Qwen/Qwen3-Coder-Next", "description": "Ultra-sparse coding MoE for repository-scale agents with 256K context." },


### PR DESCRIPTION
## Summary
This PR adds five new large language models to the available model roster in both development and production environments. These models expand the range of capabilities available to users, including flagship reasoning models, vision-language models, mobile-optimized multimodal models, and efficient instruction-following models.

## Key Changes
- Added GLM-5 (745B MoE) for agentic reasoning, coding, and creative writing
- Added Qwen3-VL-235B-A22B-Instruct for vision-language tasks, document processing, and GUI automation
- Added Gemma-3n-E4B-it for mobile-first multimodal inference supporting text, images, video, and audio
- Added NVIDIA-Nemotron-Nano-9B-v2 with Mamba-Transformer hybrid architecture and 128K context window
- Added Mistral-7B-Instruct-v0.2 as an efficient 7B model with 32K context for dialogue and coding

## Implementation Details
- Updated both `chart/env/dev.yaml` and `chart/env/prod.yaml` to maintain consistency across environments
- New models are positioned at the beginning of the MODELS list, making them primary options in the router
- Each model includes a descriptive label highlighting its key capabilities and use cases

https://claude.ai/code/session_01GEYyMFu5WpcT5YrfrPe1ZC