### PR TITLE
Replace copy-to-clipboard with send-to-chat for error modal

### DIFF
--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -36,6 +36,7 @@
 	import type { RouterFollowUp, RouterExample } from "$lib/constants/routerExamples";
 	import { allBaseServersEnabled, mcpServersLoaded } from "$lib/stores/mcpServers";
 	import { shareModal } from "$lib/stores/shareModal";
+	import { pendingChatInput } from "$lib/stores/pendingChatInput";
 	import LucideHammer from "~icons/lucide/hammer";
 
 	import { fly } from "svelte/transition";
@@ -357,6 +358,13 @@
 
 		const match = activeExamples.find((ex) => ex.prompt.trim() === firstUserMessage.content.trim());
 		activeRouterExamplePrompt = match ? match.prompt : null;
+	});
+
+	$effect(() => {
+		if ($pendingChatInput) {
+			draft = $pendingChatInput;
+			pendingChatInput.set(undefined);
+		}
 	});
 
 	function triggerPrompt(prompt: string) {

--- a/src/lib/stores/pendingChatInput.ts
+++ b/src/lib/stores/pendingChatInput.ts
@@ -1,0 +1,3 @@
+import { writable } from "svelte/store";
+
+export const pendingChatInput = writable<string | undefined>(undefined);


### PR DESCRIPTION
## Summary
Refactored the HTML preview modal's error handling to send caught errors directly to the chat input instead of copying them to the clipboard. This improves the user workflow by allowing users to immediately discuss errors with the AI without manual steps.

## Key Changes
- **Removed clipboard functionality**: Deleted the `copy()` function and related state (`copied`, `copyTimer`) from `HtmlPreviewModal.svelte`
- **Added pending chat input store**: Created new `pendingChatInput.ts` store to manage text that should be populated into the chat input
- **Updated error button behavior**: Changed the error button from copying text to setting the pending chat input and closing the modal
- **Integrated with ChatWindow**: Added effect in `ChatWindow.svelte` to watch the `pendingChatInput` store and populate the draft when a value is set
- **Removed unused imports**: Cleaned up `CarbonCopy` icon import from the modal component

## Implementation Details
The new flow works as follows:
1. User clicks the error button in the HTML preview modal
2. Error text is set to the `pendingChatInput` store
3. Modal closes automatically
4. `ChatWindow` detects the store change and populates the draft input
5. Store is cleared to prevent re-triggering

This approach provides a seamless experience where errors can be immediately discussed in the chat context.

https://claude.ai/code/session_01LFvYspLi5dDTqf3env7Eoj