### PR TITLE
Remove responsive prose sizing from chat messages

### DIFF
--- a/src/lib/components/chat/ChatMessage.svelte
+++ b/src/lib/components/chat/ChatMessage.svelte
@@ -304,7 +304,7 @@
 									/>
 								{:else if part && part.trim().length > 0}
 									<div
-										class="prose max-w-none dark:prose-invert max-sm:prose-sm prose-headings:font-semibold prose-h1:text-lg prose-h2:text-base prose-h3:text-base prose-pre:bg-gray-800 prose-img:my-0 prose-img:cursor-pointer prose-img:rounded-lg dark:prose-pre:bg-gray-900"
+										class="prose max-w-none dark:prose-invert prose-headings:font-semibold prose-h1:text-lg prose-h2:text-base prose-h3:text-base prose-pre:bg-gray-800 prose-img:my-0 prose-img:cursor-pointer prose-img:rounded-lg dark:prose-pre:bg-gray-900"
 									>
 										<MarkdownRenderer content={part} loading={isLast && loading} />
 									</div>
@@ -312,7 +312,7 @@
 							{/each}
 						{:else}
 							<div
-								class="prose max-w-none dark:prose-invert max-sm:prose-sm prose-headings:font-semibold prose-h1:text-lg prose-h2:text-base prose-h3:text-base prose-pre:bg-gray-800 prose-img:my-0 prose-img:cursor-pointer prose-img:rounded-lg dark:prose-pre:bg-gray-900"
+								class="prose max-w-none dark:prose-invert prose-headings:font-semibold prose-h1:text-lg prose-h2:text-base prose-h3:text-base prose-pre:bg-gray-800 prose-img:my-0 prose-img:cursor-pointer prose-img:rounded-lg dark:prose-pre:bg-gray-900"
 							>
 								<MarkdownRenderer content={block.content} loading={isLast && loading} />
 							</div>
@@ -411,7 +411,7 @@
 	<div
 		class="group relative {alternatives.length > 1 && editMsdgId === null
 			? 'mb-7'
-			: ''} w-full items-start justify-start gap-4 max-sm:text-sm"
+			: ''} w-full items-start justify-start gap-4"
 		data-message-id={message.id}
 		data-message-type="user"
 		role="presentation"


### PR DESCRIPTION
## Summary
This PR removes responsive text sizing utilities from chat message components to provide consistent typography across all screen sizes.

## Key Changes
- Removed `max-sm:prose-sm` class from two markdown prose containers in ChatMessage component (lines 307 and 414)
- Removed `max-sm:text-sm` class from the user message wrapper div (line 414)

## Details
The changes ensure that chat messages maintain uniform font sizing regardless of viewport size. Previously, small screens would have reduced prose and text sizes, which has now been standardized to use the default prose sizing across all devices.

https://claude.ai/code/session_012JxqPi2YowuFqRMTyqwHTC