### PR TITLE
Add three new Qwen3.5 models to LLM router configuration

### DIFF
--- a/chart/env/dev.yaml
+++ b/chart/env/dev.yaml
@@ -79,6 +79,9 @@ envVars:
   PUBLIC_LLM_ROUTER_ALIAS_ID: "omni"
   MODELS: >
     [
+      { "id": "Qwen/Qwen3.5-122B-A10B", "description": "Multimodal MoE excelling at agentic tool use with 1M context and 201 languages." },
+      { "id": "Qwen/Qwen3.5-35B-A3B", "description": "Compact multimodal MoE with hybrid DeltaNet, 1M context, and 201 languages." },
+      { "id": "Qwen/Qwen3.5-27B", "description": "Dense multimodal hybrid with top-tier reasoning density and 1M context." },
       { "id": "Qwen/Qwen3.5-397B-A17B", "description": "Native multimodal MoE with hybrid attention, 1M context, and 201 languages.", "parameters": { "max_tokens": 32768 } },
       { "id": "allenai/Olmo-3.1-32B-Think", "description": "Updated Olmo Think with extended RL for stronger math, code, and instruction following." },
       { "id": "MiniMaxAI/MiniMax-M2.5", "description": "Frontier 230B MoE agent for top-tier coding, tool calling, and fast inference." },

--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -89,6 +89,9 @@ envVars:
   PUBLIC_LLM_ROUTER_ALIAS_ID: "omni"
   MODELS: >
     [
+      { "id": "Qwen/Qwen3.5-122B-A10B", "description": "Multimodal MoE excelling at agentic tool use with 1M context and 201 languages." },
+      { "id": "Qwen/Qwen3.5-35B-A3B", "description": "Compact multimodal MoE with hybrid DeltaNet, 1M context, and 201 languages." },
+      { "id": "Qwen/Qwen3.5-27B", "description": "Dense multimodal hybrid with top-tier reasoning density and 1M context." },
       { "id": "Qwen/Qwen3.5-397B-A17B", "description": "Native multimodal MoE with hybrid attention, 1M context, and 201 languages.", "parameters": { "max_tokens": 32768 } },
       { "id": "allenai/Olmo-3.1-32B-Think", "description": "Updated Olmo Think with extended RL for stronger math, code, and instruction following." },
       { "id": "MiniMaxAI/MiniMax-M2.5", "description": "Frontier 230B MoE agent for top-tier coding, tool calling, and fast inference." },


### PR DESCRIPTION
## Summary
This PR adds three new Qwen3.5 model variants to the available LLM models in both development and production environments.

## Key Changes
- Added `Qwen/Qwen3.5-122B-A10B`: Multimodal MoE model optimized for agentic tool use with 1M context window and support for 201 languages
- Added `Qwen/Qwen3.5-35B-A3B`: Compact multimodal MoE variant featuring hybrid DeltaNet architecture, 1M context, and 201 language support
- Added `Qwen/Qwen3.5-27B`: Dense multimodal hybrid model with strong reasoning capabilities and 1M context window
- Updated both `chart/env/dev.yaml` and `chart/env/prod.yaml` to maintain consistency across environments

## Implementation Details
The new models are inserted before the existing `Qwen/Qwen3.5-397B-A17B` entry in the MODELS configuration list, providing users with additional options across different model sizes and capabilities while maintaining the existing model hierarchy.

https://claude.ai/code/session_01NkF1hxHBFwTgZ7s84Svn5f