### PR TITLE
Add Capacitor support with configurable API base URL

### DIFF
--- a/.env
+++ b/.env
@@ -28,6 +28,7 @@ PUBLIC_SHARE_PREFIX=
 PUBLIC_GOOGLE_ANALYTICS_ID=
 PUBLIC_PLAUSIBLE_SCRIPT_URL=
 PUBLIC_APPLE_APP_ID=
+PUBLIC_API_BASE_URL= # Set to backend origin for Capacitor/native builds (e.g. https://huggingface.co/chat)
 
 COUPLE_SESSION_WITH_COOKIE_NAME=
 # when OPEN_ID is configured, users are required to login after the welcome modal

--- a/CAPACITOR_READINESS.md
+++ b/CAPACITOR_READINESS.md
@@ -12,17 +12,17 @@ is still required — the app cannot function as a standalone client-only mobile
 
 ## What's Already Capacitor-Ready
 
-| Area | Status | Detail |
-|------|--------|--------|
-| Static adapter | Ready | `@sveltejs/adapter-static` installed, `npm run build:static` works |
-| SPA routing | Ready | `fallback: "index.html"`, `strict: false` configured |
-| No +page.server.ts | Ready | Zero server-side page load files — all loads are universal |
-| No +layout.server.ts | Ready | Zero server layout files |
-| UI components | Ready | 80+ Svelte components are pure client-side, zero server imports |
-| HTML template | Ready | Viewport already set for mobile (`maximum-scale=1, user-scalable=no`) |
-| Icons/assets | Ready | Multiple icon sizes in `static/`, PWA manifest configured |
-| TypeScript target | Ready | ES2018 — compatible with Capacitor WebViews |
-| Theme detection | Ready | Dark mode via localStorage + `matchMedia` with proper fallback |
+| Area                 | Status | Detail                                                                |
+| -------------------- | ------ | --------------------------------------------------------------------- |
+| Static adapter       | Ready  | `@sveltejs/adapter-static` installed, `npm run build:static` works    |
+| SPA routing          | Ready  | `fallback: "index.html"`, `strict: false` configured                  |
+| No +page.server.ts   | Ready  | Zero server-side page load files — all loads are universal            |
+| No +layout.server.ts | Ready  | Zero server layout files                                              |
+| UI components        | Ready  | 80+ Svelte components are pure client-side, zero server imports       |
+| HTML template        | Ready  | Viewport already set for mobile (`maximum-scale=1, user-scalable=no`) |
+| Icons/assets         | Ready  | Multiple icon sizes in `static/`, PWA manifest configured             |
+| TypeScript target    | Ready  | ES2018 — compatible with Capacitor WebViews                           |
+| Theme detection      | Ready  | Dark mode via localStorage + `matchMedia` with proper fallback        |
 
 ## Architecture
 
@@ -53,8 +53,8 @@ which talks to a remote Node.js backend over HTTPS.
 
 ```typescript
 const baseUrl = browser
-    ? `${window.location.origin}${base}/api/v2`
-    : `${origin ?? "http://localhost:5173"}${base}/api/v2`;
+	? `${window.location.origin}${base}/api/v2`
+	: `${origin ?? "http://localhost:5173"}${base}/api/v2`;
 ```
 
 In Capacitor, `window.location.origin` becomes `capacitor://localhost`, which won't reach
@@ -75,29 +75,29 @@ redirects, token refresh, and session cookies all require server mediation.
 
 ## Browser API Compatibility Issues
 
-| API | Severity | Issue |
-|-----|----------|-------|
-| `window.location.origin` | Critical | Returns `capacitor://localhost` in native context |
-| Relative fetch URLs | Critical | `/conversation/[id]` won't resolve without backend |
-| `document.cookie` | High | May not work in WebView |
-| `MediaRecorder` / `getUserMedia` | High | Needs Capacitor microphone plugin |
-| `ReadableStream.pipeThrough` | High | Some Android WebViews lack support |
-| `localStorage` | Medium | Works but no encryption, cleared on app updates |
-| Hardcoded `huggingface.co` URLs | Medium | Fail offline, can't be overridden |
+| API                              | Severity | Issue                                              |
+| -------------------------------- | -------- | -------------------------------------------------- |
+| `window.location.origin`         | Critical | Returns `capacitor://localhost` in native context  |
+| Relative fetch URLs              | Critical | `/conversation/[id]` won't resolve without backend |
+| `document.cookie`                | High     | May not work in WebView                            |
+| `MediaRecorder` / `getUserMedia` | High     | Needs Capacitor microphone plugin                  |
+| `ReadableStream.pipeThrough`     | High     | Some Android WebViews lack support                 |
+| `localStorage`                   | Medium   | Works but no encryption, cleared on app updates    |
+| Hardcoded `huggingface.co` URLs  | Medium   | Fail offline, can't be overridden                  |
 
 ## Remaining Work
 
