### PR TITLE
fix: use h-dvh for top-level app height

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" class="h-full">
+<html lang="en">
 	<head>
 		<meta charset="utf-8" />
 		<meta
@@ -26,7 +26,7 @@
 		</script>
 		%sveltekit.head%
 	</head>
-	<body data-sveltekit-preload-data="hover" class="h-full dark:bg-gray-900">
+	<body data-sveltekit-preload-data="hover" class="h-dvh dark:bg-gray-900">
 		<div id="app" class="contents h-full">%sveltekit.body%</div>
 
 		<!-- Google Tag Manager -->

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -253,7 +253,7 @@
 <BackgroundGenerationPoller />
 
 <div
-	class="fixed grid h-full w-screen grid-cols-1 grid-rows-[auto,1fr] overflow-hidden text-smd {!isNavCollapsed
+	class="fixed grid h-dvh w-screen grid-cols-1 grid-rows-[auto,1fr] overflow-hidden text-smd {!isNavCollapsed
 		? 'md:grid-cols-[290px,1fr]'
 		: 'md:grid-cols-[0px,1fr]'} transition-[300ms] [transition-property:grid-template-columns] dark:text-gray-300 md:grid-rows-[1fr]"
 >


### PR DESCRIPTION
## Summary
- Replace `h-full` (`height: 100%`) with `h-dvh` (`height: 100dvh`) on `<html>`, `<body>`, and the root layout container
- On mobile browsers, `100%`/`100vh` doesn't account for the dynamic address bar, causing content to be hidden behind it. `dvh` (dynamic viewport height) adjusts automatically as the browser chrome shows/hides

## Test plan
- [ ] Desktop: verify layout looks identical (dvh == vh when there's no dynamic browser chrome)
- [ ] Mobile (iOS Safari / Android Chrome): verify the chat input is fully visible and not hidden behind the address bar
- [ ] Resize browser window — layout should remain correct