### PR TITLE
Add haptic feedback when streaming starts

### DIFF
--- a/src/lib/utils/haptics.ts
+++ b/src/lib/utils/haptics.ts
@@ -62,3 +62,11 @@ export function error() {
 export function selection() {
 	fire("selection");
 }
+
+/** Stream start burst — multiple short vibrations for a "machine starting up" feel. */
+export function streamStart(): void {
+	if (!enabled || !browser) return;
+	if (typeof navigator.vibrate !== "function") return;
+	// Three quick pulses: two short taps + a slightly longer finish
+	navigator.vibrate([50, 30, 50, 30, 80]);
+}

--- a/src/routes/conversation/[id]/+page.svelte
+++ b/src/routes/conversation/[id]/+page.svelte
@@ -28,6 +28,7 @@
 	import { updateDebouncer } from "$lib/utils/updates.js";
 	import SubscribeModal from "$lib/components/SubscribeModal.svelte";
 	import { loading } from "$lib/stores/loading.js";
+	import { streamStart } from "$lib/utils/haptics";
 	import { requireAuthUser } from "$lib/utils/auth.js";
 	import { isConversationGenerationActive } from "$lib/utils/generationState";
 
@@ -319,6 +320,9 @@
 						updateDebouncer.maxUpdateTime
 					) {
 						flushBuffer(currentTime);
+					}
+					if (pending) {
+						streamStart();
 					}
 					pending = false;
 				} else if (update.type === MessageUpdateType.FinalAnswer) {


### PR DESCRIPTION
## Summary
Added haptic feedback to provide tactile notification when a message stream begins, enhancing user experience by signaling the start of AI response generation.

## Changes
- **New haptic function**: Added `streamStart()` function to `src/lib/utils/haptics.ts` that triggers a distinctive three-pulse vibration pattern (50ms, 30ms, 50ms, 30ms, 80ms) to simulate a "machine starting up" feel
- **Integration**: Imported and triggered `streamStart()` in the conversation page when a pending message stream begins, providing immediate haptic feedback to users

## Implementation Details
- The `streamStart()` function follows the existing haptics pattern with proper feature detection (`navigator.vibrate` check) and respects the global `enabled` and `browser` flags
- The haptic feedback is triggered at the moment a stream becomes pending, giving users immediate tactile confirmation that their message is being processed
- The vibration pattern uses varied pulse lengths to create a distinctive "startup" sensation distinct from other haptic feedback in the app

https://claude.ai/code/session_01Ewm55pEVHLfFzPHxmMyecw