-| Task | Effort | Detail |
-|------|--------|--------|
-| Make API base URL configurable | Small | Add `PUBLIC_API_BASE_URL` to `APIClient.ts` |
-| Add CORS for Capacitor origin | Small | Backend must accept `capacitor://localhost` |
-| Handle cookie-less auth | Medium | Bearer token auth or WebView cookie jar |
-| Add `capacitor.config.ts` | Small | Point `webDir` to static build output |
-| Install Capacitor packages | Small | `@capacitor/core`, `@capacitor/cli`, platform packages |
-| iOS safe area CSS | Small | `env(safe-area-inset-*)` for notch/home indicator |
-| Voice recording plugin | Medium | Replace raw `getUserMedia` with Capacitor plugin |
-| Test streaming on Android | Medium | Verify `ReadableStream` + `TextDecoderStream` |
-| Handle deep links for OAuth | Medium | Register URL scheme for login redirect |
+| Task                           | Effort | Detail                                                 |
+| ------------------------------ | ------ | ------------------------------------------------------ |
+| Make API base URL configurable | Small  | Add `PUBLIC_API_BASE_URL` to `APIClient.ts`            |
+| Add CORS for Capacitor origin  | Small  | Backend must accept `capacitor://localhost`            |
+| Handle cookie-less auth        | Medium | Bearer token auth or WebView cookie jar                |
+| Add `capacitor.config.ts`      | Small  | Point `webDir` to static build output                  |
+| Install Capacitor packages     | Small  | `@capacitor/core`, `@capacitor/cli`, platform packages |
+| iOS safe area CSS              | Small  | `env(safe-area-inset-*)` for notch/home indicator      |
+| Voice recording plugin         | Medium | Replace raw `getUserMedia` with Capacitor plugin       |
+| Test streaming on Android      | Medium | Verify `ReadableStream` + `TextDecoderStream`          |
+| Handle deep links for OAuth    | Medium | Register URL scheme for login redirect                 |
 
 ## Prior Art
 

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -1,0 +1,9 @@
+import type { CapacitorConfig } from "@capacitor/cli";
+
+const config: CapacitorConfig = {
+	appId: "co.huggingface.chat",
+	appName: "HuggingChat",
+	webDir: "build",
+};
+
+export default config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
 			"name": "chat-ui",
 			"version": "0.20.0",
 			"dependencies": {
+				"@capacitor/core": "^6.0.0",
 				"@huggingface/hub": "^2.2.0",
 				"@huggingface/inference": "^4.11.3",
 				"@iconify-json/bi": "^1.1.21",
@@ -50,6 +51,7 @@
 				"zod": "^3.22.3"
 			},
 			"devDependencies": {
+				"@capacitor/cli": "^6.0.0",
 				"@faker-js/faker": "^8.4.1",
 				"@iconify-json/carbon": "^1.1.16",
 				"@iconify-json/eos-icons": "^1.1.6",
@@ -293,6 +295,123 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@capacitor/cli": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/@capacitor/cli/-/cli-6.2.1.tgz",
+			"integrity": "sha512-JKl0FpFge8PgQNInw12kcKieQ4BmOyazQ4JGJOfEpVXlgrX1yPhSZTPjngupzTCiK3I7q7iGG5kjun0fDqgSCA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@ionic/cli-framework-output": "^2.2.5",
+				"@ionic/utils-fs": "^3.1.6",
+				"@ionic/utils-subprocess": "2.1.11",
+				"@ionic/utils-terminal": "^2.3.3",
+				"commander": "^9.3.0",
+				"debug": "^4.3.4",
+				"env-paths": "^2.2.0",
+				"kleur": "^4.1.4",
+				"native-run": "^2.0.0",
+				"open": "^8.4.0",
+				"plist": "^3.0.5",
+				"prompts": "^2.4.2",
+				"rimraf": "^4.4.1",
+				"semver": "^7.3.7",
+				"tar": "^6.1.11",
+				"tslib": "^2.4.0",
+				"xml2js": "^0.5.0"
+			},
+			"bin": {
+				"cap": "bin/capacitor",
+				"capacitor": "bin/capacitor"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@capacitor/cli/node_modules/commander": {
+			"version": "9.5.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+			"integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.20.0 || >=14"
+			}
+		},
+		"node_modules/@capacitor/cli/node_modules/glob": {
+			"version": "9.3.5",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
+			"integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
+			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"minimatch": "^8.0.2",
+				"minipass": "^4.2.4",
+				"path-scurry": "^1.6.1"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@capacitor/cli/node_modules/minimatch": {
+			"version": "8.0.7",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.7.tgz",
+			"integrity": "sha512-V+1uQNdzybxa14e/p00HZnQNNcTjnRJjDxg2V8wtkjFctq4M7hXFws4oekyTP0Jebeq7QYtpFyOeBAjc88zvYg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@capacitor/cli/node_modules/minipass": {
+			"version": "4.2.8",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
+			"integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@capacitor/cli/node_modules/rimraf": {
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-4.4.1.tgz",
+			"integrity": "sha512-Gk8NlF062+T9CqNGn6h4tls3k6T1+/nXdOcSZVikNVtlRdYpA7wRJJMoXmuvOnLW844rPjdQ7JgXCYM6PPC/og==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"glob": "^9.2.0"
+			},
+			"bin": {
+				"rimraf": "dist/cjs/src/bin.js"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@capacitor/core": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/@capacitor/core/-/core-6.2.1.tgz",
+			"integrity": "sha512-urZwxa7hVE/BnA18oCFAdizXPse6fCKanQyEqpmz6cBJ2vObwMpyJDG5jBeoSsgocS9+Ax+9vb4ducWJn0y2qQ==",
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.1.0"
 			}
 		},
 		"node_modules/@csstools/color-helpers": {
@@ -1636,6 +1755,421 @@
 				"@swc/helpers": "^0.5.0"
 			}
 		},
