### PR TITLE
fix: graceful degradation when API calls fail in root layout

### DIFF
--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -36,8 +36,12 @@ export function useSettingsStore() {
 	return getContext<SettingsStoreWritable>("settings");
 }
 
-export function createSettingsStore(initialValue: Omit<SettingsStore, "recentlySaved">) {
+export function createSettingsStore(
+	initialValue: Omit<SettingsStore, "recentlySaved">,
+	opts?: { isFallback?: boolean }
+) {
 	const baseStore = writable({ ...initialValue, recentlySaved: false });
+	let canPersist = !opts?.isFallback;
 
 	let timeoutId: NodeJS.Timeout;
 	let showSavedOnNextSync = false;
@@ -48,7 +52,7 @@ export function createSettingsStore(initialValue: Omit<SettingsStore, "recentlyS
 			...settings,
 		}));
 
-		if (browser) {
+		if (browser && canPersist) {
 			showSavedOnNextSync = true; // User edit, should show "Saved"
 			clearTimeout(timeoutId);
 			timeoutId = setTimeout(async () => {
@@ -107,7 +111,7 @@ export function createSettingsStore(initialValue: Omit<SettingsStore, "recentlyS
 		}));
 
 		// Save to server (debounced) - note: we don't set showSavedOnNextSync
-		if (browser) {
+		if (browser && canPersist) {
 			clearTimeout(timeoutId);
 			timeoutId = setTimeout(async () => {
 				await fetch(`${base}/settings`, {
@@ -143,7 +147,7 @@ export function createSettingsStore(initialValue: Omit<SettingsStore, "recentlyS
 			...settings,
 		}));
 
-		if (browser) {
+		if (browser && canPersist) {
 			await fetch(`${base}/settings`, {
 				method: "POST",
 				headers: {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -122,7 +122,7 @@
 		}
 	});
 
-	const settings = createSettingsStore(data.settings);
+	const settings = createSettingsStore(data.settings, { isFallback: data.settingsIsFallback });
 
 	$effect(() => {
 		setHapticsEnabled($settings.hapticsEnabled);

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -4,12 +4,16 @@ import { useAPIClient, handleResponse } from "$lib/APIClient";
 import { getConfigManager } from "$lib/utils/PublicConfig.svelte";
 import type { GETModelsResponse, FeatureFlags } from "$lib/server/api/types";
 
-async function withFallback<T>(promise: Promise<T>, fallback: T, label?: string): Promise<T> {
+async function withFallback<T>(
+	promise: Promise<T>,
+	fallback: T,
+	label?: string
+): Promise<{ value: T; isFallback: boolean }> {
 	try {
-		return await promise;
+		return { value: await promise, isFallback: false };
 	} catch (e) {
 		console.warn(`[layout] ${label ?? "API call"} failed, using fallback:`, e);
-		return fallback;
+		return { value: fallback, isFallback: true };
 	}
 }
 
@@ -50,8 +54,8 @@ export const load = async ({ depends, fetch, url }) => {
 
 	const client = useAPIClient({ fetch, origin: url.origin });
 
-	const [settings, models, user, publicConfig, featureFlags, conversationsData] =
-		(await Promise.all([
+	const [settingsResult, modelsResult, userResult, publicConfig, featureFlagsResult, conversationsResult] =
+		await Promise.all([
 			withFallback(
 				client.user.settings.get().then(handleResponse),
 				{
@@ -94,14 +98,14 @@ export const load = async ({ depends, fetch, url }) => {
 				},
 				"conversations"
 			),
-		])) as [
-			SettingsResponse,
-			GETModelsResponse,
-			UserInfo | null,
-			Record<string, unknown>,
-			FeatureFlags,
-			{ conversations: ConversationListItem[]; hasMore: boolean },
-		];
+		]);
+
+	const settings = settingsResult.value as SettingsResponse;
+	const settingsIsFallback = settingsResult.isFallback;
+	const models = modelsResult.value as GETModelsResponse;
+	const user = userResult.value as UserInfo | null;
+	const featureFlags = featureFlagsResult.value as FeatureFlags;
+	const conversationsData = conversationsResult.value as { conversations: ConversationListItem[]; hasMore: boolean };
 
 	const defaultModel = models[0];
 
@@ -130,6 +134,7 @@ export const load = async ({ depends, fetch, url }) => {
 				? new Date(settings.welcomeModalSeenAt)
 				: null,
 		},
+		settingsIsFallback,
 		publicConfig: getConfigManager(publicConfig as Record<`PUBLIC_${string}`, string>),
 		...featureFlags,
 	};


### PR DESCRIPTION
## Summary
- Wrap auth-dependent API calls in `withFallback()` so the root layout doesn't crash on session expiry or API failures
- Keep `public-config` as a hard requirement (needed to render anything)
- Log swallowed errors via `console.warn` for debugging
- Fixes `Internal Error` when expired session causes 302/401 on `/api/v2/models`

## Problem
When a user's session expires mid-navigation, API calls in `+layout.ts` fail with 302/401. Since all calls are in a `Promise.all` with no error handling, a single failure crashes the entire app shell with an unhelpful "Internal Error" page.

## Changes
- `src/routes/+layout.ts`: Add `withFallback<T>()` helper, wrap auth-dependent calls with safe defaults

## Test plan
- [ ] Clear cookies while app is open, navigate — should show logged-out state, not crash
- [ ] Normal authenticated flow still works
- [ ] Check browser console for warning when fallback is used

🤖 Generated with [Claude Code](https://claude.com/claude-code)