### PR TITLE
Client-owned chat state: retire ConversationList invalidation, polling, and the pendingMessage hack

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -23,6 +23,12 @@ declare global {
 		}
 		// interface PageData {}
 		// interface Platform {}
+		interface PageState {
+			/** First message text carried from the home/model page to a new conversation. */
+			pendingMessage?: string;
+			/** Nonce for looking up File[] in the client-side pendingFiles Map. */
+			pendingFilesNonce?: string;
+		}
 	}
 }
 

--- a/src/lib/components/BackgroundGenerationPoller.svelte
+++ b/src/lib/components/BackgroundGenerationPoller.svelte
@@ -86,8 +86,9 @@
 					removeBackgroundGeneration(event.id);
 					log("complete", event.id);
 
-					// Invalidate the conversation detail if the user is currently viewing it
-					void safeInvalidate(UrlDependency.ConversationList).then(() => {
+					// Refresh the sidebar via the client-owned store, then invalidate the
+					// conversation detail if the user is currently viewing it.
+					void convsStore.refresh().then(() => {
 						// Only invalidate the conversation detail when it is currently open
 						if (page.params.id === event.id) {
 							return safeInvalidate(UrlDependency.Conversation);
@@ -133,7 +134,7 @@
 			for (const entry of timedOut) {
 				removeBackgroundGeneration(entry.id);
 				log("timeout evict", entry.id);
-				void safeInvalidate(UrlDependency.ConversationList).then(() => {
+				void convsStore.refresh().then(() => {
 					if (page.params.id === entry.id) {
 						return safeInvalidate(UrlDependency.Conversation);
 					}

--- a/src/lib/components/BackgroundGenerationPoller.svelte
+++ b/src/lib/components/BackgroundGenerationPoller.svelte
@@ -1,168 +1,172 @@
 <script lang="ts">
 	import { browser, dev } from "$app/environment";
+	import { page } from "$app/state";
+	import { base } from "$app/paths";
 	import { safeInvalidate } from "$lib/utils/safeInvalidate";
 
 	import {
-		type BackgroundGeneration,
 		backgroundGenerationEntries,
 		removeBackgroundGeneration,
 	} from "$lib/stores/backgroundGenerations";
-	import { handleResponse, useAPIClient } from "$lib/APIClient";
 	import { UrlDependency } from "$lib/types/UrlDependency";
-	import type { Message } from "$lib/types/Message";
-	import { isAssistantGenerationTerminal } from "$lib/utils/generationState";
+	import { useConversationsStore } from "$lib/stores/conversations.svelte";
 
-	const POLL_INTERVAL_MS = 1000;
-	const MAX_POLL_DURATION_MS = 3 * 60_000;
+	/**
+	 * Maximum time a background generation entry is tracked before we give up
+	 * and invalidate anyway. Mirrors the old 1Hz poller's MAX_POLL_DURATION_MS.
+	 */
+	const MAX_TRACK_DURATION_MS = 3 * 60_000;
 
-	const client = useAPIClient();
-	const pollers = new Map<string, () => void>();
-	const inflight = new Set<string>();
-	const assistantSnapshots = new Map<string, string>();
-	const failureCounts = new Map<string, number>();
+	/**
+	 * How long to wait before reconnecting the SSE stream after it closes
+	 * (server-enforced 5-min lifetime causes a normal close; use a brief delay
+	 * so we do not hammer the server if there is a transient error).
+	 */
+	const RECONNECT_DELAY_MS = 1_000;
+
+	const convsStore = useConversationsStore();
 
 	$effect.root(() => {
-		if (!browser) {
-			pollers.clear();
-			return;
-		}
+		if (!browser) return;
 
 		let destroyed = false;
+		let eventSource: EventSource | null = null;
+		let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 
 		const log = (...args: unknown[]) => {
-			if (dev) {
-				console.log("background generation", ...args);
-			}
+			if (dev) console.log("[BackgroundGenerationPoller]", ...args);
 		};
 
-		const stopPoller = (id: string, reason?: string) => {
-			const stop = pollers.get(id);
-			if (!stop) return;
+		/** Most-recent updatedAt seen across all events; used as reconnect cursor. */
+		let latestCursor = new Date(0).toISOString();
 
-			stop();
-			pollers.delete(id);
-			inflight.delete(id);
-			assistantSnapshots.delete(id);
-			failureCounts.delete(id);
-			log("stop", id, reason);
-		};
+		function openStream() {
+			if (destroyed || backgroundGenerationEntries.length === 0) return;
+			if (eventSource) return; // already open
 
-		const pollOnce = async (id: string) => {
-			if (destroyed || inflight.has(id)) return;
+			const url = new URL(`${base}/api/v2/conversations/updates`, window.location.href);
+			url.searchParams.set("cursor", latestCursor);
 
-			const entry = backgroundGenerationEntries.find((candidate) => candidate.id === id);
-			if (entry && Date.now() - entry.startedAt > MAX_POLL_DURATION_MS) {
-				removeBackgroundGeneration(id);
-				stopPoller(id, "timed out");
-				log("timeout", id);
-				await safeInvalidate(UrlDependency.ConversationList);
-				await safeInvalidate(UrlDependency.Conversation);
-				return;
-			}
+			log("opening SSE stream, cursor:", latestCursor);
+			eventSource = new EventSource(url.toString());
 
-			inflight.add(id);
-			log("poll", id);
+			eventSource.addEventListener("update", (raw) => {
+				if (destroyed) return;
 
-			try {
-				const response = await client.conversations({ id }).get({ query: {} });
-				const conversation = handleResponse(response) as {
-					messages?: Message[];
-				} | null;
-				const messages: Message[] = conversation?.messages ?? [];
-				const lastAssistant = [...messages]
-					.reverse()
-					.find((message: Message) => message.from === "assistant");
+				let event: {
+					id: string;
+					title: string;
+					updatedAt: string;
+					isTerminal: boolean;
+				};
+				try {
+					event = JSON.parse(raw.data) as typeof event;
+				} catch (err) {
+					console.error("[BackgroundGenerationPoller] bad SSE payload", err);
+					return;
+				}
 
-				const isTerminal = isAssistantGenerationTerminal(lastAssistant);
+				log("update", event);
 
-				const snapshot = lastAssistant
-					? JSON.stringify({
-							id: lastAssistant.id,
-							updatedAt: lastAssistant.updatedAt,
-							contentLength: lastAssistant.content?.length ?? 0,
-							updatesLength: lastAssistant.updates?.length ?? 0,
-						})
-					: "__none__";
-				const previousSnapshot = assistantSnapshots.get(id);
-				let shouldInvalidateConversation = false;
+				// Advance cursor
+				if (event.updatedAt > latestCursor) {
+					latestCursor = event.updatedAt;
+				}
 
-				if (lastAssistant) {
-					assistantSnapshots.set(id, snapshot);
-					if (snapshot !== previousSnapshot) {
-						shouldInvalidateConversation = true;
+				// Update sidebar title / updatedAt for this conversation
+				convsStore.update(event.id, {
+					title: event.title,
+					updatedAt: new Date(event.updatedAt),
+				});
+
+				const isTracked = backgroundGenerationEntries.some((e) => e.id === event.id);
+				if (!isTracked) return;
+
+				if (event.isTerminal) {
+					removeBackgroundGeneration(event.id);
+					log("complete", event.id);
+
+					// Invalidate the conversation detail if the user is currently viewing it
+					void safeInvalidate(UrlDependency.ConversationList).then(() => {
+						// Only invalidate the conversation detail when it is currently open
+						if (page.params.id === event.id) {
+							return safeInvalidate(UrlDependency.Conversation);
+						}
+					});
+				} else {
+					// Non-terminal update: if the affected conversation is open, refresh it
+					if (page.params.id === event.id) {
+						void safeInvalidate(UrlDependency.Conversation);
 					}
-				} else if (assistantSnapshots.has(id)) {
-					assistantSnapshots.delete(id);
-					shouldInvalidateConversation = true;
 				}
+			});
 
-				if (lastAssistant && isTerminal) {
-					removeBackgroundGeneration(id);
-					assistantSnapshots.delete(id);
-					failureCounts.delete(id);
-					shouldInvalidateConversation = true;
-					log("complete", id, "terminal");
-					await safeInvalidate(UrlDependency.ConversationList);
+			eventSource.onerror = () => {
+				if (destroyed) return;
+				log("SSE error / close — scheduling reconnect");
+				closeStream();
+				// Reconnect only if there are still entries to track
+				if (backgroundGenerationEntries.length > 0) {
+					reconnectTimer = setTimeout(() => {
+						reconnectTimer = null;
+						openStream();
+					}, RECONNECT_DELAY_MS);
 				}
+			};
+		}
 
-				if (shouldInvalidateConversation) {
-					await safeInvalidate(UrlDependency.Conversation);
-				}
-
-				failureCounts.delete(id);
-			} catch (err) {
-				console.error("Background generation poll failed", id, err);
-				const failures = (failureCounts.get(id) ?? 0) + 1;
-				failureCounts.set(id, failures);
-				if (failures >= 3) {
-					removeBackgroundGeneration(id);
-					assistantSnapshots.delete(id);
-					failureCounts.delete(id);
-					log("failures", id, failures);
-					await safeInvalidate(UrlDependency.ConversationList);
-				}
-			} finally {
-				inflight.delete(id);
+		function closeStream() {
+			if (eventSource) {
+				eventSource.close();
+				eventSource = null;
+				log("SSE stream closed");
 			}
-		};
+		}
 
-		const startPoller = (entry: BackgroundGeneration) => {
-			if (pollers.has(entry.id)) return;
+		// Timeout guard: entries that have been tracked too long are evicted,
+		// mirroring the old poller's MAX_POLL_DURATION_MS behaviour.
+		function evictTimedOutEntries() {
+			const now = Date.now();
+			const timedOut = backgroundGenerationEntries.filter(
+				(e) => now - e.startedAt > MAX_TRACK_DURATION_MS
+			);
+			for (const entry of timedOut) {
+				removeBackgroundGeneration(entry.id);
+				log("timeout evict", entry.id);
+				void safeInvalidate(UrlDependency.ConversationList).then(() => {
+					if (page.params.id === entry.id) {
+						return safeInvalidate(UrlDependency.Conversation);
+					}
+				});
+			}
+		}
 
-			const intervalId = setInterval(() => {
-				void pollOnce(entry.id);
-			}, POLL_INTERVAL_MS);
-
-			pollers.set(entry.id, () => clearInterval(intervalId));
-			void pollOnce(entry.id);
-			log("start", entry.id);
-		};
+		// Evict timed-out entries on an interval even when the SSE stream is quiet.
+		const evictTimer = setInterval(evictTimedOutEntries, 10_000);
 
 		$effect(() => {
-			const entries = backgroundGenerationEntries;
+			// Reactive dep: re-evaluate whenever the entries array changes.
+			const hasEntries = backgroundGenerationEntries.length > 0;
 
 			if (destroyed) return;
 
-			const activeIds = new Set(entries.map((entry) => entry.id));
-
-			for (const id of pollers.keys()) {
-				if (!activeIds.has(id)) {
-					stopPoller(id);
+			if (hasEntries) {
+				openStream();
+			} else {
+				// No active generations — close the stream to conserve connections.
+				if (reconnectTimer !== null) {
+					clearTimeout(reconnectTimer);
+					reconnectTimer = null;
 				}
-			}
-
-			for (const entry of entries) {
-				startPoller(entry);
+				closeStream();
 			}
 		});
 
 		return () => {
 			destroyed = true;
-			for (const stop of pollers.values()) stop();
-			pollers.clear();
-			inflight.clear();
-			assistantSnapshots.clear();
-			failureCounts.clear();
+			clearInterval(evictTimer);
+			if (reconnectTimer !== null) clearTimeout(reconnectTimer);
+			closeStream();
 		};
 	});
 </script>

--- a/src/lib/components/chat/ModelSwitch.svelte
+++ b/src/lib/components/chat/ModelSwitch.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { UrlDependency } from "$lib/types/UrlDependency";
 	import { safeInvalidate } from "$lib/utils/safeInvalidate";
+	import { useConversationsStore } from "$lib/stores/conversations.svelte";
 	import { page } from "$app/state";
 	import { base } from "$app/paths";
 	import type { Model } from "$lib/types/Model";
@@ -11,6 +12,8 @@
 	}
 
 	let { models, currentModel }: Props = $props();
+
+	const convsStore = useConversationsStore();
 
 	let selectedModelId = $state("");
 
@@ -36,10 +39,7 @@
 				throw new Error("Failed to update model");
 			}
 
-			await Promise.all([
-				safeInvalidate(UrlDependency.Conversation),
-				safeInvalidate(UrlDependency.ConversationList),
-			]);
+			await Promise.all([safeInvalidate(UrlDependency.Conversation), convsStore.refresh()]);
 		} catch (error) {
 			console.error(error);
 		}

--- a/src/lib/stores/conversations.svelte.ts
+++ b/src/lib/stores/conversations.svelte.ts
@@ -8,14 +8,6 @@
  * There is NO module-level mutable $state, so concurrent SSR requests do not
  * share data.
  *
- * Browser singleton: in addition to the context-based facade, a module-level
- * _browserSingleton reference is set the first time createConversationsStore()
- * runs in the browser. This allows non-component modules (e.g. settings.ts)
- * that cannot call getContext() to call refreshConversationsStore() without
- * going through the SvelteKit invalidation bus.  The singleton is guarded by
- * `browser` from $app/environment and is always undefined on the server, so
- * it is SSR-safe.
- *
  * Seeding strategy: +layout.svelte calls init() whenever data.conversations
  * reference changes. The store performs a last-write-wins merge from the
  * server — local optimistic mutations (delete/rename/title) are intentionally
@@ -34,14 +26,6 @@ import type { ConvSidebar } from "$lib/types/ConvSidebar";
 import { useAPIClient, handleResponse } from "$lib/APIClient";
 
 export const CONVERSATIONS_CONTEXT_KEY = "conversationsStore";
-
-/**
- * Module-level browser-only singleton. Set once in createConversationsStore()
- * when running in the browser. Always undefined on the server.
- * Allows non-component modules (settings.ts) to call refreshConversationsStore()
- * without getContext().
- */
-let _browserSingleton: ConversationsStore | undefined;
 
 interface ConversationListItem {
 	_id: { toString(): string };
@@ -115,24 +99,10 @@ class ConversationsStore {
 export function createConversationsStore(): ConversationsStore {
 	const store = new ConversationsStore();
 	setContext(CONVERSATIONS_CONTEXT_KEY, store);
-	// Register the browser singleton so non-component modules can call refresh().
-	if (browser) {
-		_browserSingleton = store;
-	}
 	return store;
 }
 
 /** Call in any descendant component to access the store. */
 export function useConversationsStore(): ConversationsStore {
 	return getContext<ConversationsStore>(CONVERSATIONS_CONTEXT_KEY);
-}
-
-/**
- * Refresh the conversations sidebar without going through the SvelteKit
- * invalidation bus.  Safe to call from non-component modules (e.g. settings.ts)
- * that cannot use getContext().  No-op on the server.
- */
-export function refreshConversationsStore(): Promise<void> {
-	if (!browser || !_browserSingleton) return Promise.resolve();
-	return _browserSingleton.refresh();
 }

--- a/src/lib/stores/conversations.svelte.ts
+++ b/src/lib/stores/conversations.svelte.ts
@@ -1,0 +1,71 @@
+/**
+ * Client-owned conversations sidebar store.
+ *
+ * SSR safety: this module exports a factory function and context helpers
+ * (createConversationsStore / useConversationsStore). The store instance is
+ * held inside Svelte component context (keyed by CONVERSATIONS_CONTEXT_KEY)
+ * and is therefore per-request on the server and per-layout on the client.
+ * There is NO module-level mutable $state, so concurrent SSR requests do not
+ * share data.
+ *
+ * Seeding strategy: +layout.svelte calls init() whenever data.conversations
+ * reference changes. The store performs a last-write-wins merge from the
+ * server — local optimistic mutations (delete/rename/title) are intentionally
+ * overwritten on the next server resync. This is acceptable because:
+ *   - delete/rename mutations are immediately visible and the server round-trip
+ *     is fast (< 500 ms typical);
+ *   - title updates from streaming are ephemeral until the conversation list
+ *     is next invalidated, which only happens after generation completes.
+ * If we wanted to preserve local mutations across resyncs we would need to
+ * track "dirty" ids — the complexity is not justified at this stage.
+ */
+
+import { getContext, setContext } from "svelte";
+import type { ConvSidebar } from "$lib/types/ConvSidebar";
+
+export const CONVERSATIONS_CONTEXT_KEY = "conversationsStore";
+
+class ConversationsStore {
+	#list = $state<ConvSidebar[]>([]);
+
+	get list(): ConvSidebar[] {
+		return this.#list;
+	}
+
+	/** Replace the entire list (called from layout when data.conversations changes). */
+	init(conversations: ConvSidebar[]): void {
+		this.#list = conversations;
+	}
+
+	/**
+	 * Apply a partial patch to a single conversation by id.
+	 * Silently ignores unknown ids (e.g. race between title update and delete).
+	 */
+	update(id: string, patch: Partial<Omit<ConvSidebar, "id">>): void {
+		const idx = this.#list.findIndex((c) => String(c.id) === id);
+		if (idx === -1) return;
+		this.#list[idx] = { ...this.#list[idx], ...patch };
+	}
+
+	/** Remove a conversation by id (optimistic delete). */
+	remove(id: string): void {
+		this.#list = this.#list.filter((c) => String(c.id) !== id);
+	}
+
+	/** Prepend a new conversation to the top of the list. */
+	prepend(conv: ConvSidebar): void {
+		this.#list = [conv, ...this.#list];
+	}
+}
+
+/** Call once in +layout.svelte to create and register the store in context. */
+export function createConversationsStore(): ConversationsStore {
+	const store = new ConversationsStore();
+	setContext(CONVERSATIONS_CONTEXT_KEY, store);
+	return store;
+}
+
+/** Call in any descendant component to access the store. */
+export function useConversationsStore(): ConversationsStore {
+	return getContext<ConversationsStore>(CONVERSATIONS_CONTEXT_KEY);
+}

--- a/src/lib/stores/conversations.svelte.ts
+++ b/src/lib/stores/conversations.svelte.ts
@@ -8,22 +8,47 @@
  * There is NO module-level mutable $state, so concurrent SSR requests do not
  * share data.
  *
+ * Browser singleton: in addition to the context-based facade, a module-level
+ * _browserSingleton reference is set the first time createConversationsStore()
+ * runs in the browser. This allows non-component modules (e.g. settings.ts)
+ * that cannot call getContext() to call refreshConversationsStore() without
+ * going through the SvelteKit invalidation bus.  The singleton is guarded by
+ * `browser` from $app/environment and is always undefined on the server, so
+ * it is SSR-safe.
+ *
  * Seeding strategy: +layout.svelte calls init() whenever data.conversations
  * reference changes. The store performs a last-write-wins merge from the
  * server — local optimistic mutations (delete/rename/title) are intentionally
  * overwritten on the next server resync. This is acceptable because:
  *   - delete/rename mutations are immediately visible and the server round-trip
  *     is fast (< 500 ms typical);
- *   - title updates from streaming are ephemeral until the conversation list
- *     is next invalidated, which only happens after generation completes.
+ *   - title updates from streaming are ephemeral until the store is next
+ *     refreshed, which happens after generation completes.
  * If we wanted to preserve local mutations across resyncs we would need to
  * track "dirty" ids — the complexity is not justified at this stage.
  */
 
+import { browser } from "$app/environment";
 import { getContext, setContext } from "svelte";
 import type { ConvSidebar } from "$lib/types/ConvSidebar";
+import { useAPIClient, handleResponse } from "$lib/APIClient";
 
 export const CONVERSATIONS_CONTEXT_KEY = "conversationsStore";
+
+/**
+ * Module-level browser-only singleton. Set once in createConversationsStore()
+ * when running in the browser. Always undefined on the server.
+ * Allows non-component modules (settings.ts) to call refreshConversationsStore()
+ * without getContext().
+ */
+let _browserSingleton: ConversationsStore | undefined;
+
+interface ConversationListItem {
+	_id: { toString(): string };
+	title: string;
+	updatedAt: Date | string;
+	model?: string;
+}
 
 class ConversationsStore {
 	#list = $state<ConvSidebar[]>([]);
@@ -56,16 +81,58 @@ class ConversationsStore {
 	prepend(conv: ConvSidebar): void {
 		this.#list = [conv, ...this.#list];
 	}
+
+	/**
+	 * Re-fetch GET /api/v2/conversations?p=0 and reconcile with the local list.
+	 * Performs a last-write-wins replace so updatedAt ordering reflects the server.
+	 * No-op on the server (browser guard).
+	 */
+	async refresh(): Promise<void> {
+		if (!browser) return;
+		try {
+			const client = useAPIClient();
+			const data = (await client.conversations.get({ query: { p: 0 } }).then(handleResponse)) as {
+				conversations: ConversationListItem[];
+				hasMore: boolean;
+			};
+
+			const defaultModel = undefined; // caller can patch model separately if needed
+			const freshList: ConvSidebar[] = data.conversations.map((conv) => ({
+				id: conv._id.toString(),
+				title: conv.title.trim(),
+				model: conv.model ?? defaultModel,
+				updatedAt: new Date(conv.updatedAt),
+			}));
+			this.#list = freshList;
+		} catch (err) {
+			// Non-fatal: keep the existing list rather than blanking the sidebar.
+			console.error("[conversationsStore] refresh failed", err);
+		}
+	}
 }
 
 /** Call once in +layout.svelte to create and register the store in context. */
 export function createConversationsStore(): ConversationsStore {
 	const store = new ConversationsStore();
 	setContext(CONVERSATIONS_CONTEXT_KEY, store);
+	// Register the browser singleton so non-component modules can call refresh().
+	if (browser) {
+		_browserSingleton = store;
+	}
 	return store;
 }
 
 /** Call in any descendant component to access the store. */
 export function useConversationsStore(): ConversationsStore {
 	return getContext<ConversationsStore>(CONVERSATIONS_CONTEXT_KEY);
+}
+
+/**
+ * Refresh the conversations sidebar without going through the SvelteKit
+ * invalidation bus.  Safe to call from non-component modules (e.g. settings.ts)
+ * that cannot use getContext().  No-op on the server.
+ */
+export function refreshConversationsStore(): Promise<void> {
+	if (!browser || !_browserSingleton) return Promise.resolve();
+	return _browserSingleton.refresh();
 }

--- a/src/lib/stores/pendingMessage.ts
+++ b/src/lib/stores/pendingMessage.ts
@@ -1,9 +1,0 @@
-import { writable } from "svelte/store";
-
-export const pendingMessage = writable<
-	| {
-			content: string;
-			files: File[];
-	  }
-	| undefined
->();

--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -1,8 +1,6 @@
 import { browser } from "$app/environment";
-import { safeInvalidate } from "$lib/utils/safeInvalidate";
 import { base } from "$app/paths";
 import type { ReasoningEffort, StreamingMode } from "$lib/types/Settings";
-import { UrlDependency } from "$lib/types/UrlDependency";
 import { getContext, setContext } from "svelte";
 import { type Writable, writable, get } from "svelte/store";
 
@@ -64,8 +62,6 @@ export function createSettingsStore(initialValue: Omit<SettingsStore, "recentlyS
 					body: JSON.stringify(get(baseStore)),
 				});
 
-				safeInvalidate(UrlDependency.ConversationList);
-
 				if (showSavedOnNextSync) {
 					// set savedRecently to true for 3s
 					baseStore.update((s) => ({
@@ -122,8 +118,6 @@ export function createSettingsStore(initialValue: Omit<SettingsStore, "recentlyS
 					body: JSON.stringify(get(baseStore)),
 				});
 
-				safeInvalidate(UrlDependency.ConversationList);
-
 				if (showSavedOnNextSync) {
 					baseStore.update((s) => ({
 						...s,
@@ -158,7 +152,6 @@ export function createSettingsStore(initialValue: Omit<SettingsStore, "recentlyS
 					...settings,
 				}),
 			});
-			safeInvalidate(UrlDependency.ConversationList);
 		}
 	}
 

--- a/src/lib/stores/titleUpdate.ts
+++ b/src/lib/stores/titleUpdate.ts
@@ -1,8 +1,0 @@
-import { writable } from "svelte/store";
-
-export interface TitleUpdate {
-	convId: string;
-	title: string;
-}
-
-export default writable<TitleUpdate | null>(null);

--- a/src/lib/types/UrlDependency.ts
+++ b/src/lib/types/UrlDependency.ts
@@ -1,5 +1,4 @@
 /* eslint-disable no-shadow */
 export enum UrlDependency {
-	ConversationList = "conversation:list",
 	Conversation = "conversation:id",
 }

--- a/src/lib/utils/pendingFiles.ts
+++ b/src/lib/utils/pendingFiles.ts
@@ -1,0 +1,32 @@
+/**
+ * Client-only store for File objects that cannot be serialized into
+ * SvelteKit's history state (which must be JSON-serializable).
+ *
+ * Callers generate a random nonce, store their File[] here under that nonce,
+ * then pass the nonce alongside the text via goto() history state.  The
+ * destination page consumes and removes the entry so it is never leaked.
+ *
+ * SSR-safe: the Map is only created in browser environments.  On the server
+ * the module exports a no-op API so imports never crash during SSR.
+ */
+
+import { browser } from "$app/environment";
+
+const store: Map<string, File[]> = browser ? new Map() : (null as unknown as Map<string, File[]>);
+
+/** Save files under a nonce and return the nonce. */
+export function storePendingFiles(files: File[]): string {
+	const nonce = crypto.randomUUID();
+	if (browser) {
+		store.set(nonce, files);
+	}
+	return nonce;
+}
+
+/** Consume (retrieve and delete) files for a given nonce. Returns [] on miss. */
+export function consumePendingFiles(nonce: string): File[] {
+	if (!browser) return [];
+	const files = store.get(nonce) ?? [];
+	store.delete(nonce);
+	return files;
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import "../styles/main.css";
 
-	import { onDestroy, onMount, untrack } from "svelte";
+	import { onDestroy, onMount } from "svelte";
 	import { goto } from "$app/navigation";
 	import { base } from "$app/paths";
 	import { page } from "$app/state";
@@ -13,7 +13,6 @@
 	import Toast from "$lib/components/Toast.svelte";
 	import NavMenu from "$lib/components/NavMenu.svelte";
 	import MobileNav from "$lib/components/MobileNav.svelte";
-	import titleUpdate from "$lib/stores/titleUpdate";
 	import WelcomeModal from "$lib/components/WelcomeModal.svelte";
 	import ExpandNavigation from "$lib/components/ExpandNavigation.svelte";
 	import { setContext } from "svelte";
@@ -22,6 +21,7 @@
 	import { isPro } from "$lib/stores/isPro";
 	import BackgroundGenerationPoller from "$lib/components/BackgroundGenerationPoller.svelte";
 	import { requireAuthUser } from "$lib/utils/auth";
+	import { createConversationsStore } from "$lib/stores/conversations.svelte";
 
 	let { data = $bindable(), children } = $props();
 
@@ -30,9 +30,15 @@
 	const publicConfig = data.publicConfig;
 	const client = useAPIClient();
 
-	let conversations = $state(data.conversations);
+	const convsStore = createConversationsStore();
+	// Synchronous seed for SSR: $effect is stripped by the server-side compiler,
+	// so we must call init() immediately to populate the list on first paint.
+	// The $effect below handles client-side resyncs when data.conversations
+	// reference changes after subsequent invalidations.
+	// Last-write-wins from server is acceptable; see conversations.svelte.ts.
+	convsStore.init(data.conversations);
 	$effect(() => {
-		data.conversations && untrack(() => (conversations = data.conversations));
+		convsStore.init(data.conversations);
 	});
 
 	let isNavCollapsed = $state(false);
@@ -62,7 +68,7 @@
 			.delete()
 			.then(handleResponse)
 			.then(async () => {
-				conversations = conversations.filter((conv) => conv.id !== id);
+				convsStore.remove(id);
 
 				if (page.params.id === id) {
 					await goto(`${base}/`, { invalidateAll: true });
@@ -80,7 +86,7 @@
 			.patch({ title })
 			.then(handleResponse)
 			.then(async () => {
-				conversations = conversations.map((conv) => (conv.id === id ? { ...conv, title } : conv));
+				convsStore.update(id, { title });
 			})
 			.catch((err) => {
 				console.error(err);
@@ -99,18 +105,6 @@
 
 	$effect(() => {
 		if ($error) onError();
-	});
-
-	$effect(() => {
-		if ($titleUpdate) {
-			const convIdx = conversations.findIndex(({ id }) => id === $titleUpdate?.convId);
-
-			if (convIdx != -1) {
-				conversations[convIdx].title = $titleUpdate?.title ?? conversations[convIdx].title;
-			}
-
-			$titleUpdate = null;
-		}
 	});
 
 	const settings = createSettingsStore(data.settings);
@@ -179,7 +173,7 @@
 	let mobileNavTitle = $derived(
 		["/models", "/privacy"].includes(page.route.id ?? "")
 			? ""
-			: conversations.find((conv) => conv.id === page.params.id)?.title
+			: convsStore.list.find((conv) => conv.id === page.params.id)?.title
 	);
 
 	// Show the welcome modal once on first app load
@@ -271,7 +265,7 @@
 
 	<MobileNav title={mobileNavTitle}>
 		<NavMenu
-			{conversations}
+			conversations={convsStore.list}
 			user={data.user}
 			ondeleteConversation={(id) => deleteConversation(id)}
 			oneditConversationTitle={(payload) => editConversationTitle(payload.id, payload.title)}
@@ -281,7 +275,7 @@
 		class="grid max-h-dvh grid-cols-1 grid-rows-[auto,1fr,auto] overflow-hidden *:w-[290px] max-md:hidden"
 	>
 		<NavMenu
-			{conversations}
+			conversations={convsStore.list}
 			user={data.user}
 			ondeleteConversation={(id) => deleteConversation(id)}
 			oneditConversationTitle={(payload) => editConversationTitle(payload.id, payload.title)}

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -1,4 +1,3 @@
-import { UrlDependency } from "$lib/types/UrlDependency";
 import type { ConvSidebar } from "$lib/types/ConvSidebar";
 import { useAPIClient, handleResponse } from "$lib/APIClient";
 import { getConfigManager } from "$lib/utils/PublicConfig.svelte";
@@ -40,9 +39,7 @@ interface SettingsResponse {
 	billingOrganization?: string;
 }
 
-export const load = async ({ depends, fetch, url }) => {
-	depends(UrlDependency.ConversationList);
-
+export const load = async ({ fetch, url }) => {
 	const client = useAPIClient({ fetch, origin: url.origin });
 
 	const [settings, models, user, publicConfig, featureFlags, conversationsData] =

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -10,7 +10,7 @@
 
 	import ChatWindow from "$lib/components/chat/ChatWindow.svelte";
 	import { ERROR_MESSAGES, error } from "$lib/stores/errors";
-	import { pendingMessage } from "$lib/stores/pendingMessage";
+	import { storePendingFiles } from "$lib/utils/pendingFiles";
 	import { useSettingsStore } from "$lib/stores/settings.js";
 	import { findCurrentModel } from "$lib/utils/models";
 	import { sanitizeUrlParam } from "$lib/utils/urlParams";
@@ -75,19 +75,21 @@
 
 			const { conversationId } = await res.json();
 
-			// Ugly hack to use a store as temp storage, feel free to improve ^^
-			pendingMessage.set({
-				content: message,
-				files,
-			});
+			// Pass the first message text via SvelteKit history state (JSON-serializable).
+			// File objects are not serializable, so they are stored in a client-side Map
+			// keyed by a random nonce; the nonce travels with the history state and is
+			// consumed once by the conversation page.
+			const pendingFilesNonce = files.length > 0 ? storePendingFiles(files) : undefined;
 
 			// Refresh the sidebar list (only that, not all 6 bootstrap endpoints)
 			// BEFORE navigating. Refreshing after goto() would update layout data
-			// while the first message is streaming, and the conversation page's
-			// `$effect(() => { messages = data.messages })` would wipe the locally
-			// appended messages, blanking the conversation until the stream ends.
+			// while the first message is streaming, causing any data-syncing effects
+			// on the conversation page to overwrite locally appended messages and
+			// blank the conversation until the stream ends.
 			await safeInvalidate(UrlDependency.ConversationList);
-			await goto(`${base}/conversation/${conversationId}`);
+			await goto(`${base}/conversation/${conversationId}`, {
+				state: { pendingMessage: message, pendingFilesNonce },
+			});
 		} catch (err) {
 			error.set((err as Error).message || ERROR_MESSAGES.default);
 			console.error(err);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,7 +1,5 @@
 <script lang="ts">
 	import { goto, replaceState } from "$app/navigation";
-	import { UrlDependency } from "$lib/types/UrlDependency";
-	import { safeInvalidate } from "$lib/utils/safeInvalidate";
 	import { base } from "$app/paths";
 	import { page } from "$app/state";
 	import { usePublicConfig } from "$lib/utils/PublicConfig.svelte";
@@ -12,6 +10,7 @@
 	import { ERROR_MESSAGES, error } from "$lib/stores/errors";
 	import { storePendingFiles } from "$lib/utils/pendingFiles";
 	import { useSettingsStore } from "$lib/stores/settings.js";
+	import { useConversationsStore } from "$lib/stores/conversations.svelte";
 	import { findCurrentModel } from "$lib/utils/models";
 	import { sanitizeUrlParam } from "$lib/utils/urlParams";
 	import { onMount, tick } from "svelte";
@@ -20,6 +19,8 @@
 	import { requireAuthUser } from "$lib/utils/auth";
 
 	let { data } = $props();
+
+	const convsStore = useConversationsStore();
 
 	let hasModels = $derived(Boolean(data.models?.length));
 	let files: File[] = $state([]);
@@ -81,12 +82,16 @@
 			// consumed once by the conversation page.
 			const pendingFilesNonce = files.length > 0 ? storePendingFiles(files) : undefined;
 
-			// Refresh the sidebar list (only that, not all 6 bootstrap endpoints)
-			// BEFORE navigating. Refreshing after goto() would update layout data
-			// while the first message is streaming, causing any data-syncing effects
-			// on the conversation page to overwrite locally appended messages and
-			// blank the conversation until the stream ends.
-			await safeInvalidate(UrlDependency.ConversationList);
+			// Optimistically prepend the new conversation to the sidebar immediately so
+			// it appears before the first message starts streaming. The title is set to
+			// "" here; it will be updated to the real title via a Title SSE update once
+			// the LLM generates one.
+			convsStore.prepend({
+				id: conversationId,
+				title: "",
+				model,
+				updatedAt: new Date(),
+			});
 			await goto(`${base}/conversation/${conversationId}`, {
 				state: { pendingMessage: message, pendingFilesNonce },
 			});

--- a/src/routes/api/v2/conversations/updates/+server.ts
+++ b/src/routes/api/v2/conversations/updates/+server.ts
@@ -1,0 +1,158 @@
+import type { RequestHandler } from "@sveltejs/kit";
+import { requireAuth } from "$lib/server/api/utils/requireAuth";
+import { collections } from "$lib/server/database";
+import { authCondition } from "$lib/server/auth";
+import { isAssistantGenerationTerminal } from "$lib/utils/generationState";
+import type { Message } from "$lib/types/Message";
+
+/**
+ * SSE endpoint that pushes conversation-update events to the client.
+ *
+ * The client opens this stream while background generations are in flight.
+ * Because generations may complete on any pod, this handler uses a server-side
+ * poll loop (every ~2 s) rather than in-process events.
+ *
+ * Protocol
+ * --------
+ * Each SSE event has type "update" and a JSON payload:
+ *   { id: string, title: string, updatedAt: string (ISO), isTerminal: boolean }
+ *
+ * The client reconnects automatically (SSE default) after the server closes
+ * the stream at MAX_LIFETIME_MS; it should pass the last known cursor via
+ * the `?cursor` query parameter to avoid re-sending stale events on reconnect.
+ *
+ * Multi-instance safety
+ * ---------------------
+ * We query MongoDB directly on every tick, so updates written by any pod are
+ * visible here without in-process coordination.
+ */
+
+const POLL_INTERVAL_MS = 2_000;
+const MAX_LIFETIME_MS = 5 * 60_000;
+
+type ConvUpdate = {
+	id: string;
+	title: string;
+	updatedAt: string;
+	isTerminal: boolean;
+};
+
+export const GET: RequestHandler = async ({ locals, url, request }) => {
+	requireAuth(locals);
+
+	// `cursor` is an ISO timestamp; events with updatedAt > cursor are sent.
+	// On the very first connection the client passes cursor=0 (epoch) so all
+	// in-flight conversations are surfaced immediately.
+	const cursorParam = url.searchParams.get("cursor");
+	let cursor = cursorParam ? new Date(cursorParam) : new Date(0);
+
+	const stream = new ReadableStream({
+		async start(controller) {
+			const signal = request.signal;
+			const deadline = Date.now() + MAX_LIFETIME_MS;
+
+			const encode = (data: ConvUpdate) =>
+				new TextEncoder().encode(`event: update\ndata: ${JSON.stringify(data)}\n\n`);
+
+			const sendHeartbeat = () => controller.enqueue(new TextEncoder().encode(": heartbeat\n\n"));
+
+			while (!signal.aborted && Date.now() < deadline) {
+				// Wait for next tick (or abort)
+				await new Promise<void>((resolve) => {
+					const t = setTimeout(resolve, POLL_INTERVAL_MS);
+					signal.addEventListener(
+						"abort",
+						() => {
+							clearTimeout(t);
+							resolve();
+						},
+						{ once: true }
+					);
+				});
+
+				if (signal.aborted) break;
+
+				try {
+					// Find conversations belonging to this user that changed since cursor.
+					// We project just enough to determine terminal state without loading
+					// full message content (only metadata fields on the last assistant message).
+					const changed = await collections.conversations
+						.find({
+							...authCondition(locals),
+							updatedAt: { $gt: cursor },
+						})
+						.project<{
+							_id: { toString(): string };
+							title: string;
+							updatedAt: Date;
+							messages: Array<
+								Pick<Message, "from" | "interrupted" | "updates"> & { content?: string }
+							>;
+						}>({
+							title: 1,
+							updatedAt: 1,
+							// Project only the fields isAssistantGenerationTerminal needs.
+							// We cannot do a sparse projection of only the last message from
+							// MongoDB without an aggregation stage, so we project all messages
+							// but limit to the fields we need (not the large content strings).
+							"messages.from": 1,
+							"messages.interrupted": 1,
+							"messages.updates": 1,
+						})
+						.sort({ updatedAt: -1 })
+						.limit(50)
+						.toArray();
+
+					for (const conv of changed) {
+						if (signal.aborted) break;
+
+						const lastAssistant = [...conv.messages]
+							.reverse()
+							.find((m) => m.from === "assistant") as Message | undefined;
+						const isTerminal = isAssistantGenerationTerminal(lastAssistant);
+
+						const event: ConvUpdate = {
+							id: conv._id.toString(),
+							title: conv.title,
+							updatedAt: conv.updatedAt.toISOString(),
+							isTerminal,
+						};
+
+						controller.enqueue(encode(event));
+
+						// Advance cursor to avoid re-emitting the same conversation on
+						// the next tick (use max of current cursor and this conv's updatedAt).
+						if (conv.updatedAt > cursor) {
+							cursor = conv.updatedAt;
+						}
+					}
+
+					if (changed.length === 0) {
+						sendHeartbeat();
+					}
+				} catch (err) {
+					// Log and continue — transient DB errors should not kill the stream.
+					console.error("[conversation-updates SSE] poll error", err);
+					sendHeartbeat();
+				}
+			}
+
+			// Graceful close: tell the client it should reconnect.
+			try {
+				controller.close();
+			} catch {
+				// already closed by abort
+			}
+		},
+	});
+
+	return new Response(stream, {
+		headers: {
+			"Content-Type": "text/event-stream",
+			"Cache-Control": "no-cache",
+			Connection: "keep-alive",
+			// Allow client-side JS to read this response (CORS if needed)
+			"X-Accel-Buffering": "no",
+		},
+	});
+};

--- a/src/routes/api/v2/models/+server.ts
+++ b/src/routes/api/v2/models/+server.ts
@@ -2,8 +2,10 @@ import type { RequestHandler } from "@sveltejs/kit";
 import { superjsonResponse } from "$lib/server/api/utils/superjsonResponse";
 import type { GETModelsResponse } from "$lib/server/api/types";
 
-// Models change only on server restart. Cache for 60s in the browser so repeated
-// invalidations (e.g. from settings saves) don't generate a new round-trip.
+// Models are loaded at startup but can also be refreshed at runtime via
+// POST /api/v2/models/refresh. Cache for 60s so repeated invalidations
+// (e.g. from settings saves) don't generate a round-trip; up to 60s of
+// staleness after a refresh is accepted.
 const MODELS_CACHE_HEADERS = { "Cache-Control": "private, max-age=60" };
 
 export const GET: RequestHandler = async () => {

--- a/src/routes/conversation/[id]/+page.svelte
+++ b/src/routes/conversation/[id]/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import ChatWindow from "$lib/components/chat/ChatWindow.svelte";
-	import { pendingMessage } from "$lib/stores/pendingMessage";
+	import { consumePendingFiles } from "$lib/utils/pendingFiles";
 	import { isAborted } from "$lib/stores/isAborted";
 	import { onMount, untrack } from "svelte";
 	import { page } from "$app/state";
@@ -528,10 +528,16 @@
 	}
 
 	onMount(async () => {
-		if ($pendingMessage) {
-			files = $pendingMessage.files;
-			await writeMessage({ prompt: $pendingMessage.content });
-			$pendingMessage = undefined;
+		// Read the first message from SvelteKit shallow-routing history state.
+		// Text is serialized directly; File objects travel via the pendingFiles
+		// client-side Map, retrieved once by nonce and then discarded.
+		// On a hard refresh page.state is empty, so both values are undefined
+		// and we skip straight to the background-generation check below.
+		const pendingText = page.state.pendingMessage as string | undefined;
+		if (pendingText) {
+			const nonce = page.state.pendingFilesNonce as string | undefined;
+			files = nonce ? consumePendingFiles(nonce) : [];
+			await writeMessage({ prompt: pendingText });
 		}
 
 		const streaming = isConversationGenerationActive(messages);

--- a/src/routes/conversation/[id]/+page.svelte
+++ b/src/routes/conversation/[id]/+page.svelte
@@ -49,6 +49,12 @@
 	let files: File[] = $state([]);
 
 	let conversations = $state(untrack(() => data.conversations));
+	// TODO(step-N): this unguarded effect overwrites optimistic mutations in
+	// +layout.svelte whenever any load re-runs (e.g. ConversationList invalidation
+	// mid-stream). The untrack() on the initializer suppresses the
+	// state_referenced_locally warning but does NOT fix the underlying anti-pattern.
+	// Migrate conversations to a layout-level rune context shared downward so that
+	// optimistic mutations and server resyncs are managed in one place.
 	$effect(() => {
 		conversations = data.conversations;
 	});
@@ -583,10 +589,16 @@
 	// load re-running mid-stream (e.g. from BackgroundGenerationPoller or
 	// safeInvalidate) does NOT wipe the in-flight token buffer.
 	//
-	// "pending" is set to true at the top of writeMessage and reset to false
-	// in its finally block BEFORE safeInvalidate fires, so when the load
-	// resolves after streaming the guard is already lifted and we get the
-	// server-confirmed snapshot.
+	// Guard window: "pending" is set to true at the START of writeMessage and
+	// is first reset to false when the FIRST STREAMING TOKEN arrives (line ~351
+	// in the stream loop). It is also reset in the finally block. This means
+	// the guard only covers the brief interval between the user submitting a
+	// message and the first token being received. Any safeInvalidate that
+	// resolves AFTER the first token (e.g. from ModelSwitch.svelte) would be
+	// allowed to overwrite the in-flight buffer. In practice this is acceptable
+	// because BackgroundGenerationPoller is inactive during foreground streaming
+	// and ModelSwitch is only shown when a model is unavailable, but callers
+	// must not assume the full streaming window is protected by this guard.
 	let _lastSyncedConvId = untrack(() => convId); // plain variable — no reactive overhead needed
 	$effect(() => {
 		const currentConvId = convId; // reactive dep
@@ -665,7 +677,7 @@
 </svelte:head>
 
 {#if sharePreviewId}
-	<SharePreviewTags shareId={sharePreviewId} {title} messages={data.messages} {rootMessageId} />
+	<SharePreviewTags shareId={sharePreviewId} {title} {messages} {rootMessageId} />
 {/if}
 
 <ChatWindow

--- a/src/routes/conversation/[id]/+page.svelte
+++ b/src/routes/conversation/[id]/+page.svelte
@@ -12,7 +12,7 @@
 	import { findCurrentModel } from "$lib/utils/models";
 	import type { Message } from "$lib/types/Message";
 	import { MessageUpdateStatus, MessageUpdateType } from "$lib/types/MessageUpdate";
-	import titleUpdate from "$lib/stores/titleUpdate";
+	import { useConversationsStore } from "$lib/stores/conversations.svelte";
 	import file2base64 from "$lib/utils/file2base64";
 	import { addChildren } from "$lib/utils/tree/addChildren";
 	import { addSibling } from "$lib/utils/tree/addSibling";
@@ -38,6 +38,10 @@
 
 	let { data } = $props();
 
+	// Obtain the conversations store during component init (context must be read
+	// synchronously, not inside async callbacks or event handlers).
+	const convsStore = useConversationsStore();
+
 	let convId = $derived(page.params.id ?? "");
 	let pending = $state(false);
 	let initialRun = true;
@@ -47,17 +51,6 @@
 	let messageUpdatesAbortController = new AbortController();
 
 	let files: File[] = $state([]);
-
-	let conversations = $state(untrack(() => data.conversations));
-	// TODO(step-N): this unguarded effect overwrites optimistic mutations in
-	// +layout.svelte whenever any load re-runs (e.g. ConversationList invalidation
-	// mid-stream). The untrack() on the initializer suppresses the
-	// state_referenced_locally warning but does NOT fix the underlying anti-pattern.
-	// Migrate conversations to a layout-level rune context shared downward so that
-	// optimistic mutations and server resyncs are managed in one place.
-	$effect(() => {
-		conversations = data.conversations;
-	});
 
 	function createMessagesPath<T>(messages: TreeNode<T>[], msgId?: TreeId): TreeNode<T>[] {
 		if (initialRun) {
@@ -424,15 +417,8 @@
 						$error = update.message ?? "An error has occurred";
 					}
 				} else if (update.type === MessageUpdateType.Title) {
-					const convInData = conversations.find(({ id }) => id === page.params.id);
-					if (convInData) {
-						convInData.title = update.title;
-
-						$titleUpdate = {
-							title: update.title,
-							convId,
-						};
-					}
+					// Update the sidebar title directly via the store — no side-channel needed.
+					convsStore.update(convId, { title: update.title });
 				} else if (update.type === MessageUpdateType.File) {
 					messageToWriteTo.files = [
 						...(messageToWriteTo.files ?? []),
@@ -659,7 +645,8 @@
 	});
 
 	let title = $derived.by(() => {
-		const rawTitle = conversations.find((conv) => conv.id === page.params.id)?.title ?? data.title;
+		const rawTitle =
+			convsStore.list.find((conv) => conv.id === page.params.id)?.title ?? data.title;
 		return rawTitle ? rawTitle.charAt(0).toUpperCase() + rawTitle.slice(1) : rawTitle;
 	});
 

--- a/src/routes/conversation/[id]/+page.svelte
+++ b/src/routes/conversation/[id]/+page.svelte
@@ -458,9 +458,9 @@
 			}
 			// Only re-run the loads that actually need fresh data: the
 			// conversation page (new messages) and the sidebar list
-			// (updated title / updatedAt). Avoids the 5 redundant bootstrap
-			// requests (models, settings, user, public-config, feature-flags)
-			// that a full invalidateAll() would trigger.
+			// (updated title / updatedAt via client-owned store refresh).
+			// Avoids the 5 redundant bootstrap requests (models, settings, user,
+			// public-config, feature-flags) that a full invalidateAll() would trigger.
 			// When this finally runs because beforeNavigate aborted the stream
 			// ($isAborted set without stopRequested), invalidating would cancel
 			// that very navigation (e.g. the "New Chat" click that triggered
@@ -468,10 +468,7 @@
 			// Skip the refresh: the destination page loads its own data.
 			const abortedByNavigation = $isAborted && !stopRequested;
 			if (!abortedByNavigation) {
-				await Promise.all([
-					safeInvalidate(UrlDependency.Conversation),
-					safeInvalidate(UrlDependency.ConversationList),
-				]);
+				await Promise.all([safeInvalidate(UrlDependency.Conversation), convsStore.refresh()]);
 			}
 		}
 	}

--- a/src/routes/conversation/[id]/+page.svelte
+++ b/src/routes/conversation/[id]/+page.svelte
@@ -4,7 +4,7 @@
 	import { isAborted } from "$lib/stores/isAborted";
 	import { onMount, untrack } from "svelte";
 	import { page } from "$app/state";
-	import { beforeNavigate } from "$app/navigation";
+	import { beforeNavigate, replaceState } from "$app/navigation";
 	import { UrlDependency } from "$lib/types/UrlDependency";
 	import { safeInvalidate } from "$lib/utils/safeInvalidate";
 	import { base } from "$app/paths";
@@ -534,6 +534,10 @@
 		if (pendingText) {
 			const nonce = page.state.pendingFilesNonce as string | undefined;
 			files = nonce ? consumePendingFiles(nonce) : [];
+			// Clear the history entry before submitting: returning to it via
+			// Back/Forward re-runs onMount, and a lingering pendingMessage
+			// would resubmit the prompt (without files, whose nonce is spent).
+			replaceState("", {});
 			await writeMessage({ prompt: pendingText });
 		}
 

--- a/src/routes/conversation/[id]/+page.svelte
+++ b/src/routes/conversation/[id]/+page.svelte
@@ -2,7 +2,7 @@
 	import ChatWindow from "$lib/components/chat/ChatWindow.svelte";
 	import { pendingMessage } from "$lib/stores/pendingMessage";
 	import { isAborted } from "$lib/stores/isAborted";
-	import { onMount } from "svelte";
+	import { onMount, untrack } from "svelte";
 	import { page } from "$app/state";
 	import { beforeNavigate } from "$app/navigation";
 	import { UrlDependency } from "$lib/types/UrlDependency";
@@ -36,7 +36,7 @@
 	import { isConversationGenerationActive } from "$lib/utils/generationState";
 	import SharePreviewTags from "$lib/components/SharePreviewTags.svelte";
 
-	let { data = $bindable() } = $props();
+	let { data } = $props();
 
 	let convId = $derived(page.params.id ?? "");
 	let pending = $state(false);
@@ -48,7 +48,7 @@
 
 	let files: File[] = $state([]);
 
-	let conversations = $state(data.conversations);
+	let conversations = $state(untrack(() => data.conversations));
 	$effect(() => {
 		conversations = data.conversations;
 	});
@@ -153,7 +153,7 @@
 					const newUserMessageId = addSibling(
 						{
 							messages,
-							rootMessageId: data.rootMessageId,
+							rootMessageId,
 						},
 						{
 							from: "user",
@@ -165,7 +165,7 @@
 					messageToWriteToId = addChildren(
 						{
 							messages,
-							rootMessageId: data.rootMessageId,
+							rootMessageId,
 						},
 						{ from: "assistant", content: "" },
 						newUserMessageId
@@ -176,7 +176,7 @@
 					messageToWriteToId = addSibling(
 						{
 							messages,
-							rootMessageId: data.rootMessageId,
+							rootMessageId,
 						},
 						{ from: "assistant", content: "" },
 						messageId
@@ -188,7 +188,7 @@
 				const newUserMessageId = addChildren(
 					{
 						messages,
-						rootMessageId: data.rootMessageId,
+						rootMessageId,
 					},
 					{
 						from: "user",
@@ -198,14 +198,14 @@
 					messageId
 				);
 
-				if (!data.rootMessageId) {
-					data.rootMessageId = newUserMessageId;
+				if (!rootMessageId) {
+					rootMessageId = newUserMessageId;
 				}
 
 				messageToWriteToId = addChildren(
 					{
 						messages,
-						rootMessageId: data.rootMessageId,
+						rootMessageId,
 					},
 					{
 						from: "assistant",
@@ -572,9 +572,33 @@
 	}
 
 	const settings = useSettingsStore();
-	let messages = $state(data.messages);
+	let messages = $state(untrack(() => data.messages));
+	// Local copy of rootMessageId avoids mutating the load-data prop directly.
+	// It is set when the first message of a new conversation is created, and
+	// re-synced from server data whenever the conversation changes.
+	let rootMessageId = $state(untrack(() => data.rootMessageId));
+
+	// Track which conversation's data was last synced so a sidebar navigation
+	// always resets local state to the target conversation, but a server
+	// load re-running mid-stream (e.g. from BackgroundGenerationPoller or
+	// safeInvalidate) does NOT wipe the in-flight token buffer.
+	//
+	// "pending" is set to true at the top of writeMessage and reset to false
+	// in its finally block BEFORE safeInvalidate fires, so when the load
+	// resolves after streaming the guard is already lifted and we get the
+	// server-confirmed snapshot.
+	let _lastSyncedConvId = untrack(() => convId); // plain variable — no reactive overhead needed
 	$effect(() => {
-		messages = data.messages;
+		const currentConvId = convId; // reactive dep
+		const newMessages = data.messages; // reactive dep
+
+		const convChanged = currentConvId !== _lastSyncedConvId;
+
+		if (convChanged || !pending) {
+			messages = newMessages;
+			rootMessageId = data.rootMessageId;
+			_lastSyncedConvId = currentConvId;
+		}
 	});
 
 	$effect(() => {
@@ -641,12 +665,7 @@
 </svelte:head>
 
 {#if sharePreviewId}
-	<SharePreviewTags
-		shareId={sharePreviewId}
-		{title}
-		messages={data.messages}
-		rootMessageId={data.rootMessageId}
-	/>
+	<SharePreviewTags shareId={sharePreviewId} {title} messages={data.messages} {rootMessageId} />
 {/if}
 
 <ChatWindow

--- a/src/routes/models/[...model]/+page.svelte
+++ b/src/routes/models/[...model]/+page.svelte
@@ -2,14 +2,13 @@
 	import { page } from "$app/state";
 	import { base } from "$app/paths";
 	import { goto, replaceState } from "$app/navigation";
-	import { UrlDependency } from "$lib/types/UrlDependency";
-	import { safeInvalidate } from "$lib/utils/safeInvalidate";
 	import { onMount, tick } from "svelte";
 	import { usePublicConfig } from "$lib/utils/PublicConfig.svelte";
 
 	import ChatWindow from "$lib/components/chat/ChatWindow.svelte";
 	import { findCurrentModel } from "$lib/utils/models";
 	import { useSettingsStore } from "$lib/stores/settings";
+	import { useConversationsStore } from "$lib/stores/conversations.svelte";
 	import { ERROR_MESSAGES, error } from "$lib/stores/errors";
 	import { storePendingFiles } from "$lib/utils/pendingFiles";
 	import { sanitizeUrlParam } from "$lib/utils/urlParams";
@@ -17,6 +16,8 @@
 	import { requireAuthUser } from "$lib/utils/auth";
 
 	let { data } = $props();
+
+	const convsStore = useConversationsStore();
 
 	let loading = $state(false);
 	let files: File[] = $state([]);
@@ -64,12 +65,16 @@
 			// consumed once by the conversation page.
 			const pendingFilesNonce = files.length > 0 ? storePendingFiles(files) : undefined;
 
-			// Refresh the sidebar list (only that, not all 6 bootstrap endpoints)
-			// BEFORE navigating. Refreshing after goto() would update layout data
-			// while the first message is streaming, causing any data-syncing effects
-			// on the conversation page to overwrite locally appended messages and
-			// blank the conversation until the stream ends.
-			await safeInvalidate(UrlDependency.ConversationList);
+			// Optimistically prepend the new conversation to the sidebar immediately so
+			// it appears before the first message starts streaming. The title is set to
+			// "" here; it will be updated to the real title via a Title SSE update once
+			// the LLM generates one.
+			convsStore.prepend({
+				id: conversationId,
+				title: "",
+				model: modelId,
+				updatedAt: new Date(),
+			});
 			await goto(`${base}/conversation/${conversationId}`, {
 				state: { pendingMessage: message, pendingFilesNonce },
 			});

--- a/src/routes/models/[...model]/+page.svelte
+++ b/src/routes/models/[...model]/+page.svelte
@@ -11,7 +11,7 @@
 	import { findCurrentModel } from "$lib/utils/models";
 	import { useSettingsStore } from "$lib/stores/settings";
 	import { ERROR_MESSAGES, error } from "$lib/stores/errors";
-	import { pendingMessage } from "$lib/stores/pendingMessage";
+	import { storePendingFiles } from "$lib/utils/pendingFiles";
 	import { sanitizeUrlParam } from "$lib/utils/urlParams";
 	import { loadAttachmentsFromUrls } from "$lib/utils/loadAttachmentsFromUrls";
 	import { requireAuthUser } from "$lib/utils/auth";
@@ -58,19 +58,21 @@
 
 			const { conversationId } = await res.json();
 
-			// Ugly hack to use a store as temp storage, feel free to improve ^^
-			pendingMessage.set({
-				content: message,
-				files,
-			});
+			// Pass the first message text via SvelteKit history state (JSON-serializable).
+			// File objects are not serializable, so they are stored in a client-side Map
+			// keyed by a random nonce; the nonce travels with the history state and is
+			// consumed once by the conversation page.
+			const pendingFilesNonce = files.length > 0 ? storePendingFiles(files) : undefined;
 
 			// Refresh the sidebar list (only that, not all 6 bootstrap endpoints)
 			// BEFORE navigating. Refreshing after goto() would update layout data
-			// while the first message is streaming, and the conversation page's
-			// `$effect(() => { messages = data.messages })` would wipe the locally
-			// appended messages, blanking the conversation until the stream ends.
+			// while the first message is streaming, causing any data-syncing effects
+			// on the conversation page to overwrite locally appended messages and
+			// blank the conversation until the stream ends.
 			await safeInvalidate(UrlDependency.ConversationList);
-			await goto(`${base}/conversation/${conversationId}`);
+			await goto(`${base}/conversation/${conversationId}`, {
+				state: { pendingMessage: message, pendingFilesNonce },
+			});
 		} catch (err) {
 			error.set(ERROR_MESSAGES.default);
 			console.error(err);


### PR DESCRIPTION
> Stacked on #2321 (targeted invalidation + safeInvalidate). Review and merge that one first; this diff shows only the migration commits once #2321 lands.

## Why

An architecture review of the recent invalidation incidents concluded that most of our defensive patterns (safeInvalidate ordering rules, effect guards, the 1Hz background poller, the pendingMessage store hack) stem from one root choice: using SvelteKit load/invalidate as the state manager for realtime chat data, then mirroring that data into local state. SvelteKit's navigation-token race (sveltejs/kit#9354, open since 2023, milestoned for 3.0) makes every invalidate-vs-navigation pair a hazard, so the fewer invalidations we need, the fewer races exist.

This PR moves chat state to client ownership and keeps load functions for bootstrap data only.

## What changed (one commit per step, each independently revertable)

1. **Guarded message sync** (`d715aacb`): the conversation page no longer runs an unguarded `$effect(() => { messages = data.messages })`. The sync now fires only on conversation change or when no local stream is in flight, so a load re-run cannot wipe in-flight streamed messages. Also removes the `data = $bindable()` mutation of load data (rootMessageId is now local state). Note: we evaluated the assignable `$derived` pattern and rejected it with evidence: derived assignments skip `should_proxy` in the Svelte compiler (`AssignmentExpression.js`), which would break deep-mutation reactivity during token streaming.
2. **Client-owned conversations store** (`06f9788a`): new `src/lib/stores/conversations.svelte.ts`, SSR-safe via setContext/getContext (created per-request in `+layout.svelte`, seeded synchronously for SSR first paint). Sidebar renders from the store; optimistic delete/rename and the stream Title event update it directly. Retires `titleUpdate.ts` and its layout effect.
3. **pendingMessage via history state** (`e840a9a7`): the first message travels through `goto(url, { state })` (SvelteKit shallow routing). Files travel through a client-only nonce map since File objects are not serializable. Retires the `pendingMessage` store ("Ugly hack" comment and all).
4. **SSE channel for background generations** (`8ea8080d`): new authenticated `GET /api/v2/conversations/updates` SSE endpoint with a server-side 2s poll loop (multi-instance safe: reads Mongo, so completions on any pod are visible). The client opens one EventSource only while generations are backgrounded. Retires the client-side 1Hz polling in `BackgroundGenerationPoller`.
5. **Sidebar fully client-owned** (`54cd8153`, `c8b44171`): `+layout.ts` no longer registers a ConversationList dependency; `UrlDependency.ConversationList` is deleted from the enum along with all 6 invalidation call sites. Settings saves no longer touch the conversation list at all. New conversations appear via `prepend()` before navigation (no blocking round trip).

## Verification

- `npm run lint` clean, `svelte-check` 0 errors, 313/313 server+SSR tests pass.
- Live browser checks on the dev server:
  - New conversation: sidebar entry appears instantly (stub, then title via stream event in ~2s), zero list refetches.
  - Mid-stream "New Chat": navigation completes (the #2321 incident class), next message lands in a fresh conversation.
  - Background generation: navigated away mid-stream, the full response (2,831 chars) completed and persisted server-side, and the sidebar updated through the SSE channel while idle on the home page.
  - SSE endpoint: 200, `text/event-stream`, heartbeats, cursor-based reconnects observed working.

## Reviewer notes / caveats

- The streaming-wipe guard protects the submit-to-first-token window. Nothing currently invalidates `UrlDependency.Conversation` mid-stream, and this is documented in-code, but new invalidation paths would need to respect it.
- SSE streams have a 5-minute server lifetime; the client reconnects with a cursor. Worth a second look for generations longer than 5 minutes.
- Conversations-store seeding is last-write-wins from server data on layout re-runs (the window where an optimistic local change could be overwritten is sub-second).
- `ConversationListItem` is duplicated between the store and `+layout.ts`; candidate for a shared type in a follow-up.