### PR TITLE
Fix CI race in treeHelpers.spec database initialization

### DIFF
--- a/src/lib/utils/tree/treeHelpers.spec.ts
+++ b/src/lib/utils/tree/treeHelpers.spec.ts
@@ -1,11 +1,13 @@
-import { collections } from "$lib/server/database";
+import { getCollectionsEarly } from "$lib/server/database";
 import { ObjectId } from "mongodb";
 import { describe, expect, it } from "vitest";
 
 // function used to insert conversations used for testing
+const getConversations = async () => (await getCollectionsEarly()).conversations;
 
 export const insertLegacyConversation = async () => {
-	const res = await collections.conversations.insertOne({
+	const conversations = await getConversations();
+	const res = await conversations.insertOne({
 		_id: new ObjectId(),
 		createdAt: new Date(),
 		updatedAt: new Date(),
@@ -39,7 +41,8 @@ export const insertLegacyConversation = async () => {
 };
 
 export const insertLinearBranchConversation = async () => {
-	const res = await collections.conversations.insertOne({
+	const conversations = await getConversations();
+	const res = await conversations.insertOne({
 		_id: new ObjectId(),
 		createdAt: new Date(),
 		updatedAt: new Date(),
@@ -82,7 +85,8 @@ export const insertLinearBranchConversation = async () => {
 };
 
 export const insertSideBranchesConversation = async () => {
-	const res = await collections.conversations.insertOne({
+	const conversations = await getConversations();
+	const res = await conversations.insertOne({
 		_id: new ObjectId(),
 		createdAt: new Date(),
 		updatedAt: new Date(),


### PR DESCRIPTION
## Summary
Fixes the failing CI tests in `src/lib/utils/tree/treeHelpers.spec.ts` from PR #2059 by ensuring DB collections are initialized before inserts.

## Root cause
The spec directly used `collections` from `$lib/server/database` before initialization completed in CI, causing:
- `TypeError: Cannot read properties of undefined (reading 'conversations')`

## Changes
- Switched `treeHelpers.spec.ts` to call `getCollectionsEarly()` and use the returned `conversations` collection before each insert helper call.
- Kept all tests (no removals), since they are relevant integration coverage.

## Validation
- `npm run test -- src/lib/utils/tree/treeHelpers.spec.ts --run`
- `npm run test -- --run` (22/22 files, 155/155 tests passed)
