### PR TITLE
Cap code block height while streaming, auto-scroll to bottom

### DIFF
--- a/src/lib/components/CodeBlock.svelte
+++ b/src/lib/components/CodeBlock.svelte
@@ -14,6 +14,10 @@
 	let { code = "", rawCode = "", loading = false }: Props = $props();
 
 	let previewOpen = $state(false);
+	let preEl = $state<HTMLPreElement | null>(null);
+	// Pause auto-scroll once the user scrolls up to read earlier lines, so we
+	// don't fight them while tokens keep streaming in.
+	let userScrolled = $state(false);
 
 	function hasStrictHtml5Doctype(input: string): boolean {
 		if (!input) return false;
@@ -29,6 +33,20 @@
 	}
 
 	let showPreview = $derived(hasStrictHtml5Doctype(rawCode) || isSvgDocument(rawCode));
+
+	function handleScroll() {
+		if (!preEl) return;
+		const distanceFromBottom = preEl.scrollHeight - preEl.scrollTop - preEl.clientHeight;
+		userScrolled = distanceFromBottom > 10;
+	}
+
+	$effect(() => {
+		// Re-run on every streamed chunk by reading code.
+		code;
+		if (loading && preEl && !userScrolled) {
+			preEl.scrollTop = preEl.scrollHeight;
+		}
+	});
 </script>
 
 <div class="group relative my-4 rounded-lg">
@@ -63,7 +81,11 @@
 			/>
 		</div>
 	</div>
-	<pre class="scrollbar-custom overflow-auto px-5 font-mono transition-[height]"><code
+	<pre
+		bind:this={preEl}
+		onscroll={handleScroll}
+		class="scrollbar-custom overflow-auto px-5 font-mono transition-[height]"
+		class:max-h-96={loading}><code
 			><!-- eslint-disable svelte/no-at-html-tags -->{@html DOMPurify.sanitize(code)}</code
 		></pre>
 


### PR DESCRIPTION
## Summary

- Long code blocks pushed everything else off-screen during generation. Cap the `<pre>` to `max-h-96` while the block is streaming, and drop the cap as soon as the closing ``` arrives so the full code becomes visible.
- Auto-scroll the pre to the bottom on each streamed chunk so the freshest tokens stay in view, mirroring the streaming feel of the thinking block.
- Pause auto-scroll if the user scrolls up inside the pre to read earlier lines — we don't fight them while tokens keep streaming.

## Test plan

- [ ] Trigger a response with a long code block; while it streams, the `<pre>` is capped and the latest tokens stay visible.
- [ ] Scroll up inside the pre mid-generation; auto-scroll pauses. Scroll back to bottom; it resumes.
- [ ] Once the block closes (mid-message or end-of-message), the cap drops and the full code is visible.
- [ ] Plain (non-streaming) messages render code blocks at full height as before.