### PR TITLE
fix(settings): defer to router for model tool/multimodal capability on HuggingChat

### DIFF
--- a/src/lib/components/Switch.svelte
+++ b/src/lib/components/Switch.svelte
@@ -5,9 +5,10 @@
 		checked: boolean;
 		name: string;
 		size?: "sm" | "md";
+		disabled?: boolean;
 	}
 
-	let { checked = $bindable(), name, size = "md" }: Props = $props();
+	let { checked = $bindable(), name, size = "md", disabled = false }: Props = $props();
 
 	// Explicit class strings per size (Tailwind needs literal class names to scan).
 	const trackClasses = $derived(
@@ -18,11 +19,13 @@
 	const thumbClasses = $derived(size === "sm" ? "h-2.5 w-2.5" : "h-3.5 w-3.5");
 
 	function toggle() {
+		if (disabled) return;
 		checked = !checked;
 		tap();
 	}
 
 	function onKeydown(e: KeyboardEvent) {
+		if (disabled) return;
 		if (e.key === " " || e.key === "Enter") {
 			e.preventDefault();
 			toggle();
@@ -30,16 +33,25 @@
 	}
 </script>
 
-<input bind:checked type="checkbox" {name} class="peer pointer-events-none absolute opacity-0" />
+<input
+	bind:checked
+	{disabled}
+	type="checkbox"
+	{name}
+	class="peer pointer-events-none absolute opacity-0"
+/>
 <div
 	aria-checked={checked}
+	aria-disabled={disabled}
 	aria-roledescription="switch"
 	aria-label="switch"
 	role="switch"
-	tabindex="0"
+	tabindex={disabled ? -1 : 0}
 	onclick={toggle}
 	onkeydown={onKeydown}
-	class="relative inline-flex shrink-0 cursor-pointer items-center rounded-full bg-gray-300 shadow-inner ring-gray-400 peer-checked:bg-blue-600 hover:bg-gray-400 peer-checked:hover:bg-blue-600 focus-visible:ring focus-visible:ring-offset-1 dark:bg-gray-600 dark:ring-gray-700 dark:hover:bg-gray-500 dark:peer-checked:hover:bg-blue-600 {trackClasses}"
+	class="relative inline-flex shrink-0 items-center rounded-full bg-gray-300 shadow-inner ring-gray-400 peer-checked:bg-blue-600 focus-visible:ring focus-visible:ring-offset-1 dark:bg-gray-600 dark:ring-gray-700 {trackClasses} {disabled
+		? 'cursor-not-allowed opacity-50'
+		: 'cursor-pointer hover:bg-gray-400 peer-checked:hover:bg-blue-600 dark:hover:bg-gray-500 dark:peer-checked:hover:bg-blue-600'}"
 >
 	<div class="rounded-full bg-white shadow-sm transition-transform {thumbClasses}"></div>
 </div>

--- a/src/routes/api/v2/user/settings/+server.ts
+++ b/src/routes/api/v2/user/settings/+server.ts
@@ -2,6 +2,7 @@ import type { RequestHandler } from "@sveltejs/kit";
 import { superjsonResponse } from "$lib/server/api/utils/superjsonResponse";
 import { collections } from "$lib/server/database";
 import { authCondition } from "$lib/server/auth";
+import { config } from "$lib/server/config";
 import { requireAuth } from "$lib/server/api/utils/requireAuth";
 import { defaultModel, models, validateModel } from "$lib/server/models";
 import { DEFAULT_SETTINGS, type SettingsEditable } from "$lib/types/Settings";
@@ -65,8 +66,10 @@ export const GET: RequestHandler = async ({ locals }) => {
 
 		customPrompts: settings?.customPrompts ?? {},
 		customPromptsEnabled: settings?.customPromptsEnabled ?? {},
-		multimodalOverrides: settings?.multimodalOverrides ?? {},
-		toolsOverrides: settings?.toolsOverrides ?? {},
+		// On HuggingChat, tool/multimodal capability comes from the upstream router,
+		// so we hide any per-user overrides (existing or new) instead of letting them apply.
+		multimodalOverrides: config.isHuggingChat ? {} : (settings?.multimodalOverrides ?? {}),
+		toolsOverrides: config.isHuggingChat ? {} : (settings?.toolsOverrides ?? {}),
 		providerOverrides: settings?.providerOverrides ?? {},
 		billingOrganization: settings?.billingOrganization ?? undefined,
 	});
