### PR TITLE
fix: prevent SSRF via redirect bypass in ssrfSafeFetch

### DIFF
--- a/src/lib/server/urlSafety.test.ts
+++ b/src/lib/server/urlSafety.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { isValidUrl } from "./urlSafety";
+
+describe("isValidUrl", () => {
+	it("allows normal HTTPS URLs", () => {
+		expect(isValidUrl("https://example.com")).toBe(true);
+		expect(isValidUrl("https://huggingface.co/docs")).toBe(true);
+	});
+
+	it("rejects HTTP URLs", () => {
+		expect(isValidUrl("http://example.com")).toBe(false);
+		expect(isValidUrl("http://169.254.170.23/v1/credentials")).toBe(false);
+	});
+
+	it("rejects localhost", () => {
+		expect(isValidUrl("https://localhost")).toBe(false);
+		expect(isValidUrl("https://localhost:3000")).toBe(false);
+	});
+
+	it("rejects private/internal IPs", () => {
+		expect(isValidUrl("https://127.0.0.1")).toBe(false);
+		expect(isValidUrl("https://192.168.1.1")).toBe(false);
+		expect(isValidUrl("https://172.16.0.1")).toBe(false);
+		expect(isValidUrl("https://169.254.170.23")).toBe(false);
+	});
+
+	it("allows 10.0.0.0/8 (used by internal LBs in cluster)", () => {
+		expect(isValidUrl("https://10.0.0.1")).toBe(true);
+		expect(isValidUrl("https://10.0.240.151")).toBe(true);
+	});
+
+	it("rejects non-URL strings", () => {
+		expect(isValidUrl("not-a-url")).toBe(false);
+		expect(isValidUrl("")).toBe(false);
+		expect(isValidUrl("ftp://example.com")).toBe(false);
+	});
+});

--- a/src/lib/server/urlSafety.ts
+++ b/src/lib/server/urlSafety.ts
@@ -99,6 +99,7 @@ const ssrfSafeAgent = new Agent({
 });
 
 const MAX_REDIRECTS = 5;
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
 
 /**
  * Fetch wrapper that validates resolved IPs at connection time
@@ -112,17 +113,18 @@ export async function ssrfSafeFetch(url: string | URL, init?: RequestInit): Prom
 	const callerHandlesRedirects = init?.redirect === "manual";
 
 	let currentUrl = url.toString();
+	let currentInit = init;
 	let redirectCount = 0;
 
 	// eslint-disable-next-line no-constant-condition
 	while (true) {
 		const response = (await undiciFetch(currentUrl, {
-			...(init as Record<string, unknown>),
+			...(currentInit as Record<string, unknown>),
 			redirect: "manual",
 			dispatcher: ssrfSafeAgent,
 		})) as unknown as Response;
 
-		if (!callerHandlesRedirects && response.status >= 300 && response.status < 400) {
+		if (!callerHandlesRedirects && REDIRECT_STATUSES.has(response.status)) {
 			redirectCount++;
 			if (redirectCount > MAX_REDIRECTS) {
 				throw new Error("Too many redirects");
@@ -136,6 +138,15 @@ export async function ssrfSafeFetch(url: string | URL, init?: RequestInit): Prom
 			const redirectUrl = new URL(location, currentUrl).toString();
 			if (!isValidUrl(redirectUrl)) {
 				throw new Error(`Redirect to unsafe URL blocked (SSRF): ${redirectUrl}`);
+			}
+
+			// Per fetch spec: 301/302/303 switch POST/PUT to GET and drop the body
+			if (
+				[301, 302, 303].includes(response.status) &&
+				init?.method &&
+				/^(POST|PUT)$/i.test(init.method)
+			) {
+				currentInit = { ...init, method: "GET", body: undefined };
 			}
 
 			currentUrl = redirectUrl;

--- a/src/lib/server/urlSafety.ts
+++ b/src/lib/server/urlSafety.ts
@@ -110,8 +110,31 @@ const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
  * followed internally with each hop validated by `isValidUrl`.
  */
 export async function ssrfSafeFetch(url: string | URL, init?: RequestInit): Promise<Response> {
-	const callerHandlesRedirects = init?.redirect === "manual";
+	const callerRedirect = init?.redirect ?? "follow";
 
+	if (callerRedirect === "error") {
+		// Honour redirect:"error" — make the request and throw if we get a redirect
+		const response = (await undiciFetch(url.toString(), {
+			...(init as Record<string, unknown>),
+			redirect: "manual",
+			dispatcher: ssrfSafeAgent,
+		})) as unknown as Response;
+		if (REDIRECT_STATUSES.has(response.status)) {
+			throw new TypeError("unexpected redirect");
+		}
+		return response;
+	}
+
+	if (callerRedirect === "manual") {
+		// Caller handles redirects — return as-is
+		return (await undiciFetch(url.toString(), {
+			...(init as Record<string, unknown>),
+			redirect: "manual",
+			dispatcher: ssrfSafeAgent,
+		})) as unknown as Response;
+	}
+
+	// Default: follow redirects with SSRF validation on each hop
 	let currentUrl = url.toString();
 	let currentInit = init;
 	let redirectCount = 0;
@@ -124,7 +147,7 @@ export async function ssrfSafeFetch(url: string | URL, init?: RequestInit): Prom
 			dispatcher: ssrfSafeAgent,
 		})) as unknown as Response;
 
