### PR TITLE
Add four new LLM models to dev and prod environments

### DIFF
--- a/chart/env/dev.yaml
+++ b/chart/env/dev.yaml
@@ -79,6 +79,10 @@ envVars:
   PUBLIC_LLM_ROUTER_ALIAS_ID: "omni"
   MODELS: >
     [
+      { "id": "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4", "description": "Hybrid Mamba-Transformer 550B MoE with 55B active params for efficient agentic reasoning.", "supportsReasoning": true },
+      { "id": "Qwen/Qwen3.6-27B", "description": "Dense 27B hybrid with DeltaNet attention and 1M context." },
+      { "id": "meta-llama/Llama-4-Scout-17B-16E-Instruct", "description": "Native multimodal 17B MoE with 16 experts and very long context." },
+      { "id": "CohereLabs/c4ai-command-r7b-12-2024", "description": "Compact 7B Command R for multilingual RAG, tool use, and agents." },
       { "id": "pearl-ai/Gemma-4-31B-it-pearl", "description": "Community Gemma-4-31B variant integrated with Pearl mining for chain-validated inference." },
       { "id": "inclusionAI/Ling-2.6-1T", "description": "1T MoE with 50B active params, hybrid MLA-Linear attention, and fast thinking." },
       { "id": "deepseek-ai/DeepSeek-V4-Pro", "description": "Frontier 1.6T MoE with 49B active params, hybrid attention, and 1M context.", "parameters": { "max_tokens": 49152 }, "supportsReasoning": true },

--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -89,6 +89,10 @@ envVars:
   PUBLIC_LLM_ROUTER_ALIAS_ID: "omni"
   MODELS: >
     [
+      { "id": "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4", "description": "Hybrid Mamba-Transformer 550B MoE with 55B active params for efficient agentic reasoning.", "supportsReasoning": true },
+      { "id": "Qwen/Qwen3.6-27B", "description": "Dense 27B hybrid with DeltaNet attention and 1M context." },
+      { "id": "meta-llama/Llama-4-Scout-17B-16E-Instruct", "description": "Native multimodal 17B MoE with 16 experts and very long context." },
+      { "id": "CohereLabs/c4ai-command-r7b-12-2024", "description": "Compact 7B Command R for multilingual RAG, tool use, and agents." },
       { "id": "pearl-ai/Gemma-4-31B-it-pearl", "description": "Community Gemma-4-31B variant integrated with Pearl mining for chain-validated inference." },
       { "id": "inclusionAI/Ling-2.6-1T", "description": "1T MoE with 50B active params, hybrid MLA-Linear attention, and fast thinking." },
       { "id": "deepseek-ai/DeepSeek-V4-Pro", "description": "Frontier 1.6T MoE with 49B active params, hybrid attention, and 1M context.", "parameters": { "max_tokens": 49152 }, "supportsReasoning": true },


### PR DESCRIPTION
## Summary
Added four new language models to the available model roster in both development and production environments. These models expand the range of capabilities available to users, including reasoning-capable models, multimodal options, and specialized variants.

## Changes
- Added NVIDIA Nemotron-3-Ultra-550B-A55B-NVFP4: A 550B hybrid Mamba-Transformer MoE model with 55B active parameters, marked as supporting reasoning
- Added Qwen/Qwen3.6-27B: A dense 27B hybrid model with DeltaNet attention and 1M context window
- Added meta-llama/Llama-4-Scout-17B-16E-Instruct: A native multimodal 17B MoE model with 16 experts and extended context
- Added CohereLabs/c4ai-command-r7b-12-2024: A compact 7B Command R model optimized for multilingual RAG, tool use, and agentic tasks

All four models were added to the `MODELS` configuration in both `chart/env/dev.yaml` and `chart/env/prod.yaml`, positioned before the existing Gemma-4-31B model in the list.

## Implementation Details
- The new models are inserted at the beginning of the models array to prioritize them in the model selection order
- One model (NVIDIA Nemotron) includes the `supportsReasoning: true` flag to indicate advanced reasoning capabilities
- All models include descriptive text highlighting their key architectural features and use cases

https://claude.ai/code/session_01KAGFGxpsNpgLUZB8AySB3t