### PR TITLE
fix(chat): use `lucide/settings-2` icon for settings

### DIFF
--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -10,9 +10,9 @@
 	import IconOmni from "$lib/components/icons/IconOmni.svelte";
 	import IconCheap from "$lib/components/icons/IconCheap.svelte";
 	import IconFast from "$lib/components/icons/IconFast.svelte";
-	import CarbonCaretDown from "~icons/carbon/caret-down";
 	import { PROVIDERS_HUB_ORGS } from "@huggingface/inference";
 	import CarbonDirectionRight from "~icons/carbon/direction-right-01";
+	import IconSettings from "~icons/lucide/settings-2";
 	import IconArrowUp from "~icons/lucide/arrow-up";
 	import IconMic from "~icons/lucide/mic";
 
@@ -946,7 +946,7 @@
 										</span>
 									{/if}
 								{/if}
-								<CarbonCaretDown class="-ml-0.5 shrink-0 text-xxs" />
+								<IconSettings class="mr-1.5 -ml-0.5 shrink-0 pr-0.5 pl-0 text-xxs" />
 							</a>
 						{:else if showRouterDetails && streamingRouterMetadata?.route}
 							<div


### PR DESCRIPTION
## Problem
The icon next to the current model indicator in chat is associated with dropdowns, intuitively a hint to the user that the model can be changed for the conversation. This is not the case, and actually brings up the settings modal.

## Solution
Change this to `lucide/settings-2`, given its similarity to the controls in the settings modal.

### Screenshots
#### Before
Per #2296

#### After
<img width="448" height="135" alt="image" src="https://github.com/user-attachments/assets/543f3285-34ba-4221-b202-3f41bcd62915" />
