### PR TITLE
Wrap model settings page in key block to reset DOM on navigation

### DIFF
--- a/src/routes/settings/(nav)/[...model]/+page.svelte
+++ b/src/routes/settings/(nav)/[...model]/+page.svelte
@@ -151,406 +151,410 @@
 	] as const;
 </script>
 
-<div class="flex flex-col items-start">
-	<div class="mb-4 flex flex-col gap-px">
-		<h2 class="text-base font-semibold md:text-lg">
-			{model.displayName}
-		</h2>
+<!-- Key on modelId so the DOM is rebuilt when navigating between models:
+     reused switches/textareas would otherwise animate to the new model's values -->
+{#key modelId}
+	<div class="flex flex-col items-start">
+		<div class="mb-4 flex flex-col gap-px">
+			<h2 class="text-base font-semibold md:text-lg">
+				{model.displayName}
+			</h2>
 
-		{#if model.description}
-			<p class="line-clamp-2 whitespace-pre-wrap text-sm text-gray-600 dark:text-gray-400">
-				{model.description}
-			</p>
-		{/if}
-	</div>
-
-	<!-- Actions -->
-	<div class="mb-4 flex flex-wrap items-center gap-1.5">
-		<button
-			class="flex w-fit items-center rounded-full bg-black px-3 py-1.5 text-sm !text-white shadow-sm hover:bg-black/90 dark:bg-white/80 dark:!text-gray-900 dark:hover:bg-white/90"
-			name="Activate model"
-			onclick={(e) => {
-				e.stopPropagation();
-				settings.instantSet({
-					activeModel: modelId,
-				});
-				goto(`${base}/`);
-			}}
-		>
-			<CarbonChat class="mr-1.5 text-sm" />
-			New chat
-		</button>
-
-		{#if model.modelUrl}
-			<a
-				href={model.modelUrl || "https://huggingface.co/" + model.name}
-				target="_blank"
-				rel="noreferrer"
-				class="inline-flex items-center rounded-full border border-gray-200 px-2.5 py-1 text-sm hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700/60"
-			>
-				<CarbonArrowUpRight class="mr-1.5 shrink-0 text-xs " />
-				Model page
-			</a>
-		{/if}
-
-		{#if model.datasetName || model.datasetUrl}
-			<a
-				href={model.datasetUrl || "https://huggingface.co/datasets/" + model.datasetName}
-				target="_blank"
-				rel="noreferrer"
-				class="inline-flex items-center rounded-full border border-gray-200 px-2.5 py-1 text-sm hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700/60"
-			>
-				<CarbonArrowUpRight class="mr-1.5 shrink-0 text-xs " />
-				Dataset page
-			</a>
-		{/if}
-
-		{#if model.websiteUrl}
-			<a
-				href={model.websiteUrl}
-				target="_blank"
-				class="inline-flex items-center rounded-full border border-gray-200 px-2.5 py-1 text-sm hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700/60"
-				rel="noreferrer"
-			>
-				<CarbonArrowUpRight class="mr-1.5 shrink-0 text-xs " />
-				Model website
-			</a>
-		{/if}
-
-		{#if publicConfig.isHuggingChat}
-			{#if !model?.isRouter}
-				<a
-					href={"https://huggingface.co/" + model.name + "?inference_api=true"}
-					target="_blank"
-					rel="noreferrer"
-					class="inline-flex items-center rounded-full border border-gray-200 px-2.5 py-1 text-sm hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700/60"
-				>
-					<CarbonCode class="mr-1.5 shrink-0 text-xs" />
-					Use via API
-				</a>
-				<a
-					href={"https://huggingface.co/" + model.name}
-					target="_blank"
-					rel="noreferrer"
-					class="inline-flex items-center rounded-full border border-gray-200 px-2.5 py-1 text-sm hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700/60"
-				>
-					<CarbonArrowUpRight class="mr-1.5 shrink-0 text-xs" />
-					View model card
-				</a>
+			{#if model.description}
+				<p class="line-clamp-2 whitespace-pre-wrap text-sm text-gray-600 dark:text-gray-400">
+					{model.description}
+				</p>
 			{/if}
-			<CopyToClipBoardBtn
-				value="{publicConfig.PUBLIC_ORIGIN || page.url.origin}{base}/models/{model.id}"
-				classNames="inline-flex items-center rounded-full border border-gray-200 px-2.5 py-1 text-sm hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700/60"
-			>
-				<div class="flex items-center gap-1.5">
-					<CarbonCopy class="shrink-0 text-xs" />Copy direct link
-				</div>
-			</CopyToClipBoardBtn>
-		{/if}
-	</div>
-
-	<div class="relative flex w-full flex-col gap-2">
-		{#if model?.isRouter}
-			<p class="mb-3 mt-2 rounded-lg bg-gray-100 px-3 py-2 text-sm dark:bg-white/5">
-				<IconOmni classNames="-translate-y-px" />
-				{model.displayName} routes your messages to the best underlying model depending on your request.
-			</p>
-		{/if}
-		<div class="flex w-full flex-row items-center justify-between">
-			<h3 class="text-[15px] font-semibold text-gray-800 dark:text-gray-200">System Prompt</h3>
-			<div class="flex items-center gap-2">
-				<div
-					class="flex select-none items-center gap-1.5 text-[11px] font-medium text-gray-600 dark:text-gray-400"
-				>
-					<span>Enabled</span>
-					<Switch
-						name="customPromptEnabled"
-						size="sm"
-						bind:checked={getCustomPromptEnabled, setCustomPromptEnabled}
-					/>
-				</div>
-				{#if hasCustomPreprompt}
-					<button
-						type="button"
-						aria-label="Reset system prompt"
-						title="Reset to default"
-						class="grid size-6 place-items-center rounded-md text-gray-500 hover:bg-gray-100 hover:text-gray-800 dark:text-gray-400 dark:hover:bg-white/10 dark:hover:text-gray-200"
-						onclick={(e) => {
-							e.stopPropagation();
-							settings.update((s) => ({
-								...s,
-								customPrompts: { ...s.customPrompts, [modelId]: model.preprompt },
-							}));
-						}}
-					>
-						<CarbonReset class="size-3.5" />
-					</button>
-				{/if}
-			</div>
 		</div>
 
-		<textarea
-			aria-label="Custom system prompt"
-			rows="8"
-			disabled={!getCustomPromptEnabled()}
-			class="scrollbar-custom w-full resize-none rounded-md border border-gray-200 bg-gray-50 p-2 text-[13px] transition-opacity dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200"
-			class:opacity-30={!getCustomPromptEnabled()}
-			bind:value={getCustomPrompt, setCustomPrompt}
-		></textarea>
-		<!-- Capabilities -->
-		<div
-			class="mt-3 rounded-xl border border-gray-200 bg-white px-3 shadow-sm dark:border-gray-700 dark:bg-gray-800"
-		>
-			<div class="divide-y divide-gray-200 dark:divide-gray-700">
-				<div class="flex items-start justify-between py-3">
-					<div>
-						<div class="text-[13px] font-medium text-gray-800 dark:text-gray-200">
-							Tool calling (functions)
-						</div>
-						<p class="text-[12px] text-gray-500 dark:text-gray-400">
-							{#if publicConfig.isHuggingChat}
-								Determined by the inference provider for this model.
-							{:else}
-								Enable tools and allow the model to call them in chat.
-							{/if}
-						</p>
-					</div>
-					<Switch
-						name="forceTools"
-						disabled={publicConfig.isHuggingChat}
-						bind:checked={getToolsOverride, setToolsOverride}
-					/>
-				</div>
+		<!-- Actions -->
+		<div class="mb-4 flex flex-wrap items-center gap-1.5">
+			<button
+				class="flex w-fit items-center rounded-full bg-black px-3 py-1.5 text-sm !text-white shadow-sm hover:bg-black/90 dark:bg-white/80 dark:!text-gray-900 dark:hover:bg-white/90"
+				name="Activate model"
+				onclick={(e) => {
+					e.stopPropagation();
+					settings.instantSet({
+						activeModel: modelId,
+					});
+					goto(`${base}/`);
+				}}
+			>
+				<CarbonChat class="mr-1.5 text-sm" />
+				New chat
+			</button>
 
-				<div class="flex items-start justify-between py-3">
-					<div>
-						<div class="text-[13px] font-medium text-gray-800 dark:text-gray-200">
-							Multimodal support (image inputs)
-						</div>
-						<p class="text-[12px] text-gray-500 dark:text-gray-400">
-							{#if publicConfig.isHuggingChat}
-								Determined by the inference provider for this model.
-							{:else}
-								Enable image uploads and send images to this model.
-							{/if}
-						</p>
-					</div>
-					<Switch
-						name="forceMultimodal"
-						disabled={publicConfig.isHuggingChat}
-						bind:checked={getMultimodalOverride, setMultimodalOverride}
-					/>
-				</div>
+			{#if model.modelUrl}
+				<a
+					href={model.modelUrl || "https://huggingface.co/" + model.name}
+					target="_blank"
+					rel="noreferrer"
+					class="inline-flex items-center rounded-full border border-gray-200 px-2.5 py-1 text-sm hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700/60"
+				>
+					<CarbonArrowUpRight class="mr-1.5 shrink-0 text-xs " />
+					Model page
+				</a>
+			{/if}
 
-				<div class="flex items-start justify-between py-3">
-					<div>
-						<div class="text-[13px] font-medium text-gray-800 dark:text-gray-200">
-							Reasoning effort
-						</div>
-						<p class="text-[12px] text-gray-500 dark:text-gray-400">
-							{#if publicConfig.isHuggingChat}
-								Determined by the inference provider for this model.
-							{:else}
-								Show a Low / Medium / High selector in the chat footer for this model.
-							{/if}
-						</p>
-					</div>
-					<Switch
-						name="forceReasoning"
-						disabled={publicConfig.isHuggingChat}
-						bind:checked={getReasoningOverride, setReasoningOverride}
-					/>
-				</div>
+			{#if model.datasetName || model.datasetUrl}
+				<a
+					href={model.datasetUrl || "https://huggingface.co/datasets/" + model.datasetName}
+					target="_blank"
+					rel="noreferrer"
+					class="inline-flex items-center rounded-full border border-gray-200 px-2.5 py-1 text-sm hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700/60"
+				>
+					<CarbonArrowUpRight class="mr-1.5 shrink-0 text-xs " />
+					Dataset page
+				</a>
+			{/if}
 
-				<div class="flex items-start justify-between py-3">
-					<div>
-						<div
-							class="flex items-center gap-1.5 text-[13px] font-medium text-gray-800 dark:text-gray-200"
+			{#if model.websiteUrl}
+				<a
+					href={model.websiteUrl}
+					target="_blank"
+					class="inline-flex items-center rounded-full border border-gray-200 px-2.5 py-1 text-sm hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700/60"
+					rel="noreferrer"
+				>
+					<CarbonArrowUpRight class="mr-1.5 shrink-0 text-xs " />
+					Model website
+				</a>
+			{/if}
+
+			{#if publicConfig.isHuggingChat}
+				{#if !model?.isRouter}
+					<a
+						href={"https://huggingface.co/" + model.name + "?inference_api=true"}
+						target="_blank"
+						rel="noreferrer"
+						class="inline-flex items-center rounded-full border border-gray-200 px-2.5 py-1 text-sm hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700/60"
+					>
+						<CarbonCode class="mr-1.5 shrink-0 text-xs" />
+						Use via API
+					</a>
+					<a
+						href={"https://huggingface.co/" + model.name}
+						target="_blank"
+						rel="noreferrer"
+						class="inline-flex items-center rounded-full border border-gray-200 px-2.5 py-1 text-sm hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700/60"
+					>
+						<CarbonArrowUpRight class="mr-1.5 shrink-0 text-xs" />
+						View model card
+					</a>
+				{/if}
+				<CopyToClipBoardBtn
+					value="{publicConfig.PUBLIC_ORIGIN || page.url.origin}{base}/models/{model.id}"
+					classNames="inline-flex items-center rounded-full border border-gray-200 px-2.5 py-1 text-sm hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700/60"
+				>
+					<div class="flex items-center gap-1.5">
+						<CarbonCopy class="shrink-0 text-xs" />Copy direct link
+					</div>
+				</CopyToClipBoardBtn>
+			{/if}
+		</div>
+
+		<div class="relative flex w-full flex-col gap-2">
+			{#if model?.isRouter}
+				<p class="mb-3 mt-2 rounded-lg bg-gray-100 px-3 py-2 text-sm dark:bg-white/5">
+					<IconOmni classNames="-translate-y-px" />
+					{model.displayName} routes your messages to the best underlying model depending on your request.
+				</p>
+			{/if}
+			<div class="flex w-full flex-row items-center justify-between">
+				<h3 class="text-[15px] font-semibold text-gray-800 dark:text-gray-200">System Prompt</h3>
+				<div class="flex items-center gap-2">
+					<div
+						class="flex select-none items-center gap-1.5 text-[11px] font-medium text-gray-600 dark:text-gray-400"
+					>
+						<span>Enabled</span>
+						<Switch
+							name="customPromptEnabled"
+							size="sm"
+							bind:checked={getCustomPromptEnabled, setCustomPromptEnabled}
+						/>
+					</div>
+					{#if hasCustomPreprompt}
+						<button
+							type="button"
+							aria-label="Reset system prompt"
+							title="Reset to default"
+							class="grid size-6 place-items-center rounded-md text-gray-500 hover:bg-gray-100 hover:text-gray-800 dark:text-gray-400 dark:hover:bg-white/10 dark:hover:text-gray-200"
+							onclick={(e) => {
+								e.stopPropagation();
+								settings.update((s) => ({
+									...s,
+									customPrompts: { ...s.customPrompts, [modelId]: model.preprompt },
+								}));
+							}}
 						>
-							Artifacts
-							<span
-								class="rounded-full bg-gray-100 px-1.5 py-px text-[10px] font-semibold uppercase text-gray-500 dark:bg-gray-700 dark:text-gray-400"
-							>
-								Beta
-							</span>
-						</div>
-						<p class="text-[12px] text-gray-500 dark:text-gray-400">
-							Let the model create apps, documents and diagrams in a side panel with live preview.
-						</p>
-					</div>
-					<!-- Not provider-determined, so user-editable even on HuggingChat -->
-					<Switch
-						name="artifactsOverride"
-						bind:checked={getArtifactsOverride, setArtifactsOverride}
-					/>
+							<CarbonReset class="size-3.5" />
+						</button>
+					{/if}
 				</div>
+			</div>
 
-				{#if model?.isRouter}
+			<textarea
+				aria-label="Custom system prompt"
+				rows="8"
+				disabled={!getCustomPromptEnabled()}
+				class="scrollbar-custom w-full resize-none rounded-md border border-gray-200 bg-gray-50 p-2 text-[13px] transition-opacity dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200"
+				class:opacity-30={!getCustomPromptEnabled()}
+				bind:value={getCustomPrompt, setCustomPrompt}
+			></textarea>
+			<!-- Capabilities -->
+			<div
+				class="mt-3 rounded-xl border border-gray-200 bg-white px-3 shadow-sm dark:border-gray-700 dark:bg-gray-800"
+			>
+				<div class="divide-y divide-gray-200 dark:divide-gray-700">
 					<div class="flex items-start justify-between py-3">
 						<div>
 							<div class="text-[13px] font-medium text-gray-800 dark:text-gray-200">
-								Hide prompt examples
+								Tool calling (functions)
 							</div>
 							<p class="text-[12px] text-gray-500 dark:text-gray-400">
-								Hide the prompt suggestions above the chat input.
+								{#if publicConfig.isHuggingChat}
+									Determined by the inference provider for this model.
+								{:else}
+									Enable tools and allow the model to call them in chat.
+								{/if}
 							</p>
 						</div>
 						<Switch
-							name="hidePromptExamples"
-							bind:checked={getHidePromptExamples, setHidePromptExamples}
+							name="forceTools"
+							disabled={publicConfig.isHuggingChat}
+							bind:checked={getToolsOverride, setToolsOverride}
 						/>
 					</div>
-				{/if}
-			</div>
-		</div>
 
-		{#if publicConfig.isHuggingChat && model.providers?.length && !model?.isRouter}
-			<div
-				class="mt-3 flex flex-col items-start gap-2.5 rounded-xl border border-gray-200 bg-white px-3 py-3 shadow-sm dark:border-gray-700 dark:bg-gray-800"
-			>
-				<div>
-					<div class="text-[13px] font-medium text-gray-800 dark:text-gray-200">
-						Inference Providers
-					</div>
-					<p class="text-[12px] text-gray-500 dark:text-gray-400">
-						Choose which Inference Provider to use with this model. You can also manage provider
-						preferences in <a
-							class="underline decoration-gray-400 hover:decoration-gray-700 dark:decoration-gray-500 dark:hover:decoration-gray-300"
-							target="_blank"
-							href="https://huggingface.co/settings/inference-providers/settings"
-							>your HF settings</a
-						>.
-					</p>
-				</div>
-				<Select.Root
-					type="single"
-					value={getProviderOverride()}
-					onValueChange={(v) => v && setProviderOverride(v)}
-				>
-					<Select.Trigger
-						aria-label="Select inference provider"
-						class="inline-flex w-auto items-center justify-between gap-2 rounded-lg border border-gray-200 bg-white px-2 py-2 text-sm text-gray-800 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-200 dark:hover:bg-gray-800"
-					>
-						{@const currentValue = getProviderOverride()}
-						{@const currentPolicy = PROVIDER_POLICIES.find((p) => p.value === currentValue)}
-						{@const currentProvider = providerList.find((p) => p.provider === currentValue)}
-						<span class="flex items-center gap-2">
-							{#if currentValue === "auto"}
-								<span class="grid size-5 flex-none place-items-center rounded-md bg-gray-500/10">
-									<CarbonMagicWandFilled class="size-3 text-gray-700 dark:text-gray-300" />
-								</span>
-							{:else if currentValue === "fastest"}
-								<span
-									class="grid size-5 flex-none place-items-center rounded-md bg-green-500/10 text-green-600 dark:text-green-500"
-								>
-									<IconFast classNames="size-3" />
-								</span>
-							{:else if currentValue === "cheapest"}
-								<span
-									class="grid size-5 flex-none place-items-center rounded-md bg-blue-500/10 text-blue-600 dark:text-blue-500"
-								>
-									<IconCheap classNames="size-3" />
-								</span>
-							{:else if currentProvider}
-								{@const hubOrg =
-									PROVIDERS_HUB_ORGS[currentValue as keyof typeof PROVIDERS_HUB_ORGS]}
-								{#if hubOrg}
-									<span
-										class="flex size-5 flex-none items-center justify-center rounded-md bg-gray-500/10 p-0.5"
-									>
-										<img
-											src="https://huggingface.co/api/avatars/{hubOrg}"
-											alt=""
-											class="size-full rounded"
-										/>
-									</span>
+					<div class="flex items-start justify-between py-3">
+						<div>
+							<div class="text-[13px] font-medium text-gray-800 dark:text-gray-200">
+								Multimodal support (image inputs)
+							</div>
+							<p class="text-[12px] text-gray-500 dark:text-gray-400">
+								{#if publicConfig.isHuggingChat}
+									Determined by the inference provider for this model.
+								{:else}
+									Enable image uploads and send images to this model.
 								{/if}
-							{/if}
-							{currentPolicy?.label ?? currentProvider?.provider ?? currentValue}
-						</span>
-						<CarbonChevronDown class="size-4 text-gray-500" />
-					</Select.Trigger>
-					<Select.Portal>
-						<Select.Content
-							class="scrollbar-custom z-50 max-h-60 overflow-y-auto rounded-xl border border-gray-200 bg-white/95 p-1 shadow-lg backdrop-blur dark:border-gray-700 dark:bg-gray-800/95"
-							sideOffset={4}
-						>
-							<Select.Group>
-								<Select.GroupHeading
-									class="px-2 py-1.5 text-xs font-medium text-gray-500 dark:text-gray-400"
+							</p>
+						</div>
+						<Switch
+							name="forceMultimodal"
+							disabled={publicConfig.isHuggingChat}
+							bind:checked={getMultimodalOverride, setMultimodalOverride}
+						/>
+					</div>
+
+					<div class="flex items-start justify-between py-3">
+						<div>
+							<div class="text-[13px] font-medium text-gray-800 dark:text-gray-200">
+								Reasoning effort
+							</div>
+							<p class="text-[12px] text-gray-500 dark:text-gray-400">
+								{#if publicConfig.isHuggingChat}
+									Determined by the inference provider for this model.
+								{:else}
+									Show a Low / Medium / High selector in the chat footer for this model.
+								{/if}
+							</p>
+						</div>
+						<Switch
+							name="forceReasoning"
+							disabled={publicConfig.isHuggingChat}
+							bind:checked={getReasoningOverride, setReasoningOverride}
+						/>
+					</div>
+
+					<div class="flex items-start justify-between py-3">
+						<div>
+							<div
+								class="flex items-center gap-1.5 text-[13px] font-medium text-gray-800 dark:text-gray-200"
+							>
+								Artifacts
+								<span
+									class="rounded-full bg-gray-100 px-1.5 py-px text-[10px] font-semibold uppercase text-gray-500 dark:bg-gray-700 dark:text-gray-400"
 								>
-									Selection mode
-								</Select.GroupHeading>
-								{#each PROVIDER_POLICIES as opt (opt.value)}
-									<Select.Item
-										value={opt.value}
-										class="flex cursor-pointer select-none items-center gap-2 rounded-lg px-2 py-1.5 text-sm text-gray-700 outline-none data-[highlighted]:bg-gray-100 dark:text-gray-200 dark:data-[highlighted]:bg-white/10"
-									>
-										{#if opt.value === "auto"}
-											<span
-												class="grid size-5 flex-none place-items-center rounded-md bg-gray-500/10"
-											>
-												<CarbonMagicWandFilled class="size-3 text-gray-700 dark:text-gray-300" />
-											</span>
-										{:else if opt.value === "fastest"}
-											<span
-												class="grid size-5 flex-none place-items-center rounded-md bg-green-500/10 text-green-600 dark:text-green-500"
-											>
-												<IconFast classNames="size-3" />
-											</span>
-										{:else if opt.value === "cheapest"}
-											<span
-												class="grid size-5 flex-none place-items-center rounded-md bg-blue-500/10 text-blue-600 dark:text-blue-500"
-											>
-												<IconCheap classNames="size-3" />
-											</span>
-										{/if}
-										<span class="flex-1">{opt.label}</span>
-										{#if getProviderOverride() === opt.value}
-											<LucideCheck class="size-4 text-gray-500" />
-										{/if}
-									</Select.Item>
-								{/each}
-							</Select.Group>
-							<div class="my-1 h-px bg-gray-200 dark:bg-gray-700"></div>
-							<Select.Group>
-								<Select.GroupHeading
-									class="px-2 py-1.5 text-xs font-medium text-gray-500 dark:text-gray-400"
-								>
-									Specific provider
-								</Select.GroupHeading>
-								{#each providerList as prov (prov.provider)}
-									{@const hubOrg =
-										PROVIDERS_HUB_ORGS[prov.provider as keyof typeof PROVIDERS_HUB_ORGS]}
-									<Select.Item
-										value={prov.provider}
-										class="flex cursor-pointer select-none items-center gap-2 rounded-lg px-2 py-1.5 text-sm text-gray-700 outline-none data-[highlighted]:bg-gray-100 dark:text-gray-200 dark:data-[highlighted]:bg-white/10"
-									>
-										{#if hubOrg}
-											<span
-												class="flex size-5 flex-none items-center justify-center rounded-md bg-gray-500/10 p-0.5"
-											>
-												<img
-													src="https://huggingface.co/api/avatars/{hubOrg}"
-													alt=""
-													class="size-full rounded"
-												/>
-											</span>
-										{:else}
-											<span class="size-5"></span>
-										{/if}
-										<span class="flex-1">{prov.provider}</span>
-										{#if getProviderOverride() === prov.provider}
-											<LucideCheck class="size-4 text-gray-500" />
-										{/if}
-									</Select.Item>
-								{/each}
-							</Select.Group>
-						</Select.Content>
-					</Select.Portal>
-				</Select.Root>
+									Beta
+								</span>
+							</div>
+							<p class="text-[12px] text-gray-500 dark:text-gray-400">
+								Let the model create apps, documents and diagrams in a side panel with live preview.
+							</p>
+						</div>
+						<!-- Not provider-determined, so user-editable even on HuggingChat -->
+						<Switch
+							name="artifactsOverride"
+							bind:checked={getArtifactsOverride, setArtifactsOverride}
+						/>
+					</div>
+
+					{#if model?.isRouter}
+						<div class="flex items-start justify-between py-3">
+							<div>
+								<div class="text-[13px] font-medium text-gray-800 dark:text-gray-200">
+									Hide prompt examples
+								</div>
+								<p class="text-[12px] text-gray-500 dark:text-gray-400">
+									Hide the prompt suggestions above the chat input.
+								</p>
+							</div>
+							<Switch
+								name="hidePromptExamples"
+								bind:checked={getHidePromptExamples, setHidePromptExamples}
+							/>
+						</div>
+					{/if}
+				</div>
 			</div>
-		{/if}
-		<!-- Tokenizer-based token counting disabled in this build -->
+
+			{#if publicConfig.isHuggingChat && model.providers?.length && !model?.isRouter}
+				<div
+					class="mt-3 flex flex-col items-start gap-2.5 rounded-xl border border-gray-200 bg-white px-3 py-3 shadow-sm dark:border-gray-700 dark:bg-gray-800"
+				>
+					<div>
+						<div class="text-[13px] font-medium text-gray-800 dark:text-gray-200">
+							Inference Providers
+						</div>
+						<p class="text-[12px] text-gray-500 dark:text-gray-400">
+							Choose which Inference Provider to use with this model. You can also manage provider
+							preferences in <a
+								class="underline decoration-gray-400 hover:decoration-gray-700 dark:decoration-gray-500 dark:hover:decoration-gray-300"
+								target="_blank"
+								href="https://huggingface.co/settings/inference-providers/settings"
+								>your HF settings</a
+							>.
+						</p>
+					</div>
+					<Select.Root
+						type="single"
+						value={getProviderOverride()}
+						onValueChange={(v) => v && setProviderOverride(v)}
+					>
+						<Select.Trigger
+							aria-label="Select inference provider"
+							class="inline-flex w-auto items-center justify-between gap-2 rounded-lg border border-gray-200 bg-white px-2 py-2 text-sm text-gray-800 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-200 dark:hover:bg-gray-800"
+						>
+							{@const currentValue = getProviderOverride()}
+							{@const currentPolicy = PROVIDER_POLICIES.find((p) => p.value === currentValue)}
+							{@const currentProvider = providerList.find((p) => p.provider === currentValue)}
+							<span class="flex items-center gap-2">
+								{#if currentValue === "auto"}
+									<span class="grid size-5 flex-none place-items-center rounded-md bg-gray-500/10">
+										<CarbonMagicWandFilled class="size-3 text-gray-700 dark:text-gray-300" />
+									</span>
+								{:else if currentValue === "fastest"}
+									<span
+										class="grid size-5 flex-none place-items-center rounded-md bg-green-500/10 text-green-600 dark:text-green-500"
+									>
+										<IconFast classNames="size-3" />
+									</span>
+								{:else if currentValue === "cheapest"}
+									<span
+										class="grid size-5 flex-none place-items-center rounded-md bg-blue-500/10 text-blue-600 dark:text-blue-500"
+									>
+										<IconCheap classNames="size-3" />
+									</span>
+								{:else if currentProvider}
+									{@const hubOrg =
+										PROVIDERS_HUB_ORGS[currentValue as keyof typeof PROVIDERS_HUB_ORGS]}
+									{#if hubOrg}
+										<span
+											class="flex size-5 flex-none items-center justify-center rounded-md bg-gray-500/10 p-0.5"
+										>
+											<img
+												src="https://huggingface.co/api/avatars/{hubOrg}"
+												alt=""
+												class="size-full rounded"
+											/>
+										</span>
+									{/if}
+								{/if}
+								{currentPolicy?.label ?? currentProvider?.provider ?? currentValue}
+							</span>
+							<CarbonChevronDown class="size-4 text-gray-500" />
+						</Select.Trigger>
+						<Select.Portal>
+							<Select.Content
+								class="scrollbar-custom z-50 max-h-60 overflow-y-auto rounded-xl border border-gray-200 bg-white/95 p-1 shadow-lg backdrop-blur dark:border-gray-700 dark:bg-gray-800/95"
+								sideOffset={4}
+							>
+								<Select.Group>
+									<Select.GroupHeading
+										class="px-2 py-1.5 text-xs font-medium text-gray-500 dark:text-gray-400"
+									>
+										Selection mode
+									</Select.GroupHeading>
+									{#each PROVIDER_POLICIES as opt (opt.value)}
+										<Select.Item
+											value={opt.value}
+											class="flex cursor-pointer select-none items-center gap-2 rounded-lg px-2 py-1.5 text-sm text-gray-700 outline-none data-[highlighted]:bg-gray-100 dark:text-gray-200 dark:data-[highlighted]:bg-white/10"
+										>
+											{#if opt.value === "auto"}
+												<span
+													class="grid size-5 flex-none place-items-center rounded-md bg-gray-500/10"
+												>
+													<CarbonMagicWandFilled class="size-3 text-gray-700 dark:text-gray-300" />
+												</span>
+											{:else if opt.value === "fastest"}
+												<span
+													class="grid size-5 flex-none place-items-center rounded-md bg-green-500/10 text-green-600 dark:text-green-500"
+												>
+													<IconFast classNames="size-3" />
+												</span>
+											{:else if opt.value === "cheapest"}
+												<span
+													class="grid size-5 flex-none place-items-center rounded-md bg-blue-500/10 text-blue-600 dark:text-blue-500"
+												>
+													<IconCheap classNames="size-3" />
+												</span>
+											{/if}
+											<span class="flex-1">{opt.label}</span>
+											{#if getProviderOverride() === opt.value}
+												<LucideCheck class="size-4 text-gray-500" />
+											{/if}
+										</Select.Item>
+									{/each}
+								</Select.Group>
+								<div class="my-1 h-px bg-gray-200 dark:bg-gray-700"></div>
+								<Select.Group>
+									<Select.GroupHeading
+										class="px-2 py-1.5 text-xs font-medium text-gray-500 dark:text-gray-400"
+									>
+										Specific provider
+									</Select.GroupHeading>
+									{#each providerList as prov (prov.provider)}
+										{@const hubOrg =
+											PROVIDERS_HUB_ORGS[prov.provider as keyof typeof PROVIDERS_HUB_ORGS]}
+										<Select.Item
+											value={prov.provider}
+											class="flex cursor-pointer select-none items-center gap-2 rounded-lg px-2 py-1.5 text-sm text-gray-700 outline-none data-[highlighted]:bg-gray-100 dark:text-gray-200 dark:data-[highlighted]:bg-white/10"
+										>
+											{#if hubOrg}
+												<span
+													class="flex size-5 flex-none items-center justify-center rounded-md bg-gray-500/10 p-0.5"
+												>
+													<img
+														src="https://huggingface.co/api/avatars/{hubOrg}"
+														alt=""
+														class="size-full rounded"
+													/>
+												</span>
+											{:else}
+												<span class="size-5"></span>
+											{/if}
+											<span class="flex-1">{prov.provider}</span>
+											{#if getProviderOverride() === prov.provider}
+												<LucideCheck class="size-4 text-gray-500" />
+											{/if}
+										</Select.Item>
+									{/each}
+								</Select.Group>
+							</Select.Content>
+						</Select.Portal>
+					</Select.Root>
+				</div>
+			{/if}
+			<!-- Tokenizer-based token counting disabled in this build -->
+		</div>
 	</div>
-</div>
+{/key}


### PR DESCRIPTION
## Summary
Fixes an issue where interactive components (switches, textareas) on the model settings page would animate to new values instead of resetting when navigating between different models.

## Changes
- Wrapped the entire model settings page content in a Svelte `{#key modelId}` block
- This forces the DOM to be rebuilt when the `modelId` changes, ensuring all form controls reset to their initial state rather than animating between model values
- Added explanatory comment documenting the purpose of the key block

## Implementation Details
The key block ensures that when a user navigates from one model's settings to another, all interactive elements (Switch components, textarea values, etc.) are destroyed and recreated with the new model's values, providing a cleaner UX than animated transitions between different states.

https://claude.ai/code/session_01WbucqYEz3f7grsBEUeA6d7