### PR TITLE
docs: document REASONING_SUMMARY env flag

### DIFF
--- a/.env
+++ b/.env
@@ -48,6 +48,14 @@ MODELS=
 # to use for internal tasks (title summarization, etc). If not set, the current model will be used
 TASK_MODEL=
 
+## Reasoning
+# Reasoning-capable models stream their chain-of-thought. Set to "true" to also
+# generate short, periodic natural-language summaries of that reasoning, shown as
+# status updates while the model thinks. This issues additional LLM calls (using
+# TASK_MODEL if set, otherwise the conversation model), so it is disabled by
+# default. Leave empty/unset to disable.
+REASONING_SUMMARY=
+
 ## LLM Router Configuration
 # Path to routes policy (JSON array). Required when the router is enabled; must point to a valid JSON file.
 # The router uses heuristic-based selection to pick the best model for each request.

--- a/docs/source/configuration/overview.md
+++ b/docs/source/configuration/overview.md
@@ -55,6 +55,16 @@ TASK_MODEL=meta-llama/Llama-3.1-8B-Instruct
 
 If not set, the current conversation model is used.
 
+## Reasoning
+
+Reasoning-capable models stream their chain-of-thought. To also generate short, periodic natural-language summaries of that reasoning (shown as status updates while the model thinks), enable:
+
+```ini
+REASONING_SUMMARY=true
+```
+
+This issues additional LLM calls (using `TASK_MODEL` if set, otherwise the conversation model), so it is **disabled by default**. Leave it unset or empty to keep reasoning summaries off.
+
 ## Voice Transcription
 
 Enable voice input with Whisper:


### PR DESCRIPTION
## Problem

Issue #1720 asks for a way to disable the reasoning-summary feature (e.g. to avoid the extra rate-limited LLM calls it makes).

That control **already exists**: in `src/lib/server/textGeneration/generate.ts`, the periodic reasoning summary is only generated when `REASONING_SUMMARY === "true"`, so it is **off by default**. The problem is purely discoverability — `REASONING_SUMMARY` is read via `Reflect.get(config, "REASONING_SUMMARY")` and is **not documented** in `.env` or the configuration docs, so users have no way to know it exists or that it can be left disabled.

Closes #1720.

## Changes

- **`.env`**: add a new `## Reasoning` section documenting `REASONING_SUMMARY`, noting it is opt-in and issues additional LLM calls when enabled.
- **`docs/source/configuration/overview.md`**: add a `## Reasoning` section describing the flag.

No behaviour change — this documents the existing flag and makes it clear it can be left unset/empty to keep reasoning summaries off.

## Testing

- `npx prettier --check` passes on both changed files.