### PR TITLE
Fix code block size in artifact panel to match chat prose

### DIFF
--- a/src/lib/components/chat/ArtifactPanel.svelte
+++ b/src/lib/components/chat/ArtifactPanel.svelte
@@ -378,9 +378,10 @@
 			{/if}
 		{:else}
 			<!-- Same .prose pre styling as chat code blocks so the syntax theme matches
-			     exactly in both modes; !border-0 since the panel provides its own frame -->
+			     exactly in both modes; text-smd matches the chat prose root so the code
+			     renders at the same size; !border-0 since the panel provides its own frame -->
 			<div
-				class="prose h-full max-w-none dark:prose-invert prose-pre:my-0 prose-pre:h-full prose-pre:rounded-none"
+				class="prose h-full max-w-none text-smd dark:prose-invert prose-pre:my-0 prose-pre:h-full prose-pre:rounded-none"
 			>
 				<!-- eslint-disable svelte/no-at-html-tags -->
 				<pre


### PR DESCRIPTION
## Summary
Fixes the font size of code blocks displayed in the artifact panel to match the size of code blocks in the chat interface, ensuring visual consistency across both modes.

## Changes
- Added `text-smd` class to the prose container in ArtifactPanel to match the text size used in the chat prose root
- Updated the comment to document that `text-smd` ensures code renders at the same size in both the artifact panel and chat interface

## Details
The artifact panel was rendering code blocks at a different size than the chat interface because it was missing the `text-smd` class that's applied to the chat prose root. This change aligns the styling so code blocks appear consistently sized regardless of where they're displayed.

https://claude.ai/code/session_013cFkJHtAVT5LYJ7bHVzMQp