### PR TITLE
Called N tools summary (variant): flat blocks while streaming, nest on final answer

### DIFF
--- a/src/lib/components/chat/ChatMessage.svelte
+++ b/src/lib/components/chat/ChatMessage.svelte
@@ -21,6 +21,7 @@
 	import { PROVIDERS_HUB_ORGS } from "@huggingface/inference";
 	import { requireAuthUser } from "$lib/utils/auth";
 	import ToolUpdate from "./ToolUpdate.svelte";
+	import ToolCallsSummary from "./ToolCallsSummary.svelte";
 	import { isMessageToolUpdate } from "$lib/utils/messageUpdates";
 	import { MessageUpdateType, type MessageToolUpdate } from "$lib/types/MessageUpdate";
 	import ImageLightbox from "./ImageLightbox.svelte";
@@ -130,7 +131,6 @@
 
 	// Zero-config reasoning autodetection: detect <think> blocks in content
 	const THINK_BLOCK_REGEX = /(<think>[\s\S]*?(?:<\/think>|$))/gi;
-	let hasClientThink = $derived(message.content.split(THINK_BLOCK_REGEX).length > 1);
 
 	// Strip think blocks for clipboard copy (always, regardless of detection)
 	let contentWithoutThink = $derived.by(() =>
@@ -139,9 +139,37 @@
 
 	type Block =
 		| { type: "text"; content: string }
+		| { type: "think"; content: string; closed: boolean }
 		| { type: "tool"; uuid: string; updates: MessageToolUpdate[] };
 
 	type ToolBlock = Extract<Block, { type: "tool" }>;
+	type ProcessBlock = Extract<Block, { type: "think" } | { type: "tool" }>;
+
+	type RenderUnit =
+		| { kind: "text"; content: string }
+		| { kind: "group"; blocks: ProcessBlock[]; toolCount: number };
+
+	// Expand any text block containing <think>…</think> into dedicated think blocks
+	// so reasoning can be grouped/collapsed separately from the answer text.
+	function expandThinkBlocks(input: Block[]): Block[] {
+		const out: Block[] = [];
+		for (const block of input) {
+			if (block.type !== "text") {
+				out.push(block);
+				continue;
+			}
+			for (const part of block.content.split(THINK_BLOCK_REGEX)) {
+				if (!part) continue;
+				if (part.startsWith("<think>")) {
+					const closed = part.endsWith("</think>");
+					out.push({ type: "think", content: part.slice(7, closed ? -8 : undefined), closed });
+				} else if (part.trim().length > 0) {
+					out.push({ type: "text", content: part });
+				}
+			}
+		}
+		return out;
+	}
 
 	let blocks = $derived.by(() => {
 		const updates = message.updates ?? [];
@@ -152,8 +180,9 @@
 
 		// Fast path: no tool updates at all
 		if (!hasTools && updates.length === 0) {
-			if (message.content) return [{ type: "text" as const, content: message.content }];
-			return [];
+			return expandThinkBlocks(
+				message.content ? [{ type: "text" as const, content: message.content }] : []
+			);
 		}
 
 		for (const update of updates) {
@@ -219,7 +248,31 @@
 			res.push({ type: "text" as const, content: message.content });
 		}
 
-		return res;
+		return expandThinkBlocks(res);
+	});
+
+	// Coalesce consecutive process blocks (thinking + tools) into groups so they can
+	// collapse into a single "Called N tools" / "Thought" summary. Text passes through.
+	let renderUnits = $derived.by(() => {
+		const units: RenderUnit[] = [];
+		let current: ProcessBlock[] | null = null;
+		const flush = () => {
+			if (current && current.length) {
+				const toolCount = current.filter((b) => b.type === "tool").length;
+				units.push({ kind: "group", blocks: current, toolCount });
+			}
+			current = null;
+		};
+		for (const block of blocks) {
+			if (block.type === "think" || block.type === "tool") {
+				(current ??= []).push(block);
+			} else {
+				flush();
+				units.push({ kind: "text", content: block.content });
+			}
+		}
+		flush();
+		return units;
 	});
 
 	$effect(() => {
@@ -275,45 +328,44 @@
 				{#if isLast && loading && blocks.length === 0}
 					<IconLoading classNames="loading inline ml-2 first:ml-0" />
 				{/if}
-				{#each blocks as block, blockIndex (block.type === "tool" ? `${block.uuid}-${blockIndex}` : `text-${blockIndex}`)}
-					{#if block.type === "tool"}
+				{#each renderUnits as unit, unitIndex (unit.kind === "group" ? `group-${unitIndex}` : `text-${unitIndex}`)}
+					{#if unit.kind === "text"}
+						{#if isLast && loading && unit.content.length === 0}
+							<IconLoading classNames="loading inline ml-2 first:ml-0" />
+						{:else if unit.content.trim().length > 0}
+							<div
+								class="prose max-w-none dark:prose-invert prose-headings:font-semibold prose-h1:text-lg prose-h2:text-base prose-h3:text-base prose-pre:bg-gray-800 prose-img:my-0 prose-img:cursor-pointer prose-img:rounded-lg dark:prose-pre:bg-gray-900"
+							>
+								<MarkdownRenderer content={unit.content} loading={isLast && loading} />
+							</div>
+						{/if}
+					{:else if unit.kind === "group"}
+						{@const isActive = isLast && loading && unitIndex === renderUnits.length - 1}
 						<div
 							data-exclude-from-copy
 							class="has-[+.prose]:!mb-2 [&:not(:last-child)]:mb-1 [.prose+&]:mt-3"
 						>
-							<ToolUpdate tool={block.updates} {loading} />
-						</div>
-					{:else if block.type === "text"}
-						{#if isLast && loading && block.content.length === 0}
-							<IconLoading classNames="loading inline ml-2 first:ml-0" />
-						{/if}
-
-						{#if hasClientThink}
-							{@const parts = block.content.split(THINK_BLOCK_REGEX)}
-							{#each parts as part}
-								{#if part && part.startsWith("<think>")}
-									{@const isClosed = part.endsWith("</think>")}
-									{@const thinkContent = part.slice(7, isClosed ? -8 : undefined)}
-
-									<OpenReasoningResults
-										content={thinkContent}
-										loading={isLast && loading && !isClosed}
-									/>
-								{:else if part && part.trim().length > 0}
-									<div
-										class="prose max-w-none dark:prose-invert prose-headings:font-semibold prose-h1:text-lg prose-h2:text-base prose-h3:text-base prose-pre:bg-gray-800 prose-img:my-0 prose-img:cursor-pointer prose-img:rounded-lg dark:prose-pre:bg-gray-900"
-									>
-										<MarkdownRenderer content={part} loading={isLast && loading} />
-									</div>
+							{#if isActive}
+								<!-- Streaming: show only the current (last) block, not the previous calls -->
+								{@const active = unit.blocks[unit.blocks.length - 1]}
+								{#if active.type === "think"}
+									<OpenReasoningResults content={active.content} loading={!active.closed} />
+								{:else}
+									<ToolUpdate tool={active.updates} {loading} />
 								{/if}
-							{/each}
-						{:else if block.content.trim().length > 0}
-							<div
-								class="prose max-w-none dark:prose-invert prose-headings:font-semibold prose-h1:text-lg prose-h2:text-base prose-h3:text-base prose-pre:bg-gray-800 prose-img:my-0 prose-img:cursor-pointer prose-img:rounded-lg dark:prose-pre:bg-gray-900"
-							>
-								<MarkdownRenderer content={block.content} loading={isLast && loading} />
-							</div>
-						{/if}
+							{:else if unit.blocks.length > 1}
+								<!-- Done: collapse the whole run into a single summary -->
+								<ToolCallsSummary blocks={unit.blocks} toolCount={unit.toolCount} />
+							{:else}
+								<!-- Done: a lone process block stays standalone -->
+								{@const only = unit.blocks[0]}
+								{#if only.type === "think"}
+									<OpenReasoningResults content={only.content} loading={false} />
+								{:else}
+									<ToolUpdate tool={only.updates} loading={false} />
+								{/if}
+							{/if}
+						</div>
 					{/if}
 				{/each}
 			</div>

--- a/src/lib/components/chat/ChatMessage.svelte
+++ b/src/lib/components/chat/ChatMessage.svelte
@@ -171,6 +171,20 @@
 		return out;
 	}
 
+	// While the active group is streaming, show the current step: the latest
+	// thinking block plus every tool after it. This keeps a parallel batch of
+	// tools all visible at once, while still hiding earlier completed steps.
+	function currentStepBlocks(groupBlocks: ProcessBlock[]): ProcessBlock[] {
+		let start = 0;
+		for (let i = groupBlocks.length - 1; i >= 0; i -= 1) {
+			if (groupBlocks[i].type === "think") {
+				start = i;
+				break;
+			}
+		}
+		return groupBlocks.slice(start);
+	}
+
 	let blocks = $derived.by(() => {
 		const updates = message.updates ?? [];
 		const res: Block[] = [];
@@ -346,13 +360,15 @@
 							class="has-[+.prose]:!mb-2 [&:not(:last-child)]:mb-1 [.prose+&]:mt-3"
 						>
 							{#if isActive}
-								<!-- Streaming: show only the current (last) block, not the previous calls -->
-								{@const active = unit.blocks[unit.blocks.length - 1]}
-								{#if active.type === "think"}
-									<OpenReasoningResults content={active.content} loading={!active.closed} />
-								{:else}
-									<ToolUpdate tool={active.updates} {loading} />
-								{/if}
+								<!-- Streaming: show the current step (latest thinking + any parallel
+								     tools after it), not the previously-completed calls -->
+								{#each currentStepBlocks(unit.blocks) as block, i (block.type === "tool" ? `tool-${block.uuid}-${i}` : `think-${i}`)}
+									{#if block.type === "think"}
+										<OpenReasoningResults content={block.content} loading={!block.closed} />
+									{:else}
+										<ToolUpdate tool={block.updates} {loading} />
+									{/if}
+								{/each}
 							{:else if unit.blocks.length > 1}
 								<!-- Done: collapse the whole run into a single summary -->
 								<ToolCallsSummary blocks={unit.blocks} toolCount={unit.toolCount} />

--- a/src/lib/components/chat/ChatMessage.svelte
+++ b/src/lib/components/chat/ChatMessage.svelte
@@ -171,20 +171,6 @@
 		return out;
 	}
 
-	// While the active group is streaming, show the current step: the latest
-	// thinking block plus every tool after it. This keeps a parallel batch of
-	// tools all visible at once, while still hiding earlier completed steps.
-	function currentStepBlocks(groupBlocks: ProcessBlock[]): ProcessBlock[] {
-		let start = 0;
-		for (let i = groupBlocks.length - 1; i >= 0; i -= 1) {
-			if (groupBlocks[i].type === "think") {
-				start = i;
-				break;
-			}
-		}
-		return groupBlocks.slice(start);
-	}
-
 	let blocks = $derived.by(() => {
 		const updates = message.updates ?? [];
 		const res: Block[] = [];
@@ -289,6 +275,15 @@
 		return units;
 	});
 
+	// Still mid-process (thinking / calling tools, no answer yet) → render the
+	// blocks flat like today. Once the final answer starts streaming the last
+	// block becomes text, so this flips to false and the nested summary takes over.
+	let isProcessStreaming = $derived.by(() => {
+		if (!isLast || !loading) return false;
+		const last = blocks.at(-1);
+		return !!last && (last.type === "think" || last.type === "tool");
+	});
+
 	$effect(() => {
 		if (isCopied) {
 			setTimeout(() => {
@@ -342,48 +337,68 @@
 				{#if isLast && loading && blocks.length === 0}
 					<IconLoading classNames="loading inline ml-2 first:ml-0" />
 				{/if}
-				{#each renderUnits as unit, unitIndex (unit.kind === "group" ? `group-${unitIndex}` : `text-${unitIndex}`)}
-					{#if unit.kind === "text"}
-						{#if isLast && loading && unit.content.length === 0}
-							<IconLoading classNames="loading inline ml-2 first:ml-0" />
-						{:else if unit.content.trim().length > 0}
+				{#if isProcessStreaming}
+					<!-- Streaming the thinking / tool phase: render every block flat and
+					     inline, exactly like today. Nesting kicks in once the answer starts. -->
+					{#each blocks as block, blockIndex (block.type === "tool" ? `tool-${block.uuid}-${blockIndex}` : `block-${blockIndex}`)}
+						{#if block.type === "text"}
+							{#if block.content.trim().length > 0}
+								<div
+									class="prose max-w-none dark:prose-invert prose-headings:font-semibold prose-h1:text-lg prose-h2:text-base prose-h3:text-base prose-pre:bg-gray-800 prose-img:my-0 prose-img:cursor-pointer prose-img:rounded-lg dark:prose-pre:bg-gray-900"
+								>
+									<MarkdownRenderer content={block.content} loading={isLast && loading} />
+								</div>
+							{/if}
+						{:else}
 							<div
-								class="prose max-w-none dark:prose-invert prose-headings:font-semibold prose-h1:text-lg prose-h2:text-base prose-h3:text-base prose-pre:bg-gray-800 prose-img:my-0 prose-img:cursor-pointer prose-img:rounded-lg dark:prose-pre:bg-gray-900"
+								data-exclude-from-copy
+								class="has-[+.prose]:!mb-2 [&:not(:last-child)]:mb-1 [.prose+&]:mt-3"
 							>
-								<MarkdownRenderer content={unit.content} loading={isLast && loading} />
+								{#if block.type === "think"}
+									<OpenReasoningResults
+										content={block.content}
+										loading={isLast && loading && !block.closed}
+									/>
+								{:else}
+									<ToolUpdate tool={block.updates} {loading} />
+								{/if}
 							</div>
 						{/if}
-					{:else if unit.kind === "group"}
-						{@const isActive = isLast && loading && unitIndex === renderUnits.length - 1}
-						<div
-							data-exclude-from-copy
-							class="has-[+.prose]:!mb-2 [&:not(:last-child)]:mb-1 [.prose+&]:mt-3"
-						>
-							{#if isActive}
-								<!-- Streaming: show the current step (latest thinking + any parallel
-								     tools after it), not the previously-completed calls -->
-								{#each currentStepBlocks(unit.blocks) as block, i (block.type === "tool" ? `tool-${block.uuid}-${i}` : `think-${i}`)}
-									{#if block.type === "think"}
-										<OpenReasoningResults content={block.content} loading={!block.closed} />
-									{:else}
-										<ToolUpdate tool={block.updates} {loading} />
-									{/if}
-								{/each}
-							{:else if unit.blocks.length > 1}
-								<!-- Done: collapse the whole run into a single summary -->
-								<ToolCallsSummary blocks={unit.blocks} toolCount={unit.toolCount} />
-							{:else}
-								<!-- Done: a lone process block stays standalone -->
-								{@const only = unit.blocks[0]}
-								{#if only.type === "think"}
-									<OpenReasoningResults content={only.content} loading={false} />
-								{:else}
-									<ToolUpdate tool={only.updates} loading={false} />
-								{/if}
+					{/each}
+				{:else}
+					<!-- Answer started or generation finished: nest the process blocks. -->
+					{#each renderUnits as unit, unitIndex (unit.kind === "group" ? `group-${unitIndex}` : `text-${unitIndex}`)}
+						{#if unit.kind === "text"}
+							{#if isLast && loading && unit.content.length === 0}
+								<IconLoading classNames="loading inline ml-2 first:ml-0" />
+							{:else if unit.content.trim().length > 0}
+								<div
+									class="prose max-w-none dark:prose-invert prose-headings:font-semibold prose-h1:text-lg prose-h2:text-base prose-h3:text-base prose-pre:bg-gray-800 prose-img:my-0 prose-img:cursor-pointer prose-img:rounded-lg dark:prose-pre:bg-gray-900"
+								>
+									<MarkdownRenderer content={unit.content} loading={isLast && loading} />
+								</div>
 							{/if}
-						</div>
-					{/if}
-				{/each}
+						{:else if unit.kind === "group"}
+							<div
+								data-exclude-from-copy
+								class="has-[+.prose]:!mb-2 [&:not(:last-child)]:mb-1 [.prose+&]:mt-3"
+							>
+								{#if unit.blocks.length > 1}
+									<!-- Collapse the whole run into a single summary -->
+									<ToolCallsSummary blocks={unit.blocks} toolCount={unit.toolCount} />
+								{:else}
+									<!-- A lone process block stays standalone -->
+									{@const only = unit.blocks[0]}
+									{#if only.type === "think"}
+										<OpenReasoningResults content={only.content} loading={false} />
+									{:else}
+										<ToolUpdate tool={only.updates} loading={false} />
+									{/if}
+								{/if}
+							</div>
+						{/if}
+					{/each}
+				{/if}
 			</div>
 		</div>
 

--- a/src/lib/components/chat/ToolCallsSummary.svelte
+++ b/src/lib/components/chat/ToolCallsSummary.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+	import type { MessageToolUpdate } from "$lib/types/MessageUpdate";
+	import CarbonChevronRight from "~icons/carbon/chevron-right";
+	import OpenReasoningResults from "./OpenReasoningResults.svelte";
+	import ToolUpdate from "./ToolUpdate.svelte";
+
+	type ProcessBlock =
+		| { type: "think"; content: string; closed: boolean }
+		| { type: "tool"; uuid: string; updates: MessageToolUpdate[] };
+
+	interface Props {
+		blocks: ProcessBlock[];
+		toolCount: number;
+	}
+
+	let { blocks, toolCount }: Props = $props();
+	let isOpen = $state(false);
+
+	let label = $derived(
+		toolCount > 0 ? `Called ${toolCount} tool${toolCount === 1 ? "" : "s"}` : "Thought"
+	);
+</script>
+
+<div class="flex max-w-full select-none flex-col items-start">
+	<!-- Summary header — aligns with the normal answer block -->
+	<button
+		type="button"
+		class="group/header flex max-w-full cursor-pointer items-center gap-1 whitespace-nowrap text-left focus:outline-none"
+		onclick={() => (isOpen = !isOpen)}
+		aria-label={isOpen ? "Collapse" : "Expand"}
+	>
+		<span
+			class="shrink-0 text-sm font-medium transition-colors group-hover/header:text-gray-600 dark:group-hover/header:text-gray-300 {isOpen
+				? 'text-gray-600 dark:text-gray-300'
+				: 'text-gray-500 dark:text-gray-400'}"
+		>
+			{label}
+		</span>
+		<CarbonChevronRight
+			class="size-3.5 shrink-0 transition-all duration-200 group-hover/header:text-gray-600 dark:group-hover/header:text-gray-300 {isOpen
+				? 'rotate-90 text-gray-600 dark:text-gray-300'
+				: 'text-gray-400'}"
+		/>
+	</button>
+
+	<!-- Child rows — 8px left offset from the summary header -->
+	{#if isOpen}
+		<div class="mt-1 w-full pl-2">
+			{#each blocks as block, i (block.type === "tool" ? `tool-${block.uuid}-${i}` : `think-${i}`)}
+				{#if block.type === "think"}
+					<OpenReasoningResults content={block.content} loading={false} />
+				{:else}
+					<ToolUpdate tool={block.updates} loading={false} />
+				{/if}
+			{/each}
+		</div>
+	{/if}
+</div>

--- a/src/lib/components/chat/ToolCallsSummary.svelte.test.ts
+++ b/src/lib/components/chat/ToolCallsSummary.svelte.test.ts
@@ -1,0 +1,62 @@
+import ToolCallsSummary from "./ToolCallsSummary.svelte";
+import { render } from "vitest-browser-svelte";
+import { page } from "@vitest/browser/context";
+
+import { describe, expect, it } from "vitest";
+
+type ProcessBlock =
+	| { type: "think"; content: string; closed: boolean }
+	| { type: "tool"; uuid: string; updates: [] };
+
+const thinkBlock = (content: string): ProcessBlock => ({ type: "think", content, closed: true });
+const toolBlock = (uuid: string): ProcessBlock => ({ type: "tool", uuid, updates: [] });
+
+describe("ToolCallsSummary", () => {
+	it("is collapsed by default (children hidden)", async () => {
+		const { baseElement } = render(ToolCallsSummary, {
+			blocks: [thinkBlock("Reasoning A"), thinkBlock("Reasoning B")],
+			toolCount: 0,
+		});
+
+		// Only the header button is rendered; the 8px-offset child container is absent
+		expect(baseElement.querySelector(".pl-2")).toBeNull();
+	});
+
+	it("labels the header by tool count", async () => {
+		expect(
+			render(ToolCallsSummary, { blocks: [toolBlock("a")], toolCount: 1 }).baseElement.textContent
+		).toContain("Called 1 tool");
+
+		expect(
+			render(ToolCallsSummary, {
+				blocks: [toolBlock("a"), toolBlock("b")],
+				toolCount: 2,
+			}).baseElement.textContent
+		).toContain("Called 2 tools");
+	});
+
+	it("labels a tool-less run as 'Thought'", async () => {
+		const { baseElement } = render(ToolCallsSummary, {
+			blocks: [thinkBlock("A"), thinkBlock("B")],
+			toolCount: 0,
+		});
+		expect(baseElement.textContent).toContain("Thought");
+	});
+
+	it("reveals indented child rows when expanded", async () => {
+		const { baseElement } = render(ToolCallsSummary, {
+			blocks: [thinkBlock("Reasoning A"), thinkBlock("Reasoning B")],
+			toolCount: 0,
+		});
+
+		const toggle = baseElement.querySelector("button");
+		if (!toggle) throw new Error("expected summary header button");
+		toggle.click();
+		await new Promise((r) => setTimeout(r, 0));
+
+		// Child container with the 8px (pl-2) left offset now exists
+		expect(baseElement.querySelector(".pl-2")).not.toBeNull();
+		// Each child reasoning block contributes its own collapsible "Thinking" header
+		expect(page.getByText("Thinking").elements().length).toBe(2);
+	});
+});

--- a/src/lib/components/chat/ToolCallsSummary.svelte.test.ts
+++ b/src/lib/components/chat/ToolCallsSummary.svelte.test.ts
@@ -57,6 +57,6 @@ describe("ToolCallsSummary", () => {
 		// Child container with the 8px (pl-2) left offset now exists
 		expect(baseElement.querySelector(".pl-2")).not.toBeNull();
 		// Each child reasoning block contributes its own collapsible "Thinking" header
-		expect(page.getByText("Thinking").elements().length).toBe(2);
+		expect(page.getByText("Thinking").elements).toHaveLength(2);
 	});
 });


### PR DESCRIPTION
Alternative to #2297. Same `Called N tools` / `Thought` summary, but a different streaming behavior.

## Difference from #2297

- **#2297**: during streaming it shows only the *current step* (latest thinking + the parallel tool batch), hiding earlier completed blocks, then nests into the summary.
- **This PR**: during the thinking/tool phase the blocks render **flat and inline exactly like `main` today** (all of them, nothing hidden). The nesting into `Called N tools ›` only happens **once the final answer text starts streaming** (summary shown above the still-streaming answer), and stays nested for finished / historical messages.

Everything else (the `ToolCallsSummary` component, `Called N tools` vs `Thought` label, 8px-indented children, `<think>` splitting, `renderUnits` grouping) is identical.

## How

`ChatMessage.svelte` only:
- New message-level `isProcessStreaming` derived (`isLast && loading && last block is think/tool`).
- Two render paths: flat (iterate `blocks`, like `main`) while `isProcessStreaming`, nested (iterate `renderUnits` → summary/standalone/text) otherwise.
- Removes the per-group "active / current step" logic and the `currentStepBlocks` helper from #2297.

## Note

Interleaved narration emitted *between* two tool batches mid-stream briefly makes the last block a text block, so the view can nest then un-nest when the next tool starts. Uncommon; the standard think -> tools -> answer flow never flip-flops.

## Testing

- `npm run check` and `npm run lint` pass clean.
- Verified the nested/done state renders correctly in a live tools conversation (collapsed `Thinking ›`, pre-tool text, collapsed `Called 5 tools ›`, answer).
- `npm run test` (ssr + server) unaffected.