### PR TITLE
Render image URLs in tool output details as inline images

### DIFF
--- a/src/lib/components/chat/ToolUpdate.svelte
+++ b/src/lib/components/chat/ToolUpdate.svelte
@@ -85,18 +85,35 @@
 		);
 	};
 
+	// Some MCP proxies (e.g. hf.co/mcp with the "Skip Gradio Images" account flag)
+	// strip base64 image blocks and leave only an "Image URL: https://..." text
+	// block, so fall back to rendering image URLs found in the text.
+	const IMAGE_URL_REGEX =
+		/https?:\/\/[^\s"'<>)\]]+\.(?:png|jpe?g|webp|gif|avif|svg)(?:\?[^\s"'<>)\]]*)?/gi;
+
+	const getImageUrls = (text: string | undefined): string[] => {
+		if (!text) return [];
+		return [...new Set(text.match(IMAGE_URL_REGEX) ?? [])];
+	};
+
 	interface ParsedToolOutput {
 		text?: string;
 		images: McpImageContent[];
+		imageUrls: string[];
 		metadata: Array<[string, unknown]>;
 	}
 
 	const parseToolOutputs = (outputs: ToolOutput[]): ParsedToolOutput[] =>
-		outputs.map((output) => ({
-			text: getOutputText(output),
-			images: getImageBlocks(output),
-			metadata: getMetadataEntries(output),
-		}));
+		outputs.map((output) => {
+			const text = getOutputText(output);
+			const images = getImageBlocks(output);
+			return {
+				text,
+				images,
+				imageUrls: images.length > 0 ? [] : getImageUrls(text),
+				metadata: getMetadataEntries(output),
+			};
+		});
 </script>
 
 {#if toolFnName}
@@ -171,13 +188,21 @@
 											class="scrollbar-custom max-h-60 overflow-y-auto whitespace-pre-wrap break-all rounded-lg bg-gray-100 p-2 font-mono text-xs dark:bg-gray-800/70">{parsedOutput.text}</pre>
 									{/if}
 
-									{#if parsedOutput.images.length > 0}
+									{#if parsedOutput.images.length > 0 || parsedOutput.imageUrls.length > 0}
 										<div class="flex flex-wrap gap-2">
 											{#each parsedOutput.images as image, imageIndex}
 												<img
 													alt={`Tool result image ${imageIndex + 1}`}
 													class="max-h-60 cursor-pointer rounded border border-gray-200 dark:border-gray-700"
 													src={`data:${image.mimeType};base64,${image.data}`}
+												/>
+											{/each}
+											{#each parsedOutput.imageUrls as imageUrl, imageIndex}
+												<img
+													alt={`Tool result image ${imageIndex + 1}`}
+													class="max-h-60 cursor-pointer rounded border border-gray-200 dark:border-gray-700"
+													src={imageUrl}
+													loading="lazy"
 												/>
 											{/each}
 										</div>

--- a/src/lib/components/chat/ToolUpdate.svelte
+++ b/src/lib/components/chat/ToolUpdate.svelte
@@ -203,6 +203,7 @@
 													class="max-h-60 cursor-pointer rounded border border-gray-200 dark:border-gray-700"
 													src={imageUrl}
 													loading="lazy"
+													referrerpolicy="no-referrer"
 												/>
 											{/each}
 										</div>


### PR DESCRIPTION
## Context

Images stopped showing in the tool-call output details (e.g. `gr1_qwen_image_fast_infer` results showed only `Image URL: https://...image.webp` as raw text).

Investigation traced it end to end:

- chat-ui renders tool images from MCP base64 `{type: "image", data, mimeType}` content blocks — that path is unchanged and works.
- The Gradio space (`multimodalart/Qwen-Image-Fast`, pinned Gradio 5.39) still returns the base64 image block + the `Image URL:` text block (verified by calling its MCP endpoint directly).
- The deployed `hf.co/mcp` (`@huggingface/mcp-services` v0.3.19) strips image content blocks for accounts whose MCP settings include the `NO_GRADIO_IMAGE_CONTENT` ("Skip Gradio Images") flag — `GET /api/settings/mcp` confirmed the flag is set on the affected account, and an authenticated A/B call confirmed only text blocks survive the proxy.

So the base64 block never reaches chat-ui in that configuration, and the only image reference left is the URL inside the text.

## Change

`ToolUpdate.svelte` now falls back to extracting image URLs (`png/jpg/jpeg/webp/gif/avif/svg`, query strings allowed) from the output text and renders them inline — only when the output carries no base64 image blocks, so nothing is shown twice in the normal case.

## Testing

- Regex validated against the real Gradio output shape (`Image URL: https://...hf.space/--replicas/.../image.webp` + seed line), markdown-wrapped URLs, query strings, and non-image URLs (ignored).
- `npm run check`: 0 errors (1 pre-existing warning in `ChatMessage.svelte`).
- Prettier/ESLint clean; `server` (310 tests) and `ssr` workspaces pass. Client browser workspace is opt-in (`VITEST_BROWSER=true`) and was not run.

https://claude.ai/code/session_01EvvtbhEB86c56RNjf9sPZx

---
_Generated by [Claude Code](https://claude.ai/code/session_01EvvtbhEB86c56RNjf9sPZx)_