### PR TITLE
Show streaming reasoning in a fixed-height fade viewport

### DIFF
--- a/src/lib/components/chat/ChatMessage.svelte
+++ b/src/lib/components/chat/ChatMessage.svelte
@@ -474,7 +474,7 @@
 					</form>
 				{/if}
 			</div>
-			<div class="absolute -bottom-4 ml-3.5 flex w-full gap-1.5">
+			<div class="absolute -bottom-4 ml-3.5 flex w-full items-center gap-1.5">
 				{#if alternatives.length > 1 && editMsdgId === null}
 					<Alternatives
 						{message}

--- a/src/lib/components/chat/OpenReasoningResults.svelte
+++ b/src/lib/components/chat/OpenReasoningResults.svelte
@@ -58,10 +58,32 @@
 
 	<!-- Expandable content -->
 	{#if isOpen}
-		<div
-			class="prose prose-sm mt-2 max-w-none text-sm leading-relaxed text-gray-500 dark:prose-invert dark:text-gray-400"
-		>
-			<MarkdownRenderer {content} {loading} />
-		</div>
+		{#if loading}
+			<!--
+				Streaming view: fixed-height viewport, content bottom-aligned so newly
+				arriving tokens stay visible while older lines scroll off the top behind
+				a gradient fade. Works for any model output format (no parsing).
+			-->
+			<div class="thinking-viewport mt-2 flex max-h-16 flex-col justify-end overflow-hidden">
+				<div
+					class="prose prose-sm max-w-none text-sm leading-relaxed text-gray-500 dark:prose-invert dark:text-gray-400 [&>:first-child]:mt-0 [&>:last-child]:mb-0"
+				>
+					<MarkdownRenderer {content} {loading} />
+				</div>
+			</div>
+		{:else}
+			<div
+				class="prose prose-sm mt-2 max-w-none text-sm leading-relaxed text-gray-500 dark:prose-invert dark:text-gray-400"
+			>
+				<MarkdownRenderer {content} {loading} />
+			</div>
+		{/if}
 	{/if}
 </BlockWrapper>
+
+<style>
+	.thinking-viewport {
+		-webkit-mask-image: linear-gradient(to bottom, transparent 0%, black 50%);
+		mask-image: linear-gradient(to bottom, transparent 0%, black 50%);
+	}
+</style>

--- a/src/lib/components/chat/OpenReasoningResults.svelte
+++ b/src/lib/components/chat/OpenReasoningResults.svelte
@@ -64,7 +64,7 @@
 				arriving tokens stay visible while older lines scroll off the top behind
 				a gradient fade. Works for any model output format (no parsing).
 			-->
-			<div class="thinking-viewport mt-2 flex max-h-16 flex-col justify-end overflow-hidden">
+			<div class="thinking-viewport mt-2 flex max-h-80 flex-col justify-end overflow-hidden">
 				<div
 					class="prose prose-sm max-w-none text-sm leading-relaxed text-gray-500 dark:prose-invert dark:text-gray-400 [&>:first-child]:mt-0 [&>:last-child]:mb-0"
 				>

--- a/src/lib/components/chat/OpenReasoningResults.svelte
+++ b/src/lib/components/chat/OpenReasoningResults.svelte
@@ -96,9 +96,9 @@
 		display: inline-block;
 		background-image: linear-gradient(
 			90deg,
-			rgba(0, 0, 0, 0.85) 0%,
-			rgba(0, 0, 0, 0.2) 50%,
-			rgba(0, 0, 0, 0.85) 100%
+			rgba(107, 114, 128, 1) 0%,
+			rgba(107, 114, 128, 0.3) 50%,
+			rgba(107, 114, 128, 1) 100%
 		);
 		background-size: 220% 100%;
 		animation: router-shimmer 2.8s linear infinite;

--- a/src/lib/components/chat/OpenReasoningResults.svelte
+++ b/src/lib/components/chat/OpenReasoningResults.svelte
@@ -83,7 +83,7 @@
 
 <style>
 	.thinking-viewport {
-		-webkit-mask-image: linear-gradient(to bottom, transparent 0%, black 50%);
-		mask-image: linear-gradient(to bottom, transparent 0%, black 50%);
+		-webkit-mask-image: linear-gradient(to bottom, transparent 0, black 48px);
+		mask-image: linear-gradient(to bottom, transparent 0, black 48px);
 	}
 </style>

--- a/src/lib/components/chat/OpenReasoningResults.svelte
+++ b/src/lib/components/chat/OpenReasoningResults.svelte
@@ -12,6 +12,11 @@
 	let isOpen = $state(false);
 	let wasLoading = $state(false);
 	let initialized = $state(false);
+	// Reactive size bindings (powered by ResizeObserver under the hood) — used
+	// to apply the fade mask only when the streamed content actually overflows
+	// the viewport, so short reasoning isn't unnecessarily faded at the top.
+	let viewportHeight = $state(0);
+	let contentHeight = $state(0);
 
 	// Track loading transitions to auto-expand/collapse
 	$effect(() => {
@@ -64,8 +69,13 @@
 				arriving tokens stay visible while older lines scroll off the top behind
 				a gradient fade. Works for any model output format (no parsing).
 			-->
-			<div class="thinking-viewport mt-2 flex max-h-80 flex-col justify-end overflow-hidden">
+			<div
+				bind:clientHeight={viewportHeight}
+				class="thinking-viewport mt-2 flex max-h-80 flex-col justify-end overflow-hidden"
+				class:has-overflow={contentHeight > viewportHeight}
+			>
 				<div
+					bind:clientHeight={contentHeight}
 					class="prose prose-sm max-w-none text-sm leading-relaxed text-gray-500 dark:prose-invert dark:text-gray-400 [&>:first-child]:mt-0 [&>:last-child]:mb-0"
 				>
 					<MarkdownRenderer {content} {loading} />
@@ -82,7 +92,7 @@
 </BlockWrapper>
 
 <style>
-	.thinking-viewport {
+	.thinking-viewport.has-overflow {
 		-webkit-mask-image: linear-gradient(to bottom, transparent 0, black 48px);
 		mask-image: linear-gradient(to bottom, transparent 0, black 48px);
 	}

--- a/src/lib/components/chat/OpenReasoningResults.svelte
+++ b/src/lib/components/chat/OpenReasoningResults.svelte
@@ -45,7 +45,7 @@
 			class="text-sm font-medium transition-colors group-hover/header:text-gray-600 dark:group-hover/header:text-gray-300 {isOpen
 				? 'text-gray-600 dark:text-gray-300'
 				: 'text-gray-500 dark:text-gray-400'}"
-			class:router-shimmer={loading}
+			class:thinking-shimmer={loading}
 		>
 			Thinking
 		</span>
@@ -85,5 +85,34 @@
 	.thinking-viewport {
 		-webkit-mask-image: linear-gradient(to bottom, transparent 0, black 48px);
 		mask-image: linear-gradient(to bottom, transparent 0, black 48px);
+	}
+	/*
+	 * Variant of router-shimmer (defined in main.css) — light mode inverted so
+	 * the text reads dark with a brighter spot sweeping across, instead of
+	 * medium-gray with darker edges. Dark mode keeps the same bright-spot
+	 * behavior as router-shimmer.
+	 */
+	.thinking-shimmer {
+		display: inline-block;
+		background-image: linear-gradient(
+			90deg,
+			rgba(0, 0, 0, 0.85) 0%,
+			rgba(0, 0, 0, 0.2) 50%,
+			rgba(0, 0, 0, 0.85) 100%
+		);
+		background-size: 220% 100%;
+		animation: router-shimmer 2.8s linear infinite;
+		background-clip: text;
+		-webkit-background-clip: text;
+		color: transparent;
+		-webkit-text-fill-color: transparent;
+	}
+	:global(.dark) .thinking-shimmer {
+		background-image: linear-gradient(
+			90deg,
+			rgba(255, 255, 255, 0.15) 0%,
+			rgba(255, 255, 255, 0.7) 50%,
+			rgba(255, 255, 255, 0.15) 100%
+		);
 	}
 </style>

--- a/src/lib/components/chat/OpenReasoningResults.svelte.test.ts
+++ b/src/lib/components/chat/OpenReasoningResults.svelte.test.ts
@@ -1,0 +1,50 @@
+import OpenReasoningResults from "./OpenReasoningResults.svelte";
+import { render } from "vitest-browser-svelte";
+import { page } from "@vitest/browser/context";
+
+import { describe, expect, it } from "vitest";
+
+const LONG_REASONING = Array.from(
+	{ length: 20 },
+	(_, i) => `Paragraph ${i + 1}: thinking about something here that goes on for a bit.`
+).join("\n\n");
+
+describe("OpenReasoningResults", () => {
+	it("renders the streaming viewport when loading", async () => {
+		const { baseElement } = render(OpenReasoningResults, {
+			content: LONG_REASONING,
+			loading: true,
+		});
+
+		const viewport = baseElement.querySelector(".thinking-viewport") as HTMLElement | null;
+		if (!viewport) throw new Error("expected .thinking-viewport to be rendered");
+		// Scoped <style> block applies the gradient fade mask
+		const style = getComputedStyle(viewport);
+		const hasMask =
+			style.maskImage?.includes("linear-gradient") ||
+			(style as unknown as { webkitMaskImage?: string }).webkitMaskImage?.includes(
+				"linear-gradient"
+			);
+		expect(hasMask).toBe(true);
+
+		// Full content is in the DOM (CSS clipping handles the visual cropping)
+		expect(page.getByText("Paragraph 20:", { exact: false })).toBeInTheDocument();
+		expect(page.getByText("Paragraph 1:", { exact: false })).toBeInTheDocument();
+	});
+
+	it("renders the full text view when not loading", async () => {
+		const { baseElement } = render(OpenReasoningResults, {
+			content: LONG_REASONING,
+			loading: false,
+		});
+
+		// After streaming, default state is collapsed; expand it
+		const toggle = baseElement.querySelector("button");
+		if (!toggle) throw new Error("expected toggle button to be rendered");
+		toggle.click();
+
+		// No streaming viewport when not loading
+		await new Promise((r) => setTimeout(r, 0));
+		expect(baseElement.querySelector(".thinking-viewport")).toBeNull();
+	});
+});


### PR DESCRIPTION
## Summary

- Render the streaming `<think>` block in a 320px viewport with a 48px gradient fade at the top, content bottom-aligned so newly arriving tokens stay visible while older lines scroll off behind the fade. CSS-only, no per-model parsing — works uniformly for DeepSeek R1, gpt-oss, Qwen3, etc.
- Apply the fade mask only when content actually overflows the viewport (via Svelte 5 `bind:clientHeight`), so short reasoning isn't faded for no reason.
- Invert the "Thinking" header shimmer in light mode (anchored to `text-gray-500` so the resting color matches when streaming ends), keeping dark mode unchanged. Uses a separate `thinking-shimmer` class so other `router-shimmer` consumers are untouched.
- Vertically center the alternatives nav and copy/edit buttons under each message — the row was missing `items-center` so the `h-6` nav and `h-5` buttons aligned to the top.

## Test plan

- [ ] Open a conversation with a thinking-capable model (e.g., DeepSeek R1, gpt-oss) and verify the streaming "Thinking" block is capped at 320px with a soft fade at the top
- [ ] Confirm short reasoning (a few lines) is NOT faded — fade should appear only once content exceeds the viewport
- [ ] After streaming ends, expanding the block shows full text without any fade
- [ ] In light mode, the animated "Thinking" label reads dark with a brighter spot sweeping across (not the previous medium-gray with darker edges)
- [ ] Hover over an assistant message and verify the alternatives `< 16 / 16 >` nav and the Edit/Copy buttons are vertically aligned in the row below