### PR TITLE
[codex] improve smooth streaming flow

### DIFF
--- a/src/lib/utils/messageUpdates.spec.ts
+++ b/src/lib/utils/messageUpdates.spec.ts
@@ -131,6 +131,76 @@ describe("smoothStreamUpdates", () => {
 		expect(streamText(updates)).toBe("word ".repeat(40));
 	});
 
+	it("resumes smoothing after a control update catches up", async () => {
+		const source: MessageUpdate[] = [
+			{ type: MessageUpdateType.Stream, token: "word ".repeat(40) },
+			{ type: MessageUpdateType.Title, title: "done" },
+			{ type: MessageUpdateType.Stream, token: "more ".repeat(20) },
+		];
+		const delays: number[] = [];
+		const seen: Array<{ update: MessageUpdate; time: number }> = [];
+		let nowMs = 0;
+
+		for await (const update of smoothStreamUpdates(fromArray(source), {
+			minDelayMs: 5,
+			maxDelayMs: 80,
+			minRateCharsPerMs: 0.3,
+			_internal: {
+				now: () => nowMs,
+				sleep: async (ms: number) => {
+					delays.push(ms);
+					nowMs += ms;
+				},
+				detectChunk: (buffer) => /\S+\s+/.exec(buffer)?.[0] ?? null,
+			},
+		})) {
+			seen.push({ update, time: nowMs });
+		}
+
+		const titleIndex = seen.findIndex((item) => item.update.type === MessageUpdateType.Title);
+		expect(titleIndex).toBeGreaterThan(0);
+		expect(seen[titleIndex]?.time).toBe(0);
+
+		const streamAfterTitle = seen
+			.slice(titleIndex + 1)
+			.filter((item) => item.update.type === MessageUpdateType.Stream);
+		expect(streamAfterTitle.length).toBeGreaterThan(2);
+		expect(streamAfterTitle.at(-1)?.time).toBeGreaterThan(seen[titleIndex]?.time ?? 0);
+		expect(delays.length).toBeGreaterThan(0);
+		expect(delays.every((d) => d >= 5 && d <= 80)).toBe(true);
+		expect(streamText(seen.map((item) => item.update))).toBe(
+			"word ".repeat(40) + "more ".repeat(20)
+		);
+	});
+
+	it("does not include the immediate first stream chunk in pacing rate", async () => {
+		const source: MessageUpdate[] = [{ type: MessageUpdateType.Stream, token: "abcdefghij k " }];
+		const delays: number[] = [];
+		let nowMs = 0;
+		let streamChunks = 0;
+
+		for await (const update of smoothStreamUpdates(fromArray(source), {
+			minDelayMs: 0,
+			maxDelayMs: 80,
+			minRateCharsPerMs: 0.3,
+			_internal: {
+				now: () => nowMs,
+				sleep: async (ms: number) => {
+					delays.push(ms);
+					nowMs += ms;
+				},
+				detectChunk: (buffer) => /\S+\s+/.exec(buffer)?.[0] ?? null,
+			},
+		})) {
+			if (update.type === MessageUpdateType.Stream) {
+				streamChunks += 1;
+				if (streamChunks === 1) nowMs = 1;
+			}
+		}
+
+		expect(delays[0]).toBeGreaterThanOrEqual(6);
+	});
+
 	it("spreads burst tokens over time", async () => {
 		const bigToken = "word ".repeat(40); // 200 chars, 40 words
 		const source: MessageUpdate[] = [{ type: MessageUpdateType.Stream, token: bigToken }];

--- a/src/lib/utils/messageUpdates.spec.ts
+++ b/src/lib/utils/messageUpdates.spec.ts
@@ -49,6 +49,27 @@ describe("smoothStreamUpdates", () => {
 		expect(streamText(updates)).toBe("Hello world!");
 	});
 
+	it("strips transport padding before detecting chunks", async () => {
+		const source: MessageUpdate[] = [
+			{ type: MessageUpdateType.Stream, token: "Hel".padEnd(16, "\0") },
+			{ type: MessageUpdateType.Stream, token: "lo ".padEnd(16, "\0") },
+			{ type: MessageUpdateType.Stream, token: "wor".padEnd(16, "\0") },
+			{ type: MessageUpdateType.Stream, token: "ld!".padEnd(16, "\0") },
+		];
+
+		const updates = await collect(
+			smoothStreamUpdates(fromArray(source), {
+				minDelayMs: 0,
+				maxDelayMs: 0,
+				_internal: { detectChunk: (buffer) => /\S+\s+/.exec(buffer)?.[0] ?? null },
+			})
+		);
+
+		const streamedChunks = updates.filter((u) => u.type === MessageUpdateType.Stream);
+		expect(streamedChunks.map((u) => u.token)).toEqual(["Hello ", "world!"]);
+		expect(streamText(updates)).toBe("Hello world!");
+	});
+
 	it("flushes buffered stream text before non-stream updates", async () => {
 		const source: MessageUpdate[] = [
 			{ type: MessageUpdateType.Stream, token: "hello" },
@@ -63,6 +84,51 @@ describe("smoothStreamUpdates", () => {
 		expect(updates[1]).toMatchObject({ type: MessageUpdateType.Stream });
 		expect(updates[2]).toEqual({ type: MessageUpdateType.Title, title: "done" });
 		expect(streamText(updates)).toBe("hello world");
+	});
+
+	it("does not stall on long unbroken text", async () => {
+		const source: MessageUpdate[] = [{ type: MessageUpdateType.Stream, token: "a".repeat(95) }];
+
+		const updates = await collect(
+			smoothStreamUpdates(fromArray(source), {
+				minDelayMs: 0,
+				maxDelayMs: 0,
+				maxChunkChars: 32,
+			})
+		);
+
+		const streamedChunks = updates.filter((u) => u.type === MessageUpdateType.Stream);
+		expect(streamedChunks.map((u) => u.token.length)).toEqual([32, 32, 31]);
+		expect(streamText(updates)).toBe("a".repeat(95));
+	});
+
+	it("lets control updates catch up to queued stream backlog", async () => {
+		const source: MessageUpdate[] = [
+			{ type: MessageUpdateType.Stream, token: "word ".repeat(40) },
+			{ type: MessageUpdateType.Title, title: "done" },
+		];
+		const delays: number[] = [];
+		let nowMs = 0;
+
+		const updates = await collect(
+			smoothStreamUpdates(fromArray(source), {
+				minDelayMs: 5,
+				maxDelayMs: 80,
+				minRateCharsPerMs: 0.3,
+				_internal: {
+					now: () => nowMs,
+					sleep: async (ms: number) => {
+						delays.push(ms);
+						nowMs += ms;
+					},
+					detectChunk: (buffer) => /\S+\s+/.exec(buffer)?.[0] ?? null,
+				},
+			})
+		);
+
+		expect(updates.at(-1)).toEqual({ type: MessageUpdateType.Title, title: "done" });
+		expect(delays).toEqual([]);
+		expect(streamText(updates)).toBe("word ".repeat(40));
 	});
 
 	it("spreads burst tokens over time", async () => {
@@ -165,6 +231,30 @@ describe("smoothStreamUpdates", () => {
 				})
 			)
 		).rejects.toThrow("source failed");
+	});
+
+	it("flushes partial buffered text before source errors", async () => {
+		async function* failingSource(): AsyncGenerator<MessageUpdate> {
+			yield { type: MessageUpdateType.Stream, token: "hel" };
+			throw new Error("source failed");
+		}
+
+		const seen: MessageUpdate[] = [];
+		let seenError: Error | null = null;
+		try {
+			for await (const update of smoothStreamUpdates(failingSource(), {
+				minDelayMs: 0,
+				maxDelayMs: 0,
+				_internal: { detectChunk: (buffer) => /\S+\s+/.exec(buffer)?.[0] ?? null },
+			})) {
+				seen.push(update);
+			}
+		} catch (error) {
+			seenError = error as Error;
+		}
+
+		expect(streamText(seen)).toBe("hel");
+		expect(seenError?.message).toBe("source failed");
 	});
 
 	it("drains queued stream chunks before throwing source errors", async () => {

--- a/src/lib/utils/messageUpdates.ts
+++ b/src/lib/utils/messageUpdates.ts
@@ -223,14 +223,8 @@ export async function* smoothStreamUpdates(
 	const flushPendingBuffer = () => {
 		if (pendingBuffer.length === 0) return;
 
-		while (countCodePoints(pendingBuffer) > chunkCharLimit) {
-			const chunk = takePrefixByCodePoints(pendingBuffer, chunkCharLimit);
+		for (const chunk of splitByCodePointLimit(pendingBuffer, chunkCharLimit)) {
 			enqueue({ type: MessageUpdateType.Stream, token: chunk });
-			pendingBuffer = pendingBuffer.slice(chunk.length);
-		}
-
-		if (pendingBuffer.length > 0) {
-			enqueue({ type: MessageUpdateType.Stream, token: pendingBuffer });
 		}
 		pendingBuffer = "";
 	};
@@ -266,9 +260,17 @@ export async function* smoothStreamUpdates(
 		});
 
 	// Character-rate targeting consumer
-	let totalCharsEmitted = 0;
-	let firstEmitAt: number | null = null;
-	let emittedStreamChunk = false;
+	let pacedCharsEmitted = 0;
+	let pacingStartedAt: number | null = null;
+	let emittedPacedStreamChunk = false;
+	let resetPacingAfterControl = false;
+
+	const resetPacing = () => {
+		pacedCharsEmitted = 0;
+		pacingStartedAt = null;
+		emittedPacedStreamChunk = false;
+		resetPacingAfterControl = false;
+	};
 
 	while (!producerDone || outputQueue.length > 0) {
 		if (outputQueue.length === 0) {
@@ -280,32 +282,40 @@ export async function* smoothStreamUpdates(
 		if (!update) continue;
 		if (update.type !== MessageUpdateType.Stream) {
 			queuedControlUpdates = Math.max(0, queuedControlUpdates - 1);
+			if (resetPacingAfterControl) resetPacing();
 		}
 
 		if (update.type === MessageUpdateType.Stream) {
 			const tokenLen = update.token.length;
 			queuedStreamChars = Math.max(0, queuedStreamChars - tokenLen);
+			const catchingUpToControlUpdate = queuedControlUpdates > 0;
 
-			if (firstEmitAt === null) firstEmitAt = now();
+			if (catchingUpToControlUpdate) {
+				resetPacingAfterControl = true;
+			} else {
+				if (resetPacingAfterControl) resetPacing();
+				if (pacingStartedAt === null) pacingStartedAt = now();
 
-			if (emittedStreamChunk && queuedControlUpdates === 0) {
-				const elapsedMs = now() - firstEmitAt;
-				const currentRate = elapsedMs > 0 ? totalCharsEmitted / elapsedMs : 0;
-				const backlogChars = tokenLen + queuedStreamChars;
-				const backlogRate = maxBufferedMs > 0 ? backlogChars / maxBufferedMs : 0;
-				const targetRate = Math.max(currentRate, minRateCharsPerMs, backlogRate);
-				const rawDelay = tokenLen / targetRate;
-				const underBacklogPressure = backlogRate > minRateCharsPerMs;
-				const effectiveMinDelayMs = underBacklogPressure ? 0 : minDelayMs;
-				const delayMs = Math.round(Math.max(effectiveMinDelayMs, Math.min(maxDelayMs, rawDelay)));
+				if (emittedPacedStreamChunk) {
+					const elapsedMs = now() - pacingStartedAt;
+					const currentRate = elapsedMs > 0 ? pacedCharsEmitted / elapsedMs : 0;
+					const backlogChars = tokenLen + queuedStreamChars;
+					const backlogRate = maxBufferedMs > 0 ? backlogChars / maxBufferedMs : 0;
+					const targetRate = Math.max(currentRate, minRateCharsPerMs, backlogRate);
+					const rawDelay = tokenLen / targetRate;
+					const underBacklogPressure = backlogRate > minRateCharsPerMs;
+					const effectiveMinDelayMs = underBacklogPressure ? 0 : minDelayMs;
+					const delayMs = Math.round(Math.max(effectiveMinDelayMs, Math.min(maxDelayMs, rawDelay)));
 
-				if (delayMs > 0) {
-					await sleep(delayMs);
+					if (delayMs > 0) {
+						await sleep(delayMs);
+					}
+
+					pacedCharsEmitted += tokenLen;
+				} else {
+					emittedPacedStreamChunk = true;
 				}
 			}
-
-			emittedStreamChunk = true;
-			totalCharsEmitted += tokenLen;
 		}
 
 		yield update;
@@ -322,27 +332,54 @@ function takeNextStreamChunk(
 ): string | null {
 	const detectedChunk = chunkDetector(buffer);
 	if (detectedChunk) {
-		if (countCodePoints(detectedChunk) <= maxChunkChars) return detectedChunk;
-		return takePrefixByCodePoints(detectedChunk, maxChunkChars);
+		const { prefix } = takePrefixByCodePoints(detectedChunk, maxChunkChars);
+		return prefix;
 	}
 
-	if (countCodePoints(buffer) < maxChunkChars) return null;
-	return takePrefixByCodePoints(buffer, maxChunkChars);
+	const { prefix, reachedLimit } = takePrefixByCodePoints(buffer, maxChunkChars);
+	return reachedLimit ? prefix : null;
 }
 
-function countCodePoints(value: string): number {
-	return Array.from(value).length;
-}
-
-function takePrefixByCodePoints(value: string, maxChars: number): string {
+function splitByCodePointLimit(value: string, maxChars: number): string[] {
+	const chunks: string[] = [];
+	let start = 0;
 	let end = 0;
 	let count = 0;
+
 	for (const char of value) {
 		end += char.length;
 		count += 1;
-		if (count >= maxChars) break;
+
+		if (count >= maxChars) {
+			chunks.push(value.slice(start, end));
+			start = end;
+			count = 0;
+		}
 	}
-	return value.slice(0, end);
+
+	if (start < value.length) {
+		chunks.push(value.slice(start));
+	}
+
+	return chunks;
+}
+
+function takePrefixByCodePoints(
+	value: string,
+	maxChars: number
+): { prefix: string; reachedLimit: boolean } {
+	let end = 0;
+	let count = 0;
+
+	for (const char of value) {
+		end += char.length;
+		count += 1;
+		if (count >= maxChars) {
+			return { prefix: value.slice(0, end), reachedLimit: true };
+		}
+	}
+
+	return { prefix: value, reachedLimit: false };
 }
 
 function createWordChunkDetector(): ChunkDetector {

--- a/src/lib/utils/messageUpdates.ts
+++ b/src/lib/utils/messageUpdates.ts
@@ -35,6 +35,7 @@ type SmoothStreamConfig = {
 	maxDelayMs?: number;
 	minRateCharsPerMs?: number;
 	maxBufferedMs?: number;
+	maxChunkChars?: number;
 	_internal?: {
 		now?: () => number;
 		sleep?: (ms: number) => Promise<void>;
@@ -136,8 +137,20 @@ async function* endpointStreamToIterator(
 
 		const { messageUpdates, remainingText } = parseMessageUpdates(prevChunk + value);
 		prevChunk = remainingText;
-		for (const messageUpdate of messageUpdates) yield messageUpdate;
+		for (const messageUpdate of messageUpdates) {
+			const normalized = normalizeStreamUpdate(messageUpdate);
+			if (normalized) yield normalized;
+		}
 	}
+}
+
+function normalizeStreamUpdate(update: MessageUpdate): MessageUpdate | null {
+	if (update.type !== MessageUpdateType.Stream) return update;
+
+	const token = update.token.replaceAll("\0", "");
+	if (!token) return null;
+
+	return token === update.token ? update : { ...update, token };
 }
 
 function parseMessageUpdates(value: string): {
@@ -169,28 +182,56 @@ export async function* smoothStreamUpdates(
 		maxDelayMs = 80,
 		minRateCharsPerMs = 0.3,
 		maxBufferedMs = 400,
-		_internal: { now = () => performance.now(), sleep = defaultSleep, detectChunk } = {},
+		maxChunkChars = 80,
+		_internal: {
+			now = () => globalThis.performance?.now?.() ?? Date.now(),
+			sleep = defaultSleep,
+			detectChunk,
+		} = {},
 	}: SmoothStreamConfig = {}
 ): AsyncGenerator<MessageUpdate> {
 	const chunkDetector = detectChunk ?? createWordChunkDetector();
-	const eventTarget = new EventTarget();
-	const outputQueue: Array<{ update: MessageUpdate }> = [];
+	const chunkCharLimit = Math.max(1, maxChunkChars);
+	const outputQueue: MessageUpdate[] = [];
 	let producerDone = false;
 	let producerError: unknown = null;
 	let pendingBuffer = "";
 	let queuedStreamChars = 0;
+	let queuedControlUpdates = 0;
+	let wakeConsumer: (() => void) | undefined;
+
+	const wake = () => {
+		wakeConsumer?.();
+		wakeConsumer = undefined;
+	};
+
+	const waitForQueue = () =>
+		new Promise<void>((resolve) => {
+			wakeConsumer = resolve;
+		});
 
 	const enqueue = (update: MessageUpdate) => {
 		if (update.type === MessageUpdateType.Stream) {
 			queuedStreamChars += update.token.length;
+		} else {
+			queuedControlUpdates += 1;
 		}
-		outputQueue.push({ update });
-		eventTarget.dispatchEvent(new Event("next"));
+		outputQueue.push(update);
+		wake();
 	};
 
 	const flushPendingBuffer = () => {
 		if (pendingBuffer.length === 0) return;
-		enqueue({ type: MessageUpdateType.Stream, token: pendingBuffer });
+
+		while (countCodePoints(pendingBuffer) > chunkCharLimit) {
+			const chunk = takePrefixByCodePoints(pendingBuffer, chunkCharLimit);
+			enqueue({ type: MessageUpdateType.Stream, token: chunk });
+			pendingBuffer = pendingBuffer.slice(chunk.length);
+		}
+
+		if (pendingBuffer.length > 0) {
+			enqueue({ type: MessageUpdateType.Stream, token: pendingBuffer });
+		}
 		pendingBuffer = "";
 	};
 
@@ -202,11 +243,12 @@ export async function* smoothStreamUpdates(
 				continue;
 			}
 
-			if (!messageUpdate.token) continue;
+			const token = messageUpdate.token.replaceAll("\0", "");
+			if (!token) continue;
 
-			pendingBuffer += messageUpdate.token;
+			pendingBuffer += token;
 			let chunk: string | null;
-			while ((chunk = chunkDetector(pendingBuffer)) !== null) {
+			while ((chunk = takeNextStreamChunk(pendingBuffer, chunkDetector, chunkCharLimit)) !== null) {
 				if (chunk.length === 0) break;
 				enqueue({ type: MessageUpdateType.Stream, token: chunk });
 				pendingBuffer = pendingBuffer.slice(chunk.length);
@@ -215,53 +257,92 @@ export async function* smoothStreamUpdates(
 		flushPendingBuffer();
 	})()
 		.catch((error) => {
+			flushPendingBuffer();
 			producerError = error;
 		})
 		.finally(() => {
 			producerDone = true;
-			eventTarget.dispatchEvent(new Event("next"));
+			wake();
 		});
 
 	// Character-rate targeting consumer
 	let totalCharsEmitted = 0;
 	let firstEmitAt: number | null = null;
+	let emittedStreamChunk = false;
 
 	while (!producerDone || outputQueue.length > 0) {
 		if (outputQueue.length === 0) {
-			await waitForEvent(eventTarget, "next");
+			await waitForQueue();
 			continue;
 		}
 
-		const next = outputQueue.shift();
-		if (!next) continue;
+		const update = outputQueue.shift();
+		if (!update) continue;
+		if (update.type !== MessageUpdateType.Stream) {
+			queuedControlUpdates = Math.max(0, queuedControlUpdates - 1);
+		}
 
-		if (next.update.type === MessageUpdateType.Stream) {
-			const tokenLen = next.update.token.length;
+		if (update.type === MessageUpdateType.Stream) {
+			const tokenLen = update.token.length;
 			queuedStreamChars = Math.max(0, queuedStreamChars - tokenLen);
-			totalCharsEmitted += tokenLen;
 
 			if (firstEmitAt === null) firstEmitAt = now();
 
-			const elapsedMs = now() - firstEmitAt;
-			const currentRate = elapsedMs > 0 ? totalCharsEmitted / elapsedMs : 0;
-			const backlogChars = tokenLen + queuedStreamChars;
-			const backlogRate = maxBufferedMs > 0 ? backlogChars / maxBufferedMs : 0;
-			const targetRate = Math.max(currentRate, minRateCharsPerMs, backlogRate);
-			const rawDelay = tokenLen / targetRate;
-			const underBacklogPressure = backlogRate > minRateCharsPerMs;
-			const effectiveMinDelayMs = underBacklogPressure ? 0 : minDelayMs;
-			const delayMs = Math.round(Math.max(effectiveMinDelayMs, Math.min(maxDelayMs, rawDelay)));
+			if (emittedStreamChunk && queuedControlUpdates === 0) {
+				const elapsedMs = now() - firstEmitAt;
+				const currentRate = elapsedMs > 0 ? totalCharsEmitted / elapsedMs : 0;
+				const backlogChars = tokenLen + queuedStreamChars;
+				const backlogRate = maxBufferedMs > 0 ? backlogChars / maxBufferedMs : 0;
+				const targetRate = Math.max(currentRate, minRateCharsPerMs, backlogRate);
+				const rawDelay = tokenLen / targetRate;
+				const underBacklogPressure = backlogRate > minRateCharsPerMs;
+				const effectiveMinDelayMs = underBacklogPressure ? 0 : minDelayMs;
+				const delayMs = Math.round(Math.max(effectiveMinDelayMs, Math.min(maxDelayMs, rawDelay)));
 
-			if (delayMs > 0) {
-				await sleep(delayMs);
+				if (delayMs > 0) {
+					await sleep(delayMs);
+				}
 			}
+
+			emittedStreamChunk = true;
+			totalCharsEmitted += tokenLen;
 		}
 
-		yield next.update;
+		yield update;
 	}
 
 	await producer;
 	if (producerError) throw producerError;
+}
+
+function takeNextStreamChunk(
+	buffer: string,
+	chunkDetector: ChunkDetector,
+	maxChunkChars: number
+): string | null {
+	const detectedChunk = chunkDetector(buffer);
+	if (detectedChunk) {
+		if (countCodePoints(detectedChunk) <= maxChunkChars) return detectedChunk;
+		return takePrefixByCodePoints(detectedChunk, maxChunkChars);
+	}
+
+	if (countCodePoints(buffer) < maxChunkChars) return null;
+	return takePrefixByCodePoints(buffer, maxChunkChars);
+}
+
+function countCodePoints(value: string): number {
+	return Array.from(value).length;
+}
+
+function takePrefixByCodePoints(value: string, maxChars: number): string {
+	let end = 0;
+	let count = 0;
+	for (const char of value) {
+		end += char.length;
+		count += 1;
+		if (count >= maxChars) break;
+	}
+	return value.slice(0, end);
 }
 
 function createWordChunkDetector(): ChunkDetector {
@@ -319,7 +400,3 @@ export const isMessageToolProgressUpdate = (
 
 const defaultSleep = (ms: number): Promise<void> =>
 	new Promise((resolve) => setTimeout(resolve, ms));
-const waitForEvent = (eventTarget: EventTarget, eventName: string) =>
-	new Promise<boolean>((resolve) =>
-		eventTarget.addEventListener(eventName, () => resolve(true), { once: true })
-	);

--- a/src/routes/conversation/[id]/+page.svelte
+++ b/src/routes/conversation/[id]/+page.svelte
@@ -294,12 +294,6 @@
 					return;
 				}
 
-				// Remove null characters added due to remote keylogging prevention
-				// See server code for more details
-				if (update.type === MessageUpdateType.Stream) {
-					update.token = update.token.replaceAll("\0", "");
-				}
-
 				const isKeepAlive =
 					update.type === MessageUpdateType.Status &&
 					update.status === MessageUpdateStatus.KeepAlive;


### PR DESCRIPTION
## Summary

- Normalize stream transport padding before raw or smooth stream handling.
- Improve smooth streaming so long unbroken output is chunked, partial buffered text is flushed on source errors, and control updates can catch up to queued stream text.
- Simplify the conversation page by removing duplicate stream-token padding cleanup.

## Why

The existing smooth stream flow stripped server padding only after the smoother had already seen the tokens. That could make artificial padding affect chunk detection and pacing. The smoother also waited behind cosmetic delays even when tool/status/final updates were queued.

## Impact

Smooth streaming should feel more consistent across provider chunk shapes, avoid stalls on long unbroken text, and surface control updates without unnecessary delay. Raw mode still keeps provider-native stream chunking, now with transport padding normalized at the iterator boundary.

## Validation

- `npm test -- --run src/lib/utils/messageUpdates.spec.ts`
- `npm run check` (0 errors; existing `ChatMessage.svelte:274` a11y warning remains)
- `npx prettier --check src/lib/utils/messageUpdates.ts src/lib/utils/messageUpdates.spec.ts 'src/routes/conversation/[id]/+page.svelte'`