### PR TITLE
feat: enable Exa crawling_exa MCP tool

### DIFF
--- a/chart/env/dev.yaml
+++ b/chart/env/dev.yaml
@@ -72,7 +72,7 @@ envVars:
   LLM_ROUTER_TOOLS_MODEL: "moonshotai/Kimi-K2-Instruct-0905"
   TRANSCRIPTION_MODEL: "openai/whisper-large-v3-turbo"
   MCP_SERVERS: >
-    [{"name": "Web Search (Exa)", "url": "https://mcp.exa.ai/mcp"}, {"name": "Hugging Face", "url": "https://hf.co/mcp?login"}]
+    [{"name": "Web Search (Exa)", "url": "https://mcp.exa.ai/mcp?tools=web_search_exa,get_code_context_exa,crawling_exa"}, {"name": "Hugging Face", "url": "https://hf.co/mcp?login"}]
   MCP_TOOL_TIMEOUT_MS: "120000"
   PUBLIC_LLM_ROUTER_DISPLAY_NAME: "Omni"
   PUBLIC_LLM_ROUTER_LOGO_URL: "https://cdn-uploads.huggingface.co/production/uploads/5f17f0a0925b9863e28ad517/C5V0v1xZXv6M7FXsdJH9b.png"

--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -82,7 +82,7 @@ envVars:
   LLM_ROUTER_TOOLS_MODEL: "moonshotai/Kimi-K2-Instruct-0905"
   TRANSCRIPTION_MODEL: "openai/whisper-large-v3-turbo"
   MCP_SERVERS: >
-    [{"name": "Web Search (Exa)", "url": "https://mcp.exa.ai/mcp"}, {"name": "Hugging Face", "url": "https://hf.co/mcp?login"}]
+    [{"name": "Web Search (Exa)", "url": "https://mcp.exa.ai/mcp?tools=web_search_exa,get_code_context_exa,crawling_exa"}, {"name": "Hugging Face", "url": "https://hf.co/mcp?login"}]
   MCP_TOOL_TIMEOUT_MS: "120000"
   PUBLIC_LLM_ROUTER_DISPLAY_NAME: "Omni"
   PUBLIC_LLM_ROUTER_LOGO_URL: "https://cdn-uploads.huggingface.co/production/uploads/5f17f0a0925b9863e28ad517/C5V0v1xZXv6M7FXsdJH9b.png"


### PR DESCRIPTION
## Summary
- Enables the `crawling_exa` tool on the Exa MCP server, allowing the assistant to fetch full content from specific URLs via Exa's content API
- Uses the explicit `?tools=` URL parameter to select `web_search_exa`, `get_code_context_exa`, and `crawling_exa` (drops `company_research_exa`)
- Applied to both dev and prod configs

## Test plan
- [ ] Verify Exa MCP tools list includes `crawling_exa` after deploy
- [ ] Test that web search and code context tools still work as before
- [ ] Test fetching a specific URL via the crawling tool in a conversation