### PR TITLE
Replace nav item edit/delete buttons with a kebab dropdown

### DIFF
--- a/src/lib/components/NavConversationItem.svelte
+++ b/src/lib/components/NavConversationItem.svelte
@@ -6,7 +6,7 @@
 
 	import CarbonTrashCan from "~icons/carbon/trash-can";
 	import CarbonEdit from "~icons/carbon/edit";
-	import CarbonOverflowMenuVertical from "~icons/carbon/overflow-menu-vertical";
+	import CarbonOverflowMenuHorizontal from "~icons/carbon/overflow-menu-horizontal";
 	import type { ConvSidebar } from "$lib/types/ConvSidebar";
 
 	import EditConversationModal from "$lib/components/EditConversationModal.svelte";
@@ -109,7 +109,7 @@
 					aria-label="Conversation actions"
 					title="More options"
 				>
-					<CarbonOverflowMenuVertical class="text-xs" />
+					<CarbonOverflowMenuHorizontal class="text-xs" />
 				</DropdownMenu.Trigger>
 				<DropdownMenu.Portal>
 					<DropdownMenu.Content

--- a/src/lib/components/NavConversationItem.svelte
+++ b/src/lib/components/NavConversationItem.svelte
@@ -6,7 +6,7 @@
 
 	import CarbonTrashCan from "~icons/carbon/trash-can";
 	import CarbonEdit from "~icons/carbon/edit";
-	import CarbonOverflowMenuHorizontal from "~icons/carbon/overflow-menu-horizontal";
+	import LucideEllipsis from "~icons/lucide/ellipsis";
 	import type { ConvSidebar } from "$lib/types/ConvSidebar";
 
 	import EditConversationModal from "$lib/components/EditConversationModal.svelte";
@@ -109,7 +109,7 @@
 					aria-label="Conversation actions"
 					title="More options"
 				>
-					<CarbonOverflowMenuHorizontal class="text-xs" />
+					<LucideEllipsis class="text-sm" />
 				</DropdownMenu.Trigger>
 				<DropdownMenu.Portal>
 					<DropdownMenu.Content

--- a/src/lib/components/NavConversationItem.svelte
+++ b/src/lib/components/NavConversationItem.svelte
@@ -2,9 +2,11 @@
 	import { base } from "$app/paths";
 	import { page } from "$app/state";
 	import { tick } from "svelte";
+	import { DropdownMenu } from "bits-ui";
 
 	import CarbonTrashCan from "~icons/carbon/trash-can";
 	import CarbonEdit from "~icons/carbon/edit";
+	import CarbonOverflowMenuVertical from "~icons/carbon/overflow-menu-vertical";
 	import type { ConvSidebar } from "$lib/types/ConvSidebar";
 
 	import EditConversationModal from "$lib/components/EditConversationModal.svelte";
@@ -22,6 +24,7 @@
 
 	let deleteOpen = $state(false);
 	let renameOpen = $state(false);
+	let isMenuOpen = $state(false);
 	let inlineEditing = $state(false);
 	let inlineCancelled = $state(false);
 	let inlineTitle = $state("");
@@ -52,18 +55,9 @@
 	}
 </script>
 
-<a
-	data-sveltekit-noscroll
-	data-sveltekit-preload-data="tap"
-	href="{base}/conversation/{conv.id}"
-	class="group flex h-[2.08rem] flex-none items-center gap-1.5 rounded-lg pl-2 pr-2 text-gray-600 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700 max-sm:h-10
+<div
+	class="group flex h-[2.08rem] flex-none items-center gap-1.5 rounded-lg pl-2 pr-1.5 text-gray-600 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700 max-sm:h-10
 		{conv.id === page.params.id ? 'bg-gray-100 dark:bg-gray-700' : ''}"
-	onclick={(e) => {
-		if (e.detail >= 2) {
-			e.preventDefault();
-			startInlineEdit();
-		}
-	}}
 >
 	{#if inlineEditing}
 		<input
@@ -81,47 +75,72 @@
 				}
 			}}
 			onblur={commitInlineEdit}
-			onclick={(e) => e.preventDefault()}
 			class="my-0 h-full min-w-0 flex-1 truncate border-none bg-transparent p-0 text-inherit outline-none first-letter:uppercase focus:ring-0"
 		/>
 	{:else}