+		"node_modules/@ionic/cli-framework-output": {
+			"version": "2.2.8",
+			"resolved": "https://registry.npmjs.org/@ionic/cli-framework-output/-/cli-framework-output-2.2.8.tgz",
+			"integrity": "sha512-TshtaFQsovB4NWRBydbNFawql6yul7d5bMiW1WYYf17hd99V6xdDdk3vtF51bw6sLkxON3bDQpWsnUc9/hVo3g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@ionic/utils-terminal": "2.3.5",
+				"debug": "^4.0.0",
+				"tslib": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@ionic/utils-array": {
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/@ionic/utils-array/-/utils-array-2.1.5.tgz",
+			"integrity": "sha512-HD72a71IQVBmQckDwmA8RxNVMTbxnaLbgFOl+dO5tbvW9CkkSFCv41h6fUuNsSEVgngfkn0i98HDuZC8mk+lTA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.0.0",
+				"tslib": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=10.3.0"
+			}
+		},
+		"node_modules/@ionic/utils-fs": {
+			"version": "3.1.7",
+			"resolved": "https://registry.npmjs.org/@ionic/utils-fs/-/utils-fs-3.1.7.tgz",
+			"integrity": "sha512-2EknRvMVfhnyhL1VhFkSLa5gOcycK91VnjfrTB0kbqkTFCOXyXgVLI5whzq7SLrgD9t1aqos3lMMQyVzaQ5gVA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/fs-extra": "^8.0.0",
+				"debug": "^4.0.0",
+				"fs-extra": "^9.0.0",
+				"tslib": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@ionic/utils-object": {
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/@ionic/utils-object/-/utils-object-2.1.5.tgz",
+			"integrity": "sha512-XnYNSwfewUqxq+yjER1hxTKggftpNjFLJH0s37jcrNDwbzmbpFTQTVAp4ikNK4rd9DOebX/jbeZb8jfD86IYxw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.0.0",
+				"tslib": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=10.3.0"
+			}
+		},
+		"node_modules/@ionic/utils-process": {
+			"version": "2.1.10",
+			"resolved": "https://registry.npmjs.org/@ionic/utils-process/-/utils-process-2.1.10.tgz",
+			"integrity": "sha512-mZ7JEowcuGQK+SKsJXi0liYTcXd2bNMR3nE0CyTROpMECUpJeAvvaBaPGZf5ERQUPeWBVuwqAqjUmIdxhz5bxw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@ionic/utils-object": "2.1.5",
+				"@ionic/utils-terminal": "2.3.3",
+				"debug": "^4.0.0",
+				"signal-exit": "^3.0.3",
+				"tree-kill": "^1.2.2",
+				"tslib": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=10.3.0"
+			}
+		},
+		"node_modules/@ionic/utils-process/node_modules/@ionic/utils-terminal": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/@ionic/utils-terminal/-/utils-terminal-2.3.3.tgz",
+			"integrity": "sha512-RnuSfNZ5fLEyX3R5mtcMY97cGD1A0NVBbarsSQ6yMMfRJ5YHU7hHVyUfvZeClbqkBC/pAqI/rYJuXKCT9YeMCQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/slice-ansi": "^4.0.0",
+				"debug": "^4.0.0",
+				"signal-exit": "^3.0.3",
+				"slice-ansi": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0",
+				"tslib": "^2.0.1",
+				"untildify": "^4.0.0",
+				"wrap-ansi": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=10.3.0"
+			}
+		},
+		"node_modules/@ionic/utils-process/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@ionic/utils-process/node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@ionic/utils-process/node_modules/signal-exit": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/@ionic/utils-process/node_modules/slice-ansi": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+			"integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"astral-regex": "^2.0.0",
+				"is-fullwidth-code-point": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/slice-ansi?sponsor=1"
+			}
+		},
+		"node_modules/@ionic/utils-process/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@ionic/utils-process/node_modules/wrap-ansi": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/@ionic/utils-stream": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/@ionic/utils-stream/-/utils-stream-3.1.5.tgz",
+			"integrity": "sha512-hkm46uHvEC05X/8PHgdJi4l4zv9VQDELZTM+Kz69odtO9zZYfnt8DkfXHJqJ+PxmtiE5mk/ehJWLnn/XAczTUw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.0.0",
+				"tslib": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=10.3.0"
+			}
+		},
+		"node_modules/@ionic/utils-subprocess": {
+			"version": "2.1.11",
+			"resolved": "https://registry.npmjs.org/@ionic/utils-subprocess/-/utils-subprocess-2.1.11.tgz",
+			"integrity": "sha512-6zCDixNmZCbMCy5np8klSxOZF85kuDyzZSTTQKQP90ZtYNCcPYmuFSzaqDwApJT4r5L3MY3JrqK1gLkc6xiUPw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@ionic/utils-array": "2.1.5",
+				"@ionic/utils-fs": "3.1.6",
+				"@ionic/utils-process": "2.1.10",
+				"@ionic/utils-stream": "3.1.5",
+				"@ionic/utils-terminal": "2.3.3",
+				"cross-spawn": "^7.0.3",
+				"debug": "^4.0.0",
+				"tslib": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=10.3.0"
+			}
+		},
+		"node_modules/@ionic/utils-subprocess/node_modules/@ionic/utils-fs": {
+			"version": "3.1.6",
+			"resolved": "https://registry.npmjs.org/@ionic/utils-fs/-/utils-fs-3.1.6.tgz",
+			"integrity": "sha512-eikrNkK89CfGPmexjTfSWl4EYqsPSBh0Ka7by4F0PLc1hJZYtJxUZV3X4r5ecA8ikjicUmcbU7zJmAjmqutG/w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/fs-extra": "^8.0.0",
+				"debug": "^4.0.0",
+				"fs-extra": "^9.0.0",
+				"tslib": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=10.3.0"
+			}
+		},
+		"node_modules/@ionic/utils-subprocess/node_modules/@ionic/utils-terminal": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/@ionic/utils-terminal/-/utils-terminal-2.3.3.tgz",
+			"integrity": "sha512-RnuSfNZ5fLEyX3R5mtcMY97cGD1A0NVBbarsSQ6yMMfRJ5YHU7hHVyUfvZeClbqkBC/pAqI/rYJuXKCT9YeMCQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/slice-ansi": "^4.0.0",
+				"debug": "^4.0.0",
+				"signal-exit": "^3.0.3",
+				"slice-ansi": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0",
+				"tslib": "^2.0.1",
+				"untildify": "^4.0.0",
+				"wrap-ansi": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=10.3.0"
+			}
+		},
+		"node_modules/@ionic/utils-subprocess/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@ionic/utils-subprocess/node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@ionic/utils-subprocess/node_modules/signal-exit": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/@ionic/utils-subprocess/node_modules/slice-ansi": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+			"integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"astral-regex": "^2.0.0",
+				"is-fullwidth-code-point": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/slice-ansi?sponsor=1"
+			}
+		},
+		"node_modules/@ionic/utils-subprocess/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@ionic/utils-subprocess/node_modules/wrap-ansi": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/@ionic/utils-terminal": {
+			"version": "2.3.5",
+			"resolved": "https://registry.npmjs.org/@ionic/utils-terminal/-/utils-terminal-2.3.5.tgz",
+			"integrity": "sha512-3cKScz9Jx2/Pr9ijj1OzGlBDfcmx7OMVBt4+P1uRR0SSW4cm1/y3Mo4OY3lfkuaYifMNBW8Wz6lQHbs1bihr7A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/slice-ansi": "^4.0.0",
+				"debug": "^4.0.0",
+				"signal-exit": "^3.0.3",
+				"slice-ansi": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0",
+				"tslib": "^2.0.1",
+				"untildify": "^4.0.0",
+				"wrap-ansi": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@ionic/utils-terminal/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@ionic/utils-terminal/node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@ionic/utils-terminal/node_modules/signal-exit": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/@ionic/utils-terminal/node_modules/slice-ansi": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+			"integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"astral-regex": "^2.0.0",
+				"is-fullwidth-code-point": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/slice-ansi?sponsor=1"
+			}
+		},
+		"node_modules/@ionic/utils-terminal/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@ionic/utils-terminal/node_modules/wrap-ansi": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
 		"node_modules/@isaacs/cliui": {
 			"version": "8.0.2",
 			"resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -2781,6 +3315,16 @@
 			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
 			"license": "MIT"
 		},
