### PR TITLE
feat: add acceptedFileMimetypes to model config

### DIFF
--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -309,7 +309,7 @@
 		providerOverride && providerOverride !== "auto" && !currentModel.isRouter
 	);
 
-	// Always allow common text-like files; add images only when model is multimodal
+	// Always allow common text-like files; add images when multimodal; add declared file types
 	import { TEXT_MIME_ALLOWLIST, IMAGE_MIME_ALLOWLIST_DEFAULT } from "$lib/constants/mime";
 
 	let activeMimeTypes = $derived(
@@ -319,6 +319,7 @@
 				...(modelIsMultimodal
 					? (currentModel.multimodalAcceptedMimetypes ?? [...IMAGE_MIME_ALLOWLIST_DEFAULT])
 					: []),
+				...(currentModel.acceptedFileMimetypes ?? []),
 			])
 		)
 	);

--- a/src/lib/server/api/types.ts
+++ b/src/lib/server/api/types.ts
@@ -16,6 +16,7 @@ export type GETModelsResponse = Array<{
 	preprompt?: string;
 	multimodal: boolean;
 	multimodalAcceptedMimetypes?: string[];
+	acceptedFileMimetypes?: string[];
 	supportsTools?: boolean;
 	unlisted: boolean;
 	hasInferenceAPI: boolean;

--- a/src/lib/server/models.ts
+++ b/src/lib/server/models.ts
@@ -56,6 +56,8 @@ const modelConfig = z.object({
 		.optional(),
 	multimodal: z.boolean().default(false),
 	multimodalAcceptedMimetypes: z.array(z.string()).optional(),
+	/** MIME types the model accepts as file attachments (e.g. ["application/pdf", "image/*"]) */
+	acceptedFileMimetypes: z.array(z.string()).optional(),
 	// Aggregated tool-calling capability across providers (HF router)
 	supportsTools: z.boolean().default(false),
 	unlisted: z.boolean().default(false),

--- a/src/lib/types/Model.ts
+++ b/src/lib/types/Model.ts
@@ -17,6 +17,7 @@ export type Model = Pick<
 	| "preprompt"
 	| "multimodal"
 	| "multimodalAcceptedMimetypes"
+	| "acceptedFileMimetypes"
 	| "unlisted"
 	| "hasInferenceAPI"
 	| "providers"

--- a/src/routes/api/v2/models/+server.ts
+++ b/src/routes/api/v2/models/+server.ts
@@ -26,6 +26,7 @@ export const GET: RequestHandler = async () => {
 					preprompt: model.preprompt,
 					multimodal: model.multimodal,
 					multimodalAcceptedMimetypes: model.multimodalAcceptedMimetypes,
+					acceptedFileMimetypes: model.acceptedFileMimetypes,
 					supportsTools: (model as unknown as { supportsTools?: boolean }).supportsTools ?? false,
 					unlisted: model.unlisted,
 					hasInferenceAPI: model.hasInferenceAPI,


### PR DESCRIPTION
## Summary

- Adds `acceptedFileMimetypes` field to model config schema, allowing models to declare which file MIME types they accept (e.g. `["application/pdf", "image/*"]`)
- Plumbs the field through the API response and frontend type so the upload UI adapts per model
- Frontend merges `acceptedFileMimetypes` with existing `multimodalAcceptedMimetypes` to build the active MIME list

This is the foundation for native file handling per provider — models declare what they support, and endpoint adapters deliver files in the appropriate format.

**Example config:**
```json
{
  "name": "gpt-4o",
  "multimodal": true,
  "acceptedFileMimetypes": ["application/pdf"]
}
```

Related: #2188, #482, #609, #1505, #1652

## Test plan

- [ ] Verify model without `acceptedFileMimetypes` behaves as before (text + images only)
- [ ] Verify model with `acceptedFileMimetypes: ["application/pdf"]` shows PDF in file picker
- [ ] Verify MIME types merge correctly (no duplicates) when both multimodal and file types set

🤖 Generated with [Claude Code](https://claude.com/claude-code)