### PR TITLE
Reduce reasoning viewport max height on mobile

### DIFF
--- a/src/lib/components/chat/OpenReasoningResults.svelte
+++ b/src/lib/components/chat/OpenReasoningResults.svelte
@@ -71,7 +71,7 @@
 			-->
 			<div
 				bind:clientHeight={viewportHeight}
-				class="thinking-viewport mt-2 flex max-h-80 flex-col justify-end overflow-hidden"
+				class="thinking-viewport mt-2 flex max-h-56 flex-col justify-end overflow-hidden md:max-h-80"
 				class:has-overflow={contentHeight > viewportHeight}
 			>
 				<div


### PR DESCRIPTION
Drop the streaming-reasoning viewport from 320px to 224px (~30% less) on
screens narrower than the md breakpoint. Desktop keeps the existing 320px
ceiling so longer chain-of-thought stays readable on larger viewports.

https://claude.ai/code/session_01PD3VAeKBX6HDRLCvH7H5Hs