### PR TITLE
Move avatar before username in NavMenu

### DIFF
--- a/src/lib/components/NavMenu.svelte
+++ b/src/lib/components/NavMenu.svelte
@@ -177,7 +177,7 @@
 		>
 			<img
 				src="https://huggingface.co/api/users/{user.username}/avatar?redirect=true"
-				class="size-4 rounded-full border bg-gray-500 dark:border-white/40"
+				class="size-3.5 rounded-full border bg-gray-500 dark:border-white/40"
 				alt=""
 			/>
 			<span


### PR DESCRIPTION
## Summary
- Move user avatar to appear before the username in the sidebar nav menu
- Remove `ml-auto` conditional logic on the avatar (now always first in the row)
- Consistent `h-9` height on the user row

## Test plan
- [ ] Verify avatar appears before username in the sidebar
- [ ] Check with PRO badge visible (HuggingChat)
- [ ] Check without PRO badge
- [ ] Verify dark mode styling