### PR TITLE
Add DeepSeek-V4-Pro and Kimi-K2.6 models to LLM router

### DIFF
--- a/chart/env/dev.yaml
+++ b/chart/env/dev.yaml
@@ -79,6 +79,8 @@ envVars:
   PUBLIC_LLM_ROUTER_ALIAS_ID: "omni"
   MODELS: >
     [
+      { "id": "deepseek-ai/DeepSeek-V4-Pro", "description": "Frontier 1.6T MoE with 49B active params, hybrid attention, and 1M context." },
+      { "id": "moonshotai/Kimi-K2.6", "description": "Native multimodal 1T MoE for long-horizon coding and 300-sub-agent swarms." },
       { "id": "MiniMaxAI/MiniMax-M2.7", "description": "Self-evolving 230B MoE agent for frontier coding, reasoning, and tool use." },
       { "id": "zai-org/GLM-5.1", "description": "Upgraded 754B MoE for agentic coding, extended reasoning, and tool use.", "parameters": { "max_tokens": 49152 } },
       { "id": "zai-org/GLM-5.1-FP8", "description": "FP8 GLM-5.1 for efficient agentic coding and reasoning inference.", "parameters": { "max_tokens": 49152 } },

--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -89,6 +89,8 @@ envVars:
   PUBLIC_LLM_ROUTER_ALIAS_ID: "omni"
   MODELS: >
     [
+      { "id": "deepseek-ai/DeepSeek-V4-Pro", "description": "Frontier 1.6T MoE with 49B active params, hybrid attention, and 1M context." },
+      { "id": "moonshotai/Kimi-K2.6", "description": "Native multimodal 1T MoE for long-horizon coding and 300-sub-agent swarms." },
       { "id": "MiniMaxAI/MiniMax-M2.7", "description": "Self-evolving 230B MoE agent for frontier coding, reasoning, and tool use." },
       { "id": "zai-org/GLM-5.1", "description": "Upgraded 754B MoE for agentic coding, extended reasoning, and tool use.", "parameters": { "max_tokens": 49152 } },
       { "id": "zai-org/GLM-5.1-FP8", "description": "FP8 GLM-5.1 for efficient agentic coding and reasoning inference.", "parameters": { "max_tokens": 49152 } },


### PR DESCRIPTION
## Summary
Add two new frontier language models to the available LLM options in both development and production environments.

## Changes
- Added `deepseek-ai/DeepSeek-V4-Pro`: A 1.6T MoE model with 49B active parameters, hybrid attention mechanism, and 1M context window
- Added `moonshotai/Kimi-K2.6`: A native multimodal 1T MoE model optimized for long-horizon coding tasks and supporting 300-sub-agent swarms
- Updated both `chart/env/dev.yaml` and `chart/env/prod.yaml` to include these models at the beginning of the MODELS list

## Details
Both models are positioned as frontier-class reasoning and coding models that complement the existing MiniMax and GLM offerings in the router configuration.

https://claude.ai/code/session_01NGqW9eMxFQ3BsDufrN26xt