### PR TITLE
fix: don't treat touch-screen laptops as virtual-keyboard devices

### DIFF
--- a/src/lib/utils/isVirtualKeyboard.spec.ts
+++ b/src/lib/utils/isVirtualKeyboard.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { detectVirtualKeyboard } from "./isVirtualKeyboard";
+
+const DESKTOP_UA =
+	"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36";
+const IPHONE_UA =
+	"Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Mobile/15E148 Safari/604.1";
+
+describe("detectVirtualKeyboard", () => {
+	it("returns true for a device with a coarse primary pointer (phone/tablet)", () => {
+		expect(detectVirtualKeyboard({ hasCoarsePrimaryPointer: true, userAgent: IPHONE_UA })).toBe(
+			true
+		);
+	});
+
+	it("returns false for a touch-screen laptop (fine primary pointer, desktop UA)", () => {
+		expect(detectVirtualKeyboard({ hasCoarsePrimaryPointer: false, userAgent: DESKTOP_UA })).toBe(
+			false
+		);
+	});
+
+	it("returns false for a regular desktop without touch", () => {
+		expect(detectVirtualKeyboard({ hasCoarsePrimaryPointer: false, userAgent: DESKTOP_UA })).toBe(
+			false
+		);
+	});
+
+	it("falls back to the user agent when no coarse pointer is reported", () => {
+		const oldAndroidUA =
+			"Mozilla/5.0 (Linux; Android 4.4.2) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0 Mobile Safari/537.36";
+		expect(detectVirtualKeyboard({ hasCoarsePrimaryPointer: false, userAgent: oldAndroidUA })).toBe(
+			true
+		);
+	});
+});

--- a/src/lib/utils/isVirtualKeyboard.ts
+++ b/src/lib/utils/isVirtualKeyboard.ts
@@ -1,16 +1,33 @@
 import { browser } from "$app/environment";
 
+/**
+ * Pure heuristic deciding whether a device relies on an on-screen (virtual)
+ * keyboard, based on the relevant device signals. Extracted from
+ * {@link isVirtualKeyboard} so it can be unit-tested without browser globals.
+ *
+ * Devices that pop up an on-screen keyboard (phones, tablets) expose a coarse
+ * primary pointer. Touch-screen laptops report touch capability too, but their
+ * primary pointer is a mouse/trackpad (fine), so they must NOT be treated as
+ * virtual-keyboard devices — otherwise Enter-to-send and related behaviour
+ * break on those machines.
+ */
+export function detectVirtualKeyboard(opts: {
+	hasCoarsePrimaryPointer: boolean;
+	userAgent: string;
+}): boolean {
+	if (opts.hasCoarsePrimaryPointer) return true;
+
+	// Fallback to user agent string check for browsers without pointer media queries.
+	return /android|webos|iphone|ipad|ipod|blackberry|iemobile|opera mini/i.test(
+		opts.userAgent.toLowerCase()
+	);
+}
+
 export function isVirtualKeyboard(): boolean {
 	if (!browser) return false;
 
-	// Check for touch capability
-	if (navigator.maxTouchPoints > 0 && screen.width <= 768) return true;
-
-	// Check for touch events
-	if ("ontouchstart" in window) return true;
-
-	// Fallback to user agent string check
-	const userAgent = navigator.userAgent.toLowerCase();
-
-	return /android|webos|iphone|ipad|ipod|blackberry|iemobile|opera mini/i.test(userAgent);
+	return detectVirtualKeyboard({
+		hasCoarsePrimaryPointer: window.matchMedia?.("(pointer: coarse)").matches ?? false,
+		userAgent: navigator.userAgent,
+	});
 }


### PR DESCRIPTION
## Problem

`isVirtualKeyboard()` returned `true` whenever `"ontouchstart" in window` was truthy. That check is satisfied by **touch-screen laptops** (Windows touch laptops, Chromebooks, etc.), not just phones and tablets. As a result those machines were given the mobile UI behaviour, which most visibly **breaks Enter-to-send** (the keydown handler in `ChatInput.svelte` bails out when `isVirtualKeyboard()` is true) and changes focus/spacing handling in `ChatWindow.svelte`.

Closes #1767.

## Fix

Detect on-screen-keyboard devices via the **coarse primary pointer** media query (`(pointer: coarse)`) instead of mere touch capability:

- Phones / tablets report a coarse primary pointer → still treated as virtual-keyboard devices.
- Touch-screen laptops keep a **fine** primary pointer (mouse/trackpad) → no longer misclassified, so Enter-to-send works again.
- The existing user-agent regex is kept as a fallback for browsers without pointer media-query support.

The decision logic is extracted into a pure `detectVirtualKeyboard()` helper that takes the device signals as input, so it can be unit-tested without browser globals. `isVirtualKeyboard()` remains the thin browser wrapper and its public signature is unchanged.

## Testing

- Added `src/lib/utils/isVirtualKeyboard.spec.ts` covering phone (coarse pointer), touch-screen laptop (fine pointer + desktop UA), plain desktop, and the user-agent fallback path.
- `npm run test` (server workspace) passes.
- `npm run lint` and `npm run check` pass with no new errors.