### PR TITLE
Add min/max width constraints to prose table cells

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -83,6 +83,12 @@ body {
 		@apply block max-w-full overflow-x-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-black/10 scrollbar-thumb-rounded-full scrollbar-w-1 hover:scrollbar-thumb-black/20 dark:scrollbar-thumb-white/10 dark:hover:scrollbar-thumb-white/20;
 	}
 
+	/* Prevent columns from squishing on narrow viewports; long content wraps instead of dominating. */
+	.prose :is(th, td) {
+		min-width: 6rem;
+		max-width: 16rem;
+	}
+
 	/* .scrollbar-custom {
 		@apply scrollbar-thin scrollbar-track-transparent scrollbar-thumb-black/10 scrollbar-thumb-rounded-full scrollbar-w-1 hover:scrollbar-thumb-black/20 dark:scrollbar-thumb-white/10 dark:hover:scrollbar-thumb-white/20;
 	} */


### PR DESCRIPTION
## Summary
Added CSS constraints to table cells (`<th>` and `<td>`) within prose content to improve layout behavior on narrow viewports and prevent content from being squeezed.

## Changes
- Added `min-width: 6rem` to ensure table cells maintain a minimum readable width
- Added `max-width: 16rem` to force long content to wrap instead of dominating the layout
- Applied these constraints to both header and data cells in prose-styled tables

## Details
This prevents table columns from becoming too narrow on mobile devices while also ensuring that excessively long content doesn't break the layout by forcing columns to expand beyond a reasonable width. Content will now wrap naturally within the defined constraints rather than causing horizontal overflow or layout distortion.

https://claude.ai/code/session_011coCCTuFxERp5pK3Hkrok9