-		if (!callerHandlesRedirects && REDIRECT_STATUSES.has(response.status)) {
+		if (REDIRECT_STATUSES.has(response.status)) {
 			redirectCount++;
 			if (redirectCount > MAX_REDIRECTS) {
 				throw new Error("Too many redirects");
@@ -140,11 +163,11 @@ export async function ssrfSafeFetch(url: string | URL, init?: RequestInit): Prom
 				throw new Error(`Redirect to unsafe URL blocked (SSRF): ${redirectUrl}`);
 			}
 
-			// Per fetch spec: 301/302/303 switch POST/PUT to GET and drop the body
+			// Per fetch spec: 301/302 rewrite POST→GET; 303 rewrites any non-GET/HEAD→GET
+			const method = (currentInit?.method ?? "GET").toUpperCase();
 			if (
-				[301, 302, 303].includes(response.status) &&
-				init?.method &&
-				/^(POST|PUT)$/i.test(init.method)
+				([301, 302].includes(response.status) && method === "POST") ||
+				(response.status === 303 && method !== "GET" && method !== "HEAD")
 			) {
 				currentInit = { ...init, method: "GET", body: undefined };
 			}

--- a/src/lib/server/urlSafety.ts
+++ b/src/lib/server/urlSafety.ts
@@ -98,13 +98,50 @@ const ssrfSafeAgent = new Agent({
 	},
 });
 
+const MAX_REDIRECTS = 5;
+
 /**
- * Fetch wrapper that validates resolved IPs at connection time.
- * Use this for any outbound request where the URL may come from user input.
+ * Fetch wrapper that validates resolved IPs at connection time
+ * and validates redirect targets to prevent SSRF via open redirects.
+ *
+ * If the caller sets `redirect: "manual"`, redirects are returned as-is
+ * (the caller is responsible for validation). Otherwise, redirects are
+ * followed internally with each hop validated by `isValidUrl`.
  */
-export function ssrfSafeFetch(url: string | URL, init?: RequestInit): Promise<Response> {
-	return undiciFetch(url, {
-		...(init as Record<string, unknown>),
-		dispatcher: ssrfSafeAgent,
-	}) as unknown as Promise<Response>;
+export async function ssrfSafeFetch(url: string | URL, init?: RequestInit): Promise<Response> {
+	const callerHandlesRedirects = init?.redirect === "manual";
+
+	let currentUrl = url.toString();
+	let redirectCount = 0;
+
+	// eslint-disable-next-line no-constant-condition
+	while (true) {
+		const response = (await undiciFetch(currentUrl, {
+			...(init as Record<string, unknown>),
+			redirect: "manual",
+			dispatcher: ssrfSafeAgent,
+		})) as unknown as Response;
+
+		if (!callerHandlesRedirects && response.status >= 300 && response.status < 400) {
+			redirectCount++;
+			if (redirectCount > MAX_REDIRECTS) {
+				throw new Error("Too many redirects");
+			}
+
+			const location = response.headers.get("location");
+			if (!location) {
+				throw new Error("Redirect without Location header");
+			}
+
+			const redirectUrl = new URL(location, currentUrl).toString();
+			if (!isValidUrl(redirectUrl)) {
+				throw new Error(`Redirect to unsafe URL blocked (SSRF): ${redirectUrl}`);
+			}
+
+			currentUrl = redirectUrl;
+			continue;
+		}
+
+		return response;
+	}
 }


### PR DESCRIPTION
## Summary

- `ssrfSafeFetch` relied on undici's custom DNS `lookup` callback for SSRF protection, but undici skips DNS lookup for raw IP literals during automatic redirect following. An attacker could use an open redirect (e.g. `httpbin.org/redirect-to`) to redirect to internal IPs like `169.254.170.23` (EKS Pod Identity Agent) or `127.0.0.1`.
- Fix: `ssrfSafeFetch` now follows redirects manually, validating each hop with `isValidUrl()` (HTTPS-only, no private IPs). Callers that already set `redirect: "manual"` (like `fetch-url`) are unaffected — they get the redirect response as-is.
- Adds unit tests for `isValidUrl`.

Reported via HackerOne #3640042.