### PR TITLE
fix(chat/effort): drive caret icon by dropdown state

### DIFF
--- a/src/lib/components/chat/ThinkingEffortChip.svelte
+++ b/src/lib/components/chat/ThinkingEffortChip.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { DropdownMenu } from "bits-ui";
 	import CarbonCaretDown from "~icons/carbon/caret-down";
+	import CarbonCaretUp from "~icons/carbon/caret-up";
 	import LucideCheck from "~icons/lucide/check";
 	import { useSettingsStore } from "$lib/stores/settings";
 	import type { ReasoningEffort } from "$lib/types/Settings";
@@ -15,6 +16,8 @@
 
 	let current = $derived($settings.reasoningEffortOverrides?.[modelId]);
 	let label = $derived(current ? capitalize(current) : "Default");
+
+	let isDropdownOpen = $state(false);
 
 	function capitalize(s: string) {
 		return s.charAt(0).toUpperCase() + s.slice(1);
@@ -40,14 +43,18 @@
 	];
 </script>
 
-<DropdownMenu.Root>
+<DropdownMenu.Root bind:open={isDropdownOpen}>
 	<DropdownMenu.Trigger
 		class="inline-flex items-center gap-1 hover:underline"
 		aria-label="Select thinking effort"
 		title="Thinking effort"
 	>
 		Effort: {label}
-		<CarbonCaretDown class="-ml-0.5 text-xxs" />
+		{#if isDropdownOpen}
+			<CarbonCaretUp class="-ml-0.5 text-xxs" />
+		{:else}
+			<CarbonCaretDown class="-ml-0.5 text-xxs" />
+		{/if}
 	</DropdownMenu.Trigger>
 	<DropdownMenu.Portal>
 		<DropdownMenu.Content


### PR DESCRIPTION
## Problem
The current chat window is reliant on CarbonCaretDown, which may not be the most suitable depending on context.

In particular:
- the caret next to the model display name is slightly misleading, given that it opens the settings modal
- the caret used in ThinkingEffortChip could change depending on whether the dropdown menu is open

## Solution
Replace CarbonCaretDown with more suitable icons
- ~use a gear icon next to the model display name so it is clearer that tapping would bring up the settings modal~ submitted separately as #2300, using `lucide/settings-2`
- listen to thinking effort dropdown menu state, and use that to determine whether caret down (closed) or caret up (open) should be displayed

### Screenshots
#### Before
<img alt="before" src="https://github.com/user-attachments/assets/4c1c541f-9d1f-4a95-9193-e85f501ffbce" />

#### After
<img alt="after" src="https://github.com/user-attachments/assets/39fa2cbc-5e69-4255-9901-18b5445d0cca" />
