### PR TITLE
fix(mcp): sanitize tool JSON Schemas so one bad tool can't break tool-calling

### DIFF
--- a/src/lib/server/mcp/tools.test.ts
+++ b/src/lib/server/mcp/tools.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeJsonSchema } from "./tools";
+
+// The real `write_file` inputSchema served today by hf.co/mcp. The properties
+// `private`, `revision`, `commit_message`, `commit_description` are shaped
+// `{ description, default: null }` with NO `type`, which strict providers
+// (Fireworks) reject under tool_choice:"auto" — taking down the whole tools array.
+const writeFileSchema: Record<string, unknown> = {
+	$schema: "http://json-schema.org/draft-07/schema#",
+	additionalProperties: false,
+	type: "object",
+	required: ["content", "repo_id", "path_in_repo"],
+	properties: {
+		content: { description: "String content to write to the Hub.", type: "string" },
+		repo_id: { description: "Hub repo id, or bucket id when repo_type is bucket.", type: "string" },
+		path_in_repo: { description: "File path to create in the repo.", type: "string" },
+		repo_type: {
+			default: "model",
+			description: "Repository type.",
+			enum: ["model", "dataset", "space", "bucket"],
+			type: "string",
+		},
+		create_pr: {
+			default: false,
+			description: "Open repo uploads as a pull request.",
+			type: "boolean",
+		},
+		// the four offenders: no `type`, `default: null`
+		private: { default: null, description: "Optional privacy setting." },
+		revision: { default: null, description: "Branch or revision for repo uploads." },
+		commit_message: { default: null, description: "Optional commit message." },
+		commit_description: { default: null, description: "Optional commit description." },
+	},
+};
+
+describe("sanitizeJsonSchema", () => {
+	it("adds a `type` to type-less properties and drops their null defaults", () => {
+		const out = sanitizeJsonSchema(writeFileSchema);
+		const props = out.properties as Record<string, Record<string, unknown>>;
+		for (const key of ["private", "revision", "commit_message", "commit_description"]) {
+			expect(props[key].type).toBe("string");
+			expect("default" in props[key]).toBe(false);
+		}
+	});
+
+	it("leaves typed/enum properties and non-null defaults untouched", () => {
+		const out = sanitizeJsonSchema(writeFileSchema);
+		const props = out.properties as Record<string, Record<string, unknown>>;
+		expect(props.repo_id).toEqual({
+			description: "Hub repo id, or bucket id when repo_type is bucket.",
+			type: "string",
+		});
+		expect(props.repo_type.enum).toEqual(["model", "dataset", "space", "bucket"]);
+		expect(props.repo_type.type).toBe("string");
+		expect(props.repo_type.default).toBe("model");
+		expect(props.create_pr.default).toBe(false);
+		expect(props.create_pr.type).toBe("boolean");
+	});
+
+	it("preserves boolean additionalProperties and the required array", () => {
+		const out = sanitizeJsonSchema(writeFileSchema);
+		expect(out.additionalProperties).toBe(false);
+		expect(out.required).toEqual(["content", "repo_id", "path_in_repo"]);
+		expect(out.type).toBe("object");
+	});
+
+	it("leaves an empty {} property as match-anything (hf.co/mcp store_files `files`)", () => {
+		const out = sanitizeJsonSchema({ type: "object", properties: { files: {} } });
+		const props = out.properties as Record<string, Record<string, unknown>>;
+		expect(props.files).toEqual({});
+	});
+
+	it("preserves an arbitrary additionalProperties map (hf.co/mcp `hf_jobs.args`)", () => {
+		const out = sanitizeJsonSchema({
+			type: "object",
+			properties: {
+				args: { type: "object", description: "Args as a JSON object", additionalProperties: {} },
+			},
+		});
+		const props = out.properties as Record<string, Record<string, unknown>>;
+		// must NOT be narrowed to { type: "string" } — that would reject non-string values
+		expect(props.args.additionalProperties).toEqual({});
+	});
+
+	it("recurses into nested object properties and array items", () => {
+		const out = sanitizeJsonSchema({
+			type: "object",
+			properties: {
+				nested: { type: "object", properties: { inner: { default: null, description: "x" } } },
+				list: { type: "array", items: { default: null, description: "y" } },
+			},
+		});
+		const props = out.properties as Record<string, Record<string, unknown>>;
+		const inner = (props.nested.properties as Record<string, Record<string, unknown>>).inner;
+		expect(inner.type).toBe("string");
+		expect("default" in inner).toBe(false);
+		expect((props.list.items as Record<string, unknown>).type).toBe("string");
+	});
+
+	it("does not coerce a node that already implies a type via combinators", () => {
+		const out = sanitizeJsonSchema({
+			type: "object",
+			properties: { choice: { anyOf: [{ type: "string" }, { type: "number" }] } },
+		});
+		const props = out.properties as Record<string, Record<string, unknown>>;
+		expect("type" in props.choice).toBe(false);
+	});
+
+	it("is idempotent", () => {
+		const once = sanitizeJsonSchema(writeFileSchema);
+		const twice = sanitizeJsonSchema(once);
+		expect(twice).toEqual(once);
+	});
+
+	it("does not mutate the input", () => {
+		const before = JSON.stringify(writeFileSchema);
+		sanitizeJsonSchema(writeFileSchema);
+		expect(JSON.stringify(writeFileSchema)).toBe(before);
+	});
+});

