### PR TITLE
Add connection pooling and idle management for MCP clients

### DIFF
--- a/src/lib/server/mcp/clientPool.ts
+++ b/src/lib/server/mcp/clientPool.ts
@@ -19,6 +19,17 @@ const SWEEP_INTERVAL_MS = 60_000;
 
 let sweeper: ReturnType<typeof setInterval> | undefined;
 
+// Dispose of a still-healthy pooled client. Per the MCP Streamable HTTP spec, clients
+// SHOULD explicitly terminate sessions they no longer need (HTTP DELETE) before dropping
+// the connection; servers that don't support it reply 405, which the SDK treats as ok.
+async function disposeClient(client: Client) {
+	const transport = client.transport;
+	if (transport instanceof StreamableHTTPClientTransport) {
+		await transport.terminateSession().catch(() => {});
+	}
+	await client.close?.().catch(() => {});
+}
+
 function ensureSweeper() {
 	if (sweeper) return;
 	sweeper = setInterval(() => {
@@ -26,7 +37,7 @@ function ensureSweeper() {
 		for (const [key, entry] of pool) {
 			if (entry.activeCalls === 0 && now - entry.lastUsedAt > IDLE_TTL_MS) {
 				pool.delete(key);
-				entry.client.close?.().catch(() => {});
+				void disposeClient(entry.client);
 			}
 		}
 	}, SWEEP_INTERVAL_MS);
@@ -121,9 +132,7 @@ export function releaseClient(client: Client) {
 
 export async function drainPool() {
 	for (const [key, entry] of pool) {
-		try {
-			await entry.client.close?.();
-		} catch {}
+		await disposeClient(entry.client);
 		pool.delete(key);
 	}
 }

--- a/src/lib/server/mcp/clientPool.ts
+++ b/src/lib/server/mcp/clientPool.ts
@@ -4,7 +4,34 @@ import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 import type { McpServerConfig } from "./httpClient";
 import { ssrfSafeFetch } from "$lib/server/urlSafety";
 
-const pool = new Map<string, Client>();
+type PoolEntry = { client: Client; lastUsedAt: number };
+
+const pool = new Map<string, PoolEntry>();
+
+// Reuse a recently-used client as-is; ping it first if it has been idle longer than this,
+// since proxies / load balancers silently reap idle connections.
+const PING_AFTER_IDLE_MS = 30_000;
+const PING_TIMEOUT_MS = 5_000;
+// Close clients idle longer than this. Must stay well above MCP tool timeouts so the sweeper
+// never closes a client with an in-flight call.
+const IDLE_TTL_MS = 10 * 60_000;
+const SWEEP_INTERVAL_MS = 60_000;
+
+let sweeper: ReturnType<typeof setInterval> | undefined;
+
+function ensureSweeper() {
+	if (sweeper) return;
+	sweeper = setInterval(() => {
+		const now = Date.now();
+		for (const [key, entry] of pool) {
+			if (now - entry.lastUsedAt > IDLE_TTL_MS) {
+				pool.delete(key);
+				entry.client.close?.().catch(() => {});
+			}
+		}
+	}, SWEEP_INTERVAL_MS);
+	sweeper.unref?.();
+}
 
 function keyOf(server: McpServerConfig) {
 	const headers = Object.entries(server.headers ?? {})
@@ -17,7 +44,22 @@ function keyOf(server: McpServerConfig) {
 export async function getClient(server: McpServerConfig, signal?: AbortSignal): Promise<Client> {
 	const key = keyOf(server);
 	const existing = pool.get(key);
-	if (existing) return existing;
+	if (existing) {
+		if (Date.now() - existing.lastUsedAt <= PING_AFTER_IDLE_MS) {
+			existing.lastUsedAt = Date.now();
+			return existing.client;
+		}
+		try {
+			await existing.client.ping({ signal, timeout: PING_TIMEOUT_MS });
+			existing.lastUsedAt = Date.now();
+			return existing.client;
+		} catch (err) {
+			if (signal?.aborted) throw err;
+			// Stale connection; evict it (unless a concurrent caller already replaced it) and reconnect.
+			if (pool.get(key) === existing) pool.delete(key);
+			existing.client.close?.().catch(() => {});
+		}
+	}
 
 	let firstError: unknown;
 	const client = new Client({ name: "chat-ui-mcp", version: "0.1.0" });
@@ -50,14 +92,15 @@ export async function getClient(server: McpServerConfig, signal?: AbortSignal): 
 		throw err;
 	}
 
-	pool.set(key, client);
+	pool.set(key, { client, lastUsedAt: Date.now() });
+	ensureSweeper();
 	return client;
 }
 
 export async function drainPool() {
-	for (const [key, client] of pool) {
+	for (const [key, entry] of pool) {
 		try {
-			await client.close?.();
+			await entry.client.close?.();
 		} catch {}
 		pool.delete(key);
 	}
@@ -65,9 +108,9 @@ export async function drainPool() {
 
 export function evictFromPool(server: McpServerConfig): Client | undefined {
 	const key = keyOf(server);
-	const client = pool.get(key);
-	if (client) {
+	const entry = pool.get(key);
+	if (entry) {
 		pool.delete(key);
 	}
-	return client;
+	return entry?.client;
 }

--- a/src/lib/server/mcp/clientPool.ts
+++ b/src/lib/server/mcp/clientPool.ts
@@ -4,7 +4,7 @@ import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 import type { McpServerConfig } from "./httpClient";
 import { ssrfSafeFetch } from "$lib/server/urlSafety";
 
-type PoolEntry = { client: Client; lastUsedAt: number };
+type PoolEntry = { client: Client; lastUsedAt: number; activeCalls: number };
 
 const pool = new Map<string, PoolEntry>();
 
@@ -24,7 +24,7 @@ function ensureSweeper() {
 	sweeper = setInterval(() => {
 		const now = Date.now();
 		for (const [key, entry] of pool) {
-			if (now - entry.lastUsedAt > IDLE_TTL_MS) {
+			if (entry.activeCalls === 0 && now - entry.lastUsedAt > IDLE_TTL_MS) {
 				pool.delete(key);
 				entry.client.close?.().catch(() => {});
 			}
@@ -64,7 +64,9 @@ export async function getClient(server: McpServerConfig, signal?: AbortSignal): 
 	let firstError: unknown;
 	const client = new Client({ name: "chat-ui-mcp", version: "0.1.0" });
 	const url = new URL(server.url);
-	const requestInit: RequestInit = { headers: server.headers, signal };
+	// Pooled clients outlive the request that created them, so never bind the per-request
+	// abort signal to the transport. Per-call cancellation goes through RequestOptions instead.
+	const requestInit: RequestInit = { headers: server.headers };
 	try {
 		try {
 			await client.connect(
@@ -92,9 +94,29 @@ export async function getClient(server: McpServerConfig, signal?: AbortSignal): 
 		throw err;
 	}
 
-	pool.set(key, { client, lastUsedAt: Date.now() });
+	pool.set(key, { client, lastUsedAt: Date.now(), activeCalls: 0 });
 	ensureSweeper();
 	return client;
+}
+
+/** Mark a pooled client as having an in-flight call so the sweeper won't close it. */
+export function retainClient(client: Client) {
+	for (const entry of pool.values()) {
+		if (entry.client === client) {
+			entry.activeCalls++;
+			return;
+		}
+	}
+}
+
+export function releaseClient(client: Client) {
+	for (const entry of pool.values()) {
+		if (entry.client === client) {
+			entry.activeCalls = Math.max(0, entry.activeCalls - 1);
+			entry.lastUsedAt = Date.now();
+			return;
+		}
+	}
 }
 
 export async function drainPool() {

--- a/src/lib/server/mcp/httpClient.ts
+++ b/src/lib/server/mcp/httpClient.ts
@@ -79,29 +79,33 @@ export async function callMcpTool(
 		resetTimeoutOnProgress: true,
 	};
 
+	// The connection can be closed at any point during a (potentially long-running) call,
+	// e.g. by a proxy idle timeout or a server restart, so retry on a fresh client.
+	const maxReconnectAttempts = 2;
 	let response;
-	try {
-		response = await activeClient.callTool(
-			{ name: tool, arguments: normalizedArgs },
-			undefined,
-			callToolOptions
-		);
-	} catch (err) {
-		if (!isConnectionClosedError(err)) {
-			throw err;
+	for (let attempt = 0; ; attempt++) {
+		try {
+			response = await activeClient.callTool(
+				{ name: tool, arguments: normalizedArgs },
+				undefined,
+				callToolOptions
+			);
+			break;
+		} catch (err) {
+			if (attempt >= maxReconnectAttempts || !isConnectionClosedError(err) || signal?.aborted) {
+				throw err;
+			}
+
+			// Evict stale client and close it
+			const stale = evictFromPool(server);
+			stale?.close?.().catch(() => {});
+
+			// Brief backoff before later retries (the server may be mid-restart)
+			if (attempt > 0) {
+				await new Promise((resolve) => setTimeout(resolve, 1_000 * attempt));
+			}
+			activeClient = await getClient(server, signal);
 		}
-
-		// Evict stale client and close it
-		const stale = evictFromPool(server);
-		stale?.close?.().catch(() => {});
-
-		// Retry with fresh client
-		activeClient = await getClient(server, signal);
-		response = await activeClient.callTool(
-			{ name: tool, arguments: normalizedArgs },
-			undefined,
-			callToolOptions
-		);
 	}
 
 	const parts = Array.isArray(response?.content) ? (response.content as Array<unknown>) : [];

--- a/src/lib/server/mcp/httpClient.ts
+++ b/src/lib/server/mcp/httpClient.ts
@@ -1,10 +1,18 @@
 import { Client } from "@modelcontextprotocol/sdk/client";
+import { StreamableHTTPError } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { getClient, evictFromPool, retainClient, releaseClient } from "./clientPool";
 import { config } from "$lib/server/config";
 
 function isConnectionClosedError(err: unknown): boolean {
 	const message = err instanceof Error ? err.message : String(err);
 	return message.includes("-32000") || message.toLowerCase().includes("connection closed");
+}
+
+// Per the MCP Streamable HTTP spec, a 404 on a request carrying a session ID means the
+// session expired and the client MUST start a new session with a new InitializeRequest —
+// which is exactly what reconnecting with a fresh client does.
+function isSessionExpiredError(err: unknown): boolean {
+	return err instanceof StreamableHTTPError && err.code === 404;
 }
 
 export interface McpServerConfig {
@@ -77,6 +85,8 @@ export async function callMcpTool(
 			});
 		},
 		resetTimeoutOnProgress: true,
+		// The spec requires a maximum total timeout even when progress resets the per-step one.
+		maxTotalTimeout: timeoutMs * 10,
 	};
 
 	// The connection can be closed at any point during a (potentially long-running) call,
@@ -95,7 +105,11 @@ export async function callMcpTool(
 			);
 			break;
 		} catch (err) {
-			if (attempt >= maxReconnectAttempts || !isConnectionClosedError(err) || signal?.aborted) {
+			if (
+				attempt >= maxReconnectAttempts ||
+				signal?.aborted ||
+				!(isConnectionClosedError(err) || isSessionExpiredError(err))
+			) {
 				throw err;
 			}
 

--- a/src/lib/server/mcp/httpClient.ts
+++ b/src/lib/server/mcp/httpClient.ts
@@ -1,5 +1,5 @@
 import { Client } from "@modelcontextprotocol/sdk/client";
-import { getClient, evictFromPool } from "./clientPool";
+import { getClient, evictFromPool, retainClient, releaseClient } from "./clientPool";
 import { config } from "$lib/server/config";
 
 function isConnectionClosedError(err: unknown): boolean {
@@ -61,8 +61,8 @@ export async function callMcpTool(
 			? (args as Record<string, unknown>)
 			: undefined;
 
-	// Get a (possibly pooled) client. The client itself was connected with a signal
-	// that already composes outer cancellation. We still enforce a per-call timeout here.
+	// Get a (possibly pooled) client. Cancellation and timeout are enforced per call
+	// via the request options below, not on the pooled transport itself.
 	let activeClient = client ?? (await getClient(server, signal));
 
 	const callToolOptions = {
@@ -84,8 +84,11 @@ export async function callMcpTool(
 	const maxReconnectAttempts = 2;
 	let response;
 	for (let attempt = 0; ; attempt++) {
+		// Keep a stable reference for retain/release: `activeClient` is reassigned on retry.
+		const currentClient = activeClient;
+		retainClient(currentClient);
 		try {
-			response = await activeClient.callTool(
+			response = await currentClient.callTool(
 				{ name: tool, arguments: normalizedArgs },
 				undefined,
 				callToolOptions
@@ -105,6 +108,8 @@ export async function callMcpTool(
 				await new Promise((resolve) => setTimeout(resolve, 1_000 * attempt));
 			}
 			activeClient = await getClient(server, signal);
+		} finally {
+			releaseClient(currentClient);
 		}
 	}
 

--- a/src/lib/server/textGeneration/mcp/runMcpFlow.ts
+++ b/src/lib/server/textGeneration/mcp/runMcpFlow.ts
@@ -15,7 +15,6 @@ import { buildToolPreprompt } from "../utils/toolPrompt";
 import type { EndpointMessage } from "../../endpoints/endpoints";
 import { resolveRouterTarget } from "./routerResolution";
 import { executeToolCalls, type NormalizedToolCall } from "./toolInvocation";
-import { drainPool } from "$lib/server/mcp/clientPool";
 import type { TextGenerationContext } from "../types";
 import {
 	hasAuthHeader,
@@ -773,10 +772,10 @@ export async function* runMcpFlow({
 			return "aborted";
 		}
 		logger.warn({ err: msg }, "[mcp] flow failed, falling back to default endpoint");
-	} finally {
-		// ensure MCP clients are closed after the turn
-		await drainPool();
 	}
+	// Note: pooled MCP clients are shared across concurrent requests, so they must NOT be
+	// closed here — that rejects other turns' in-flight tool calls with "-32000 Connection
+	// closed". Idle clients are reclaimed by the pool's sweeper instead (see clientPool.ts).
 
 	return "not_applicable";
 }


### PR DESCRIPTION
## Summary

Implements robust connection pooling for MCP (Model Context Protocol) clients with automatic idle detection, health checks, and graceful cleanup. This prevents connection exhaustion from proxy/load balancer timeouts and improves reliability during long-running tool calls.

## Key Changes

- **Connection pooling with idle tracking**: Store `PoolEntry` objects containing both the client and `lastUsedAt` timestamp instead of raw clients
- **Health checks on reuse**: When retrieving a cached client, ping it if idle longer than 30 seconds to detect stale connections before use
- **Automatic sweeper**: Background interval that closes clients idle longer than 10 minutes, preventing resource leaks
- **Retry logic for tool calls**: Wrap `callMcpTool` in a retry loop (up to 2 reconnect attempts) with exponential backoff when connection errors occur
- **Graceful pool lifecycle**: Remove `drainPool()` call from `runMcpFlow` since pooled clients are shared across concurrent requests; idle clients are now reclaimed by the sweeper instead

## Implementation Details

- **PING_AFTER_IDLE_MS (30s)**: Threshold for pinging idle connections to detect proxy/load balancer reaping
- **IDLE_TTL_MS (10min)**: Maximum idle time before forcefully closing a client; set well above MCP tool timeouts to avoid interrupting in-flight calls
- **SWEEP_INTERVAL_MS (60s)**: How often the sweeper runs to clean up expired clients
- **Retry backoff**: 1 second delay before second reconnect attempt (if needed) to allow server recovery during restarts
- **Signal handling**: Respects abort signals and doesn't retry if the caller has already aborted

This ensures MCP clients remain healthy across concurrent requests while preventing connection leaks and improving resilience to transient network issues.

https://claude.ai/code/session_01E3ruPikiFWdV5myhr4QDMr