### PR TITLE
fix(settings/omni): use model display name in hint banner

### DIFF
--- a/src/routes/settings/(nav)/[...model]/+page.svelte
+++ b/src/routes/settings/(nav)/[...model]/+page.svelte
@@ -242,7 +242,7 @@
 	<div class="relative flex w-full flex-col gap-2">
 		{#if model?.isRouter}
 			<p class="mb-3 mt-2 rounded-lg bg-gray-100 px-3 py-2 text-sm dark:bg-white/5">
-				<IconOmni classNames="-translate-y-px" /> Omni routes your messages to the best underlying model
+				<IconOmni classNames="-translate-y-px" /> {model.displayName} routes your messages to the best underlying model
 				depending on your request.
 			</p>
 		{/if}


### PR DESCRIPTION
<img width="640" height="197" alt="image" src="https://github.com/user-attachments/assets/d30c0f9a-ffaf-4de4-8d6d-7244cacb0af1" />

## Problem
On chat-ui instances configured with a display name other than Omni, users may still be shown that name when looking at the settings page with LLM routing turned on. This might be confusing, if they are only familiar with the display name as configured.

## Solution
Use `model.displayName` instead, which would have been configured with the env var `PUBLIC_LLM_ROUTER_DISPLAY_NAME` at init.