### PR TITLE
Simplify share thumbnail by removing model name and quotes

### DIFF
--- a/src/routes/r/[id]/thumbnail.png/+server.ts
+++ b/src/routes/r/[id]/thumbnail.png/+server.ts
@@ -4,11 +4,7 @@ import { base } from "$app/paths";
 import { collections } from "$lib/server/database";
 import { config } from "$lib/server/config";
 import { convertLegacyConversation } from "$lib/utils/tree/convertLegacyConversation";
-import {
-	cleanTextForMeta,
-	extractFirstUserPrompt,
-	renderableThumbnailText,
-} from "$lib/utils/sharePreviewText";
+import { extractFirstUserPrompt, renderableThumbnailText } from "$lib/utils/sharePreviewText";
 import { renderShareThumbnailPng } from "./shareThumbnail";
 
 // Social-preview thumbnail for shared conversations. Only shared conversations
@@ -36,7 +32,6 @@ export const GET: RequestHandler = (async ({ params }) => {
 
 	const png = await renderShareThumbnailPng({
 		prompt,
-		modelName: cleanTextForMeta(sharedConversation.model ?? "", 64),
 		isHuggingChat: config.isHuggingChat,
 		appName: config.PUBLIC_APP_NAME,
 	});

--- a/src/routes/r/[id]/thumbnail.png/shareThumbnail.ssr.test.ts
+++ b/src/routes/r/[id]/thumbnail.png/shareThumbnail.ssr.test.ts
@@ -21,7 +21,6 @@ describe("renderShareThumbnailPng", () => {
 	it("renders a PNG for a normal prompt", async () => {
 		const png = await renderShareThumbnailPng({
 			prompt: renderableThumbnailText("How do I fine-tune a model on my own dataset?", 240),
-			modelName: "moonshotai/Kimi-K2-Thinking",
 			isHuggingChat: true,
 			appName: "HuggingChat",
 		});
@@ -31,7 +30,6 @@ describe("renderShareThumbnailPng", () => {
 	it("renders the generic card when the prompt is empty", async () => {
 		const png = await renderShareThumbnailPng({
 			prompt: "",
-			modelName: "",
 			isHuggingChat: false,
 			appName: "ChatUI",
 		});
@@ -52,7 +50,6 @@ describe("renderShareThumbnailPng", () => {
 		for (const input of inputs) {
 			const png = await renderShareThumbnailPng({
 				prompt: renderableThumbnailText(input, 240),
-				modelName: "openai/gpt-oss-120b",
 				isHuggingChat: true,
 				appName: "HuggingChat",
 			});

--- a/src/routes/r/[id]/thumbnail.png/shareThumbnail.ts
+++ b/src/routes/r/[id]/thumbnail.png/shareThumbnail.ts
@@ -34,9 +34,6 @@ function el(
 	return { type, props: { style, children, ...props } };
 }
 
-const LEFT_QUOTE = String.fromCharCode(0x201c);
-const RIGHT_QUOTE = String.fromCharCode(0x201d);
-
 // White HuggingChat logo as a data URI so no network fetch happens at render
 // time. The source svg only declares height="55" against a 575x100 viewBox,
 // which makes its intrinsic size ambiguous (renderers stretch it to 575x55),
@@ -60,8 +57,6 @@ const logoElement = el(
 export interface ShareThumbnailOptions {
 	/** Sanitized prompt text (see renderableThumbnailText); "" renders the generic card */
 	prompt: string;
-	/** Model id shown at the bottom; empty string hides it */
-	modelName: string;
 	isHuggingChat: boolean;
 	/** Branding used when not HuggingChat */
 	appName: string;
@@ -69,7 +64,6 @@ export interface ShareThumbnailOptions {
 
 function shareThumbnailElement({
 	prompt,
-	modelName,
 	isHuggingChat,
 	appName,
 }: ShareThumbnailOptions): SatoriElement {
@@ -87,7 +81,7 @@ function shareThumbnailElement({
 			color: "#ffffff",
 			wordBreak: "break-word",
 		},
-		text + (prompt ? RIGHT_QUOTE : "")
+		text
 	);
 
 	const continueRow = el(
@@ -103,7 +97,7 @@ function shareThumbnailElement({
 
 	const contentColumn = el(
 		"div",
-		{ display: "flex", flexDirection: "column", alignItems: "flex-start", maxWidth: 680 },
+		{ display: "flex", flexDirection: "column", alignItems: "flex-start", maxWidth: 760 },
 		[
 			promptBlock,
 			// Short divider line under the prompt
@@ -115,21 +109,6 @@ function shareThumbnailElement({
 				marginTop: 38,
 			}),
 			continueRow,
-			modelName
-				? el(
-						"div",
-						{
-							fontSize: 22,
-							color: "#d1d5db",
-							marginTop: 28,
-							backgroundColor: "rgba(255, 255, 255, 0.06)",
-							border: "2px solid rgba(255, 255, 255, 0.18)",
-							borderRadius: 999,
-							padding: "8px 24px",
-						},
-						modelName
-					)
-				: el("div", {}),
 		]
 	);
 
@@ -144,24 +123,7 @@ function shareThumbnailElement({
 			backgroundColor: "#000000",
 			backgroundImage: `url(${backgroundDataUri})`,
 		},
-		el("div", { display: "flex", alignItems: "flex-start" }, [
-			// Hanging opening quote, top-aligned with the first prompt line
-			prompt
-				? el(
-						"div",
-						{
-							fontSize: 110,
-							fontWeight: 700,
-							lineHeight: 1,
-							color: "#ffffff",
-							marginRight: 18,
-							marginTop: -14,
-						},
-						LEFT_QUOTE
-					)
-				: el("div", { width: 24 }),
-			contentColumn,
-		])
+		contentColumn
 	);
 }
 


### PR DESCRIPTION
## Summary
Removes the model name display and decorative opening/closing quotes from the share thumbnail generation, simplifying the visual design and reducing the number of parameters passed through the thumbnail rendering pipeline.

## Key Changes
- Removed `modelName` parameter from `ShareThumbnailOptions` interface and `shareThumbnailElement()` function
- Removed the model name badge element that was displayed below the prompt
- Removed decorative left and right quote characters (`LEFT_QUOTE` and `RIGHT_QUOTE` constants)
- Removed the hanging opening quote element that was positioned above the prompt text
- Increased `maxWidth` of content column from 680 to 760 pixels to accommodate the removed quote spacing
- Updated `+server.ts` to no longer pass `modelName` when calling `renderShareThumbnailPng()`
- Removed unused `cleanTextForMeta` import from `+server.ts`
- Updated test cases to remove `modelName` parameter from test calls

## Implementation Details
The changes simplify the thumbnail layout by removing decorative elements and model metadata. The content column now spans the full available width without the hanging quote indent, resulting in a cleaner, more straightforward visual presentation of shared conversation thumbnails.

https://claude.ai/code/session_01FsvDCFTT1P9LnC4kk6RivB