### PR TITLE
fix: use npm ci in lint workflow

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -19,7 +19,7 @@ jobs:
           node-version: "20"
           cache: "npm"
       - run: |
-          npm install ci
+          npm ci
       - name: "Checking lint/format errors"
         run: |
           npm run lint


### PR DESCRIPTION
## Summary

Replace `npm install ci` with `npm ci` in the lint job of `.github/workflows/lint-and-test.yml`.

Closes #2282.

## Why

The current lint workflow step uses `npm install ci`, which is not the clean lockfile-based install intended for CI. The test job in the same workflow already uses `npm ci`.

## Impact

This keeps the lint job aligned with the lockfile and with the existing test job setup.

## Validation

- Reviewed the workflow diff
- Confirmed the change is limited to the lint workflow command