### PR TITLE
feat: add native fetch_url tool for built-in web page fetching

### DIFF
--- a/src/lib/server/fetchSafe.ts
+++ b/src/lib/server/fetchSafe.ts
@@ -1,0 +1,146 @@
+import { Agent, fetch } from "undici";
+import { isValidUrl, assertSafeIp } from "$lib/server/urlSafety";
+import dns from "node:dns";
+import { logger } from "$lib/server/logger";
+
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+const FETCH_TIMEOUT = 30_000; // 30 seconds
+const MAX_REDIRECTS = 5;
+
+/**
+ * Undici dispatcher that validates resolved IPs at connection time,
+ * preventing TOCTOU DNS rebinding attacks.
+ */
+export const ssrfSafeAgent = new Agent({
+	connect: {
+		lookup: (hostname, options, callback) => {
+			dns.lookup(hostname, options, (err, address, family) => {
+				if (err) return callback(err, "", 4);
+				if (typeof address === "string") {
+					try {
+						assertSafeIp(address, hostname);
+					} catch (e) {
+						return callback(e as Error, "", 4);
+					}
+				} else if (Array.isArray(address)) {
+					for (const entry of address) {
+						try {
+							assertSafeIp(entry.address, hostname);
+						} catch (e) {
+							return callback(e as Error, "", 4);
+						}
+					}
+				}
+				return callback(null, address, family);
+			});
+		},
+	},
+});
+
+export interface SafeFetchResult {
+	text: string;
+	statusCode: number;
+	contentType: string;
+}
+
+export async function safeFetch(
+	url: string,
+	opts?: { signal?: AbortSignal; maxBytes?: number }
+): Promise<SafeFetchResult> {
+	if (!isValidUrl(url)) {
+		throw new Error("Invalid or unsafe URL (only public HTTPS URLs are supported)");
+	}
+
+	const maxBytes = opts?.maxBytes ?? MAX_FILE_SIZE;
+
+	const controller = new AbortController();
+	const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT);
+
+	// Chain external signal if provided
+	if (opts?.signal) {
+		if (opts.signal.aborted) {
+			clearTimeout(timeoutId);
+			controller.abort();
+		} else {
+			opts.signal.addEventListener("abort", () => controller.abort(), { once: true });
+		}
+	}
+
+	let currentUrl = url;
+	let response: Awaited<ReturnType<typeof fetch>>;
+	let redirectCount = 0;
+
+	try {
+		// eslint-disable-next-line no-constant-condition
+		while (true) {
+			response = await fetch(currentUrl, {
+				signal: controller.signal,
+				redirect: "manual",
+				dispatcher: ssrfSafeAgent,
+				headers: {
+					"User-Agent": "HuggingChat-Attachment-Fetcher/1.0",
+				},
+			});
+
+			if (response.status >= 300 && response.status < 400) {
+				redirectCount++;
+				if (redirectCount > MAX_REDIRECTS) {
+					throw new Error("Too many redirects");
+				}
+
+				const location = response.headers.get("location");
+				if (!location) {
+					throw new Error("Redirect without Location header");
+				}
+
+				const redirectUrl = new URL(location, currentUrl).toString();
+
+				if (!isValidUrl(redirectUrl)) {
+					logger.warn({ redirectUrl, originalUrl: url }, "Redirect to unsafe URL blocked (SSRF)");
+					throw new Error("Redirect target is not allowed");
+				}
+
+				currentUrl = redirectUrl;
+				continue;
+			}
+
+			break;
+		}
+	} catch (err) {
+		clearTimeout(timeoutId);
+		throw err;
+	}
+
+	const contentType = response.headers.get("content-type") ?? "application/octet-stream";
+
+	if (!response.ok) {
+		clearTimeout(timeoutId);
+		return {
+			text: `HTTP error: ${response.status} ${response.statusText}`,
+			statusCode: response.status,
+			contentType,
+		};
+	}
+
+	const contentLength = response.headers.get("content-length");
+	if (contentLength && parseInt(contentLength) > maxBytes) {
+		clearTimeout(timeoutId);
+		throw new Error(`Response too large (max ${Math.round(maxBytes / 1024 / 1024)}MB)`);
+	}
+
+	try {
+		const arrayBuffer = await response.arrayBuffer();
+
+		if (arrayBuffer.byteLength > maxBytes) {
+			throw new Error(`Response too large (max ${Math.round(maxBytes / 1024 / 1024)}MB)`);
+		}
+
+		return {
+			text: new TextDecoder().decode(arrayBuffer),
+			statusCode: response.status,
+			contentType,
+		};
+	} finally {
+		clearTimeout(timeoutId);
+	}
+}

