### PR TITLE
fix: ensure chat input is focused after navigating from model settings

### DIFF
--- a/src/lib/components/chat/ChatInput.svelte
+++ b/src/lib/components/chat/ChatInput.svelte
@@ -129,8 +129,12 @@
 			textareaElement.focus();
 		}
 
-		// Retry if focus didn't take (e.g., app was still inert from a closing modal)
-		if (typeof document !== "undefined" && document.activeElement !== textareaElement) {
+		// Retry only when focus failed due to #app being inert (modal closing transition)
+		if (
+			typeof document !== "undefined" &&
+			document.activeElement !== textareaElement &&
+			document.getElementById("app")?.hasAttribute("inert")
+		) {
 			setTimeout(() => {
 				if (!textareaElement || textareaElement.disabled || isVirtualKeyboard()) return;
 				if (document.activeElement === textareaElement) return;


### PR DESCRIPTION
## Summary
- When clicking "New Chat" from a model's settings page, the chat input textarea wasn't reliably receiving focus
- The settings modal sets `inert="true"` on `#app` and removes it in `onDestroy`, but the modal's 300ms fade transition can race with the focus attempt
- Adds a 350ms retry in `focusTextarea()` that only fires when the initial focus didn't take — no-op in all other navigation paths

## Test plan
- [ ] Open model settings (click model name below chat input)
- [ ] Click "New Chat" button
- [ ] Verify the chat input is focused and ready to type
- [ ] Verify normal navigation (sidebar "New Chat", direct URL) still auto-focuses correctly