### PR TITLE
Add Qwen3.5 and Olmo-3.1-Think models to available LLM options

### DIFF
--- a/chart/env/dev.yaml
+++ b/chart/env/dev.yaml
@@ -79,6 +79,8 @@ envVars:
   PUBLIC_LLM_ROUTER_ALIAS_ID: "omni"
   MODELS: >
     [
+      { "id": "Qwen/Qwen3.5-397B-A17B", "description": "Native multimodal MoE with hybrid attention, 1M context, and 201 languages." },
+      { "id": "allenai/Olmo-3.1-32B-Think", "description": "Updated Olmo Think with extended RL for stronger math, code, and instruction following." },
       { "id": "MiniMaxAI/MiniMax-M2.5", "description": "Frontier 230B MoE agent for top-tier coding, tool calling, and fast inference." },
       { "id": "zai-org/GLM-5", "description": "Flagship 745B MoE for agentic reasoning, coding, and creative writing." },
       { "id": "Qwen/Qwen3-VL-235B-A22B-Instruct", "description": "Flagship Qwen3 vision-language MoE for visual agents, documents, and GUI automation." },

--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -89,6 +89,8 @@ envVars:
   PUBLIC_LLM_ROUTER_ALIAS_ID: "omni"
   MODELS: >
     [
+      { "id": "Qwen/Qwen3.5-397B-A17B", "description": "Native multimodal MoE with hybrid attention, 1M context, and 201 languages." },
+      { "id": "allenai/Olmo-3.1-32B-Think", "description": "Updated Olmo Think with extended RL for stronger math, code, and instruction following." },
       { "id": "MiniMaxAI/MiniMax-M2.5", "description": "Frontier 230B MoE agent for top-tier coding, tool calling, and fast inference." },
       { "id": "zai-org/GLM-5", "description": "Flagship 745B MoE for agentic reasoning, coding, and creative writing." },
       { "id": "Qwen/Qwen3-VL-235B-A22B-Instruct", "description": "Flagship Qwen3 vision-language MoE for visual agents, documents, and GUI automation." },


### PR DESCRIPTION
## Summary
This PR adds two new language models to the available LLM options in both development and production environments.

## Key Changes
- Added `Qwen/Qwen3.5-397B-A17B`: A native multimodal MoE model with hybrid attention, 1M context window, and support for 201 languages
- Added `allenai/Olmo-3.1-32B-Think`: An updated Olmo Think model with extended reinforcement learning for improved performance on math, code, and instruction following tasks
- Both models are added to the top of the model list in both `chart/env/dev.yaml` and `chart/env/prod.yaml` for consistent availability across environments

## Implementation Details
The new models are inserted at the beginning of the MODELS configuration array, making them the first available options in the LLM router. Each model includes a descriptive text that highlights its key capabilities and use cases.

https://claude.ai/code/session_01YQBrXRw5CvoG7gqsyBGSP3