### PR TITLE
fix(auth): make sameSite cookie default depend on secure flag to fix HTTP deployments

### DIFF
--- a/docs/source/configuration/common-issues.md
+++ b/docs/source/configuration/common-issues.md
@@ -6,12 +6,13 @@ This usually happens when running Chat UI over HTTP without proper cookie config
 
 **Recommended:** Set up a reverse proxy (NGINX, Caddy) to handle HTTPS.
 
-**Alternative:** If you must run over HTTP, configure cookies:
+**Alternative:** If you must run over HTTP, set the following env var:
 
 ```ini
 COOKIE_SECURE=false
-COOKIE_SAMESITE=lax
 ```
+
+This automatically sets `COOKIE_SAMESITE` to `lax`, which is the correct value for HTTP deployments. You can still override it explicitly with `COOKIE_SAMESITE=lax` if needed.
 
 Also ensure `PUBLIC_ORIGIN` matches your actual URL:
 

--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -57,15 +57,15 @@ export const OIDConfig = z
 
 export const loginEnabled = !!OIDConfig.CLIENT_ID;
 
-const sameSite = z
-	.enum(["lax", "none", "strict"])
-	.default(dev || config.ALLOW_INSECURE_COOKIES === "true" ? "lax" : "none")
-	.parse(config.COOKIE_SAMESITE === "" ? undefined : config.COOKIE_SAMESITE);
-
-const secure = z
+export const secure = z
 	.boolean()
 	.default(!(dev || config.ALLOW_INSECURE_COOKIES === "true"))
 	.parse(config.COOKIE_SECURE === "" ? undefined : config.COOKIE_SECURE === "true");
+
+export const sameSite = z
+	.enum(["lax", "none", "strict"])
+	.default(!secure || dev || config.ALLOW_INSECURE_COOKIES === "true" ? "lax" : "none")
+	.parse(config.COOKIE_SAMESITE === "" ? undefined : config.COOKIE_SAMESITE);
 
 function sanitizeReturnPath(path: string | undefined | null): string | undefined {
 	if (!path) {

--- a/src/routes/logout/+server.ts
+++ b/src/routes/logout/+server.ts
@@ -1,8 +1,8 @@
-import { dev } from "$app/environment";
 import { base } from "$app/paths";
 import { collections } from "$lib/server/database";
 import { redirect } from "@sveltejs/kit";
 import { config } from "$lib/server/config";
+import { sameSite, secure } from "$lib/server/auth";
 
 export async function POST({ locals, cookies }) {
 	await collections.sessions.deleteOne({ sessionId: locals.sessionId });
@@ -10,8 +10,8 @@ export async function POST({ locals, cookies }) {
 	cookies.delete(config.COOKIE_NAME, {
 		path: "/",
 		// So that it works inside the space's iframe
-		sameSite: dev || config.ALLOW_INSECURE_COOKIES === "true" ? "lax" : "none",
-		secure: !dev && !(config.ALLOW_INSECURE_COOKIES === "true"),
+		sameSite,
+		secure,
 		httpOnly: true,
 	});
 	return redirect(302, `${base}/`);


### PR DESCRIPTION
## Problem

When running chat-ui over plain HTTP (e.g. a local VLLM setup without TLS), the browser rejects the `hf-chat` session cookie because it is set with `Secure; SameSite=None`. Browsers require `Secure` for `SameSite=None` cookies, and drop `Secure` cookies entirely over HTTP. The result is that the session is never established: the model list endpoint succeeds (no auth required) but every conversation request returns a 403 "You don't have access to this conversation" error.

The root cause is in `src/lib/server/auth.ts`: `sameSite` was computed before `secure`, so its default of `"none"` was hardcoded for non-dev environments regardless of whether `COOKIE_SECURE=false` was set. Even when a user explicitly sets `COOKIE_SECURE=false`, the cookie was still sent as `SameSite=None`, which browsers also reject without `Secure`.

## Fix

Reorder the computation in `auth.ts` so that `secure` is resolved first, then use it to derive the `sameSite` default: when `secure=false` (HTTP mode, dev, or `ALLOW_INSECURE_COOKIES=true`), `sameSite` defaults to `"lax"` instead of `"none"`. Both variables are now exported so the `logout` route can reuse them directly instead of duplicating the logic. The docs for the common-issues page are updated to reflect that only `COOKIE_SECURE=false` is required for HTTP deployments.

Fixes #2243
