### PR TITLE
fix: set max_tokens for Qwen3.5-397B-A17B to prevent truncation

### DIFF
--- a/chart/env/dev.yaml
+++ b/chart/env/dev.yaml
@@ -79,7 +79,7 @@ envVars:
   PUBLIC_LLM_ROUTER_ALIAS_ID: "omni"
   MODELS: >
     [
-      { "id": "Qwen/Qwen3.5-397B-A17B", "description": "Native multimodal MoE with hybrid attention, 1M context, and 201 languages." },
+      { "id": "Qwen/Qwen3.5-397B-A17B", "description": "Native multimodal MoE with hybrid attention, 1M context, and 201 languages.", "parameters": { "max_tokens": 32768 } },
       { "id": "allenai/Olmo-3.1-32B-Think", "description": "Updated Olmo Think with extended RL for stronger math, code, and instruction following." },
       { "id": "MiniMaxAI/MiniMax-M2.5", "description": "Frontier 230B MoE agent for top-tier coding, tool calling, and fast inference." },
       { "id": "zai-org/GLM-5", "description": "Flagship 745B MoE for agentic reasoning, coding, and creative writing." },

--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -89,7 +89,7 @@ envVars:
   PUBLIC_LLM_ROUTER_ALIAS_ID: "omni"
   MODELS: >
     [
-      { "id": "Qwen/Qwen3.5-397B-A17B", "description": "Native multimodal MoE with hybrid attention, 1M context, and 201 languages." },
+      { "id": "Qwen/Qwen3.5-397B-A17B", "description": "Native multimodal MoE with hybrid attention, 1M context, and 201 languages.", "parameters": { "max_tokens": 32768 } },
       { "id": "allenai/Olmo-3.1-32B-Think", "description": "Updated Olmo Think with extended RL for stronger math, code, and instruction following." },
       { "id": "MiniMaxAI/MiniMax-M2.5", "description": "Frontier 230B MoE agent for top-tier coding, tool calling, and fast inference." },
       { "id": "zai-org/GLM-5", "description": "Flagship 745B MoE for agentic reasoning, coding, and creative writing." },


### PR DESCRIPTION
## Summary
- Set `max_tokens: 32768` for `Qwen/Qwen3.5-397B-A17B` in both prod and dev configs
- Together AI defaults to 2048 max_tokens when unset, causing long responses to be cut off mid-sentence
- 32768 matches Qwen's official recommendation for general use and is consistent with DeepSeek-R1's config (32000)

## Testing
Tested both providers via the HF router API with a "write a long story" prompt:

| Provider | max_tokens | completion_tokens | finish_reason |
|----------|-----------|-------------------|---------------|
| Together | default (2048) | 2,048 | `length` (cut off) |
| Together | 8,192 | 8,192 | `length` (cut off) |
| Together | 16,384 | 9,888 | `stop` |
| Together | 32,768 | 14,313 | `stop` |
| Novita | 8,192 | 9,733 | `length` (cut off) |
| Novita | 16,384 | 10,196 | `stop` |

Key findings:
- Together counts reasoning tokens against the `max_tokens` budget
- Without explicit `max_tokens`, Together defaults to 2048 and truncates immediately
- Provider caps: Together has no hard cap, Novita caps at 64,000
- Qwen recommends 32,768 for general use, 81,920 for complex reasoning