### PR TITLE
Add model avatars to settings sidebar model list

### DIFF
--- a/src/routes/settings/(nav)/+layout.svelte
+++ b/src/routes/settings/(nav)/+layout.svelte
@@ -177,7 +177,19 @@
 					data-model-id={model.id}
 					aria-label="Configure {model.displayName}"
 				>
-					<div class="mr-auto flex items-center gap-1 truncate">
+					<div class="mr-auto flex items-center gap-1.5 truncate">
+						{#if model.logoUrl}
+							<img
+								alt=""
+								src={model.logoUrl}
+								class="size-5 flex-none rounded border border-gray-200 bg-gray-50 object-cover dark:border-gray-700 dark:bg-gray-100"
+							/>
+						{:else}
+							<div
+								class="size-5 flex-none rounded border border-gray-200 bg-gray-200 dark:border-gray-700 dark:bg-gray-700"
+								aria-hidden="true"
+							></div>
+						{/if}
 						<span class="truncate">{model.displayName}</span>
 						{#if model.isRouter}
 							<IconOmni />


### PR DESCRIPTION
Display a small (20px) avatar image before each model name in the
settings navigation sidebar, using the model's logoUrl. Falls back
to a neutral gray placeholder when no logo is available.

https://claude.ai/code/session_01A6mLstGyvjbDfFPf6mUk5e