### PR TITLE
Add artifact indicator to example prompts

### DIFF
--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -48,7 +48,7 @@
 	import { usePublicConfig } from "$lib/utils/PublicConfig.svelte";
 	import { pendingChatInput } from "$lib/stores/pendingChatInput";
 	import LucideHammer from "~icons/lucide/hammer";
-	import LucideAppWindow from "~icons/lucide/app-window";
+	import LucideSparkles from "~icons/lucide/sparkles";
 
 	import { fly } from "svelte/transition";
 	import { cubicInOut } from "svelte/easing";
@@ -730,10 +730,10 @@
 							class="flex items-center gap-1 rounded-lg bg-gray-100/90 px-2 py-0.5 text-center text-sm backdrop-blur hover:text-gray-500 dark:bg-gray-700/50 dark:hover:text-gray-400"
 							onclick={() => startExample(ex)}
 						>
-							{#if ex.artifact}
-								<LucideAppWindow class="size-3 flex-none text-blue-600 dark:text-blue-400" />
-							{/if}
 							{ex.title}
+							{#if ex.artifact}
+								<LucideSparkles class="size-3 flex-none text-blue-600 dark:text-blue-400" />
+							{/if}
 						</button>
 					{/each}
 				</div>

--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -48,6 +48,7 @@
 	import { usePublicConfig } from "$lib/utils/PublicConfig.svelte";
 	import { pendingChatInput } from "$lib/stores/pendingChatInput";
 	import LucideHammer from "~icons/lucide/hammer";
+	import LucideAppWindow from "~icons/lucide/app-window";
 
 	import { fly } from "svelte/transition";
 	import { cubicInOut } from "svelte/easing";
@@ -726,9 +727,14 @@
 				>
 					{#each activeExamples as ex}
 						<button
-							class="flex items-center rounded-lg bg-gray-100/90 px-2 py-0.5 text-center text-sm backdrop-blur hover:text-gray-500 dark:bg-gray-700/50 dark:hover:text-gray-400"
-							onclick={() => startExample(ex)}>{ex.title}</button
+							class="flex items-center gap-1 rounded-lg bg-gray-100/90 px-2 py-0.5 text-center text-sm backdrop-blur hover:text-gray-500 dark:bg-gray-700/50 dark:hover:text-gray-400"
+							onclick={() => startExample(ex)}
 						>
+							{#if ex.artifact}
+								<LucideAppWindow class="size-3 flex-none text-blue-600 dark:text-blue-400" />
+							{/if}
+							{ex.title}
+						</button>
 					{/each}
 				</div>
 			{/if}

--- a/src/lib/constants/mcpExamples.ts
+++ b/src/lib/constants/mcpExamples.ts
@@ -7,21 +7,21 @@ export const mcpExamples: RouterExample[] = [
 		prompt: "Generate an image of a zebra in front of a volcanic eruption",
 	},
 	{
-		title: "Build a website",
+		title: "Celebrate 3M models",
 		prompt:
-			"Build a minimalist website with TailwindCSS presenting the current trending models on Hugging Face",
+			"Build a small celebration card with TailwindCSS for Hugging Face crossing 3 million models, with an animated counter and confetti, in a single compact HTML file",
 		followUps: [
 			{
-				title: "Trending datasets",
-				prompt: "Add a section showing the current trending datasets on Hugging Face",
+				title: "Trending models",
+				prompt: "Add a line showing today's top 3 trending models on Hugging Face",
 			},
 			{
 				title: "Surprise me",
 				prompt: "Redesign it in a completely different visual style, surprise me",
 			},
 			{
-				title: "Multilingual",
-				prompt: "Add a language switcher that translates the site into French and Japanese",
+				title: "Confetti burst",
+				prompt: "Make confetti burst from the card when I click it",
 			},
 		],
 	},

--- a/src/lib/constants/mcpExamples.ts
+++ b/src/lib/constants/mcpExamples.ts
@@ -8,6 +8,7 @@ export const mcpExamples: RouterExample[] = [
 	},
 	{
 		title: "Celebrate 3M models",
+		artifact: true,
 		prompt:
 			"Build a small celebration card with TailwindCSS for Hugging Face crossing 3 million models, with an animated counter and confetti, in a single compact HTML file",
 		followUps: [

--- a/src/lib/constants/routerExamples.ts
+++ b/src/lib/constants/routerExamples.ts
@@ -12,6 +12,8 @@ export type RouterExample = {
 	prompt: string;
 	followUps?: RouterFollowUp[];
 	attachments?: RouterExampleAttachment[];
+	/** Shows a small artifact icon on the example chip */
+	artifact?: boolean;
 };
 
 export const routerExamples: RouterExample[] = [


### PR DESCRIPTION
## Summary
Enhanced the example prompts UI to visually distinguish examples that generate artifacts (like HTML/code) from those that don't, by adding a sparkles icon indicator.

## Changes
- **Updated MCP examples**: Replaced the generic "Build a website" example with a more specific "Celebrate 3M models" example that generates an interactive HTML artifact, marked with the new `artifact` flag
- **Extended RouterExample type**: Added optional `artifact?: boolean` property to indicate when an example produces an artifact output
- **Enhanced example chip UI**: 
  - Added sparkles icon import (`LucideSparkles`)
  - Modified example button styling to include gap spacing for the icon
  - Conditionally render a blue sparkles icon next to the title when `artifact` is true
- **Updated follow-up prompts**: Adjusted follow-up suggestions for the new celebration card example to be more relevant (trending models, confetti burst interactions)

## Implementation Details
The sparkles icon uses Lucide's `sparkles` icon with `size-3` for a subtle indicator, styled in blue (`text-blue-600` / `dark:text-blue-400`) to match the design system. The icon only renders when the `artifact` property is explicitly set to `true` on a RouterExample, maintaining backward compatibility with existing examples.

https://claude.ai/code/session_01MZWqxEHWkUjMBSkg4BQeLh