+		"node_modules/@types/fs-extra": {
+			"version": "8.1.5",
+			"resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-8.1.5.tgz",
+			"integrity": "sha512-0dzKcwO+S8s2kuF5Z9oUWatQJj5Uq/iqphEtE3GQJVRRYm/tD1LglU2UnXi2A8jLq5umkGouOXOR9y0n613ZwQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
 		"node_modules/@types/js-yaml": {
 			"version": "4.0.9",
 			"resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
@@ -2866,6 +3410,13 @@
 			"version": "7.7.0",
 			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.0.tgz",
 			"integrity": "sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/slice-ansi": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@types/slice-ansi/-/slice-ansi-4.0.0.tgz",
+			"integrity": "sha512-+OpjSaq85gvlZAYINyzKpLeiFkSC4EsC6IIiT6v6TLSU5k5U83fHGj9Lel8oKEXM0HqgrMVCjXPDPVICtxF7EQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -3288,6 +3839,16 @@
 				"url": "https://opencollective.com/vitest"
 			}
 		},
+		"node_modules/@xmldom/xmldom": {
+			"version": "0.8.11",
+			"resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
+			"integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
 		"node_modules/abab": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
@@ -3537,6 +4098,16 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/astral-regex": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+			"integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/async-mutex": {
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
@@ -3552,6 +4123,16 @@
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
 			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
 			"license": "MIT"
+		},
+		"node_modules/at-least-node": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+			"integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">= 4.0.0"
+			}
 		},
 		"node_modules/atomic-sleep": {
 			"version": "1.0.0",
@@ -3649,6 +4230,16 @@
 			],
 			"license": "MIT"
 		},
+		"node_modules/big-integer": {
+			"version": "1.6.52",
+			"resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
+			"integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
+			"dev": true,
+			"license": "Unlicense",
+			"engines": {
+				"node": ">=0.6"
+			}
+		},
 		"node_modules/binary-extensions": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -3736,6 +4327,19 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/bplist-parser": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.3.2.tgz",
+			"integrity": "sha512-apC2+fspHGI3mMKj+dGevkGo/tCqVB8jMb6i+OX+E29p0Iposz07fABkRIfVUPNd5A5VbuOz1bZbnmkKLYF+wQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"big-integer": "1.6.x"
+			},
+			"engines": {
+				"node": ">= 5.10.0"
 			}
 		},
 		"node_modules/brace-expansion": {
@@ -4017,6 +4621,16 @@
 			},
 			"funding": {
 				"url": "https://paulmillr.com/funding/"
+			}
+		},
+		"node_modules/chownr": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+			"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/cli-cursor": {
@@ -4379,6 +4993,16 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/define-lazy-prop": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+			"integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -4601,6 +5225,19 @@
 			"integrity": "sha512-naiMx1Z6Nb2TxPU6fiFrUrDTjyPMLdTtaOd2oLmG8zVSg2hCWGkhPyxwk+qRmZ1ytwVqUv0u7ZcDA5+ALhaUtw==",
 			"license": "ISC"
 		},
+		"node_modules/elementtree": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/elementtree/-/elementtree-0.1.7.tgz",
+			"integrity": "sha512-wkgGT6kugeQk/P6VZ/f4T+4HB41BVgNBq5CDIZVbQ02nvTVqAiVTbskxxu3eA/X96lMlfYOwnLQpN2v5E1zDEg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"sax": "1.1.4"
+			},
+			"engines": {
+				"node": ">= 0.4.0"
+			}
+		},
 		"node_modules/emoji-regex": {
 			"version": "10.4.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
@@ -4635,6 +5272,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
+		"node_modules/env-paths": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+			"integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/environment": {
@@ -5384,6 +6031,16 @@
 				"reusify": "^1.0.4"
 			}
 		},
+		"node_modules/fd-slicer": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+			"integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"pend": "~1.2.0"
+			}
+		},
 		"node_modules/fdir": {
 			"version": "6.4.5",
 			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.5.tgz",
@@ -5629,6 +6286,58 @@
 				"node": ">= 0.8"
 			}
 		},
+		"node_modules/fs-extra": {
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+			"integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"at-least-node": "^1.0.0",
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/fs-extra/node_modules/universalify": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/fs-minipass": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+			"integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"minipass": "^3.0.0"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/fs-minipass/node_modules/minipass": {
+			"version": "3.3.6",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+			"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -5828,6 +6537,13 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/graceful-fs": {
+			"version": "4.2.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/graphemer": {
 			"version": "1.4.0",
@@ -6155,6 +6871,16 @@
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
 			"license": "ISC"
 		},
+		"node_modules/ini": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.3.tgz",
+			"integrity": "sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
 		"node_modules/inline-style-parser": {
 			"version": "0.2.6",
 			"resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.6.tgz",
@@ -6220,6 +6946,22 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-docker": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+			"integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"is-docker": "cli.js"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/is-extglob": {
@@ -6328,6 +7070,19 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/mesqueeb"
+			}
+		},
+		"node_modules/is-wsl": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+			"integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-docker": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/isexe": {
@@ -6706,6 +7461,29 @@
 			},
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/jsonfile": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+			"integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"universalify": "^2.0.0"
+			},
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.6"
+			}
+		},
+		"node_modules/jsonfile/node_modules/universalify": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 10.0.0"
 			}
 		},
 		"node_modules/katex": {
@@ -7274,6 +8052,46 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/minizlib": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+			"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"minipass": "^3.0.0",
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/minizlib/node_modules/minipass": {
+			"version": "3.3.6",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+			"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/mkdirp": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+			"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"mkdirp": "bin/cmd.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/mlly": {
 			"version": "1.7.4",
 			"resolved": "https://registry.npmjs.org/mlly/-/mlly-1.7.4.tgz",
@@ -7569,6 +8387,43 @@
 				"node": "^18 || >=20"
 			}
 		},
