### PR TITLE
Add on-device LLM models to dev and prod environments

### DIFF
--- a/chart/env/dev.yaml
+++ b/chart/env/dev.yaml
@@ -79,6 +79,11 @@ envVars:
   PUBLIC_LLM_ROUTER_ALIAS_ID: "omni"
   MODELS: >
     [
+      { "id": "Qwen/Qwen3.5-9B", "description": "Dense multimodal hybrid with 262K context excelling at reasoning on-device." },
+      { "id": "CohereLabs/tiny-aya-global", "description": "Tiny multilingual assistant covering 70+ languages for on-device deployment." },
+      { "id": "CohereLabs/tiny-aya-earth", "description": "Regional Aya for African languages with culturally tuned on-device inference." },
+      { "id": "CohereLabs/tiny-aya-fire", "description": "Regional Aya for South Asian languages with culturally tuned on-device inference." },
+      { "id": "CohereLabs/tiny-aya-water", "description": "Regional Aya for Asia-Pacific and European multilingual on-device tasks." },
       { "id": "Qwen/Qwen3.5-122B-A10B", "description": "Multimodal MoE excelling at agentic tool use with 1M context and 201 languages." },
       { "id": "Qwen/Qwen3.5-35B-A3B", "description": "Compact multimodal MoE with hybrid DeltaNet, 1M context, and 201 languages." },
       { "id": "Qwen/Qwen3.5-27B", "description": "Dense multimodal hybrid with top-tier reasoning density and 1M context." },

--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -89,6 +89,11 @@ envVars:
   PUBLIC_LLM_ROUTER_ALIAS_ID: "omni"
   MODELS: >
     [
+      { "id": "Qwen/Qwen3.5-9B", "description": "Dense multimodal hybrid with 262K context excelling at reasoning on-device." },
+      { "id": "CohereLabs/tiny-aya-global", "description": "Tiny multilingual assistant covering 70+ languages for on-device deployment." },
+      { "id": "CohereLabs/tiny-aya-earth", "description": "Regional Aya for African languages with culturally tuned on-device inference." },
+      { "id": "CohereLabs/tiny-aya-fire", "description": "Regional Aya for South Asian languages with culturally tuned on-device inference." },
+      { "id": "CohereLabs/tiny-aya-water", "description": "Regional Aya for Asia-Pacific and European multilingual on-device tasks." },
       { "id": "Qwen/Qwen3.5-122B-A10B", "description": "Multimodal MoE excelling at agentic tool use with 1M context and 201 languages." },
       { "id": "Qwen/Qwen3.5-35B-A3B", "description": "Compact multimodal MoE with hybrid DeltaNet, 1M context, and 201 languages." },
       { "id": "Qwen/Qwen3.5-27B", "description": "Dense multimodal hybrid with top-tier reasoning density and 1M context." },


### PR DESCRIPTION
## Summary
This PR adds five new lightweight language models to both development and production environments, expanding support for on-device inference with multilingual and regional capabilities.

## Key Changes
- Added `Qwen/Qwen3.5-9B`: Dense multimodal model optimized for on-device reasoning with 262K context window
- Added `CohereLabs/tiny-aya-global`: Multilingual assistant supporting 70+ languages for on-device deployment
- Added `CohereLabs/tiny-aya-earth`: Regional variant optimized for African languages with cultural tuning
- Added `CohereLabs/tiny-aya-fire`: Regional variant optimized for South Asian languages with cultural tuning
- Added `CohereLabs/tiny-aya-water`: Regional variant optimized for Asia-Pacific and European languages

## Implementation Details
- Updated both `chart/env/dev.yaml` and `chart/env/prod.yaml` to maintain consistency across environments
- New models are positioned at the beginning of the MODELS list, making them available as primary options
- Each model includes descriptive metadata highlighting their specific use cases and capabilities
- All additions focus on lightweight, on-device inference capabilities complementing the existing larger models

https://claude.ai/code/session_01Cv3ZqNWtFJ9dSbeobd1zLX