--- a/src/lib/server/textGeneration/index.ts
+++ b/src/lib/server/textGeneration/index.ts
@@ -59,6 +59,7 @@ async function* textGenerationWithoutTitle(
 			forceMultimodal: ctx.forceMultimodal,
 			forceTools: ctx.forceTools,
 			provider: ctx.provider,
+			enableNativeFetch: ctx.enableNativeFetch,
 			locals: ctx.locals,
 			preprompt,
 			abortSignal: ctx.abortController.signal,

--- a/src/lib/server/textGeneration/types.ts
+++ b/src/lib/server/textGeneration/types.ts
@@ -19,6 +19,8 @@ export interface TextGenerationContext {
 	forceTools?: boolean;
 	/** Inference provider preference: "auto", "fastest", "cheapest", or a specific provider name */
 	provider?: string;
+	/** Enable the built-in web fetch tool (default: true when absent) */
+	enableNativeFetch?: boolean;
 	locals: App.Locals | undefined;
 	abortController: AbortController;
 }

--- a/src/lib/server/tools/fetch.ts
+++ b/src/lib/server/tools/fetch.ts
@@ -1,0 +1,51 @@
+import { isValidUrl } from "$lib/server/urlSafety";
+import { safeFetch } from "$lib/server/fetchSafe";
+import type { NativeTool } from "./types";
+
+const MAX_RESPONSE_CHARS = 20_000;
+
+export const fetchTool: NativeTool = {
+	definition: {
+		type: "function",
+		function: {
+			name: "fetch_url",
+			description: "Fetches the content of a public HTTPS URL and returns it as text.",
+			parameters: {
+				type: "object",
+				properties: {
+					url: {
+						type: "string",
+						description: "The public HTTPS URL to fetch.",
+					},
+				},
+				required: ["url"],
+			},
+		},
+	},
+
+	async execute(args: Record<string, unknown>, opts?: { signal?: AbortSignal }): Promise<string> {
+		const url = typeof args.url === "string" ? args.url.trim() : "";
+
+		if (!url) {
+			return "Error: Missing required parameter 'url'.";
+		}
+
+		if (!isValidUrl(url)) {
+			return "Error: Invalid or unsafe URL. Only public HTTPS URLs are supported.";
+		}
+
+		try {
+			const result = await safeFetch(url, { signal: opts?.signal });
+
+			let body = result.text;
+			if (body.length > MAX_RESPONSE_CHARS) {
+				body = body.slice(0, MAX_RESPONSE_CHARS) + "\n\n[Content truncated]";
+			}
+
+			return `Status: ${result.statusCode}\nContent-Type: ${result.contentType}\nURL: ${url}\n\n${body}`;
+		} catch (err) {
+			const message = err instanceof Error ? err.message : String(err);
+			return `Error fetching URL: ${message}`;
+		}
+	},
+};

--- a/src/lib/server/tools/index.ts
+++ b/src/lib/server/tools/index.ts
@@ -1,0 +1,15 @@
+import { fetchTool } from "./fetch";
+import type { NativeTool } from "./types";
+
+const ALL_NATIVE_TOOLS: NativeTool[] = [fetchTool];
+
+export function getEnabledNativeTools(opts: { enableNativeFetch?: boolean }): NativeTool[] {
+	return ALL_NATIVE_TOOLS.filter((t) => {
+		if (t === fetchTool && opts.enableNativeFetch === false) return false;
+		return true;
+	});
+}
+
+export function findNativeTool(name: string): NativeTool | undefined {
+	return ALL_NATIVE_TOOLS.find((t) => t.definition.function.name === name);
+}

--- a/src/lib/server/tools/types.ts
+++ b/src/lib/server/tools/types.ts
@@ -1,0 +1,6 @@
+import type { OpenAiTool } from "$lib/server/mcp/tools";
+
+export interface NativeTool {
+	definition: OpenAiTool;
+	execute(args: Record<string, unknown>, opts?: { signal?: AbortSignal }): Promise<string>;
+}

--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -19,6 +19,7 @@ type SettingsStore = {
 	recentlySaved: boolean;
 	streamingMode: StreamingMode;
 	directPaste: boolean;
+	enableNativeFetch?: boolean;
 	billingOrganization?: string;
 };
 

--- a/src/lib/types/Settings.ts
+++ b/src/lib/types/Settings.ts
@@ -50,6 +50,9 @@ export interface Settings extends Timestamps {
 	streamingMode: StreamingMode;
 	directPaste: boolean;
 
+	/** Enable the built-in web fetch tool (default: true when absent) */
+	enableNativeFetch?: boolean;
+
 	/**
 	 * Organization to bill inference requests to (HuggingChat only).
 	 * Stores the org's preferred_username. If empty/undefined, bills to personal account.

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -32,6 +32,7 @@ interface SettingsResponse {
 	toolsOverrides: Record<string, boolean>;
 	hidePromptExamples: Record<string, boolean>;
 	providerOverrides: Record<string, string>;
+	enableNativeFetch?: boolean;
 	billingOrganization?: string;
 }
 

--- a/src/routes/api/v2/user/settings/+server.ts
+++ b/src/routes/api/v2/user/settings/+server.ts
@@ -20,6 +20,7 @@ const settingsSchema = z.object({
 	providerOverrides: z.record(z.string()).default({}),
 	streamingMode: z.enum(["raw", "smooth"]).optional(),
 	directPaste: z.boolean().default(false),
+	enableNativeFetch: z.boolean().optional(),
 	hidePromptExamples: z.record(z.boolean()).default({}),
 	billingOrganization: z.string().optional(),
 });
@@ -64,6 +65,7 @@ export const GET: RequestHandler = async ({ locals }) => {
 		multimodalOverrides: settings?.multimodalOverrides ?? {},
 		toolsOverrides: settings?.toolsOverrides ?? {},
 		providerOverrides: settings?.providerOverrides ?? {},
+		enableNativeFetch: settings?.enableNativeFetch,
 		billingOrganization: settings?.billingOrganization ?? undefined,
 	});
 };

--- a/src/routes/conversation/[id]/+server.ts
+++ b/src/routes/conversation/[id]/+server.ts
@@ -570,6 +570,7 @@ export async function POST({ request, locals, params, getClientAddress }) {
 						config.isHuggingChat && !model.isRouter
 							? userSettings?.providerOverrides?.[model.id]
 							: undefined,
+					enableNativeFetch: userSettings?.enableNativeFetch,
 					locals,
 					abortController: ctrl,
 				};

--- a/src/routes/settings/(nav)/+server.ts
+++ b/src/routes/settings/(nav)/+server.ts
@@ -16,6 +16,7 @@ const settingsSchema = z.object({
 	providerOverrides: z.record(z.string()).default({}),
 	streamingMode: z.enum(["raw", "smooth"]).optional(),
 	directPaste: z.boolean().default(false),
+	enableNativeFetch: z.boolean().optional(),
 	hidePromptExamples: z.record(z.boolean()).default({}),
 	billingOrganization: z.string().optional(),
 });

--- a/src/routes/settings/(nav)/application/+page.svelte
+++ b/src/routes/settings/(nav)/application/+page.svelte
@@ -39,6 +39,12 @@
 	function setDirectPaste(v: boolean) {
 		settings.update((s) => ({ ...s, directPaste: v }));
 	}
+	function getWebFetchEnabled() {
+		return $settings.enableNativeFetch !== false;
+	}
+	function setWebFetchEnabled(v: boolean) {
+		settings.update((s) => ({ ...s, enableNativeFetch: v }));
+	}
 
 	const client = useAPIClient();
 
@@ -212,6 +218,18 @@
 						</p>
 					</div>
 					<Switch name="directPaste" bind:checked={getDirectPaste, setDirectPaste} />
+				</div>
+
+				<div class="flex items-start justify-between py-3">
+					<div>
+						<div class="text-[13px] font-medium text-gray-800 dark:text-gray-200">
+							Web fetch tool
+						</div>
+						<p class="text-[12px] text-gray-500 dark:text-gray-400">
+							Allow the assistant to fetch public web pages when needed.
+						</p>
+					</div>
+					<Switch name="enableNativeFetch" bind:checked={getWebFetchEnabled, setWebFetchEnabled} />
 				</div>
 
 				<!-- Theme selector -->


### PR DESCRIPTION
## Summary

- Adds a built-in `fetch_url` tool so models can fetch public web pages without requiring any MCP server configuration
- Extracts shared SSRF-safe fetch helper (`fetchSafe.ts`) from the existing `/api/fetch-url` route
- Introduces an extensible native tool registry (`src/lib/server/tools/`) for future built-in tools
- Adds `enableNativeFetch` user setting (on by default) with a toggle in Application Settings ("Web fetch tool")
- Native tools are merged into the MCP flow — MCP tools take precedence on name collision at both definition and dispatch level
- Timeout now covers the full body read in `safeFetch` (not just headers/redirects)

## New files

| File | Purpose |
|------|---------|
| `src/lib/server/fetchSafe.ts` | Shared SSRF-safe fetch with DNS-time IP validation, redirect following |
| `src/lib/server/tools/types.ts` | `NativeTool` interface |
| `src/lib/server/tools/index.ts` | Registry: `getEnabledNativeTools()`, `findNativeTool()` |
| `src/lib/server/tools/fetch.ts` | `fetch_url` tool implementation (20k char truncation) |

## Modified files

Settings plumbing through all layers (Settings type → store → Zod schemas → layout → API v2 → conversation endpoint → TextGenerationContext → runMcpFlow). Settings UI toggle added after "Paste text directly".

MCP flow changes: relaxed early-exit guards so the flow proceeds with native tools even when no MCP servers are configured. Tool dispatch in `toolInvocation.ts` checks MCP mapping first, then native tools.

## Test plan

- [ ] Without MCP servers: send "fetch https://example.com and summarize it" — tool should activate and return content
- [ ] With MCP servers: both MCP tools and native fetch should appear; model can call either
- [ ] Toggle off "Web fetch tool" in settings — verify tool no longer appears
- [ ] SSRF: try `http://`, `localhost`, `127.0.0.1`, `10.0.0.1` — all rejected with clear error to model
- [ ] `npm run check` — 0 errors
- [ ] `npm run test` — 155/155 pass
- [ ] `npm run lint` — clean