### PR TITLE
fix: prevent reasoning traces from leaking into conversation titles 

### DIFF
--- a/src/lib/server/api/__tests__/conversations-id.spec.ts
+++ b/src/lib/server/api/__tests__/conversations-id.spec.ts
@@ -194,7 +194,7 @@ describe.sequential("PATCH /api/v2/conversations/[id]", () => {
 		expect(updated?.title).toBe("New Title");
 	});
 
-	it("strips <think> tags from title", async () => {
+	it("strips entire <think> reasoning blocks from title", async () => {
 		const { locals } = await createTestUser();
 		const conv = await createTestConversation(locals, { title: "Old Title" });
 
@@ -211,7 +211,48 @@ describe.sequential("PATCH /api/v2/conversations/[id]", () => {
 		expect(res.status).toBe(200);
 
 		const updated = await collections.conversations.findOne({ _id: conv._id });
-		expect(updated?.title).toBe("hiddenVisible Title");
+		expect(updated?.title).toBe("Visible Title");
+	});
+
+	it("strips capitalized <THINK> reasoning blocks from title", async () => {
+		const { locals } = await createTestUser();
+		const conv = await createTestConversation(locals, { title: "Old Title" });
+
+		const res = await PATCH({
+			locals,
+			params: { id: conv._id.toString() },
+			request: new Request("http://localhost", {
+				method: "PATCH",
+				body: JSON.stringify({ title: "<THINK>hidden</THINK>Visible Title" }),
+				headers: { "Content-Type": "application/json" },
+			}),
+		} as never);
+
+		expect(res.status).toBe(200);
+
+		const updated = await collections.conversations.findOne({ _id: conv._id });
+		expect(updated?.title).toBe("Visible Title");
+	});
+
+	it("falls back to New Chat when stripping leaves an empty title", async () => {
+		const { locals } = await createTestUser();
+		const conv = await createTestConversation(locals, { title: "Old Title" });
+
+		// An unclosed/truncated reasoning trace with no actual title after it
+		const res = await PATCH({
+			locals,
+			params: { id: conv._id.toString() },
+			request: new Request("http://localhost", {
+				method: "PATCH",
+				body: JSON.stringify({ title: "<think>Got it, let's see. The user asked" }),
+				headers: { "Content-Type": "application/json" },
+			}),
+		} as never);
+
+		expect(res.status).toBe(200);
+
+		const updated = await collections.conversations.findOne({ _id: conv._id });
+		expect(updated?.title).toBe("New Chat");
 	});
 
 	it("rejects empty title", async () => {

--- a/src/lib/server/generateFromDefaultEndpoint.ts
+++ b/src/lib/server/generateFromDefaultEndpoint.ts
@@ -7,6 +7,7 @@ export async function* generateFromDefaultEndpoint({
 	preprompt,
 	generateSettings,
 	modelId,
+	reasoningEffort,
 	locals,
 }: {
 	messages: EndpointMessage[];
@@ -14,13 +15,21 @@ export async function* generateFromDefaultEndpoint({
 	generateSettings?: Record<string, unknown>;
 	/** Optional: use this model instead of the default task model */
 	modelId?: string;
+	/** Optional: forwarded as `reasoning_effort` to reasoning-capable endpoints */
+	reasoningEffort?: "low" | "medium" | "high";
 	locals: App.Locals | undefined;
 }): AsyncGenerator<MessageUpdate, string, undefined> {
 	try {
 		// Choose endpoint based on provided modelId, else fall back to taskModel
 		const model = modelId ? (models.find((m) => m.id === modelId) ?? taskModel) : taskModel;
 		const endpoint = await model.getEndpoint();
-		const tokenStream = await endpoint({ messages, preprompt, generateSettings, locals });
+		const tokenStream = await endpoint({
+			messages,
+			preprompt,
+			generateSettings,
+			reasoningEffort,
+			locals,
+		});
 
 		for await (const output of tokenStream) {
 			// if not generated_text is here it means the generation is not done

--- a/src/lib/server/textGeneration/title.ts
+++ b/src/lib/server/textGeneration/title.ts
@@ -4,6 +4,9 @@ import { logger } from "$lib/server/logger";
 import { MessageUpdateType, type MessageUpdate } from "$lib/types/MessageUpdate";
 import type { Conversation } from "$lib/types/Conversation";
 import { getReturnFromGenerator } from "$lib/utils/getReturnFromGenerator";
+import { models, taskModel } from "$lib/server/models";
+import { stripReasoningBlocks } from "$lib/server/textGeneration/utils/routing";
+import { getFallbackTitle } from "$lib/server/textGeneration/utils/title";
 
 export async function* generateTitleForConversation(
 	conv: Conversation,
@@ -16,7 +19,7 @@ export async function* generateTitleForConversation(
 
 		const prompt = userMessage.content;
 		const modelForTitle = config.TASK_MODEL?.trim() ? config.TASK_MODEL : conv.model;
-		const title = (await generateTitle(prompt, modelForTitle, locals)) ?? "New Chat";
+		const title = (await generateTitle(prompt, modelForTitle, locals)) ?? getFallbackTitle();
 
 		yield {
 			type: MessageUpdateType.Title,
@@ -39,9 +42,16 @@ async function generateTitle(
 
 	// Tools removed: no tool-based title path
 
+	// Reasoning models tend to spend the whole token budget on a <think> trace
+	// (which then leaks into the title). Ask them to think as little as possible,
+	// and fund a larger budget so they can still emit an actual title afterwards.
+	const model = modelId ? (models.find((m) => m.id === modelId) ?? taskModel) : taskModel;
+	const isReasoning = model.supportsReasoning;
+
 	return await getReturnFromGenerator(
 		generateFromDefaultEndpoint({
 			messages: [{ from: "user", content: `User message: "${prompt}"` }],
+			reasoningEffort: isReasoning ? "low" : undefined,
 			preprompt: `You are a chat thread titling assistant.
 Goal: Produce a very short, descriptive title (2–4 words) that names the topic of the user's first message.
 
@@ -60,7 +70,9 @@ User: "请解释Transformer是如何工作的" -> Transformer 工作原理
 User: "tell me more about you" -> About the assistant
 Return only the title text.`,
 			generateSettings: {
-				max_tokens: 24,
+				// Reasoning models need headroom to finish thinking *and* emit a title;
+				// non-reasoning models stay tight to keep titles short and cheap.
+				max_tokens: isReasoning ? 256 : 24,
 				temperature: 0,
 			},
 			modelId,
@@ -69,7 +81,9 @@ Return only the title text.`,
 	)
 		.then((summary) => {
 			const firstFive = prompt.split(/\s+/g).slice(0, 5).join(" ");
-			const trimmed = String(summary ?? "").trim();
+			// Strip any leaked <think> reasoning (including unclosed/truncated blocks)
+			// before trimming; an empty result falls back to the first five words.
+			const trimmed = stripReasoningBlocks(String(summary ?? "")).trim();
 			// Fallback: if empty, return first five words only (no emoji)
 			return trimmed || firstFive;
 		})

--- a/src/lib/server/textGeneration/utils/routing.ts
+++ b/src/lib/server/textGeneration/utils/routing.ts
@@ -1,6 +1,7 @@
 import type { EndpointMessage } from "../../endpoints/endpoints";
 
-const ROUTER_REASONING_REGEX = /<think>[\s\S]*?(?:<\/think>|$)/g;
+// Case-insensitive so capitalized variants (<THINK>, <Think>) are stripped too.
+const ROUTER_REASONING_REGEX = /<think>[\s\S]*?(?:<\/think>|$)/gi;
 
 export function stripReasoningBlocks(text: string): string {
 	const stripped = text.replace(ROUTER_REASONING_REGEX, "");

--- a/src/lib/server/textGeneration/utils/title.ts
+++ b/src/lib/server/textGeneration/utils/title.ts
@@ -1,0 +1,11 @@
+/**
+ * Fallback title used when no meaningful title can be derived for a
+ * conversation — e.g. a reasoning-only model response that stripped down to
+ * nothing, or a brand-new conversation awaiting generation.
+ *
+ * Centralized so the fallback policy lives in one place and is trivial to
+ * change (or make context-aware) if review prefers something else.
+ */
+export function getFallbackTitle(): string {
+	return "New Chat";
+}

--- a/src/routes/api/v2/conversations/[id]/+server.ts
+++ b/src/routes/api/v2/conversations/[id]/+server.ts
@@ -6,6 +6,8 @@ import { collections } from "$lib/server/database";
 import { authCondition } from "$lib/server/auth";
 import { ObjectId } from "mongodb";
 import { validModelIdSchema } from "$lib/server/models";
+import { stripReasoningBlocks } from "$lib/server/textGeneration/utils/routing";
+import { getFallbackTitle } from "$lib/server/textGeneration/utils/title";
 
 export const GET: RequestHandler = async ({ locals, params, url }) => {
 	requireAuth(locals);
@@ -69,7 +71,7 @@ export const PATCH: RequestHandler = async ({ locals, params, request }) => {
 
 	const updateValues = {
 		...(title !== undefined && {
-			title: title.replace(/<\/?think>/gi, "").trim(),
+			title: stripReasoningBlocks(title).trim() || getFallbackTitle(),
 		}),
 		...(model !== undefined && { model }),
 	};

--- a/src/routes/conversation/[id]/+server.ts
+++ b/src/routes/conversation/[id]/+server.ts
@@ -27,6 +27,8 @@ import { logger } from "$lib/server/logger.js";
 import { AbortRegistry } from "$lib/server/abortRegistry";
 import { clampStoppedContent } from "$lib/server/stopTruncation";
 import { MetricsServer } from "$lib/server/metrics";
+import { stripReasoningBlocks } from "$lib/server/textGeneration/utils/routing";
+import { getFallbackTitle } from "$lib/server/textGeneration/utils/title";
 
 // How long a stop marker is protected from the pre-flight cleanup of a new
 // generation. A marker younger than this may still be awaiting observation by
@@ -479,9 +481,11 @@ export async function POST({ request, locals, params, getClientAddress }) {
 
 				// Set the title
 				else if (event.type === MessageUpdateType.Title) {
-					// Always strip <think> markers from titles when saving
-					const sanitizedTitle = event.title.replace(/<\/?think>/gi, "").trim();
-					conv.title = sanitizedTitle;
+					// Always strip <think> reasoning blocks from titles when saving.
+					// If stripping leaves nothing (e.g. a model that emitted only a
+					// reasoning trace), keep the existing title rather than blanking it.
+					const sanitizedTitle = stripReasoningBlocks(event.title).trim();
+					conv.title = sanitizedTitle || conv.title;
 					await collections.conversations.updateOne(
 						{ _id: convId },
 						{ $set: { title: conv?.title, updatedAt: new Date() } }
@@ -818,7 +822,7 @@ export async function PATCH({ request, locals, params }) {
 	// Only include defined values in the update, with title sanitized
 	const updateValues = {
 		...(values.title !== undefined && {
-			title: values.title.replace(/<\/?think>/gi, "").trim(),
+			title: stripReasoningBlocks(values.title).trim() || getFallbackTitle(),
 		}),
 		...(values.model !== undefined && { model: values.model }),
 	};


### PR DESCRIPTION
## Problem

For reasoning-capable models, generated conversation titles are sometimes the
model's chain-of-thought instead of a title — e.g. sidebar entries like
"Got it, let's see. The user asked..." or "Okay, the user wants me to
generate...".

## Root cause

Title generation runs with `max_tokens: 24`. A reasoning model spends that
entire budget on its `<think>` trace and never reaches the actual title, so
the endpoint returns an **unclosed** `<think>...` block. The title sanitizer
then ran `replace(/<\/?think>/gi, "")`, which strips only the *tags*, not the
reasoning text between/after them — so the trace leaks through as the title.

Non-reasoning models are unaffected (they emit the title directly), which is
why this is intermittent.

## Fix

1. **Strip whole reasoning blocks.** Replace the tag-only regex with the
   existing `stripReasoningBlocks` helper (`/<think>[\s\S]*?(?:<\/think>|$)/g`,
   already used on the routing path) at every title sanitizer site. The `|$`
   handles unclosed/truncated blocks. This is the provider-independent floor.
2. **Give reasoning models room.** When `model.supportsReasoning`, request
   `reasoning_effort: "low"` and raise the title budget to 256 tokens so the
   model can finish thinking *and* emit a title. Non-reasoning models keep the
   byte-identical `max_tokens: 24`, no `reasoning_effort` path — **zero
   behavior change for them.**
3. **Centralize the fallback.** When stripping leaves nothing, fall back via
   `getFallbackTitle()` (currently `"New Chat"`) so the policy lives in one
   place. The generation path additionally falls back to the first five words
   of the user message before reaching that default.

## Notes on choices

- `reasoning_effort: "low"` is within the existing `ReasoningEffort`
  (`"low" | "medium" | "high"`) union — no type change, and "low" is accepted
  by every reasoning provider we target. ("none" was rejected: not in the
  union and not universally supported.)
- `256` is headroom for a short title-prompt reasoning trace; the strip +
  fallback still cover the case where a model overruns it.

## Verification

- `npm run check`: 0 errors.
- `npm run test` (conversation API suite): updated the test that asserted the
  old leaky behavior (`<think>hidden</think>Visible Title` → it expected
  `hiddenVisible Title`; now correctly `Visible Title`), and added a test for
  the empty-after-strip → fallback path. All pass.

### Screenshots
#### Before
<img alt="image" src="https://github.com/user-attachments/assets/a8a9cce3-baaf-442e-b0cc-e9f366bd69b7" />

#### After
<img alt="image" src="https://github.com/user-attachments/assets/d88a54bd-fb7b-4bd7-9265-aa32860eba6e" />
