### PR TITLE
Add MCP server sharing via shareable links

### DIFF
--- a/src/lib/components/mcp/ServerCard.svelte
+++ b/src/lib/components/mcp/ServerCard.svelte
@@ -8,8 +8,11 @@
 	import IconTrash from "~icons/carbon/trash-can";
 	import LucideHammer from "~icons/lucide/hammer";
 	import IconSettings from "~icons/carbon/settings";
+	import IconShare from "$lib/components/icons/IconShare.svelte";
+	import IconCopy from "~icons/carbon/copy";
 	import Switch from "$lib/components/Switch.svelte";
 	import { getMcpServerFaviconUrl } from "$lib/utils/favicon";
+	import { base } from "$app/paths";
 
 	interface Props {
 		server: MCPServer;
@@ -19,6 +22,21 @@
 	let { server, isSelected }: Props = $props();
 
 	let isLoadingHealth = $state(false);
+	let shareCopied = $state(false);
+	let shareCopyTimeout: ReturnType<typeof setTimeout> | undefined;
+
+	async function handleShare() {
+		const params = new URLSearchParams({ name: server.name, url: server.url });
+		const shareUrl = `${window.location.origin}${base}/mcp/share?${params.toString()}`;
+		try {
+			await navigator.clipboard.writeText(shareUrl);
+			shareCopied = true;
+			clearTimeout(shareCopyTimeout);
+			shareCopyTimeout = setTimeout(() => (shareCopied = false), 2000);
+		} catch (err) {
+			console.error("Failed to copy share link:", err);
+		}
+	}
 
 	// Show a quick-access link ONLY for the exact HF MCP login endpoint
 	import { isStrictHfMcpLogin as isStrictHfMcpLoginUrl } from "$lib/utils/hf";
@@ -171,6 +189,20 @@
 			{/if}
 
 			{#if server.type === "custom"}
+				<button
+					onclick={handleShare}
+					class="flex items-center gap-1.5 rounded-lg border border-gray-200 bg-white px-2.5 py-[.29rem] text-xs font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
+					title="Copy a shareable link for this server"
+				>
+					{#if shareCopied}
+						<IconCopy class="size-3" />
+						Copied!
+					{:else}
+						<IconShare classNames="size-3" />
+						Share
+					{/if}
+				</button>
+
 				<button
 					onclick={handleDelete}
 					class="flex items-center gap-1.5 rounded-lg border border-red-500/15 bg-red-50 px-2.5 py-[.29rem] text-xs font-medium text-red-600 hover:bg-red-100 dark:border-red-500/25 dark:bg-red-900/30 dark:text-red-400 dark:hover:bg-red-900/50"

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -205,7 +205,7 @@
 
 	<!-- use those meta tags everywhere except on special listing pages -->
 	<!-- feel free to refacto if there's a better way -->
-	{#if !page.url.pathname.includes("/models/")}
+	{#if !page.url.pathname.includes("/models/") && !page.url.pathname.includes("/mcp/share")}
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="{publicConfig.PUBLIC_APP_NAME} - Chat with AI models" />
 		<meta name="twitter:description" content={publicConfig.PUBLIC_APP_DESCRIPTION} />

--- a/src/routes/mcp/share/+page.svelte
+++ b/src/routes/mcp/share/+page.svelte
@@ -4,14 +4,12 @@
 	import { page } from "$app/state";
 	import { usePublicConfig } from "$lib/utils/PublicConfig.svelte";
 	import { addCustomServer } from "$lib/stores/mcpServers";
-	import IconMCP from "$lib/components/icons/IconMCP.svelte";
-	import IconWarning from "~icons/carbon/warning";
-	import { getMcpServerFaviconUrl } from "$lib/utils/favicon";
+	import Modal from "$lib/components/Modal.svelte";
+	import AddServerForm from "$lib/components/mcp/AddServerForm.svelte";
+	import type { KeyValuePair } from "$lib/types/Tool";
 
 	let { data } = $props();
 	const publicConfig = usePublicConfig();
-
-	let isAdding = $state(false);
 
 	const ogTitle = $derived(
 		data.invalid
@@ -27,15 +25,13 @@
 		`${publicConfig.PUBLIC_ORIGIN || page.url.origin}${publicConfig.assetPath}/thumbnail.png`
 	);
 
-	function handleAdd() {
-		if (data.invalid || !data.url || isAdding) return;
-		isAdding = true;
-		addCustomServer({ name: data.name, url: data.url });
-		goto(`${base}/`, { invalidateAll: true });
+	function close() {
+		goto(`${base}/`);
 	}
 
-	function handleCancel() {
-		goto(`${base}/`);
+	function handleSubmit(server: { name: string; url: string; headers?: KeyValuePair[] }) {
+		addCustomServer(server);
+		goto(`${base}/`, { invalidateAll: true });
 	}
 </script>
 
@@ -54,81 +50,36 @@
 	<meta name="twitter:image" content={ogImage} />
 </svelte:head>
 
-<div class="flex min-h-dvh w-full items-center justify-center bg-gray-50 p-4 dark:bg-gray-900">
-	<div
-		class="w-full max-w-md rounded-2xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800"
-	>
-		<div class="mb-4 flex items-center gap-3">
-			<div class="flex size-12 items-center justify-center rounded-xl bg-blue-500/10">
-				<IconMCP classNames="size-7 text-blue-600 dark:text-blue-500" />
-			</div>
-			<div>
-				<h1 class="text-lg font-semibold text-gray-900 dark:text-gray-100">Add MCP server</h1>
-				<p class="text-xs text-gray-600 dark:text-gray-400">
-					Shared with you on {publicConfig.PUBLIC_APP_NAME}
-				</p>
-			</div>
+<Modal width="w-[600px]" onclose={close} closeButton>
+	<div class="p-6">
+		<div class="mb-6">
+			<h2 class="mb-1 text-xl font-semibold text-gray-900 dark:text-gray-200">Add MCP server</h2>
+			<p class="text-sm text-gray-600 dark:text-gray-400">
+				{#if data.invalid}
+					This share link is missing or invalid. Ask the sender for a new one.
+				{:else}
+					Someone shared this server with you. Review the details before adding it to {publicConfig.PUBLIC_APP_NAME}.
+				{/if}
+			</p>
 		</div>
 
-		{#if data.invalid}
-			<div
-				class="mb-4 rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800 dark:border-red-900/40 dark:bg-red-900/20 dark:text-red-200"
-			>
-				This share link is missing or invalid. Ask the sender for a new link.
-			</div>
+		{#if !data.invalid && data.url}
+			<AddServerForm
+				initialName={data.name}
+				initialUrl={data.url}
+				onsubmit={handleSubmit}
+				oncancel={close}
+			/>
+		{:else}
 			<div class="flex justify-end">
 				<button
 					type="button"
-					onclick={handleCancel}
+					onclick={close}
 					class="rounded-lg bg-gray-200 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
 				>
 					Back to {publicConfig.PUBLIC_APP_NAME}
 				</button>
 			</div>
-		{:else}
-			<div class="mb-4 rounded-lg border border-gray-200 p-4 dark:border-gray-700">
-				<div class="mb-2 flex items-center gap-2">
-					<img
-						src={getMcpServerFaviconUrl(data.url ?? "")}
-						alt=""
-						class="size-4 flex-shrink-0 rounded"
-					/>
-					<p class="truncate font-semibold text-gray-900 dark:text-gray-100">{data.name}</p>
-				</div>
-				<p class="break-all text-xs text-gray-600 dark:text-gray-400">{data.url}</p>
-			</div>
-
-			<div
-				class="mb-5 flex items-start gap-3 rounded-lg border border-amber-200 bg-amber-50 p-3 text-amber-900 dark:border-yellow-900/40 dark:bg-yellow-900/20 dark:text-yellow-100"
-			>
-				<IconWarning class="mt-0.5 size-4 flex-none text-amber-600 dark:text-yellow-300" />
-				<div class="text-[13px] leading-5">
-					<p class="font-medium">Only add servers you trust.</p>
-					<p class="mt-1 text-amber-800 dark:text-yellow-100/90">
-						This server will receive your requests, including conversation context, and can run
-						tools on your behalf. Review the URL above before continuing. Any required
-						authentication headers can be added after install.
-					</p>
-				</div>
-			</div>
-
-			<div class="flex justify-end gap-2">
-				<button
-					type="button"
-					onclick={handleCancel}
-					class="rounded-lg bg-gray-200 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
-				>
-					Cancel
-				</button>
-				<button
-					type="button"
-					onclick={handleAdd}
-					disabled={isAdding}
-					class="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
-				>
-					{isAdding ? "Adding…" : "Add to MCP"}
-				</button>
-			</div>
 		{/if}
 	</div>
-</div>
+</Modal>

--- a/src/routes/mcp/share/+page.svelte
+++ b/src/routes/mcp/share/+page.svelte
@@ -1,0 +1,134 @@
+<script lang="ts">
+	import { goto } from "$app/navigation";
+	import { base } from "$app/paths";
+	import { page } from "$app/state";
+	import { usePublicConfig } from "$lib/utils/PublicConfig.svelte";
+	import { addCustomServer } from "$lib/stores/mcpServers";
+	import IconMCP from "$lib/components/icons/IconMCP.svelte";
+	import IconWarning from "~icons/carbon/warning";
+	import { getMcpServerFaviconUrl } from "$lib/utils/favicon";
+
+	let { data } = $props();
+	const publicConfig = usePublicConfig();
+
+	let isAdding = $state(false);
+
+	const ogTitle = $derived(
+		data.invalid
+			? `Invalid MCP server link - ${publicConfig.PUBLIC_APP_NAME}`
+			: `Add ${data.name} to ${publicConfig.PUBLIC_APP_NAME}`
+	);
+	const ogDescription = $derived(
+		data.invalid
+			? "This MCP server share link is missing or invalid."
+			: `Someone shared the MCP server "${data.name}" with you. Review and add it to ${publicConfig.PUBLIC_APP_NAME}.`
+	);
+	const ogImage = $derived(
+		`${publicConfig.PUBLIC_ORIGIN || page.url.origin}${publicConfig.assetPath}/thumbnail.png`
+	);
+
+	function handleAdd() {
+		if (data.invalid || !data.url || isAdding) return;
+		isAdding = true;
+		addCustomServer({ name: data.name, url: data.url });
+		goto(`${base}/`, { invalidateAll: true });
+	}
+
+	function handleCancel() {
+		goto(`${base}/`);
+	}
+</script>
+
+<svelte:head>
+	<title>{ogTitle}</title>
+	<meta name="description" content={ogDescription} />
+	<meta property="og:title" content={ogTitle} />
+	<meta property="og:description" content={ogDescription} />
+	<meta property="og:type" content="website" />
+	<meta property="og:url" content={page.url.href} />
+	<meta property="og:image" content={ogImage} />
+	<meta property="og:site_name" content={publicConfig.PUBLIC_APP_NAME} />
+	<meta name="twitter:card" content="summary_large_image" />
+	<meta name="twitter:title" content={ogTitle} />
+	<meta name="twitter:description" content={ogDescription} />
+	<meta name="twitter:image" content={ogImage} />
+</svelte:head>
+
+<div class="flex min-h-dvh w-full items-center justify-center bg-gray-50 p-4 dark:bg-gray-900">
+	<div
+		class="w-full max-w-md rounded-2xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800"
+	>
+		<div class="mb-4 flex items-center gap-3">
+			<div class="flex size-12 items-center justify-center rounded-xl bg-blue-500/10">
+				<IconMCP classNames="size-7 text-blue-600 dark:text-blue-500" />
+			</div>
+			<div>
+				<h1 class="text-lg font-semibold text-gray-900 dark:text-gray-100">Add MCP server</h1>
+				<p class="text-xs text-gray-600 dark:text-gray-400">
+					Shared with you on {publicConfig.PUBLIC_APP_NAME}
+				</p>
+			</div>
+		</div>
+
+		{#if data.invalid}
+			<div
+				class="mb-4 rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800 dark:border-red-900/40 dark:bg-red-900/20 dark:text-red-200"
+			>
+				This share link is missing or invalid. Ask the sender for a new link.
+			</div>
+			<div class="flex justify-end">
+				<button
+					type="button"
+					onclick={handleCancel}
+					class="rounded-lg bg-gray-200 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
+				>
+					Back to {publicConfig.PUBLIC_APP_NAME}
+				</button>
+			</div>
+		{:else}
+			<div class="mb-4 rounded-lg border border-gray-200 p-4 dark:border-gray-700">
+				<div class="mb-2 flex items-center gap-2">
+					<img
+						src={getMcpServerFaviconUrl(data.url ?? "")}
+						alt=""
+						class="size-4 flex-shrink-0 rounded"
+					/>
+					<p class="truncate font-semibold text-gray-900 dark:text-gray-100">{data.name}</p>
+				</div>
+				<p class="break-all text-xs text-gray-600 dark:text-gray-400">{data.url}</p>
+			</div>
+
+			<div
+				class="mb-5 flex items-start gap-3 rounded-lg border border-amber-200 bg-amber-50 p-3 text-amber-900 dark:border-yellow-900/40 dark:bg-yellow-900/20 dark:text-yellow-100"
+			>
+				<IconWarning class="mt-0.5 size-4 flex-none text-amber-600 dark:text-yellow-300" />
+				<div class="text-[13px] leading-5">
+					<p class="font-medium">Only add servers you trust.</p>
+					<p class="mt-1 text-amber-800 dark:text-yellow-100/90">
+						This server will receive your requests, including conversation context, and can run
+						tools on your behalf. Review the URL above before continuing. Any required
+						authentication headers can be added after install.
+					</p>
+				</div>
+			</div>
+
+			<div class="flex justify-end gap-2">
+				<button
+					type="button"
+					onclick={handleCancel}
+					class="rounded-lg bg-gray-200 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
+				>
+					Cancel
+				</button>
+				<button
+					type="button"
+					onclick={handleAdd}
+					disabled={isAdding}
+					class="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+				>
+					{isAdding ? "Adding…" : "Add to MCP"}
+				</button>
+			</div>
+		{/if}
+	</div>
+</div>

--- a/src/routes/mcp/share/+page.ts
+++ b/src/routes/mcp/share/+page.ts
@@ -1,0 +1,16 @@
+import { validateMcpServerUrl } from "$lib/utils/mcpValidation";
+import type { PageLoad } from "./$types";
+
+export const load: PageLoad = ({ url }) => {
+	const rawName = url.searchParams.get("name")?.trim() ?? "";
+	const rawUrl = url.searchParams.get("url")?.trim() ?? "";
+
+	const name = rawName.slice(0, 100);
+	const validatedUrl = rawUrl ? validateMcpServerUrl(rawUrl) : null;
+
+	return {
+		name,
+		url: validatedUrl,
+		invalid: !name || !validatedUrl,
+	};
+};


### PR DESCRIPTION
## Summary
Adds the ability to share custom MCP servers with others via shareable links. Users can now generate a link for any custom MCP server that can be shared with others, who can then review and add the server to their instance.

## Key Changes
- **New share page** (`src/routes/mcp/share/+page.svelte`): Modal-based page that handles incoming MCP server share links with validation and a pre-filled form for adding the server
- **Share link generation** (`src/lib/components/mcp/ServerCard.svelte`): Added "Share" button to custom server cards that copies a shareable link to clipboard with visual feedback
- **Server validation** (`src/routes/mcp/share/+page.ts`): Page load handler that validates the shared server URL and name parameters, with proper error handling for invalid links
- **Layout exclusion**: Updated global layout to exclude the share page from default meta tags, allowing custom OG tags for better social sharing

## Implementation Details
- Share links are generated as query parameters (`name` and `url`) on the `/mcp/share` route
- The share page validates the URL using existing `validateMcpServerUrl` utility
- Copy-to-clipboard feedback shows "Copied!" for 2 seconds before reverting
- Invalid or missing share links display an error message with a back button
- Valid shares pre-populate the `AddServerForm` with server details for user review before adding
- Proper OG meta tags are set for social sharing (title, description, image)

https://claude.ai/code/session_01FYB4gqX5zm1vZHsejthcG6