+		"node_modules/native-run": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/native-run/-/native-run-2.0.3.tgz",
+			"integrity": "sha512-U1PllBuzW5d1gfan+88L+Hky2eZx+9gv3Pf6rNBxKbORxi7boHzqiA6QFGSnqMem4j0A9tZ08NMIs5+0m/VS1Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@ionic/utils-fs": "^3.1.7",
+				"@ionic/utils-terminal": "^2.3.4",
+				"bplist-parser": "^0.3.2",
+				"debug": "^4.3.4",
+				"elementtree": "^0.1.7",
+				"ini": "^4.1.1",
+				"plist": "^3.1.0",
+				"split2": "^4.2.0",
+				"through2": "^4.0.2",
+				"tslib": "^2.6.2",
+				"yauzl": "^2.10.0"
+			},
+			"bin": {
+				"native-run": "bin/native-run"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/native-run/node_modules/yauzl": {
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+			"integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"buffer-crc32": "~0.2.3",
+				"fd-slicer": "~1.1.0"
+			}
+		},
 		"node_modules/natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -7816,6 +8671,24 @@
 			"license": "MIT",
 			"dependencies": {
 				"mimic-fn": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/open": {
+			"version": "8.4.2",
+			"resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+			"integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"define-lazy-prop": "^2.0.0",
+				"is-docker": "^2.1.1",
+				"is-wsl": "^2.2.0"
 			},
 			"engines": {
 				"node": ">=12"
@@ -8394,6 +9267,21 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/plist": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz",
+			"integrity": "sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@xmldom/xmldom": "^0.8.8",
+				"base64-js": "^1.5.1",
+				"xmlbuilder": "^15.1.1"
+			},
+			"engines": {
+				"node": ">=10.4.0"
+			}
+		},
 		"node_modules/postcss": {
 			"version": "8.5.4",
 			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.4.tgz",
@@ -8810,6 +9698,30 @@
 			},
 			"engines": {
 				"node": "^16 || ^18 || >=20"
+			}
+		},
+		"node_modules/prompts": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+			"integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"kleur": "^3.0.3",
+				"sisteransi": "^1.0.5"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/prompts/node_modules/kleur": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+			"integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/proxy-addr": {
@@ -9333,6 +10245,13 @@
 				"ultrahtml": "^1.2.0"
 			}
 		},
+		"node_modules/sax": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.1.4.tgz",
+			"integrity": "sha512-5f3k2PbGGp+YtKJjOItpg3P99IMD84E4HOvcfleTb5joCHNXYLsR9yWFPOYGgaeMPDubQILTCMdsFb2OMeOjtg==",
+			"dev": true,
+			"license": "ISC"
+		},
 		"node_modules/saxes": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -9620,6 +10539,13 @@
 			"engines": {
 				"node": ">=18"
 			}
+		},
+		"node_modules/sisteransi": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+			"integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/slash": {
 			"version": "3.0.0",
@@ -10366,6 +11292,25 @@
 				"node": ">=8.10.0"
 			}
 		},
+		"node_modules/tar": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+			"integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+			"deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"chownr": "^2.0.0",
+				"fs-minipass": "^2.0.0",
+				"minipass": "^5.0.0",
+				"minizlib": "^2.1.1",
+				"mkdirp": "^1.0.3",
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/tar-stream": {
 			"version": "3.1.7",
 			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
@@ -10446,6 +11391,31 @@
 			},
 			"engines": {
 				"node": ">= 4.1.0"
+			}
+		},
+		"node_modules/through2": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+			"integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"readable-stream": "3"
+			}
+		},
+		"node_modules/through2/node_modules/readable-stream": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
 			}
 		},
 		"node_modules/tiny-inflate": {
@@ -10588,6 +11558,16 @@
 			},
 			"engines": {
 				"node": ">=14"
+			}
+		},
+		"node_modules/tree-kill": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+			"integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"tree-kill": "cli.js"
 			}
 		},
 		"node_modules/ts-api-utils": {
@@ -10829,6 +11809,16 @@
 				"vue-template-es2015-compiler": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/untildify": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+			"integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/update-browserslist-db": {
@@ -11412,6 +12402,40 @@
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=12"
+			}
+		},
+		"node_modules/xml2js": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+			"integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"sax": ">=0.6.0",
+				"xmlbuilder": "~11.0.0"
+			},
+			"engines": {
+				"node": ">=4.0.0"
+			}
+		},
+		"node_modules/xml2js/node_modules/xmlbuilder": {
+			"version": "11.0.1",
+			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+			"integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/xmlbuilder": {
+			"version": "15.1.1",
+			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+			"integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8.0"
 			}
 		},
 		"node_modules/xmlchars": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
 		"dev": "vite dev",
 		"build": "vite build",
 		"build:static": "ADAPTER=static vite build",
+		"cap:build": "ADAPTER=static vite build && cap sync",
+		"cap:ios": "cap open ios",
+		"cap:android": "cap open android",
 		"preview": "vite preview",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
