### PR TITLE
fix: include orgs with a paid plan in billing dropdown

### DIFF
--- a/src/routes/api/v2/user/billing-orgs/+server.ts
+++ b/src/routes/api/v2/user/billing-orgs/+server.ts
@@ -34,7 +34,7 @@ export const GET: RequestHandler = async ({ locals }) => {
 		const currentBillingOrg = settings?.billingOrganization;
 
 		const billingOrgs = (data.orgs ?? [])
-			.filter((org: { canPay?: boolean }) => org.canPay === true)
+			.filter((org: { canPay?: boolean; plan?: string }) => org.plan || org.canPay === true)
 			.map((org: { sub: string; name: string; preferred_username: string }) => ({
 				sub: org.sub,
 				name: org.name,


### PR DESCRIPTION
## Problem

The billing org dropdown in HuggingChat settings filters orgs on `canPay === true` only. Orgs on a Team or Enterprise plan that haven't purchased additional prepaid credits have `canPay = false`, so they don't appear in the dropdown even though their plan includes monthly inference credits ($2/seat/month).

The Hub's inference widget uses `org.plan || canPay !== false`, so those same orgs show up fine there.

## Fix

Include orgs that have a paid plan (`org.plan` is truthy) in the billing orgs filter, matching the Hub's behavior. The `plan` field is already returned by `/oauth/userinfo`.