### PR TITLE
Replace loading-dots animation with router-shimmer class

### DIFF
--- a/src/lib/components/chat/ArtifactPanel.svelte
+++ b/src/lib/components/chat/ArtifactPanel.svelte
@@ -460,7 +460,7 @@
 
 		<div class="flex min-w-0 items-center gap-2">
 			{#if isStreamingVersion}
-				<span class="loading-dots text-gray-400">
+				<span class="router-shimmer whitespace-nowrap">
 					{version?.op === "update" ? "Applying edit" : "Generating"}
 				</span>
 			{:else if errors.length > 0}
@@ -550,24 +550,5 @@
 	}
 	:global(.dark) pre.diff-view :global(.hljs-deletion) {
 		background: rgba(224, 108, 117, 0.13);
-	}
-
-	.loading-dots::after {
-		content: "";
-		animation: dots-content 0.9s steps(1, end) infinite;
-	}
-	@keyframes dots-content {
-		0% {
-			content: "";
-		}
-		33% {
-			content: ".";
-		}
-		66% {
-			content: "..";
-		}
-		88% {
-			content: "...";
-		}
 	}
 </style>


### PR DESCRIPTION
## Summary
Replaced the custom `loading-dots` CSS animation with the `router-shimmer` class in the ArtifactPanel component's streaming status indicator, and removed the now-unused animation styles.

## Changes
- Updated the streaming version indicator span to use `router-shimmer whitespace-nowrap` classes instead of `loading-dots text-gray-400`
- Removed the custom `.loading-dots::after` pseudo-element animation and associated `@keyframes dots-content` styles (which created a dot-progression animation)

## Details
This change consolidates the loading state styling by leveraging an existing `router-shimmer` class, likely providing a more consistent visual treatment across the application. The `whitespace-nowrap` class ensures the "Applying edit" or "Generating" text doesn't wrap during the animation.

https://claude.ai/code/session_019aLRi83E3hH1FYkedhTGcN