@@ -78,6 +81,11 @@ export const POST: RequestHandler = async ({ locals, request }) => {
 
 	const { welcomeModalSeen, ...parsedSettings } = settingsSchema.parse(body);
 	const streamingMode = resolveStreamingMode(parsedSettings);
+
+	if (config.isHuggingChat) {
+		parsedSettings.multimodalOverrides = {};
+		parsedSettings.toolsOverrides = {};
+	}
 
 	const settings = {
 		...parsedSettings,

--- a/src/routes/conversation/[id]/+server.ts
+++ b/src/routes/conversation/[id]/+server.ts
@@ -568,10 +568,14 @@ export async function POST({ request, locals, params, getClientAddress }) {
 					promptedAt,
 					ip: getClientAddress(),
 					username: locals.user?.username,
-					// Force-enable multimodal if user settings say so for this model
-					forceMultimodal: Boolean(userSettings?.multimodalOverrides?.[model.id]),
-					// Force-enable tools if user settings say so for this model
-					forceTools: Boolean(userSettings?.toolsOverrides?.[model.id]),
+					// Force-enable multimodal/tools if user settings say so for this model.
+					// On HuggingChat capability comes from the upstream router, so any stored
+					// per-user overrides are ignored — existing entries don't keep applying.
+					forceMultimodal:
+						!config.isHuggingChat &&
+						Boolean(userSettings?.multimodalOverrides?.[model.id]),
+					forceTools:
+						!config.isHuggingChat && Boolean(userSettings?.toolsOverrides?.[model.id]),
 					// Inference provider preference (HuggingChat only, skip for router models)
 					provider:
 						config.isHuggingChat && !model.isRouter

--- a/src/routes/settings/(nav)/+server.ts
+++ b/src/routes/settings/(nav)/+server.ts
@@ -1,6 +1,7 @@
 import { collections } from "$lib/server/database";
 import { z } from "zod";
 import { authCondition } from "$lib/server/auth";
+import { config } from "$lib/server/config";
 import { DEFAULT_SETTINGS, type SettingsEditable } from "$lib/types/Settings";
 import { resolveStreamingMode } from "$lib/utils/messageUpdates";
 
@@ -27,6 +28,12 @@ export async function POST({ request, locals }) {
 
 	const { welcomeModalSeen, ...parsedSettings } = settingsSchema.parse(body);
 	const streamingMode = resolveStreamingMode(parsedSettings);
+
+	if (config.isHuggingChat) {
+		parsedSettings.multimodalOverrides = {};
+		parsedSettings.toolsOverrides = {};
+	}
+
 	const settings = {
 		...parsedSettings,
 		streamingMode,

--- a/src/routes/settings/(nav)/[...model]/+page.svelte
+++ b/src/routes/settings/(nav)/[...model]/+page.svelte
@@ -288,10 +288,18 @@
 							Tool calling (functions)
 						</div>
 						<p class="text-[12px] text-gray-500 dark:text-gray-400">
-							Enable tools and allow the model to call them in chat.
+							{#if publicConfig.isHuggingChat}
+								Determined by the inference provider for this model.
+							{:else}
+								Enable tools and allow the model to call them in chat.
+							{/if}
 						</p>
 					</div>
-					<Switch name="forceTools" bind:checked={getToolsOverride, setToolsOverride} />
+					<Switch
+						name="forceTools"
+						disabled={publicConfig.isHuggingChat}
+						bind:checked={getToolsOverride, setToolsOverride}
+					/>
 				</div>
 
 				<div class="flex items-start justify-between py-3">
@@ -300,11 +308,16 @@
 							Multimodal support (image inputs)
 						</div>
 						<p class="text-[12px] text-gray-500 dark:text-gray-400">
-							Enable image uploads and send images to this model.
+							{#if publicConfig.isHuggingChat}
+								Determined by the inference provider for this model.
+							{:else}
+								Enable image uploads and send images to this model.
+							{/if}
 						</p>
 					</div>
 					<Switch
 						name="forceMultimodal"
+						disabled={publicConfig.isHuggingChat}
 						bind:checked={getMultimodalOverride, setMultimodalOverride}
 					/>
 				</div>

--- a/src/routes/settings/(nav)/[...model]/+page.svelte
+++ b/src/routes/settings/(nav)/[...model]/+page.svelte
@@ -105,24 +105,8 @@
 	let model = $derived(page.data.models.find((el: BackendModel) => el.id === modelId));
 	let providerList: RouterProvider[] = $derived((model?.providers ?? []) as RouterProvider[]);
 
-	// Initialize multimodal override for this model if not set yet
-	$effect(() => {
-		if (model) {
-			// Default to the model's advertised capability
-			settings.initValue("multimodalOverrides", modelId, !!model.multimodal);
-		}
-	});
-
-	// Initialize tools override for this model if not set yet
-	$effect(() => {
-		if (model) {
-			settings.initValue(
-				"toolsOverrides",
-				modelId,
-				Boolean((model as unknown as { supportsTools?: boolean }).supportsTools)
-			);
-		}
-	});
+	// multimodalOverrides/toolsOverrides intentionally have no initValue: getters fall back
+	// to the model's advertised capability, so upstream capability changes flow through.
 
 	// Ensure hidePromptExamples has an entry for this model so the switch can bind safely
 	$effect(() => {


### PR DESCRIPTION
## Summary

- Tool-calling and multimodal capabilities for a model used to be snapshotted into per-user settings (`toolsOverrides`, `multimodalOverrides`) on first visit to the model's settings page. Once written, the entry shadowed any later capability change in the upstream registry — e.g. DeepSeek-V4-Pro recently started reporting `supports_tools: true` on most providers, but users who'd visited it earlier still saw the toggle off and the wrench icon missing.
- Two commits:
  1. `0bb407f` — drop the `initValue` calls so the read-side fallback (`?? model.supportsTools` / `?? model.multimodal`) lets capability upgrades flow through automatically. Benefits both HuggingChat and self-hosted users.
  2. `86914df` — on HuggingChat specifically, the router is the source of truth, so make those toggles read-only:
     - `Switch.svelte` gains a `disabled` prop.
     - Settings page disables both toggles and rephrases the help text.
     - `/api/v2/user/settings` GET hides any stored overrides (so existing entries stop applying without a DB migration).
     - Both POST endpoints (`/settings` and `/api/v2/user/settings`) drop incoming override maps so no new spurious entries get written.
     - `conversation/[id]/+server.ts` gates `forceMultimodal` / `forceTools` on `!config.isHuggingChat` so any leftover DB rows can't force capabilities at request time either.

Self-hosted (`config.isHuggingChat = false`) behavior is unchanged: toggles are clickable, overrides read/write/apply exactly as before.

## Test plan

- [ ] On HuggingChat staging: open settings for a model whose router-reported tool support changed since last visit, confirm the wrench icon and Tool calling toggle reflect the current router value.
- [ ] Confirm both toggles render disabled with the "Determined by the inference provider for this model." note.
- [ ] Send a chat message on a tool-capable model and verify tool calls work end-to-end.
- [ ] On a self-hosted build, confirm the toggles are still clickable, persist across reloads, and that `forceTools=true` still forces tool calling on a model with `supportsTools=false`.
- [ ] `npm run check` and `npm run lint` pass.