### PR TITLE
Improve close button visual consistency in artifact panel

### DIFF
--- a/src/lib/components/chat/ArtifactPanel.svelte
+++ b/src/lib/components/chat/ArtifactPanel.svelte
@@ -13,7 +13,7 @@
 	import CopyToClipBoardBtn from "../CopyToClipBoardBtn.svelte";
 	import HtmlPreviewModal from "../HtmlPreviewModal.svelte";
 
-	import CarbonClose from "~icons/carbon/close";
+	import CarbonCloseLarge from "~icons/carbon/close-large";
 	import CarbonChevronLeft from "~icons/carbon/chevron-left";
 	import CarbonChevronRight from "~icons/carbon/chevron-right";
 	import CarbonDownload from "~icons/carbon/download";
@@ -293,13 +293,16 @@
 					</button>
 				{/if}
 			{/if}
+			<!-- close-large at text-base: the X glyph fills less of its viewBox than the
+			     sibling icons, so it needs the bump to read as the same visual size;
+			     p-1 keeps the button footprint identical to its p-1.5 text-xs siblings -->
 			<button
 				type="button"
-				class="btn ml-0.5 rounded-md p-1.5 text-xs hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-800 dark:hover:text-gray-300"
+				class="btn ml-0.5 rounded-md p-1 text-base hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-800 dark:hover:text-gray-300"
 				title="Close panel (Esc)"
 				onclick={() => artifactPanel.close()}
 			>
-				<CarbonClose />
+				<CarbonCloseLarge />
 			</button>
 		</div>
 	</header>


### PR DESCRIPTION
## Summary
Updated the close button in the artifact panel to use a larger icon variant with adjusted sizing to maintain visual consistency with neighboring controls.

## Changes
- Replaced `CarbonClose` icon with `CarbonCloseLarge` for better visual prominence
- Updated button styling:
  - Changed text size from `text-xs` to `text-base` to match the larger icon's visual weight
  - Adjusted padding from `p-1.5` to `p-1` to keep the button footprint identical to sibling controls
- Added explanatory comment documenting the sizing rationale: the close-large glyph fills less of its viewBox than sibling icons, requiring the text-base bump to read as the same visual size

## Implementation Details
The close-large icon variant has different proportions than the standard close icon, necessitating compensatory adjustments to maintain visual balance with other buttons in the header. The padding adjustment ensures the button maintains consistent dimensions despite the icon change.

https://claude.ai/code/session_01Bf3D9CxrirzJHkUBLmjANT