### PR TITLE
Add Command A+ and Gemma-4 models to dev and prod environments

### DIFF
--- a/chart/env/dev.yaml
+++ b/chart/env/dev.yaml
@@ -79,6 +79,10 @@ envVars:
   PUBLIC_LLM_ROUTER_ALIAS_ID: "omni"
   MODELS: >
     [
+      { "id": "CohereLabs/command-a-plus-05-2026-bf16", "description": "218B Command A+ MoE with 25B active, multimodal, 128K context, 48 languages." },
+      { "id": "CohereLabs/command-a-plus-05-2026-fp8", "description": "FP8 Command A+ for efficient multimodal inference with tool use and long context." },
+      { "id": "CohereLabs/command-a-plus-05-2026-w4a4", "description": "W4A4 Command A+ for ultra-efficient agent deployment with multimodal and tool use." },
+      { "id": "pearl-ai/Gemma-4-31B-it-pearl", "description": "Community Gemma-4-31B variant integrated with Pearl mining for chain-validated inference." },
       { "id": "inclusionAI/Ling-2.6-1T", "description": "1T MoE with 50B active params, hybrid MLA-Linear attention, and fast thinking." },
       { "id": "deepseek-ai/DeepSeek-V4-Pro", "description": "Frontier 1.6T MoE with 49B active params, hybrid attention, and 1M context.", "supportsReasoning": true },
       { "id": "deepseek-ai/DeepSeek-V4-Flash", "description": "Compact 284B MoE with 13B active params, hybrid attention, and 1M context." },

--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -89,6 +89,10 @@ envVars:
   PUBLIC_LLM_ROUTER_ALIAS_ID: "omni"
   MODELS: >
     [
+      { "id": "CohereLabs/command-a-plus-05-2026-bf16", "description": "218B Command A+ MoE with 25B active, multimodal, 128K context, 48 languages." },
+      { "id": "CohereLabs/command-a-plus-05-2026-fp8", "description": "FP8 Command A+ for efficient multimodal inference with tool use and long context." },
+      { "id": "CohereLabs/command-a-plus-05-2026-w4a4", "description": "W4A4 Command A+ for ultra-efficient agent deployment with multimodal and tool use." },
+      { "id": "pearl-ai/Gemma-4-31B-it-pearl", "description": "Community Gemma-4-31B variant integrated with Pearl mining for chain-validated inference." },
       { "id": "inclusionAI/Ling-2.6-1T", "description": "1T MoE with 50B active params, hybrid MLA-Linear attention, and fast thinking." },
       { "id": "deepseek-ai/DeepSeek-V4-Pro", "description": "Frontier 1.6T MoE with 49B active params, hybrid attention, and 1M context.", "supportsReasoning": true },
       { "id": "deepseek-ai/DeepSeek-V4-Flash", "description": "Compact 284B MoE with 13B active params, hybrid attention, and 1M context." },


### PR DESCRIPTION
## Summary
Adds four new LLM models to both development and production environments: three variants of Cohere's Command A+ model and a community Gemma-4 variant with Pearl mining integration.

## Changes
- Added `CohereLabs/command-a-plus-05-2026-bf16`: 218B Command A+ MoE with 25B active parameters, multimodal support, 128K context window, and 48 language support
- Added `CohereLabs/command-a-plus-05-2026-fp8`: FP8-quantized Command A+ optimized for efficient multimodal inference with tool use and long context
- Added `CohereLabs/command-a-plus-05-2026-w4a4`: W4A4-quantized Command A+ for ultra-efficient agent deployment with multimodal and tool use capabilities
- Added `pearl-ai/Gemma-4-31B-it-pearl`: Community Gemma-4-31B variant with Pearl mining integration for chain-validated inference
- Updated both `chart/env/dev.yaml` and `chart/env/prod.yaml` to maintain consistency across environments

## Implementation Details
Models are added to the `MODELS` environment variable configuration in the Helm chart values, positioned before the existing `inclusionAI/Ling-2.6-1T` model. Each model includes an `id` and descriptive text explaining its capabilities and optimizations.

https://claude.ai/code/session_0181Lf1ovHnH2sjSEHwDwqDj