### PR TITLE
Auto-open the latest artifact when viewing a shared conversation

### DIFF
--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -334,6 +334,21 @@
 		prevMessageCount = messages.length;
 	});
 
+	// Shared conversations containing artifacts usually exist to show one off:
+	// open the most recent artifact on load. Desktop only, since on mobile the
+	// panel is a fullscreen overlay that would hide the conversation entirely.
+	// Declared after the conversation-switch effect so its reset() can never
+	// close the panel after this opens it within the same flush.
+	let autoOpenedSharedArtifact = false;
+	$effect(() => {
+		if (autoOpenedSharedArtifact || !shared) return;
+		const latest = [...artifactRegistry.artifacts.values()].at(-1);
+		if (!latest) return;
+		autoOpenedSharedArtifact = true;
+		if (!window.matchMedia("(min-width: 768px)").matches) return;
+		artifactPanel.openArtifact(latest.identifier, null);
+	});
+
 	// Combined scroll dependency for the action
 	let scrollDependency = $derived({ forceReattach, scrollBehavior });
 


### PR DESCRIPTION
## What

When someone opens a shared conversation that contains artifacts, the side panel now opens automatically on the most recent artifact (latest version) instead of leaving the recipient to find and click the card. Shared conversations with artifacts usually exist to show the artifact off, so it becomes the default view.

## How

A one-shot effect in `ChatWindow`, gated on the existing `shared` flag (true in both the view-only flow and the just-imported share flow):

- opens the registry's most recent artifact at its latest version, once per load
- desktop only: on mobile the panel is a fullscreen overlay that would hide the conversation entirely, so phones keep the plain chat with cards
- declared after the conversation-switch effect, so the panel reset on switch can never close the panel this just opened within the same flush
- regular (non-shared) conversations are unaffected

This replaces an earlier draft of this PR that passed the selected artifact through share URL params (`?artifact=...&artifactVersion=...`, preserved at commit 84b5a538). The heuristic needs no action from the sharer, covers the dominant single-artifact case, and avoids threading params through the share/import redirect chain. URL-based artifact deep links can still be added on top later if needed.

## Verification

- `npm run check` clean, all 208 tests pass.
- Manual: share a conversation containing an artifact, open the `/r/...` link (logged-in and logged-out): the conversation loads with the panel open on the newest artifact. A shared conversation without artifacts loads normally. On a narrow viewport the panel stays closed.