### PR TITLE
fix: remove 10.0.0.0/8 from SSRF blocked subnets

### DIFF
--- a/src/lib/server/urlSafety.ts
+++ b/src/lib/server/urlSafety.ts
@@ -3,7 +3,6 @@ import { isIP } from "node:net";
 
 const UNSAFE_IPV4_SUBNETS = [
 	"0.0.0.0/8",
-	"10.0.0.0/8",
 	"100.64.0.0/10",
 	"127.0.0.0/8",
 	"169.254.0.0/16",


### PR DESCRIPTION
## Summary

- `huggingface.co` resolves to `10.0.x.x` in production. The SSRF protection added in #2119 blocks `10.0.0.0/8`, which broke URL attachments for any `huggingface.co` URL (docs, papers, model cards, etc).
- Removes `10.0.0.0/8` from the blocked subnets since network policies in the cluster already handle blocking unwanted internal ranges. All other SSRF protections (localhost, link-local, 172.16/12, 192.168/16, DNS rebinding, redirect validation) remain active.