@@ -19,6 +22,7 @@
 		"prepare": "husky"
 	},
 	"devDependencies": {
+		"@capacitor/cli": "^6.0.0",
 		"@faker-js/faker": "^8.4.1",
 		"@iconify-json/carbon": "^1.1.16",
 		"@iconify-json/eos-icons": "^1.1.6",
@@ -69,6 +73,7 @@
 	},
 	"type": "module",
 	"dependencies": {
+		"@capacitor/core": "^6.0.0",
 		"@huggingface/hub": "^2.2.0",
 		"@huggingface/inference": "^4.11.3",
 		"@iconify-json/bi": "^1.1.21",

--- a/src/app.html
+++ b/src/app.html
@@ -4,7 +4,7 @@
 		<meta charset="utf-8" />
 		<meta
 			name="viewport"
-			content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
+			content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
 		/>
 		<meta name="theme-color" content="rgb(249, 250, 251)" />
 		<script>

--- a/src/lib/APIClient.ts
+++ b/src/lib/APIClient.ts
@@ -2,6 +2,7 @@ import { base } from "$app/paths";
 import { browser } from "$app/environment";
 import superjson from "superjson";
 import ObjectId from "bson-objectid";
+import { apiOrigin } from "$lib/utils/apiBase";
 
 superjson.registerCustom<ObjectId, string>(
 	{
@@ -94,7 +95,7 @@ export function useAPIClient({
 } = {}) {
 	const fetcher = customFetch ?? globalThis.fetch;
 	const baseUrl = browser
-		? `${window.location.origin}${base}/api/v2`
+		? `${apiOrigin || window.location.origin}${base}/api/v2`
 		: `${origin ?? `http://localhost:5173`}${base}/api/v2`;
 
 	return {

--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -19,6 +19,7 @@
 	import RetryBtn from "../RetryBtn.svelte";
 	import file2base64 from "$lib/utils/file2base64";
 	import { base } from "$app/paths";
+	import { apiOrigin } from "$lib/utils/apiBase";
 	import ChatMessage from "./ChatMessage.svelte";
 	import ScrollToBottomBtn from "../ScrollToBottomBtn.svelte";
 	import ScrollToPreviousBtn from "../ScrollToPreviousBtn.svelte";
@@ -345,7 +346,10 @@
 	);
 
 	$effect(() => {
-		if (!(currentModel.isRouter || (modelSupportsTools && $allBaseServersEnabled)) || !messages.length) {
+		if (
+			!(currentModel.isRouter || (modelSupportsTools && $allBaseServersEnabled)) ||
+			!messages.length
+		) {
 			activeRouterExamplePrompt = null;
 			return;
 		}
@@ -381,7 +385,7 @@
 			const loadedFiles: File[] = [];
 			for (const attachment of example.attachments) {
 				try {
-					const response = await fetch(`${base}/${attachment.src}`);
+					const response = await fetch(`${apiOrigin}${base}/${attachment.src}`);
 					if (!response.ok) continue;
 
 					const blob = await response.blob();
@@ -408,7 +412,7 @@
 		isTranscribing = true;
 
 		try {
-			const response = await fetch(`${base}/api/transcribe`, {
+			const response = await fetch(`${apiOrigin}${base}/api/transcribe`, {
 				method: "POST",
 				headers: { "Content-Type": audioBlob.type },
 				body: audioBlob,
@@ -437,7 +441,7 @@
 		isTranscribing = true;
 
 		try {
-			const response = await fetch(`${base}/api/transcribe`, {
+			const response = await fetch(`${apiOrigin}${base}/api/transcribe`, {
 				method: "POST",
 				headers: { "Content-Type": audioBlob.type },
 				body: audioBlob,

--- a/src/lib/components/chat/ModelSwitch.svelte
+++ b/src/lib/components/chat/ModelSwitch.svelte
@@ -2,6 +2,7 @@
 	import { invalidateAll } from "$app/navigation";
 	import { page } from "$app/state";
 	import { base } from "$app/paths";
+	import { apiOrigin } from "$lib/utils/apiBase";
 	import type { Model } from "$lib/types/Model";
 
 	interface Props {
@@ -19,7 +20,7 @@
 		if (!page.params.id) return;
 
 		try {
-			const response = await fetch(`${base}/conversation/${page.params.id}`, {
+			const response = await fetch(`${apiOrigin}${base}/conversation/${page.params.id}`, {
 				method: "PATCH",
 				headers: {
 					"Content-Type": "application/json",

--- a/src/lib/components/chat/UrlFetchModal.svelte
+++ b/src/lib/components/chat/UrlFetchModal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import Modal from "../Modal.svelte";
 	import { base } from "$app/paths";
+	import { apiOrigin } from "$lib/utils/apiBase";
 	import { tick } from "svelte";
 	import { pickSafeMime } from "$lib/utils/mime";
 
@@ -76,7 +77,7 @@
 			// Use server proxy directly for one URL to validate size/types before creating File
 			const params = new URLSearchParams({ url: trimmed });
 			if (acceptMimeTypes.length > 0) params.set("accept", acceptMimeTypes.join(","));
-			const proxyUrl = `${base}/api/fetch-url?${params}`;
+			const proxyUrl = `${apiOrigin}${base}/api/fetch-url?${params}`;
 			const res = await fetch(proxyUrl);
 			if (!res.ok) {
 				const txt = await res.text();

--- a/src/lib/createShareLink.ts
+++ b/src/lib/createShareLink.ts
@@ -1,5 +1,6 @@
 import { base } from "$app/paths";
 import { page } from "$app/state";
+import { apiOrigin } from "$lib/utils/apiBase";
 
 // Returns a public share URL for a conversation id.
 // If `id` is already a 7-char share id, no network call is made.
@@ -12,7 +13,7 @@ export async function createShareLink(id: string): Promise<string> {
 		return `${prefix}/r/${id}`;
 	}
 
-	const res = await fetch(`${base}/conversation/${id}/share`, {
+	const res = await fetch(`${apiOrigin}${base}/conversation/${id}/share`, {
 		method: "POST",
 		headers: { "Content-Type": "application/json" },
 	});

--- a/src/lib/server/hooks/handle.ts
+++ b/src/lib/server/hooks/handle.ts
@@ -26,6 +26,20 @@ function getClientAddressSafe(event: RequestEvent): string | undefined {
 	}
 }
 
+function getAllowedOrigin(requestOrigin: string | null): string | undefined {
+	let allowedOrigin = config.PUBLIC_ORIGIN ? new URL(config.PUBLIC_ORIGIN).origin : undefined;
+
+	if (dev || !requestOrigin || isHostLocalhost(new URL(requestOrigin).hostname)) {
+		allowedOrigin = "*";
+	} else if (requestOrigin.startsWith("capacitor://")) {
+		allowedOrigin = requestOrigin;
+	} else if (allowedOrigin === requestOrigin) {
+		allowedOrigin = requestOrigin;
+	}
+
+	return allowedOrigin;
+}
+
 export async function handleRequest({ event, resolve }: HandleInput): Promise<Response> {
 	// Generate a unique request ID for this request
 	const requestId = crypto.randomUUID();
@@ -33,6 +47,22 @@ export async function handleRequest({ event, resolve }: HandleInput): Promise<Re
 	// Run the entire request handling within the request context
 	return runWithRequestContext(
 		async () => {
+			// Handle OPTIONS preflight requests for CORS
+			if (event.request.method === "OPTIONS" && event.url.pathname.startsWith(`${base}/api/`)) {
+				const requestOrigin = event.request.headers.get("origin");
+				const allowed = getAllowedOrigin(requestOrigin);
+				return new Response(null, {
+					status: 204,
+					headers: {
+						...(allowed ? { "Access-Control-Allow-Origin": allowed } : {}),
+						"Access-Control-Allow-Methods": "GET, POST, PUT, PATCH, DELETE, OPTIONS",
+						"Access-Control-Allow-Headers": "Content-Type, Authorization",
+						"Access-Control-Allow-Credentials": "true",
+						"Access-Control-Max-Age": "86400",
+					},
+				});
+			}
+
 			await ready.then(() => {
 				config.checkForUpdates();
 			});
@@ -215,21 +245,8 @@ export async function handleRequest({ event, resolve }: HandleInput): Promise<Re
 			}
 
 			if (event.url.pathname.startsWith(`${base}/api/`)) {
-				// get origin from the request
 				const requestOrigin = event.request.headers.get("origin");
-
-				// get origin from the config if its defined
-				let allowedOrigin = config.PUBLIC_ORIGIN ? new URL(config.PUBLIC_ORIGIN).origin : undefined;
-
-				if (
-					dev || // if we're in dev mode
-					!requestOrigin || // or the origin is null (SSR)
-					isHostLocalhost(new URL(requestOrigin).hostname) // or the origin is localhost
-				) {
-					allowedOrigin = "*"; // allow all origins
-				} else if (allowedOrigin === requestOrigin) {
-					allowedOrigin = requestOrigin; // echo back the caller
-				}
+				const allowedOrigin = getAllowedOrigin(requestOrigin);
 
 				if (allowedOrigin) {
 					response.headers.set("Access-Control-Allow-Origin", allowedOrigin);
@@ -238,6 +255,7 @@ export async function handleRequest({ event, resolve }: HandleInput): Promise<Re
 						"GET, POST, PUT, PATCH, DELETE, OPTIONS"
 					);
 					response.headers.set("Access-Control-Allow-Headers", "Content-Type, Authorization");
+					response.headers.set("Access-Control-Allow-Credentials", "true");
 				}
 			}
 

--- a/src/lib/stores/mcpServers.ts
+++ b/src/lib/stores/mcpServers.ts
@@ -9,6 +9,7 @@ import { base } from "$app/paths";
 import { env as publicEnv } from "$env/dynamic/public";
 import { browser } from "$app/environment";
 import type { MCPServer, ServerStatus, MCPTool } from "$lib/types/Tool";
+import { apiOrigin } from "$lib/utils/apiBase";
 
 // Namespace storage by app identity to avoid collisions across apps
 function toKeyPart(s: string | undefined): string {
@@ -142,7 +143,7 @@ export const allBaseServersEnabled = derived(
  */
 export async function refreshMcpServers() {
 	try {
-		const response = await fetch(`${base}/api/mcp/servers`);
+		const response = await fetch(`${apiOrigin}${base}/api/mcp/servers`);
 		if (!response.ok) {
 			throw new Error(`Failed to fetch base servers: ${response.statusText}`);
 		}
@@ -317,7 +318,7 @@ export async function healthCheckServer(
 	try {
 		updateServerStatus(server.id, "connecting");
 
-		const response = await fetch(`${base}/api/mcp/health`, {
+		const response = await fetch(`${apiOrigin}${base}/api/mcp/health`, {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify({ url: server.url, headers: server.headers }),

--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -5,6 +5,7 @@ import type { StreamingMode } from "$lib/types/Settings";
 import { UrlDependency } from "$lib/types/UrlDependency";
 import { getContext, setContext } from "svelte";
 import { type Writable, writable, get } from "svelte/store";
+import { apiOrigin } from "$lib/utils/apiBase";
 
 type SettingsStore = {
 	shareConversationsWithModelAuthors: boolean;
@@ -51,7 +52,7 @@ export function createSettingsStore(initialValue: Omit<SettingsStore, "recentlyS
 			showSavedOnNextSync = true; // User edit, should show "Saved"
 			clearTimeout(timeoutId);
 			timeoutId = setTimeout(async () => {
-				await fetch(`${base}/settings`, {
+				await fetch(`${apiOrigin}${base}/settings`, {
 					method: "POST",
 					headers: {
 						"Content-Type": "application/json",
@@ -109,7 +110,7 @@ export function createSettingsStore(initialValue: Omit<SettingsStore, "recentlyS
 		if (browser) {
 			clearTimeout(timeoutId);
 			timeoutId = setTimeout(async () => {
-				await fetch(`${base}/settings`, {
+				await fetch(`${apiOrigin}${base}/settings`, {
 					method: "POST",
 					headers: {
 						"Content-Type": "application/json",
@@ -143,7 +144,7 @@ export function createSettingsStore(initialValue: Omit<SettingsStore, "recentlyS
 		}));
 
 		if (browser) {
-			await fetch(`${base}/settings`, {
+			await fetch(`${apiOrigin}${base}/settings`, {
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",

--- a/src/lib/utils/apiBase.ts
+++ b/src/lib/utils/apiBase.ts
@@ -1,0 +1,11 @@
+import { PUBLIC_API_BASE_URL } from "$env/static/public";
+
+/**
+ * API origin prefix for fetch calls.
+ * - Web: "" (empty string → relative URLs, current behavior)
+ * - Capacitor: "https://myserver.com" (absolute URLs to remote backend)
+ *
+ * Set PUBLIC_API_BASE_URL at build time for native/Capacitor builds:
+ *   PUBLIC_API_BASE_URL=https://myserver.com ADAPTER=static vite build
+ */
+export const apiOrigin: string = PUBLIC_API_BASE_URL ?? "";

--- a/src/lib/utils/messageUpdates.ts
+++ b/src/lib/utils/messageUpdates.ts
@@ -11,6 +11,7 @@ import {
 } from "$lib/types/MessageUpdate";
 import type { StreamingMode } from "$lib/types/Settings";
 import type { KeyValuePair } from "$lib/types/Tool";
+import { apiOrigin } from "$lib/utils/apiBase";
 
 type MessageUpdateRequestOptions = {
 	base: string;
@@ -68,7 +69,7 @@ export async function fetchMessageUpdates(
 
 	form.append("data", optsJSON);
 
-	const response = await fetch(`${opts.base}/conversation/${conversationId}`, {
+	const response = await fetch(`${apiOrigin}${opts.base}/conversation/${conversationId}`, {
 		method: "POST",
 		body: form,
 		signal: abortController.signal,

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -9,6 +9,7 @@
 	import { error } from "$lib/stores/errors";
 	import { createSettingsStore } from "$lib/stores/settings";
 	import { loading } from "$lib/stores/loading";
+	import { apiOrigin } from "$lib/utils/apiBase";
 
 	import Toast from "$lib/components/Toast.svelte";
 	import NavMenu from "$lib/components/NavMenu.svelte";
@@ -152,7 +153,7 @@
 		if (page.url.searchParams.has("token")) {
 			const token = page.url.searchParams.get("token");
 
-			await fetch(`${base}/api/user/validate-token`, {
+			await fetch(`${apiOrigin}${base}/api/user/validate-token`, {
 				method: "POST",
 				body: JSON.stringify({ token }),
 			}).then(() => {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,6 +3,7 @@
 	import { base } from "$app/paths";
 	import { page } from "$app/state";
 	import { usePublicConfig } from "$lib/utils/PublicConfig.svelte";
+	import { apiOrigin } from "$lib/utils/apiBase";
 
 	const publicConfig = usePublicConfig();
 
@@ -41,7 +42,7 @@
 			} else {
 				model = data.models[0].id;
 			}
-			const res = await fetch(`${base}/conversation`, {
+			const res = await fetch(`${apiOrigin}${base}/conversation`, {
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",

--- a/src/routes/conversation/[id]/+page.svelte
+++ b/src/routes/conversation/[id]/+page.svelte
@@ -19,6 +19,7 @@
 	import { useSettingsStore } from "$lib/stores/settings.js";
 	import { enabledServers } from "$lib/stores/mcpServers";
 	import { browser } from "$app/environment";
+	import { apiOrigin } from "$lib/utils/apiBase";
 	import {
 		addBackgroundGeneration,
 		removeBackgroundGeneration,
@@ -431,9 +432,12 @@
 		$loading = false;
 
 		const sendStopRequest = async () => {
-			const response = await fetch(`${base}/conversation/${page.params.id}/stop-generating`, {
-				method: "POST",
-			});
+			const response = await fetch(
+				`${apiOrigin}${base}/conversation/${page.params.id}/stop-generating`,
+				{
+					method: "POST",
+				}
+			);
 			if (!response.ok) {
 				throw new Error(`Stop request failed: ${response.status}`);
 			}

--- a/src/routes/models/[...model]/+page.svelte
+++ b/src/routes/models/[...model]/+page.svelte
@@ -2,6 +2,7 @@
 	import { page } from "$app/state";
 	import { base } from "$app/paths";
 	import { goto, replaceState } from "$app/navigation";
+	import { apiOrigin } from "$lib/utils/apiBase";
 	import { onMount, tick } from "svelte";
 	import { usePublicConfig } from "$lib/utils/PublicConfig.svelte";
 
@@ -34,7 +35,7 @@
 		try {
 			loading = true;
 
-			const res = await fetch(`${base}/conversation`, {
+			const res = await fetch(`${apiOrigin}${base}/conversation`, {
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",

--- a/src/routes/models/[...model]/+page.ts
+++ b/src/routes/models/[...model]/+page.ts
@@ -1,7 +1,8 @@
 import { base } from "$app/paths";
+import { apiOrigin } from "$lib/utils/apiBase";
 
 export async function load({ params, parent, fetch }) {
-	await fetch(`${base}/api/v2/models/${params.model}/subscribe`, {
+	await fetch(`${apiOrigin}${base}/api/v2/models/${params.model}/subscribe`, {
 		method: "POST",
 	});
 

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -8,6 +8,9 @@ html,
 body {
 	overscroll-behavior: none;
 	touch-action: pan-x pan-y;
+	/* Safe area insets for native app (iOS notch, home indicator, etc.) */
+	padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom)
+		env(safe-area-inset-left);
 }
 
 @layer components {


### PR DESCRIPTION
## Summary

This PR adds Capacitor/native app support by making the API client configurable to work with remote backends. The changes enable the chat-ui SPA to run as a native iOS/Android app via Capacitor while maintaining full compatibility with the existing web deployment.

## Key Changes

- **Configurable API base URL**: Added `PUBLIC_API_BASE_URL` environment variable to `APIClient.ts` and created `src/lib/utils/apiBase.ts` to centralize API origin configuration. This allows the app to point to a remote backend when running in Capacitor (e.g., `https://myserver.com`) while defaulting to relative URLs for web deployments.

- **CORS support for Capacitor**: Enhanced `src/lib/server/hooks/handle.ts` to:
  - Handle OPTIONS preflight requests for API routes
  - Accept `capacitor://` origins in addition to configured origins
  - Add `Access-Control-Allow-Credentials` header for cookie-based auth

- **Updated all fetch calls**: Systematically updated fetch URLs across the codebase to use `apiOrigin` prefix:
  - `src/lib/APIClient.ts` - Main API client
  - `src/lib/stores/settings.ts` - Settings persistence
  - `src/lib/stores/mcpServers.ts` - MCP server management
  - `src/lib/components/chat/ChatWindow.svelte` - Chat operations
  - `src/lib/components/chat/ModelSwitch.svelte` - Model switching
  - `src/lib/components/chat/UrlFetchModal.svelte` - URL fetching
  - `src/lib/createShareLink.ts` - Share link generation
  - `src/lib/utils/messageUpdates.ts` - Message streaming
  - `src/routes/+layout.svelte` - Token validation
  - `src/routes/+page.svelte` - Conversation creation
  - `src/routes/conversation/[id]/+page.svelte` - Stop generation
  - `src/routes/models/[...model]/+page.ts` - Model subscription

- **Capacitor configuration**: Added `capacitor.config.ts` with app metadata and build output configuration.

- **Build scripts**: Added npm scripts for Capacitor workflow:
  - `cap:build` - Build static SPA and sync with Capacitor
  - `cap:ios` - Open iOS project
  - `cap:android` - Open Android project

- **Mobile viewport improvements**:
  - Added `viewport-fit=cover` to support notch/safe areas
  - Added CSS safe area insets (`env(safe-area-inset-*)`) to prevent content overlap with notches and home indicators

- **Dependencies**: Added `@capacitor/core` and `@capacitor/cli` packages.

- **Documentation**: Added comprehensive `CAPACITOR_READINESS.md` assessment documenting:
  - Current readiness status (SPA foundation complete, backend required)
  - Architecture overview (hybrid: Capacitor frontend + remote Node.js backend)
  - Critical blockers and remaining work
  - Browser API compatibility issues
  - Estimated effort (1-2 weeks)

## Implementation Details

The solution maintains a **hybrid architecture** where Capacitor wraps the static SPA frontend, which communicates with a remote Node.js backend over HTTPS. The `apiOrigin` utility provides a single source of truth for API URL configuration:

```typescript
// Web: "" (empty string → relative URLs, current behavior)
// Capacitor: "https://myserver.com" (absolute URLs to remote backend)
export const apiOrigin: string = PUBLIC_API_BASE_URL ?? "";
```

Build-time configuration:
```bash
PUBLIC_API_BASE_URL=https://myserver.com ADAPTER=static vite build
```

The CORS handling in `handle.ts` now explicitly supports Capacitor's `capacitor://localhost` origin while maintaining security for production deployments.

https://claude.ai/code/session_01Hkh2feFJ5juwX4h2mAfYba