### PR TITLE
hotfix(chart): restore LLM_ROUTER_ARCH_BASE_URL tombstone to fix Omni during rollout

### DIFF
--- a/chart/env/dev.yaml
+++ b/chart/env/dev.yaml
@@ -61,6 +61,10 @@ envVars:
   PUBLIC_PLAUSIBLE_SCRIPT_URL: "https://plausible.io/js/pa-Io_oigECawqdlgpf5qvHb.js"
 
   TASK_MODEL: "meta-llama/Llama-3.1-8B-Instruct"
+  # Tombstone: unread by current code, kept so any old pod still on the pre-#2265
+  # image (which gated Omni on LLM_ROUTER_ARCH_BASE_URL) keeps registering the alias
+  # during rollout. Safe to remove once every replica is on the new image.
+  LLM_ROUTER_ARCH_BASE_URL: "https://router.huggingface.co/v1"
   LLM_ROUTER_ROUTES_PATH: "build/client/chat/huggingchat/routes.chat.json"
   LLM_ROUTER_ENABLE_MULTIMODAL: "true"
   LLM_ROUTER_MULTIMODAL_MODEL: "moonshotai/Kimi-K2.6"

--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -71,6 +71,10 @@ envVars:
   PUBLIC_PLAUSIBLE_SCRIPT_URL: "https://plausible.io/js/pa-Io_oigECawqdlgpf5qvHb.js"
 
   TASK_MODEL: "meta-llama/Llama-3.1-8B-Instruct"
+  # Tombstone: unread by current code, kept so any old pod still on the pre-#2265
+  # image (which gated Omni on LLM_ROUTER_ARCH_BASE_URL) keeps registering the alias
+  # during rollout. Safe to remove once every replica is on the new image.
+  LLM_ROUTER_ARCH_BASE_URL: "https://router.huggingface.co/v1"
   LLM_ROUTER_ROUTES_PATH: "build/client/chat/huggingchat/routes.chat.json"
   LLM_ROUTER_ENABLE_MULTIMODAL: "true"
   LLM_ROUTER_MULTIMODAL_MODEL: "moonshotai/Kimi-K2.6"


### PR DESCRIPTION
## Summary

After #2265 merged, Omni disappeared from the HuggingChat model list. The likely cause is a deploy-ordering issue: the ConfigMap (chart yaml) rolled out before every replica picked up the new image. The pre-#2265 code gated the Omni alias on \`LLM_ROUTER_ARCH_BASE_URL\` (see \`src/lib/server/models.ts\` on the pre-merge SHA), so stripping that env var in #2265 left any still-running old pod without the alias.

This hotfix re-adds \`LLM_ROUTER_ARCH_BASE_URL\` in \`chart/env/{dev,prod}.yaml\` as a tombstone:

- New code (current main) doesn't read it.
- Old code reads it as the gate and registers Omni.

Safe to remove again once every replica is confirmed on the new image (next deploy cycle).

## Test plan

- [ ] Roll out → verify Omni reappears at the top of the HuggingChat model picker
- [ ] After full rollout, confirm new pods still show Omni (sanity check that new code's \`LLM_ROUTER_ROUTES_PATH\` gate works)