### PR TITLE
Add MiniMax-M2.7 model to available LLM options

### DIFF
--- a/chart/env/dev.yaml
+++ b/chart/env/dev.yaml
@@ -79,6 +79,7 @@ envVars:
   PUBLIC_LLM_ROUTER_ALIAS_ID: "omni"
   MODELS: >
     [
+      { "id": "MiniMaxAI/MiniMax-M2.7", "description": "Self-evolving 230B MoE agent for frontier coding, reasoning, and tool use." },
       { "id": "zai-org/GLM-5.1", "description": "Upgraded 754B MoE for agentic coding, extended reasoning, and tool use.", "parameters": { "max_tokens": 49152 } },
       { "id": "zai-org/GLM-5.1-FP8", "description": "FP8 GLM-5.1 for efficient agentic coding and reasoning inference.", "parameters": { "max_tokens": 49152 } },
       { "id": "google/gemma-4-31B-it", "description": "Dense multimodal Gemma with 256K context, reasoning, and function calling." },

--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -89,6 +89,7 @@ envVars:
   PUBLIC_LLM_ROUTER_ALIAS_ID: "omni"
   MODELS: >
     [
+      { "id": "MiniMaxAI/MiniMax-M2.7", "description": "Self-evolving 230B MoE agent for frontier coding, reasoning, and tool use." },
       { "id": "zai-org/GLM-5.1", "description": "Upgraded 754B MoE for agentic coding, extended reasoning, and tool use.", "parameters": { "max_tokens": 49152 } },
       { "id": "zai-org/GLM-5.1-FP8", "description": "FP8 GLM-5.1 for efficient agentic coding and reasoning inference.", "parameters": { "max_tokens": 49152 } },
       { "id": "google/gemma-4-31B-it", "description": "Dense multimodal Gemma with 256K context, reasoning, and function calling." },


### PR DESCRIPTION
## Summary
This PR adds support for the MiniMaxAI/MiniMax-M2.7 model across both development and production environments.

## Key Changes
- Added MiniMax-M2.7 model configuration to the LLM router in both dev and prod environments
- Model is positioned as the first option in the models list with description: "Self-evolving 230B MoE agent for frontier coding, reasoning, and tool use."
- No custom parameters specified for this model (uses defaults)

## Details
The MiniMax-M2.7 model is a 230B Mixture of Experts agent designed for advanced coding, reasoning, and tool use capabilities. It has been added to both `chart/env/dev.yaml` and `chart/env/prod.yaml` configuration files to make it available through the LLM router.

https://claude.ai/code/session_01LW25rCAUhvo5X5do5pZmgR