--- a/src/lib/server/mcp/tools.test.ts
+++ b/src/lib/server/mcp/tools.test.ts
@@ -82,6 +82,22 @@ describe("sanitizeJsonSchema", () => {
 		expect(props.args.additionalProperties).toEqual({});
 	});
 
+	it("infers object (not string) for patternProperties maps and sanitizes their sub-schemas", () => {
+		const out = sanitizeJsonSchema({
+			patternProperties: { "^x-": { default: null, description: "header value" } },
+		});
+		expect(out.type).toBe("object");
+		const pp = out.patternProperties as Record<string, Record<string, unknown>>;
+		expect(pp["^x-"].type).toBe("string");
+		expect("default" in pp["^x-"]).toBe(false);
+	});
+
+	it("infers object for a schema defined only via additionalProperties", () => {
+		const out = sanitizeJsonSchema({ additionalProperties: { type: "string" } });
+		expect(out.type).toBe("object");
+		expect(out.additionalProperties).toEqual({ type: "string" });
+	});
+
 	it("recurses into nested object properties and array items", () => {
 		const out = sanitizeJsonSchema({
 			type: "object",

--- a/src/lib/server/mcp/tools.ts
+++ b/src/lib/server/mcp/tools.ts
@@ -35,6 +35,65 @@ function sanitizeName(name: string) {
 	return name.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 64);
 }
 
+const TYPE_IMPLYING_KEYWORDS = ["enum", "const", "$ref", "anyOf", "oneOf", "allOf", "not"] as const;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Normalize an MCP tool's JSON Schema so strict OpenAI-compatible providers
+ * (e.g. Fireworks) accept it. Some MCP servers (notably hf.co/mcp's `write_file`)
+ * emit properties like `{ description, default: null }` with no `type`; providers
+ * reject those under tool_choice:"auto", and one bad tool rejects the whole array.
+ * Pure + non-mutating. Only recurses into real schema-bearing keywords, so instance
+ * data (required, enum, defaults) and boolean additionalProperties stay intact.
+ */
+export function sanitizeJsonSchema(schema: Record<string, unknown>): Record<string, unknown> {
+	const out: Record<string, unknown> = {};
+	for (const [key, value] of Object.entries(schema)) {
+		if (key === "default" && value === null) continue; // drop contradictory/uninformative null defaults
+		out[key] = value;
+	}
+
+	if (isPlainObject(out.properties)) {
+		const props: Record<string, unknown> = {};
+		for (const [name, sub] of Object.entries(out.properties)) {
+			props[name] = isPlainObject(sub) ? sanitizeJsonSchema(sub) : sub;
+		}
+		out.properties = props;
+	}
+
+	if (isPlainObject(out.items)) {
+		out.items = sanitizeJsonSchema(out.items);
+	} else if (Array.isArray(out.items)) {
+		out.items = out.items.map((s) => (isPlainObject(s) ? sanitizeJsonSchema(s) : s));
+	}
+
+	for (const kw of ["anyOf", "oneOf", "allOf"] as const) {
+		const branch = out[kw];
+		if (Array.isArray(branch)) {
+			out[kw] = branch.map((s) => (isPlainObject(s) ? sanitizeJsonSchema(s) : s));
+		}
+	}
+	if (isPlainObject(out.not)) out.not = sanitizeJsonSchema(out.not);
+	if (isPlainObject(out.additionalProperties)) {
+		// boolean form (true/false) is left untouched on purpose
+		out.additionalProperties = sanitizeJsonSchema(out.additionalProperties);
+	}
+
+	// Ensure a `type` exists when none is implied. An empty `{}` is left as-is:
+	// it means "match any value" (e.g. hf.co/mcp's `hf_jobs.args` arbitrary map),
+	// so coercing it to a string would wrongly narrow non-string arguments.
+	if (out.type === undefined && Object.keys(out).length > 0) {
+		if ("properties" in out) out.type = "object";
+		else if ("items" in out) out.type = "array";
+		else if (!TYPE_IMPLYING_KEYWORDS.some((k) => k in out)) out.type = "string";
+	}
+
+	return out;
+}
+
 function buildCacheKey(servers: McpServerConfig[]): string {
 	const normalized = servers
 		.map((server) => ({
@@ -153,8 +212,9 @@ export async function getOpenAiToolsForMcp(
 					continue;
 				}
 
-				const parameters =
-					tool.inputSchema && typeof tool.inputSchema === "object" ? tool.inputSchema : undefined;
+				const parameters = isPlainObject(tool.inputSchema)
+					? sanitizeJsonSchema(tool.inputSchema)
+					: undefined;
 				const description = tool.description ?? tool.annotations?.title;
 				const toolName = tool.name;
 

--- a/src/lib/server/mcp/tools.ts
+++ b/src/lib/server/mcp/tools.ts
@@ -36,6 +36,14 @@ function sanitizeName(name: string) {
 }
 
 const TYPE_IMPLYING_KEYWORDS = ["enum", "const", "$ref", "anyOf", "oneOf", "allOf", "not"] as const;
+const OBJECT_IMPLYING_KEYWORDS = [
+	"properties",
+	"patternProperties",
+	"additionalProperties",
+	"propertyNames",
+	"required",
+] as const;
+const ARRAY_IMPLYING_KEYWORDS = ["items", "prefixItems", "contains"] as const;
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -56,38 +64,42 @@ export function sanitizeJsonSchema(schema: Record<string, unknown>): Record<stri
 		out[key] = value;
 	}
 
-	if (isPlainObject(out.properties)) {
-		const props: Record<string, unknown> = {};
-		for (const [name, sub] of Object.entries(out.properties)) {
-			props[name] = isPlainObject(sub) ? sanitizeJsonSchema(sub) : sub;
-		}
-		out.properties = props;
-	}
+	const recurse = (value: unknown): unknown =>
+		isPlainObject(value) ? sanitizeJsonSchema(value) : value;
+	const recurseMap = (map: Record<string, unknown>): Record<string, unknown> =>
+		Object.fromEntries(Object.entries(map).map(([key, sub]) => [key, recurse(sub)]));
 
-	if (isPlainObject(out.items)) {
-		out.items = sanitizeJsonSchema(out.items);
-	} else if (Array.isArray(out.items)) {
-		out.items = out.items.map((s) => (isPlainObject(s) ? sanitizeJsonSchema(s) : s));
-	}
-
-	for (const kw of ["anyOf", "oneOf", "allOf"] as const) {
-		const branch = out[kw];
-		if (Array.isArray(branch)) {
-			out[kw] = branch.map((s) => (isPlainObject(s) ? sanitizeJsonSchema(s) : s));
-		}
-	}
-	if (isPlainObject(out.not)) out.not = sanitizeJsonSchema(out.not);
+	// Object applicators: { name -> schema } maps, plus the key schema.
+	if (isPlainObject(out.properties)) out.properties = recurseMap(out.properties);
+	if (isPlainObject(out.patternProperties))
+		out.patternProperties = recurseMap(out.patternProperties);
+	if (isPlainObject(out.propertyNames)) out.propertyNames = sanitizeJsonSchema(out.propertyNames);
+	// additionalProperties: schema form recurses; boolean form (true/false) is left untouched.
 	if (isPlainObject(out.additionalProperties)) {
-		// boolean form (true/false) is left untouched on purpose
 		out.additionalProperties = sanitizeJsonSchema(out.additionalProperties);
 	}
 
+	// Array applicators: single schema, tuple array, or contains schema.
+	if (isPlainObject(out.items)) out.items = sanitizeJsonSchema(out.items);
+	else if (Array.isArray(out.items)) out.items = out.items.map(recurse);
+	if (Array.isArray(out.prefixItems)) out.prefixItems = out.prefixItems.map(recurse);
+	if (isPlainObject(out.contains)) out.contains = sanitizeJsonSchema(out.contains);
+
+	// Schema combinators.
+	for (const kw of ["anyOf", "oneOf", "allOf"] as const) {
+		const branch = out[kw];
+		if (Array.isArray(branch)) out[kw] = branch.map(recurse);
+	}
+	if (isPlainObject(out.not)) out.not = sanitizeJsonSchema(out.not);
+
 	// Ensure a `type` exists when none is implied. An empty `{}` is left as-is:
 	// it means "match any value" (e.g. hf.co/mcp's `hf_jobs.args` arbitrary map),
-	// so coercing it to a string would wrongly narrow non-string arguments.
+	// so coercing it would wrongly narrow non-string arguments. Object/array
+	// applicator keywords (properties, patternProperties, items, ...) imply the
+	// container type, so a map/array schema is never narrowed to a string.
 	if (out.type === undefined && Object.keys(out).length > 0) {
-		if ("properties" in out) out.type = "object";
-		else if ("items" in out) out.type = "array";
+		if (OBJECT_IMPLYING_KEYWORDS.some((k) => k in out)) out.type = "object";
+		else if (ARRAY_IMPLYING_KEYWORDS.some((k) => k in out)) out.type = "array";
 		else if (!TYPE_IMPLYING_KEYWORDS.some((k) => k in out)) out.type = "string";
 	}
 


### PR DESCRIPTION
## Problem

On HuggingChat, a conversation can go through the agentic route (badge shows `agentic / Kimi-K2.6 / fireworks / MCP (2)`) yet the model replies as if it has no tools (e.g. "I don't have real-time internet access") instead of calling `web_search_exa`.

Root cause: MCP tool `inputSchema`s are forwarded to the provider verbatim. The HF MCP server's `write_file` tool ships properties (`private`, `revision`, `commit_message`, `commit_description`) shaped `{ "description": "...", "default": null }` with **no `type`**. Strict OpenAI-compatible providers (Fireworks) reject a type-less property under `tool_choice:"auto"`, and rejecting one tool rejects the **entire** `tools` array with HTTP 400. The MCP flow then swallows the error and falls back to a tool-less generation, so the model answers from training while the UI still shows the agentic/MCP badge (emitted before the failing call).

This also explains the "remove and re-add the tools fixes it" flakiness: the HF MCP server only lists `write_file` once authenticated, so when it is not ready at send time only the clean tools go out and search works.

Reproduced directly against HF inference: Exa-only tools make Kimi-K2.6 call `web_search_exa` 5/5, but the full Exa + HF payload returns HTTP 400 every time, isolated to `write_file`.

## Fix

Add a pure, non-mutating, schema-aware normalizer (`sanitizeJsonSchema`) applied at the single forwarding point in `getOpenAiToolsForMcp`. It:

- drops `default: null` (the contradictory/uninformative defaults providers choke on),
- fills in a missing `type` (`object`/`array` when implied by `properties`/`items`, else `string`), skipping nodes that already imply a type via `enum`/`const`/`$ref`/`anyOf`/`oneOf`/`allOf`/`not`,
- only recurses into real schema-bearing keywords, so instance data (`required`, `enum` values, boolean `additionalProperties`) is left intact (this avoids a second class of 400 from over-coercing),
- preserves empty `{}` schemas as match-anything, so arbitrary maps (e.g. `hf_jobs.args` which uses `additionalProperties: {}`) are not wrongly narrowed to string-only.

No changes to the MCP flow or fallback logic, just the schema that leaves for the provider.

## Tests

New `src/lib/server/mcp/tools.test.ts` (first test under `mcp/`) using `write_file`'s real schema as the fixture: type-less props gain `type:"string"` with `default:null` dropped, typed/enum props and non-null defaults stay unchanged, boolean `additionalProperties` and `required` preserved, empty `{}` and `additionalProperties: {}` preserved as match-anything, nested objects/arrays recurse, plus idempotency and non-mutation. 9 tests pass; `npm run check` and `npm run lint` clean.

## Follow-ups (not in this PR)

- Defensive completion retry: on a provider schema-400, drop the offending tool and retry instead of dropping all tools, to stay robust against future malformed third-party MCP schemas.
- Upstream: the `write_file` schema on hf.co/mcp should declare a real `type` and drop `default: null` at the source.