-		<div class="my-2 min-w-0 flex-1 truncate first-letter:uppercase">
-			<span>{conv.title}</span>
-		</div>
-	{/if}
-
-	{#if !readOnly && !inlineEditing}
-		<button
-			type="button"
-			class="flex h-5 w-5 items-center justify-center rounded md:hidden md:group-hover:flex"
-			title="Edit conversation title"
+		<a
+			data-sveltekit-noscroll
+			data-sveltekit-preload-data="tap"
+			href="{base}/conversation/{conv.id}"
+			class="my-2 min-w-0 flex-1 truncate first-letter:uppercase"
 			onclick={(e) => {
-				e.preventDefault();
-				if (requireAuthUser()) return;
-				renameOpen = true;
-			}}
-		>
-			<CarbonEdit class="text-xs text-gray-400 hover:text-gray-500 dark:hover:text-gray-300" />
-		</button>
-
-		<button
-			type="button"
-			class="flex h-5 w-5 items-center justify-center rounded md:hidden md:group-hover:flex"
-			title="Delete conversation"
-			onclick={(event) => {
-				event.preventDefault();
-				if (requireAuthUser()) return;
-				if (event.shiftKey) {
-					ondeleteConversation?.(conv.id.toString());
-				} else {
-					deleteOpen = true;
+				if (e.detail >= 2) {
+					e.preventDefault();
+					startInlineEdit();
 				}
 			}}
 		>
-			<CarbonTrashCan class="text-xs text-gray-400  hover:text-gray-500 dark:hover:text-gray-300" />
-		</button>
+			<span>{conv.title}</span>
+		</a>
+
+		{#if !readOnly}
+			<DropdownMenu.Root
+				bind:open={isMenuOpen}
+				onOpenChange={(open) => {
+					if (open && requireAuthUser()) {
+						isMenuOpen = false;
+						return;
+					}
+					isMenuOpen = open;
+				}}
+			>
+				<DropdownMenu.Trigger
+					class="flex h-6 w-6 items-center justify-center rounded-md text-gray-400 data-[state=open]:bg-gray-200 data-[state=open]:text-gray-600 hover:bg-gray-200 hover:text-gray-600 dark:data-[state=open]:bg-gray-600 dark:data-[state=open]:text-gray-200 dark:hover:bg-gray-600 dark:hover:text-gray-200 md:hidden md:group-hover:flex md:data-[state=open]:flex"
+					aria-label="Conversation actions"
+					title="More options"
+				>
+					<CarbonOverflowMenuVertical class="text-xs" />
+				</DropdownMenu.Trigger>
+				<DropdownMenu.Portal>
+					<DropdownMenu.Content
+						class="z-50 min-w-[9rem] rounded-xl border border-gray-200 bg-white/95 p-1 text-gray-800 shadow-lg backdrop-blur dark:border-gray-700/60 dark:bg-gray-800/95 dark:text-gray-100"
+						side="bottom"
+						align="end"
+						sideOffset={4}
+						trapFocus={false}
+						onCloseAutoFocus={(e) => e.preventDefault()}
+						interactOutsideBehavior="defer-otherwise-close"
+					>
+						<DropdownMenu.Item
+							class="flex h-9 select-none items-center gap-2 rounded-md px-2 text-sm text-gray-700 data-[highlighted]:bg-gray-100 focus-visible:outline-none dark:text-gray-200 dark:data-[highlighted]:bg-white/10 sm:h-8"
+							onSelect={() => (renameOpen = true)}
+						>
+							<CarbonEdit class="size-4 opacity-90 dark:opacity-80" />
+							Rename
+						</DropdownMenu.Item>
+						<DropdownMenu.Item
+							class="flex h-9 select-none items-center gap-2 rounded-md px-2 text-sm text-red-500 data-[highlighted]:bg-red-50 data-[highlighted]:text-red-600 focus-visible:outline-none dark:text-red-400 dark:data-[highlighted]:bg-red-500/10 dark:data-[highlighted]:text-red-400 sm:h-8"
+							onSelect={() => (deleteOpen = true)}
+						>
+							<CarbonTrashCan class="size-4 opacity-90 dark:opacity-80" />
+							Delete
+						</DropdownMenu.Item>
+					</DropdownMenu.Content>
+				</DropdownMenu.Portal>
+			</DropdownMenu.Root>
+		{/if}
 	{/if}
-</a>
+</div>
 
 <!-- Edit title modal -->
 {#if renameOpen}


### PR DESCRIPTION
## Summary

- Collapses the per-row **Edit** and **Delete** icon buttons in `NavConversationItem.svelte` into a single overflow-menu (kebab) trigger that opens a `bits-ui` `DropdownMenu` with **Rename** and **Delete** items.
- Restructures the row from `<a>` (with interactive children) to `<div class="group">` containing the link + a sibling dropdown — eliminates the button-inside-anchor anti-pattern that previously required `e.preventDefault()` on each button to suppress link navigation.
- Trigger uses `~icons/carbon/overflow-menu-vertical`, has hover + open background (`hover:bg-gray-200 data-[state=open]:bg-gray-200` plus dark variants), and stays visible while the menu is open via `md:data-[state=open]:flex`.
- Auth guard moves to `onOpenChange` (matches the canonical bits-ui pattern in `ChatInput.svelte`).
- Delete item gets destructive red styling.

### Behavior changes

- **Shift+click delete bypass is removed.** The 2-step menu eliminates the speed benefit and `bits-ui`'s `onSelect` does not reliably forward `shiftKey`.
- Trigger gets both `aria-label="Conversation actions"` and `title="More options"` (previous buttons used only `title`).
- All other behavior (modals, callback props, `readOnly` / `inlineEditing` suppression, mobile-always-visible / desktop-hover behavior, active-conversation highlight, double-click inline edit) is preserved.

## Test plan

- [ ] Hover a conversation row on desktop → kebab appears at the right edge with hover background.
- [ ] Click kebab → menu opens below, right-aligned; trigger stays visible while open.
- [ ] **Rename** → EditConversationModal opens, save → row title updates.
- [ ] **Delete** → DeleteConversationModal opens, confirm → row disappears.
- [ ] Click outside menu closes it; clicking another row does not double-trigger navigation (`interactOutsideBehavior="defer-otherwise-close"`).
- [ ] `Escape` closes the menu; arrow keys + Enter navigate items.
- [ ] Active conversation highlight spans the kebab area.
- [ ] Mobile (`<768px`): kebab always visible; menu opens correctly inside the drawer.
- [ ] Signed-out: clicking kebab triggers auth flow, menu does not open.
- [ ] Double-click title → inline-edit input appears, kebab hidden during edit.