### PR TITLE
Re-land client-owned chat state with the message-sync wipe fixed

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -23,6 +23,12 @@ declare global {
 		}
 		// interface PageData {}
 		// interface Platform {}
+		interface PageState {
+			/** First message text carried from the home/model page to a new conversation. */
+			pendingMessage?: string;
+			/** Nonce for looking up File[] in the client-side pendingFiles Map. */
+			pendingFilesNonce?: string;
+		}
 	}
 }
 

--- a/src/lib/components/BackgroundGenerationPoller.svelte
+++ b/src/lib/components/BackgroundGenerationPoller.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { browser, dev } from "$app/environment";
-	import { invalidate } from "$app/navigation";
+	import { safeInvalidate } from "$lib/utils/safeInvalidate";
 
 	import {
 		type BackgroundGeneration,
@@ -55,8 +55,8 @@
 				removeBackgroundGeneration(id);
 				stopPoller(id, "timed out");
 				log("timeout", id);
-				await invalidate(UrlDependency.ConversationList);
-				await invalidate(UrlDependency.Conversation);
+				await safeInvalidate(UrlDependency.ConversationList);
+				await safeInvalidate(UrlDependency.Conversation);
 				return;
 			}
 
@@ -102,11 +102,11 @@
 					failureCounts.delete(id);
 					shouldInvalidateConversation = true;
 					log("complete", id, "terminal");
-					await invalidate(UrlDependency.ConversationList);
+					await safeInvalidate(UrlDependency.ConversationList);
 				}
 
 				if (shouldInvalidateConversation) {
-					await invalidate(UrlDependency.Conversation);
+					await safeInvalidate(UrlDependency.Conversation);
 				}
 
 				failureCounts.delete(id);
@@ -119,7 +119,7 @@
 					assistantSnapshots.delete(id);
 					failureCounts.delete(id);
 					log("failures", id, failures);
-					await invalidate(UrlDependency.ConversationList);
+					await safeInvalidate(UrlDependency.ConversationList);
 				}
 			} finally {
 				inflight.delete(id);

--- a/src/lib/components/BackgroundGenerationPoller.svelte
+++ b/src/lib/components/BackgroundGenerationPoller.svelte
@@ -1,168 +1,173 @@
 <script lang="ts">
 	import { browser, dev } from "$app/environment";
+	import { page } from "$app/state";
+	import { base } from "$app/paths";
 	import { safeInvalidate } from "$lib/utils/safeInvalidate";
 
 	import {
-		type BackgroundGeneration,
 		backgroundGenerationEntries,
 		removeBackgroundGeneration,
 	} from "$lib/stores/backgroundGenerations";
-	import { handleResponse, useAPIClient } from "$lib/APIClient";
 	import { UrlDependency } from "$lib/types/UrlDependency";
-	import type { Message } from "$lib/types/Message";
-	import { isAssistantGenerationTerminal } from "$lib/utils/generationState";
+	import { useConversationsStore } from "$lib/stores/conversations.svelte";
 
-	const POLL_INTERVAL_MS = 1000;
-	const MAX_POLL_DURATION_MS = 3 * 60_000;
+	/**
+	 * Maximum time a background generation entry is tracked before we give up
+	 * and invalidate anyway. Mirrors the old 1Hz poller's MAX_POLL_DURATION_MS.
+	 */
+	const MAX_TRACK_DURATION_MS = 3 * 60_000;
 
-	const client = useAPIClient();
-	const pollers = new Map<string, () => void>();
-	const inflight = new Set<string>();
-	const assistantSnapshots = new Map<string, string>();
-	const failureCounts = new Map<string, number>();
+	/**
+	 * How long to wait before reconnecting the SSE stream after it closes
+	 * (server-enforced 5-min lifetime causes a normal close; use a brief delay
+	 * so we do not hammer the server if there is a transient error).
+	 */
+	const RECONNECT_DELAY_MS = 1_000;
+
+	const convsStore = useConversationsStore();
 
 	$effect.root(() => {
-		if (!browser) {
-			pollers.clear();
-			return;
-		}
+		if (!browser) return;
 
 		let destroyed = false;
+		let eventSource: EventSource | null = null;
+		let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 
 		const log = (...args: unknown[]) => {
-			if (dev) {
-				console.log("background generation", ...args);
-			}
+			if (dev) console.log("[BackgroundGenerationPoller]", ...args);
 		};
 
-		const stopPoller = (id: string, reason?: string) => {
-			const stop = pollers.get(id);
-			if (!stop) return;
+		/** Most-recent updatedAt seen across all events; used as reconnect cursor. */
+		let latestCursor = new Date(0).toISOString();
 
-			stop();
-			pollers.delete(id);
-			inflight.delete(id);
-			assistantSnapshots.delete(id);
-			failureCounts.delete(id);
-			log("stop", id, reason);
-		};
+		function openStream() {
+			if (destroyed || backgroundGenerationEntries.length === 0) return;
+			if (eventSource) return; // already open
 
-		const pollOnce = async (id: string) => {
-			if (destroyed || inflight.has(id)) return;
+			const url = new URL(`${base}/api/v2/conversations/updates`, window.location.href);
+			url.searchParams.set("cursor", latestCursor);
 
-			const entry = backgroundGenerationEntries.find((candidate) => candidate.id === id);
-			if (entry && Date.now() - entry.startedAt > MAX_POLL_DURATION_MS) {
-				removeBackgroundGeneration(id);
-				stopPoller(id, "timed out");
-				log("timeout", id);
-				await safeInvalidate(UrlDependency.ConversationList);
-				await safeInvalidate(UrlDependency.Conversation);
-				return;
-			}
+			log("opening SSE stream, cursor:", latestCursor);
+			eventSource = new EventSource(url.toString());
 
-			inflight.add(id);
-			log("poll", id);
+			eventSource.addEventListener("update", (raw) => {
+				if (destroyed) return;
 
-			try {
-				const response = await client.conversations({ id }).get({ query: {} });
-				const conversation = handleResponse(response) as {
-					messages?: Message[];
-				} | null;
-				const messages: Message[] = conversation?.messages ?? [];
-				const lastAssistant = [...messages]
-					.reverse()
-					.find((message: Message) => message.from === "assistant");
+				let event: {
+					id: string;
+					title: string;
+					updatedAt: string;
+					isTerminal: boolean;
+				};
+				try {
+					event = JSON.parse(raw.data) as typeof event;
+				} catch (err) {
+					console.error("[BackgroundGenerationPoller] bad SSE payload", err);
+					return;
+				}
 
-				const isTerminal = isAssistantGenerationTerminal(lastAssistant);
+				log("update", event);
 
-				const snapshot = lastAssistant
-					? JSON.stringify({
-							id: lastAssistant.id,
-							updatedAt: lastAssistant.updatedAt,
-							contentLength: lastAssistant.content?.length ?? 0,
-							updatesLength: lastAssistant.updates?.length ?? 0,
-						})
-					: "__none__";
-				const previousSnapshot = assistantSnapshots.get(id);
-				let shouldInvalidateConversation = false;
+				// Advance cursor
+				if (event.updatedAt > latestCursor) {
+					latestCursor = event.updatedAt;
+				}
 
-				if (lastAssistant) {
-					assistantSnapshots.set(id, snapshot);
-					if (snapshot !== previousSnapshot) {
-						shouldInvalidateConversation = true;
+				// Update sidebar title / updatedAt for this conversation
+				convsStore.update(event.id, {
+					title: event.title,
+					updatedAt: new Date(event.updatedAt),
+				});
+
+				const isTracked = backgroundGenerationEntries.some((e) => e.id === event.id);
+				if (!isTracked) return;
+
+				if (event.isTerminal) {
+					removeBackgroundGeneration(event.id);
+					log("complete", event.id);
+
+					// Refresh the sidebar via the client-owned store, then invalidate the
+					// conversation detail if the user is currently viewing it.
+					void convsStore.refresh().then(() => {
+						// Only invalidate the conversation detail when it is currently open
+						if (page.params.id === event.id) {
+							return safeInvalidate(UrlDependency.Conversation);
+						}
+					});
+				} else {
+					// Non-terminal update: if the affected conversation is open, refresh it
+					if (page.params.id === event.id) {
+						void safeInvalidate(UrlDependency.Conversation);
 					}
-				} else if (assistantSnapshots.has(id)) {
-					assistantSnapshots.delete(id);
-					shouldInvalidateConversation = true;
 				}
+			});
 
-				if (lastAssistant && isTerminal) {
-					removeBackgroundGeneration(id);
-					assistantSnapshots.delete(id);
-					failureCounts.delete(id);
-					shouldInvalidateConversation = true;
-					log("complete", id, "terminal");
-					await safeInvalidate(UrlDependency.ConversationList);
+			eventSource.onerror = () => {
+				if (destroyed) return;
+				log("SSE error / close — scheduling reconnect");
+				closeStream();
+				// Reconnect only if there are still entries to track
+				if (backgroundGenerationEntries.length > 0) {
+					reconnectTimer = setTimeout(() => {
+						reconnectTimer = null;
+						openStream();
+					}, RECONNECT_DELAY_MS);
 				}
+			};
+		}
 
-				if (shouldInvalidateConversation) {
-					await safeInvalidate(UrlDependency.Conversation);
-				}
-
-				failureCounts.delete(id);
-			} catch (err) {
-				console.error("Background generation poll failed", id, err);
-				const failures = (failureCounts.get(id) ?? 0) + 1;
-				failureCounts.set(id, failures);
-				if (failures >= 3) {
-					removeBackgroundGeneration(id);
-					assistantSnapshots.delete(id);
-					failureCounts.delete(id);
-					log("failures", id, failures);
-					await safeInvalidate(UrlDependency.ConversationList);
-				}
-			} finally {
-				inflight.delete(id);
+		function closeStream() {
+			if (eventSource) {
+				eventSource.close();
+				eventSource = null;
+				log("SSE stream closed");
 			}
-		};
+		}
 
-		const startPoller = (entry: BackgroundGeneration) => {
-			if (pollers.has(entry.id)) return;
+		// Timeout guard: entries that have been tracked too long are evicted,
+		// mirroring the old poller's MAX_POLL_DURATION_MS behaviour.
+		function evictTimedOutEntries() {
+			const now = Date.now();
+			const timedOut = backgroundGenerationEntries.filter(
+				(e) => now - e.startedAt > MAX_TRACK_DURATION_MS
+			);
+			for (const entry of timedOut) {
+				removeBackgroundGeneration(entry.id);
+				log("timeout evict", entry.id);
+				void convsStore.refresh().then(() => {
+					if (page.params.id === entry.id) {
+						return safeInvalidate(UrlDependency.Conversation);
+					}
+				});
+			}
+		}
 
-			const intervalId = setInterval(() => {
-				void pollOnce(entry.id);
-			}, POLL_INTERVAL_MS);
-
-			pollers.set(entry.id, () => clearInterval(intervalId));
-			void pollOnce(entry.id);
-			log("start", entry.id);
-		};
+		// Evict timed-out entries on an interval even when the SSE stream is quiet.
+		const evictTimer = setInterval(evictTimedOutEntries, 10_000);
 
 		$effect(() => {
-			const entries = backgroundGenerationEntries;
+			// Reactive dep: re-evaluate whenever the entries array changes.
+			const hasEntries = backgroundGenerationEntries.length > 0;
 
 			if (destroyed) return;
 
-			const activeIds = new Set(entries.map((entry) => entry.id));
-
-			for (const id of pollers.keys()) {
-				if (!activeIds.has(id)) {
-					stopPoller(id);
+			if (hasEntries) {
+				openStream();
+			} else {
+				// No active generations — close the stream to conserve connections.
+				if (reconnectTimer !== null) {
+					clearTimeout(reconnectTimer);
+					reconnectTimer = null;
 				}
-			}
-
-			for (const entry of entries) {
-				startPoller(entry);
+				closeStream();
 			}
 		});
 
 		return () => {
 			destroyed = true;
-			for (const stop of pollers.values()) stop();
-			pollers.clear();
-			inflight.clear();
-			assistantSnapshots.clear();
-			failureCounts.clear();
+			clearInterval(evictTimer);
+			if (reconnectTimer !== null) clearTimeout(reconnectTimer);
+			closeStream();
 		};
 	});
 </script>

--- a/src/lib/components/chat/ModelSwitch.svelte
+++ b/src/lib/components/chat/ModelSwitch.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-	import { invalidate } from "$app/navigation";
 	import { UrlDependency } from "$lib/types/UrlDependency";
+	import { safeInvalidate } from "$lib/utils/safeInvalidate";
 	import { page } from "$app/state";
 	import { base } from "$app/paths";
 	import type { Model } from "$lib/types/Model";
@@ -37,8 +37,8 @@
 			}
 
 			await Promise.all([
-				invalidate(UrlDependency.Conversation),
-				invalidate(UrlDependency.ConversationList),
+				safeInvalidate(UrlDependency.Conversation),
+				safeInvalidate(UrlDependency.ConversationList),
 			]);
 		} catch (error) {
 			console.error(error);

--- a/src/lib/components/chat/ModelSwitch.svelte
+++ b/src/lib/components/chat/ModelSwitch.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { UrlDependency } from "$lib/types/UrlDependency";
 	import { safeInvalidate } from "$lib/utils/safeInvalidate";
+	import { useConversationsStore } from "$lib/stores/conversations.svelte";
 	import { page } from "$app/state";
 	import { base } from "$app/paths";
 	import type { Model } from "$lib/types/Model";
@@ -11,6 +12,8 @@
 	}
 
 	let { models, currentModel }: Props = $props();
+
+	const convsStore = useConversationsStore();
 
 	let selectedModelId = $state("");
 
@@ -36,10 +39,7 @@
 				throw new Error("Failed to update model");
 			}
 
-			await Promise.all([
-				safeInvalidate(UrlDependency.Conversation),
-				safeInvalidate(UrlDependency.ConversationList),
-			]);
+			await Promise.all([safeInvalidate(UrlDependency.Conversation), convsStore.refresh()]);
 		} catch (error) {
 			console.error(error);
 		}

--- a/src/lib/components/chat/ModelSwitch.svelte
+++ b/src/lib/components/chat/ModelSwitch.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-	import { invalidateAll } from "$app/navigation";
+	import { invalidate } from "$app/navigation";
+	import { UrlDependency } from "$lib/types/UrlDependency";
 	import { page } from "$app/state";
 	import { base } from "$app/paths";
 	import type { Model } from "$lib/types/Model";
@@ -35,7 +36,10 @@
 				throw new Error("Failed to update model");
 			}
 
-			await invalidateAll();
+			await Promise.all([
+				invalidate(UrlDependency.Conversation),
+				invalidate(UrlDependency.ConversationList),
+			]);
 		} catch (error) {
 			console.error(error);
 		}

--- a/src/lib/server/models.ts
+++ b/src/lib/server/models.ts
@@ -1,3 +1,4 @@
+import { building } from "$app/environment";
 import { config } from "$lib/server/config";
 import type { ChatTemplateInput } from "$lib/types/Template";
 import { z } from "zod";
@@ -490,7 +491,12 @@ const rebuildModels = async (): Promise<ModelsRefreshSummary> => {
 	return applyModelState(newModels, startedAt);
 };
 
-await rebuildModels();
+// Skip the initial fetch during `vite build`: SvelteKit's analyse phase imports this
+// module, and hitting the live router from CI builds fails on rate limits (429).
+// The cache is built at server startup instead.
+if (!building) {
+	await rebuildModels();
+}
 
 export const refreshModels = async (): Promise<ModelsRefreshSummary> => {
 	if (inflightRefresh) {

--- a/src/lib/stores/conversations.svelte.ts
+++ b/src/lib/stores/conversations.svelte.ts
@@ -1,0 +1,108 @@
+/**
+ * Client-owned conversations sidebar store.
+ *
+ * SSR safety: this module exports a factory function and context helpers
+ * (createConversationsStore / useConversationsStore). The store instance is
+ * held inside Svelte component context (keyed by CONVERSATIONS_CONTEXT_KEY)
+ * and is therefore per-request on the server and per-layout on the client.
+ * There is NO module-level mutable $state, so concurrent SSR requests do not
+ * share data.
+ *
+ * Seeding strategy: +layout.svelte calls init() whenever data.conversations
+ * reference changes. The store performs a last-write-wins merge from the
+ * server — local optimistic mutations (delete/rename/title) are intentionally
+ * overwritten on the next server resync. This is acceptable because:
+ *   - delete/rename mutations are immediately visible and the server round-trip
+ *     is fast (< 500 ms typical);
+ *   - title updates from streaming are ephemeral until the store is next
+ *     refreshed, which happens after generation completes.
+ * If we wanted to preserve local mutations across resyncs we would need to
+ * track "dirty" ids — the complexity is not justified at this stage.
+ */
+
+import { browser } from "$app/environment";
+import { getContext, setContext } from "svelte";
+import type { ConvSidebar } from "$lib/types/ConvSidebar";
+import { useAPIClient, handleResponse } from "$lib/APIClient";
+
+export const CONVERSATIONS_CONTEXT_KEY = "conversationsStore";
+
+interface ConversationListItem {
+	_id: { toString(): string };
+	title: string;
+	updatedAt: Date | string;
+	model?: string;
+}
+
+class ConversationsStore {
+	#list = $state<ConvSidebar[]>([]);
+
+	get list(): ConvSidebar[] {
+		return this.#list;
+	}
+
+	/** Replace the entire list (called from layout when data.conversations changes). */
+	init(conversations: ConvSidebar[]): void {
+		this.#list = conversations;
+	}
+
+	/**
+	 * Apply a partial patch to a single conversation by id.
+	 * Silently ignores unknown ids (e.g. race between title update and delete).
+	 */
+	update(id: string, patch: Partial<Omit<ConvSidebar, "id">>): void {
+		const idx = this.#list.findIndex((c) => String(c.id) === id);
+		if (idx === -1) return;
+		this.#list[idx] = { ...this.#list[idx], ...patch };
+	}
+
+	/** Remove a conversation by id (optimistic delete). */
+	remove(id: string): void {
+		this.#list = this.#list.filter((c) => String(c.id) !== id);
+	}
+
+	/** Prepend a new conversation to the top of the list. */
+	prepend(conv: ConvSidebar): void {
+		this.#list = [conv, ...this.#list];
+	}
+
+	/**
+	 * Re-fetch GET /api/v2/conversations?p=0 and reconcile with the local list.
+	 * Performs a last-write-wins replace so updatedAt ordering reflects the server.
+	 * No-op on the server (browser guard).
+	 */
+	async refresh(): Promise<void> {
+		if (!browser) return;
+		try {
+			const client = useAPIClient();
+			const data = (await client.conversations.get({ query: { p: 0 } }).then(handleResponse)) as {
+				conversations: ConversationListItem[];
+				hasMore: boolean;
+			};
+
+			const defaultModel = undefined; // caller can patch model separately if needed
+			const freshList: ConvSidebar[] = data.conversations.map((conv) => ({
+				id: conv._id.toString(),
+				title: conv.title.trim(),
+				model: conv.model ?? defaultModel,
+				updatedAt: new Date(conv.updatedAt),
+			}));
+			this.#list = freshList;
+		} catch (err) {
+			// Non-fatal: keep the existing list rather than blanking the sidebar.
+			console.error("[conversationsStore] refresh failed", err);
+		}
+	}
+}
+
+/** Call once in +layout.svelte to create and register the store in context. */
+export function createConversationsStore(): ConversationsStore {
+	const store = new ConversationsStore();
+	setContext(CONVERSATIONS_CONTEXT_KEY, store);
+	return store;
+}
+
+/** Call in any descendant component to access the store. */
+export function useConversationsStore(): ConversationsStore {
+	return getContext<ConversationsStore>(CONVERSATIONS_CONTEXT_KEY);
+}

--- a/src/lib/stores/pendingMessage.ts
+++ b/src/lib/stores/pendingMessage.ts
@@ -1,9 +1,0 @@
-import { writable } from "svelte/store";
-
-export const pendingMessage = writable<
-	| {
-			content: string;
-			files: File[];
-	  }
-	| undefined
->();

--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -1,5 +1,5 @@
 import { browser } from "$app/environment";
-import { invalidate } from "$app/navigation";
+import { safeInvalidate } from "$lib/utils/safeInvalidate";
 import { base } from "$app/paths";
 import type { ReasoningEffort, StreamingMode } from "$lib/types/Settings";
 import { UrlDependency } from "$lib/types/UrlDependency";
@@ -64,7 +64,7 @@ export function createSettingsStore(initialValue: Omit<SettingsStore, "recentlyS
 					body: JSON.stringify(get(baseStore)),
 				});
 
-				invalidate(UrlDependency.ConversationList);
+				safeInvalidate(UrlDependency.ConversationList);
 
 				if (showSavedOnNextSync) {
 					// set savedRecently to true for 3s
@@ -122,7 +122,7 @@ export function createSettingsStore(initialValue: Omit<SettingsStore, "recentlyS
 					body: JSON.stringify(get(baseStore)),
 				});
 
-				invalidate(UrlDependency.ConversationList);
+				safeInvalidate(UrlDependency.ConversationList);
 
 				if (showSavedOnNextSync) {
 					baseStore.update((s) => ({
@@ -158,7 +158,7 @@ export function createSettingsStore(initialValue: Omit<SettingsStore, "recentlyS
 					...settings,
 				}),
 			});
-			invalidate(UrlDependency.ConversationList);
+			safeInvalidate(UrlDependency.ConversationList);
 		}
 	}
 

--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -1,8 +1,6 @@
 import { browser } from "$app/environment";
-import { safeInvalidate } from "$lib/utils/safeInvalidate";
 import { base } from "$app/paths";
 import type { ReasoningEffort, StreamingMode } from "$lib/types/Settings";
-import { UrlDependency } from "$lib/types/UrlDependency";
 import { getContext, setContext } from "svelte";
 import { type Writable, writable, get } from "svelte/store";
 
@@ -64,8 +62,6 @@ export function createSettingsStore(initialValue: Omit<SettingsStore, "recentlyS
 					body: JSON.stringify(get(baseStore)),
 				});
 
-				safeInvalidate(UrlDependency.ConversationList);
-
 				if (showSavedOnNextSync) {
 					// set savedRecently to true for 3s
 					baseStore.update((s) => ({
@@ -122,8 +118,6 @@ export function createSettingsStore(initialValue: Omit<SettingsStore, "recentlyS
 					body: JSON.stringify(get(baseStore)),
 				});
 
-				safeInvalidate(UrlDependency.ConversationList);
-
 				if (showSavedOnNextSync) {
 					baseStore.update((s) => ({
 						...s,
@@ -158,7 +152,6 @@ export function createSettingsStore(initialValue: Omit<SettingsStore, "recentlyS
 					...settings,
 				}),
 			});
-			safeInvalidate(UrlDependency.ConversationList);
 		}
 	}
 

--- a/src/lib/stores/titleUpdate.ts
+++ b/src/lib/stores/titleUpdate.ts
@@ -1,8 +1,0 @@
-import { writable } from "svelte/store";
-
-export interface TitleUpdate {
-	convId: string;
-	title: string;
-}
-
-export default writable<TitleUpdate | null>(null);

--- a/src/lib/types/Settings.ts
+++ b/src/lib/types/Settings.ts
@@ -93,7 +93,8 @@ export type SettingsEditable = Omit<Settings, "welcomeModalSeenAt" | "createdAt"
 // TODO: move this to a constant file along with other constants
 export const DEFAULT_SETTINGS = {
 	shareConversationsWithModelAuthors: true,
-	activeModel: defaultModel.id,
+	// defaultModel is unset during `vite build` (models aren't fetched at build time)
+	activeModel: defaultModel?.id ?? "",
 	customPrompts: {},
 	customPromptsEnabled: {},
 	multimodalOverrides: {},

--- a/src/lib/types/UrlDependency.ts
+++ b/src/lib/types/UrlDependency.ts
@@ -1,5 +1,4 @@
 /* eslint-disable no-shadow */
 export enum UrlDependency {
-	ConversationList = "conversation:list",
 	Conversation = "conversation:id",
 }

--- a/src/lib/utils/pendingFiles.ts
+++ b/src/lib/utils/pendingFiles.ts
@@ -1,0 +1,32 @@
+/**
+ * Client-only store for File objects that cannot be serialized into
+ * SvelteKit's history state (which must be JSON-serializable).
+ *
+ * Callers generate a random nonce, store their File[] here under that nonce,
+ * then pass the nonce alongside the text via goto() history state.  The
+ * destination page consumes and removes the entry so it is never leaked.
+ *
+ * SSR-safe: the Map is only created in browser environments.  On the server
+ * the module exports a no-op API so imports never crash during SSR.
+ */
+
+import { browser } from "$app/environment";
+
+const store: Map<string, File[]> = browser ? new Map() : (null as unknown as Map<string, File[]>);
+
+/** Save files under a nonce and return the nonce. */
+export function storePendingFiles(files: File[]): string {
+	const nonce = crypto.randomUUID();
+	if (browser) {
+		store.set(nonce, files);
+	}
+	return nonce;
+}
+
+/** Consume (retrieve and delete) files for a given nonce. Returns [] on miss. */
+export function consumePendingFiles(nonce: string): File[] {
+	if (!browser) return [];
+	const files = store.get(nonce) ?? [];
+	store.delete(nonce);
+	return files;
+}

--- a/src/lib/utils/safeInvalidate.ts
+++ b/src/lib/utils/safeInvalidate.ts
@@ -1,0 +1,33 @@
+import { invalidate } from "$app/navigation";
+import { navigating } from "$app/state";
+
+/**
+ * Run `invalidate()` without racing an in-flight navigation.
+ *
+ * Calling invalidate() while the router is mid-navigation cancels that
+ * navigation: the invalidation overwrites the router's navigation token, so
+ * the in-flight load is discarded and the user's click or goto() is silently
+ * dropped (the goto() promise can even resolve without navigating). This
+ * bites whenever a background refresh (post-stream sync, generation polling,
+ * debounced settings saves) races a navigation, e.g. clicking "New Chat"
+ * while a response is streaming.
+ *
+ * Instead of firing immediately, wait for any in-flight navigation to settle
+ * first, then run the invalidation on the destination page.
+ *
+ * Note: the router exposes a navigation a tick after it starts, so a
+ * navigation beginning in the same microtask burst as this call can still be
+ * cancelled. None of our call sites fire in that window; truly
+ * navigation-triggered refreshes must be skipped at the call site instead
+ * (see the writeMessage finally block).
+ */
+export async function safeInvalidate(resource: string | URL): Promise<void> {
+	while (navigating.to) {
+		try {
+			await navigating.complete;
+		} catch {
+			// navigation was superseded or failed; re-check and continue
+		}
+	}
+	return invalidate(resource);
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import "../styles/main.css";
 
-	import { onDestroy, onMount, untrack } from "svelte";
+	import { onDestroy, onMount } from "svelte";
 	import { goto } from "$app/navigation";
 	import { base } from "$app/paths";
 	import { page } from "$app/state";
@@ -13,7 +13,6 @@
 	import Toast from "$lib/components/Toast.svelte";
 	import NavMenu from "$lib/components/NavMenu.svelte";
 	import MobileNav from "$lib/components/MobileNav.svelte";
-	import titleUpdate from "$lib/stores/titleUpdate";
 	import WelcomeModal from "$lib/components/WelcomeModal.svelte";
 	import ExpandNavigation from "$lib/components/ExpandNavigation.svelte";
 	import { setContext } from "svelte";
@@ -22,6 +21,7 @@
 	import { isPro } from "$lib/stores/isPro";
 	import BackgroundGenerationPoller from "$lib/components/BackgroundGenerationPoller.svelte";
 	import { requireAuthUser } from "$lib/utils/auth";
+	import { createConversationsStore } from "$lib/stores/conversations.svelte";
 
 	let { data = $bindable(), children } = $props();
 
@@ -30,9 +30,15 @@
 	const publicConfig = data.publicConfig;
 	const client = useAPIClient();
 
-	let conversations = $state(data.conversations);
+	const convsStore = createConversationsStore();
+	// Synchronous seed for SSR: $effect is stripped by the server-side compiler,
+	// so we must call init() immediately to populate the list on first paint.
+	// The $effect below handles client-side resyncs when data.conversations
+	// reference changes after subsequent invalidations.
+	// Last-write-wins from server is acceptable; see conversations.svelte.ts.
+	convsStore.init(data.conversations);
 	$effect(() => {
-		data.conversations && untrack(() => (conversations = data.conversations));
+		convsStore.init(data.conversations);
 	});
 
 	let isNavCollapsed = $state(false);
@@ -62,7 +68,7 @@
 			.delete()
 			.then(handleResponse)
 			.then(async () => {
-				conversations = conversations.filter((conv) => conv.id !== id);
+				convsStore.remove(id);
 
 				if (page.params.id === id) {
 					await goto(`${base}/`, { invalidateAll: true });
@@ -80,7 +86,7 @@
 			.patch({ title })
 			.then(handleResponse)
 			.then(async () => {
-				conversations = conversations.map((conv) => (conv.id === id ? { ...conv, title } : conv));
+				convsStore.update(id, { title });
 			})
 			.catch((err) => {
 				console.error(err);
@@ -99,18 +105,6 @@
 
 	$effect(() => {
 		if ($error) onError();
-	});
-
-	$effect(() => {
-		if ($titleUpdate) {
-			const convIdx = conversations.findIndex(({ id }) => id === $titleUpdate?.convId);
-
-			if (convIdx != -1) {
-				conversations[convIdx].title = $titleUpdate?.title ?? conversations[convIdx].title;
-			}
-
-			$titleUpdate = null;
-		}
 	});
 
 	const settings = createSettingsStore(data.settings);
@@ -179,7 +173,7 @@
 	let mobileNavTitle = $derived(
 		["/models", "/privacy"].includes(page.route.id ?? "")
 			? ""
-			: conversations.find((conv) => conv.id === page.params.id)?.title
+			: convsStore.list.find((conv) => conv.id === page.params.id)?.title
 	);
 
 	// Show the welcome modal once on first app load
@@ -271,7 +265,7 @@
 
 	<MobileNav title={mobileNavTitle}>
 		<NavMenu
-			{conversations}
+			conversations={convsStore.list}
 			user={data.user}
 			ondeleteConversation={(id) => deleteConversation(id)}
 			oneditConversationTitle={(payload) => editConversationTitle(payload.id, payload.title)}
@@ -281,7 +275,7 @@
 		class="grid max-h-dvh grid-cols-1 grid-rows-[auto,1fr,auto] overflow-hidden *:w-[290px] max-md:hidden"
 	>
 		<NavMenu
-			{conversations}
+			conversations={convsStore.list}
 			user={data.user}
 			ondeleteConversation={(id) => deleteConversation(id)}
 			oneditConversationTitle={(payload) => editConversationTitle(payload.id, payload.title)}

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -1,4 +1,3 @@
-import { UrlDependency } from "$lib/types/UrlDependency";
 import type { ConvSidebar } from "$lib/types/ConvSidebar";
 import { useAPIClient, handleResponse } from "$lib/APIClient";
 import { getConfigManager } from "$lib/utils/PublicConfig.svelte";
@@ -40,9 +39,7 @@ interface SettingsResponse {
 	billingOrganization?: string;
 }
 
-export const load = async ({ depends, fetch, url }) => {
-	depends(UrlDependency.ConversationList);
-
+export const load = async ({ fetch, url }) => {
 	const client = useAPIClient({ fetch, origin: url.origin });
 
 	const [settings, models, user, publicConfig, featureFlags, conversationsData] =

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
-	import { goto, invalidate, replaceState } from "$app/navigation";
+	import { goto, replaceState } from "$app/navigation";
 	import { UrlDependency } from "$lib/types/UrlDependency";
+	import { safeInvalidate } from "$lib/utils/safeInvalidate";
 	import { base } from "$app/paths";
 	import { page } from "$app/state";
 	import { usePublicConfig } from "$lib/utils/PublicConfig.svelte";
@@ -80,11 +81,13 @@
 				files,
 			});
 
-			// Navigate first: a concurrent invalidate() re-renders this page and
-			// can cancel the navigation, leaving the pending message unsent.
+			// Refresh the sidebar list (only that, not all 6 bootstrap endpoints)
+			// BEFORE navigating. Refreshing after goto() would update layout data
+			// while the first message is streaming, and the conversation page's
+			// `$effect(() => { messages = data.messages })` would wipe the locally
+			// appended messages, blanking the conversation until the stream ends.
+			await safeInvalidate(UrlDependency.ConversationList);
 			await goto(`${base}/conversation/${conversationId}`);
-			// Then refresh only the sidebar list, not all 6 bootstrap endpoints.
-			await invalidate(UrlDependency.ConversationList);
 		} catch (err) {
 			error.set((err as Error).message || ERROR_MESSAGES.default);
 			console.error(err);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,7 +1,5 @@
 <script lang="ts">
 	import { goto, replaceState } from "$app/navigation";
-	import { UrlDependency } from "$lib/types/UrlDependency";
-	import { safeInvalidate } from "$lib/utils/safeInvalidate";
 	import { base } from "$app/paths";
 	import { page } from "$app/state";
 	import { usePublicConfig } from "$lib/utils/PublicConfig.svelte";
@@ -10,8 +8,9 @@
 
 	import ChatWindow from "$lib/components/chat/ChatWindow.svelte";
 	import { ERROR_MESSAGES, error } from "$lib/stores/errors";
-	import { pendingMessage } from "$lib/stores/pendingMessage";
+	import { storePendingFiles } from "$lib/utils/pendingFiles";
 	import { useSettingsStore } from "$lib/stores/settings.js";
+	import { useConversationsStore } from "$lib/stores/conversations.svelte";
 	import { findCurrentModel } from "$lib/utils/models";
 	import { sanitizeUrlParam } from "$lib/utils/urlParams";
 	import { onMount, tick } from "svelte";
@@ -20,6 +19,8 @@
 	import { requireAuthUser } from "$lib/utils/auth";
 
 	let { data } = $props();
+
+	const convsStore = useConversationsStore();
 
 	let hasModels = $derived(Boolean(data.models?.length));
 	let files: File[] = $state([]);
@@ -75,19 +76,25 @@
 
 			const { conversationId } = await res.json();
 
-			// Ugly hack to use a store as temp storage, feel free to improve ^^
-			pendingMessage.set({
-				content: message,
-				files,
-			});
+			// Pass the first message text via SvelteKit history state (JSON-serializable).
+			// File objects are not serializable, so they are stored in a client-side Map
+			// keyed by a random nonce; the nonce travels with the history state and is
+			// consumed once by the conversation page.
+			const pendingFilesNonce = files.length > 0 ? storePendingFiles(files) : undefined;
 
-			// Refresh the sidebar list (only that, not all 6 bootstrap endpoints)
-			// BEFORE navigating. Refreshing after goto() would update layout data
-			// while the first message is streaming, and the conversation page's
-			// `$effect(() => { messages = data.messages })` would wipe the locally
-			// appended messages, blanking the conversation until the stream ends.
-			await safeInvalidate(UrlDependency.ConversationList);
-			await goto(`${base}/conversation/${conversationId}`);
+			// Optimistically prepend the new conversation to the sidebar immediately so
+			// it appears before the first message starts streaming. The title is set to
+			// "" here; it will be updated to the real title via a Title SSE update once
+			// the LLM generates one.
+			convsStore.prepend({
+				id: conversationId,
+				title: "",
+				model,
+				updatedAt: new Date(),
+			});
+			await goto(`${base}/conversation/${conversationId}`, {
+				state: { pendingMessage: message, pendingFilesNonce },
+			});
 		} catch (err) {
 			error.set((err as Error).message || ERROR_MESSAGES.default);
 			console.error(err);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -83,12 +83,12 @@
 			const pendingFilesNonce = files.length > 0 ? storePendingFiles(files) : undefined;
 
 			// Optimistically prepend the new conversation to the sidebar immediately so
-			// it appears before the first message starts streaming. The title is set to
-			// "" here; it will be updated to the real title via a Title SSE update once
-			// the LLM generates one.
+			// it appears before the first message starts streaming. "New Chat" matches
+			// the server-side default title; the real title arrives via a Title stream
+			// update once the LLM generates one.
 			convsStore.prepend({
 				id: conversationId,
-				title: "",
+				title: "New Chat",
 				model,
 				updatedAt: new Date(),
 			});

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-	import { goto, replaceState } from "$app/navigation";
+	import { goto, invalidate, replaceState } from "$app/navigation";
+	import { UrlDependency } from "$lib/types/UrlDependency";
 	import { base } from "$app/paths";
 	import { page } from "$app/state";
 	import { usePublicConfig } from "$lib/utils/PublicConfig.svelte";
@@ -79,8 +80,12 @@
 				files,
 			});
 
-			// invalidateAll to update list of conversations
-			await goto(`${base}/conversation/${conversationId}`, { invalidateAll: true });
+			// Invalidate only the sidebar list, not all 6 bootstrap endpoints.
+			// The conversation page load re-runs automatically as a new page.
+			await Promise.all([
+				invalidate(UrlDependency.ConversationList),
+				goto(`${base}/conversation/${conversationId}`),
+			]);
 		} catch (err) {
 			error.set((err as Error).message || ERROR_MESSAGES.default);
 			console.error(err);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -80,12 +80,11 @@
 				files,
 			});
 
-			// Invalidate only the sidebar list, not all 6 bootstrap endpoints.
-			// The conversation page load re-runs automatically as a new page.
-			await Promise.all([
-				invalidate(UrlDependency.ConversationList),
-				goto(`${base}/conversation/${conversationId}`),
-			]);
+			// Navigate first: a concurrent invalidate() re-renders this page and
+			// can cancel the navigation, leaving the pending message unsent.
+			await goto(`${base}/conversation/${conversationId}`);
+			// Then refresh only the sidebar list, not all 6 bootstrap endpoints.
+			await invalidate(UrlDependency.ConversationList);
 		} catch (err) {
 			error.set((err as Error).message || ERROR_MESSAGES.default);
 			console.error(err);

--- a/src/routes/api/v2/conversations/updates/+server.ts
+++ b/src/routes/api/v2/conversations/updates/+server.ts
@@ -43,8 +43,13 @@ export const GET: RequestHandler = async ({ locals, url, request }) => {
 	// `cursor` is an ISO timestamp; events with updatedAt > cursor are sent.
 	// On the very first connection the client passes cursor=0 (epoch) so all
 	// in-flight conversations are surfaced immediately.
+	// An unparseable cursor yields an Invalid Date whose NaN time BSON-serializes
+	// as epoch while never advancing (NaN comparisons are false), so every tick
+	// would re-emit up to 50 conversations for the stream's whole lifetime.
+	// Treat invalid cursors as epoch instead.
 	const cursorParam = url.searchParams.get("cursor");
-	let cursor = cursorParam ? new Date(cursorParam) : new Date(0);
+	const parsedCursor = cursorParam ? new Date(cursorParam) : null;
+	let cursor = parsedCursor && !isNaN(parsedCursor.getTime()) ? parsedCursor : new Date(0);
 
 	const stream = new ReadableStream({
 		async start(controller) {
@@ -149,7 +154,7 @@ export const GET: RequestHandler = async ({ locals, url, request }) => {
 	return new Response(stream, {
 		headers: {
 			"Content-Type": "text/event-stream",
-			"Cache-Control": "no-cache",
+			"Cache-Control": "no-cache, no-transform",
 			Connection: "keep-alive",
 			// Allow client-side JS to read this response (CORS if needed)
 			"X-Accel-Buffering": "no",

--- a/src/routes/api/v2/conversations/updates/+server.ts
+++ b/src/routes/api/v2/conversations/updates/+server.ts
@@ -104,7 +104,12 @@ export const GET: RequestHandler = async ({ locals, url, request }) => {
 							"messages.interrupted": 1,
 							"messages.updates": 1,
 						})
-						.sort({ updatedAt: -1 })
+						// Oldest first keeps the cursor replay-safe: events are emitted in
+						// chronological order, so a reconnect with the last received
+						// updatedAt never skips older events from a partially delivered
+						// batch, and limit() truncates the NEWEST records, which remain
+						// beyond the cursor and are picked up on the next tick.
+						.sort({ updatedAt: 1 })
 						.limit(50)
 						.toArray();
 

--- a/src/routes/api/v2/conversations/updates/+server.ts
+++ b/src/routes/api/v2/conversations/updates/+server.ts
@@ -1,0 +1,158 @@
+import type { RequestHandler } from "@sveltejs/kit";
+import { requireAuth } from "$lib/server/api/utils/requireAuth";
+import { collections } from "$lib/server/database";
+import { authCondition } from "$lib/server/auth";
+import { isAssistantGenerationTerminal } from "$lib/utils/generationState";
+import type { Message } from "$lib/types/Message";
+
+/**
+ * SSE endpoint that pushes conversation-update events to the client.
+ *
+ * The client opens this stream while background generations are in flight.
+ * Because generations may complete on any pod, this handler uses a server-side
+ * poll loop (every ~2 s) rather than in-process events.
+ *
+ * Protocol
+ * --------
+ * Each SSE event has type "update" and a JSON payload:
+ *   { id: string, title: string, updatedAt: string (ISO), isTerminal: boolean }
+ *
+ * The client reconnects automatically (SSE default) after the server closes
+ * the stream at MAX_LIFETIME_MS; it should pass the last known cursor via
+ * the `?cursor` query parameter to avoid re-sending stale events on reconnect.
+ *
+ * Multi-instance safety
+ * ---------------------
+ * We query MongoDB directly on every tick, so updates written by any pod are
+ * visible here without in-process coordination.
+ */
+
+const POLL_INTERVAL_MS = 2_000;
+const MAX_LIFETIME_MS = 5 * 60_000;
+
+type ConvUpdate = {
+	id: string;
+	title: string;
+	updatedAt: string;
+	isTerminal: boolean;
+};
+
+export const GET: RequestHandler = async ({ locals, url, request }) => {
+	requireAuth(locals);
+
+	// `cursor` is an ISO timestamp; events with updatedAt > cursor are sent.
+	// On the very first connection the client passes cursor=0 (epoch) so all
+	// in-flight conversations are surfaced immediately.
+	const cursorParam = url.searchParams.get("cursor");
+	let cursor = cursorParam ? new Date(cursorParam) : new Date(0);
+
+	const stream = new ReadableStream({
+		async start(controller) {
+			const signal = request.signal;
+			const deadline = Date.now() + MAX_LIFETIME_MS;
+
+			const encode = (data: ConvUpdate) =>
+				new TextEncoder().encode(`event: update\ndata: ${JSON.stringify(data)}\n\n`);
+
+			const sendHeartbeat = () => controller.enqueue(new TextEncoder().encode(": heartbeat\n\n"));
+
+			while (!signal.aborted && Date.now() < deadline) {
+				// Wait for next tick (or abort)
+				await new Promise<void>((resolve) => {
+					const t = setTimeout(resolve, POLL_INTERVAL_MS);
+					signal.addEventListener(
+						"abort",
+						() => {
+							clearTimeout(t);
+							resolve();
+						},
+						{ once: true }
+					);
+				});
+
+				if (signal.aborted) break;
+
+				try {
+					// Find conversations belonging to this user that changed since cursor.
+					// We project just enough to determine terminal state without loading
+					// full message content (only metadata fields on the last assistant message).
+					const changed = await collections.conversations
+						.find({
+							...authCondition(locals),
+							updatedAt: { $gt: cursor },
+						})
+						.project<{
+							_id: { toString(): string };
+							title: string;
+							updatedAt: Date;
+							messages: Array<
+								Pick<Message, "from" | "interrupted" | "updates"> & { content?: string }
+							>;
+						}>({
+							title: 1,
+							updatedAt: 1,
+							// Project only the fields isAssistantGenerationTerminal needs.
+							// We cannot do a sparse projection of only the last message from
+							// MongoDB without an aggregation stage, so we project all messages
+							// but limit to the fields we need (not the large content strings).
+							"messages.from": 1,
+							"messages.interrupted": 1,
+							"messages.updates": 1,
+						})
+						.sort({ updatedAt: -1 })
+						.limit(50)
+						.toArray();
+
+					for (const conv of changed) {
+						if (signal.aborted) break;
+
+						const lastAssistant = [...conv.messages]
+							.reverse()
+							.find((m) => m.from === "assistant") as Message | undefined;
+						const isTerminal = isAssistantGenerationTerminal(lastAssistant);
+
+						const event: ConvUpdate = {
+							id: conv._id.toString(),
+							title: conv.title,
+							updatedAt: conv.updatedAt.toISOString(),
+							isTerminal,
+						};
+
+						controller.enqueue(encode(event));
+
+						// Advance cursor to avoid re-emitting the same conversation on
+						// the next tick (use max of current cursor and this conv's updatedAt).
+						if (conv.updatedAt > cursor) {
+							cursor = conv.updatedAt;
+						}
+					}
+
+					if (changed.length === 0) {
+						sendHeartbeat();
+					}
+				} catch (err) {
+					// Log and continue — transient DB errors should not kill the stream.
+					console.error("[conversation-updates SSE] poll error", err);
+					sendHeartbeat();
+				}
+			}
+
+			// Graceful close: tell the client it should reconnect.
+			try {
+				controller.close();
+			} catch {
+				// already closed by abort
+			}
+		},
+	});
+
+	return new Response(stream, {
+		headers: {
+			"Content-Type": "text/event-stream",
+			"Cache-Control": "no-cache",
+			Connection: "keep-alive",
+			// Allow client-side JS to read this response (CORS if needed)
+			"X-Accel-Buffering": "no",
+		},
+	});
+};

--- a/src/routes/api/v2/models/+server.ts
+++ b/src/routes/api/v2/models/+server.ts
@@ -2,6 +2,10 @@ import type { RequestHandler } from "@sveltejs/kit";
 import { superjsonResponse } from "$lib/server/api/utils/superjsonResponse";
 import type { GETModelsResponse } from "$lib/server/api/types";
 
+// Models change only on server restart. Cache for 60s in the browser so repeated
+// invalidations (e.g. from settings saves) don't generate a new round-trip.
+const MODELS_CACHE_HEADERS = { "Cache-Control": "private, max-age=60" };
+
 export const GET: RequestHandler = async () => {
 	try {
 		const { models } = await import("$lib/server/models");
@@ -34,7 +38,8 @@ export const GET: RequestHandler = async () => {
 					unlisted: model.unlisted,
 					hasInferenceAPI: model.hasInferenceAPI,
 					isRouter: model.isRouter,
-				})) satisfies GETModelsResponse
+				})) satisfies GETModelsResponse,
+			{ headers: MODELS_CACHE_HEADERS }
 		);
 	} catch {
 		return superjsonResponse([] as GETModelsResponse);

--- a/src/routes/api/v2/models/+server.ts
+++ b/src/routes/api/v2/models/+server.ts
@@ -2,8 +2,10 @@ import type { RequestHandler } from "@sveltejs/kit";
 import { superjsonResponse } from "$lib/server/api/utils/superjsonResponse";
 import type { GETModelsResponse } from "$lib/server/api/types";
 
-// Models change only on server restart. Cache for 60s in the browser so repeated
-// invalidations (e.g. from settings saves) don't generate a new round-trip.
+// Models are loaded at startup but can also be refreshed at runtime via
+// POST /api/v2/models/refresh. Cache for 60s so repeated invalidations
+// (e.g. from settings saves) don't generate a round-trip; up to 60s of
+// staleness after a refresh is accepted.
 const MODELS_CACHE_HEADERS = { "Cache-Control": "private, max-age=60" };
 
 export const GET: RequestHandler = async () => {

--- a/src/routes/api/v2/public-config/+server.ts
+++ b/src/routes/api/v2/public-config/+server.ts
@@ -2,6 +2,12 @@ import type { RequestHandler } from "@sveltejs/kit";
 import { superjsonResponse } from "$lib/server/api/utils/superjsonResponse";
 import { config } from "$lib/server/config";
 
+// Public config is pure env-var data that changes only on server restart.
+// Cache for 60s so back-to-back layout reloads skip the round-trip.
+const PUBLIC_CONFIG_CACHE_HEADERS = { "Cache-Control": "private, max-age=60" };
+
 export const GET: RequestHandler = async () => {
-	return superjsonResponse(await config.getPublicConfig());
+	return superjsonResponse(await config.getPublicConfig(), {
+		headers: PUBLIC_CONFIG_CACHE_HEADERS,
+	});
 };

--- a/src/routes/conversation/[id]/+page.svelte
+++ b/src/routes/conversation/[id]/+page.svelte
@@ -4,8 +4,9 @@
 	import { isAborted } from "$lib/stores/isAborted";
 	import { onMount } from "svelte";
 	import { page } from "$app/state";
-	import { beforeNavigate, invalidate } from "$app/navigation";
+	import { beforeNavigate } from "$app/navigation";
 	import { UrlDependency } from "$lib/types/UrlDependency";
+	import { safeInvalidate } from "$lib/utils/safeInvalidate";
 	import { base } from "$app/paths";
 	import { ERROR_MESSAGES, error } from "$lib/stores/errors";
 	import { findCurrentModel } from "$lib/utils/models";
@@ -468,10 +469,18 @@
 			// (updated title / updatedAt). Avoids the 5 redundant bootstrap
 			// requests (models, settings, user, public-config, feature-flags)
 			// that a full invalidateAll() would trigger.
-			await Promise.all([
-				invalidate(UrlDependency.Conversation),
-				invalidate(UrlDependency.ConversationList),
-			]);
+			// When this finally runs because beforeNavigate aborted the stream
+			// ($isAborted set without stopRequested), invalidating would cancel
+			// that very navigation (e.g. the "New Chat" click that triggered
+			// the abort) before the router even exposes it via `navigating`.
+			// Skip the refresh: the destination page loads its own data.
+			const abortedByNavigation = $isAborted && !stopRequested;
+			if (!abortedByNavigation) {
+				await Promise.all([
+					safeInvalidate(UrlDependency.Conversation),
+					safeInvalidate(UrlDependency.ConversationList),
+				]);
+			}
 		}
 	}
 

--- a/src/routes/conversation/[id]/+page.svelte
+++ b/src/routes/conversation/[id]/+page.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
 	import ChatWindow from "$lib/components/chat/ChatWindow.svelte";
-	import { pendingMessage } from "$lib/stores/pendingMessage";
+	import { consumePendingFiles } from "$lib/utils/pendingFiles";
 	import { isAborted } from "$lib/stores/isAborted";
-	import { onMount } from "svelte";
+	import { onMount, untrack } from "svelte";
 	import { page } from "$app/state";
-	import { beforeNavigate } from "$app/navigation";
+	import { beforeNavigate, replaceState } from "$app/navigation";
 	import { UrlDependency } from "$lib/types/UrlDependency";
 	import { safeInvalidate } from "$lib/utils/safeInvalidate";
 	import { base } from "$app/paths";
@@ -12,7 +12,7 @@
 	import { findCurrentModel } from "$lib/utils/models";
 	import type { Message } from "$lib/types/Message";
 	import { MessageUpdateStatus, MessageUpdateType } from "$lib/types/MessageUpdate";
-	import titleUpdate from "$lib/stores/titleUpdate";
+	import { useConversationsStore } from "$lib/stores/conversations.svelte";
 	import file2base64 from "$lib/utils/file2base64";
 	import { addChildren } from "$lib/utils/tree/addChildren";
 	import { addSibling } from "$lib/utils/tree/addSibling";
@@ -36,7 +36,11 @@
 	import { isConversationGenerationActive } from "$lib/utils/generationState";
 	import SharePreviewTags from "$lib/components/SharePreviewTags.svelte";
 
-	let { data = $bindable() } = $props();
+	let { data } = $props();
+
+	// Obtain the conversations store during component init (context must be read
+	// synchronously, not inside async callbacks or event handlers).
+	const convsStore = useConversationsStore();
 
 	let convId = $derived(page.params.id ?? "");
 	let pending = $state(false);
@@ -47,11 +51,6 @@
 	let messageUpdatesAbortController = new AbortController();
 
 	let files: File[] = $state([]);
-
-	let conversations = $state(data.conversations);
-	$effect(() => {
-		conversations = data.conversations;
-	});
 
 	function createMessagesPath<T>(messages: TreeNode<T>[], msgId?: TreeId): TreeNode<T>[] {
 		if (initialRun) {
@@ -153,7 +152,7 @@
 					const newUserMessageId = addSibling(
 						{
 							messages,
-							rootMessageId: data.rootMessageId,
+							rootMessageId,
 						},
 						{
 							from: "user",
@@ -165,7 +164,7 @@
 					messageToWriteToId = addChildren(
 						{
 							messages,
-							rootMessageId: data.rootMessageId,
+							rootMessageId,
 						},
 						{ from: "assistant", content: "" },
 						newUserMessageId
@@ -176,7 +175,7 @@
 					messageToWriteToId = addSibling(
 						{
 							messages,
-							rootMessageId: data.rootMessageId,
+							rootMessageId,
 						},
 						{ from: "assistant", content: "" },
 						messageId
@@ -188,7 +187,7 @@
 				const newUserMessageId = addChildren(
 					{
 						messages,
-						rootMessageId: data.rootMessageId,
+						rootMessageId,
 					},
 					{
 						from: "user",
@@ -198,14 +197,14 @@
 					messageId
 				);
 
-				if (!data.rootMessageId) {
-					data.rootMessageId = newUserMessageId;
+				if (!rootMessageId) {
+					rootMessageId = newUserMessageId;
 				}
 
 				messageToWriteToId = addChildren(
 					{
 						messages,
-						rootMessageId: data.rootMessageId,
+						rootMessageId,
 					},
 					{
 						from: "assistant",
@@ -418,15 +417,8 @@
 						$error = update.message ?? "An error has occurred";
 					}
 				} else if (update.type === MessageUpdateType.Title) {
-					const convInData = conversations.find(({ id }) => id === page.params.id);
-					if (convInData) {
-						convInData.title = update.title;
-
-						$titleUpdate = {
-							title: update.title,
-							convId,
-						};
-					}
+					// Update the sidebar title directly via the store — no side-channel needed.
+					convsStore.update(convId, { title: update.title });
 				} else if (update.type === MessageUpdateType.File) {
 					messageToWriteTo.files = [
 						...(messageToWriteTo.files ?? []),
@@ -466,9 +458,9 @@
 			}
 			// Only re-run the loads that actually need fresh data: the
 			// conversation page (new messages) and the sidebar list
-			// (updated title / updatedAt). Avoids the 5 redundant bootstrap
-			// requests (models, settings, user, public-config, feature-flags)
-			// that a full invalidateAll() would trigger.
+			// (updated title / updatedAt via client-owned store refresh).
+			// Avoids the 5 redundant bootstrap requests (models, settings, user,
+			// public-config, feature-flags) that a full invalidateAll() would trigger.
 			// When this finally runs because beforeNavigate aborted the stream
 			// ($isAborted set without stopRequested), invalidating would cancel
 			// that very navigation (e.g. the "New Chat" click that triggered
@@ -476,10 +468,7 @@
 			// Skip the refresh: the destination page loads its own data.
 			const abortedByNavigation = $isAborted && !stopRequested;
 			if (!abortedByNavigation) {
-				await Promise.all([
-					safeInvalidate(UrlDependency.Conversation),
-					safeInvalidate(UrlDependency.ConversationList),
-				]);
+				await Promise.all([safeInvalidate(UrlDependency.Conversation), convsStore.refresh()]);
 			}
 		}
 	}
@@ -536,10 +525,20 @@
 	}
 
 	onMount(async () => {
-		if ($pendingMessage) {
-			files = $pendingMessage.files;
-			await writeMessage({ prompt: $pendingMessage.content });
-			$pendingMessage = undefined;
+		// Read the first message from SvelteKit shallow-routing history state.
+		// Text is serialized directly; File objects travel via the pendingFiles
+		// client-side Map, retrieved once by nonce and then discarded.
+		// On a hard refresh page.state is empty, so both values are undefined
+		// and we skip straight to the background-generation check below.
+		const pendingText = page.state.pendingMessage as string | undefined;
+		if (pendingText) {
+			const nonce = page.state.pendingFilesNonce as string | undefined;
+			files = nonce ? consumePendingFiles(nonce) : [];
+			// Clear the history entry before submitting: returning to it via
+			// Back/Forward re-runs onMount, and a lingering pendingMessage
+			// would resubmit the prompt (without files, whose nonce is spent).
+			replaceState("", {});
+			await writeMessage({ prompt: pendingText });
 		}
 
 		const streaming = isConversationGenerationActive(messages);
@@ -572,9 +571,39 @@
 	}
 
 	const settings = useSettingsStore();
-	let messages = $state(data.messages);
+	let messages = $state(untrack(() => data.messages));
+	// Local copy of rootMessageId avoids mutating the load-data prop directly.
+	// It is set when the first message of a new conversation is created, and
+	// re-synced from server data whenever the conversation changes.
+	let rootMessageId = $state(untrack(() => data.rootMessageId));
+
+	// Track which conversation's data was last synced so a sidebar navigation
+	// always resets local state to the target conversation, but a server
+	// load re-running mid-stream (e.g. from BackgroundGenerationPoller or
+	// safeInvalidate) does NOT wipe the in-flight token buffer.
+	//
+	// Guard window: "pending" is set to true at the START of writeMessage and
+	// is first reset to false when the FIRST STREAMING TOKEN arrives (line ~351
+	// in the stream loop). It is also reset in the finally block. This means
+	// the guard only covers the brief interval between the user submitting a
+	// message and the first token being received. Any safeInvalidate that
+	// resolves AFTER the first token (e.g. from ModelSwitch.svelte) would be
+	// allowed to overwrite the in-flight buffer. In practice this is acceptable
+	// because BackgroundGenerationPoller is inactive during foreground streaming
+	// and ModelSwitch is only shown when a model is unavailable, but callers
+	// must not assume the full streaming window is protected by this guard.
+	let _lastSyncedConvId = untrack(() => convId); // plain variable — no reactive overhead needed
 	$effect(() => {
-		messages = data.messages;
+		const currentConvId = convId; // reactive dep
+		const newMessages = data.messages; // reactive dep
+
+		const convChanged = currentConvId !== _lastSyncedConvId;
+
+		if (convChanged || !pending) {
+			messages = newMessages;
+			rootMessageId = data.rootMessageId;
+			_lastSyncedConvId = currentConvId;
+		}
 	});
 
 	$effect(() => {
@@ -623,7 +652,8 @@
 	});
 
 	let title = $derived.by(() => {
-		const rawTitle = conversations.find((conv) => conv.id === page.params.id)?.title ?? data.title;
+		const rawTitle =
+			convsStore.list.find((conv) => conv.id === page.params.id)?.title ?? data.title;
 		return rawTitle ? rawTitle.charAt(0).toUpperCase() + rawTitle.slice(1) : rawTitle;
 	});
 
@@ -641,12 +671,7 @@
 </svelte:head>
 
 {#if sharePreviewId}
-	<SharePreviewTags
-		shareId={sharePreviewId}
-		{title}
-		messages={data.messages}
-		rootMessageId={data.rootMessageId}
-	/>
+	<SharePreviewTags shareId={sharePreviewId} {title} {messages} {rootMessageId} />
 {/if}
 
 <ChatWindow

--- a/src/routes/conversation/[id]/+page.svelte
+++ b/src/routes/conversation/[id]/+page.svelte
@@ -577,32 +577,38 @@
 	// re-synced from server data whenever the conversation changes.
 	let rootMessageId = $state(untrack(() => data.rootMessageId));
 
-	// Track which conversation's data was last synced so a sidebar navigation
-	// always resets local state to the target conversation, but a server
-	// load re-running mid-stream (e.g. from BackgroundGenerationPoller or
-	// safeInvalidate) does NOT wipe the in-flight token buffer.
+	// Resync local message state from server data ONLY when the conversation
+	// changes (sidebar navigation) or the load data itself was refreshed
+	// (post-stream invalidation). Two hard constraints, both learned from
+	// prod incidents:
 	//
-	// Guard window: "pending" is set to true at the START of writeMessage and
-	// is first reset to false when the FIRST STREAMING TOKEN arrives (line ~351
-	// in the stream loop). It is also reset in the finally block. This means
-	// the guard only covers the brief interval between the user submitting a
-	// message and the first token being received. Any safeInvalidate that
-	// resolves AFTER the first token (e.g. from ModelSwitch.svelte) would be
-	// allowed to overwrite the in-flight buffer. In practice this is acceptable
-	// because BackgroundGenerationPoller is inactive during foreground streaming
-	// and ModelSwitch is only shown when a model is unavailable, but callers
-	// must not assume the full streaming window is protected by this guard.
+	// 1. `pending` must NOT be a reactive dependency of this effect. It flips
+	//    false when the first streaming token arrives; reading it tracked made
+	//    that flip re-run the effect and overwrite the locally appended
+	//    user/assistant messages with the stale page-load snapshot, blanking
+	//    the conversation until the stream finished (prod incident 2026-06-11).
+	//    It is therefore only ever read inside untrack().
+	// 2. A sync may only happen when `data.messages` identity actually changed
+	//    (or the conversation changed): re-running this effect for any other
+	//    reason must be a no-op.
+	//
+	// A mid-stream load refresh (pending still true) is intentionally skipped;
+	// the finally block in writeMessage invalidates again after the stream
+	// ends, so the post-completion sync still lands.
 	let _lastSyncedConvId = untrack(() => convId); // plain variable — no reactive overhead needed
+	let _lastSyncedMessages = untrack(() => data.messages); // plain variable — identity tracking only
 	$effect(() => {
 		const currentConvId = convId; // reactive dep
 		const newMessages = data.messages; // reactive dep
 
 		const convChanged = currentConvId !== _lastSyncedConvId;
+		const dataChanged = newMessages !== _lastSyncedMessages;
 
-		if (convChanged || !pending) {
+		if (convChanged || (dataChanged && untrack(() => !pending))) {
 			messages = newMessages;
 			rootMessageId = data.rootMessageId;
 			_lastSyncedConvId = currentConvId;
+			_lastSyncedMessages = newMessages;
 		}
 	});
 

--- a/src/routes/conversation/[id]/+page.svelte
+++ b/src/routes/conversation/[id]/+page.svelte
@@ -4,7 +4,8 @@
 	import { isAborted } from "$lib/stores/isAborted";
 	import { onMount } from "svelte";
 	import { page } from "$app/state";
-	import { beforeNavigate, invalidateAll } from "$app/navigation";
+	import { beforeNavigate, invalidate } from "$app/navigation";
+	import { UrlDependency } from "$lib/types/UrlDependency";
 	import { base } from "$app/paths";
 	import { ERROR_MESSAGES, error } from "$lib/stores/errors";
 	import { findCurrentModel } from "$lib/utils/models";
@@ -462,7 +463,15 @@
 				await stopRequestPromise.catch(() => {});
 				stopRequestPromise = undefined;
 			}
-			await invalidateAll();
+			// Only re-run the loads that actually need fresh data: the
+			// conversation page (new messages) and the sidebar list
+			// (updated title / updatedAt). Avoids the 5 redundant bootstrap
+			// requests (models, settings, user, public-config, feature-flags)
+			// that a full invalidateAll() would trigger.
+			await Promise.all([
+				invalidate(UrlDependency.Conversation),
+				invalidate(UrlDependency.ConversationList),
+			]);
 		}
 	}
 

--- a/src/routes/models/[...model]/+page.svelte
+++ b/src/routes/models/[...model]/+page.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
 	import { page } from "$app/state";
 	import { base } from "$app/paths";
-	import { goto, invalidate, replaceState } from "$app/navigation";
+	import { goto, replaceState } from "$app/navigation";
 	import { UrlDependency } from "$lib/types/UrlDependency";
+	import { safeInvalidate } from "$lib/utils/safeInvalidate";
 	import { onMount, tick } from "svelte";
 	import { usePublicConfig } from "$lib/utils/PublicConfig.svelte";
 
@@ -63,11 +64,13 @@
 				files,
 			});
 
-			// Navigate first: a concurrent invalidate() re-renders this page and
-			// can cancel the navigation, leaving the pending message unsent.
+			// Refresh the sidebar list (only that, not all 6 bootstrap endpoints)
+			// BEFORE navigating. Refreshing after goto() would update layout data
+			// while the first message is streaming, and the conversation page's
+			// `$effect(() => { messages = data.messages })` would wipe the locally
+			// appended messages, blanking the conversation until the stream ends.
+			await safeInvalidate(UrlDependency.ConversationList);
 			await goto(`${base}/conversation/${conversationId}`);
-			// Then refresh only the sidebar list, not all 6 bootstrap endpoints.
-			await invalidate(UrlDependency.ConversationList);
 		} catch (err) {
 			error.set(ERROR_MESSAGES.default);
 			console.error(err);

--- a/src/routes/models/[...model]/+page.svelte
+++ b/src/routes/models/[...model]/+page.svelte
@@ -63,12 +63,11 @@
 				files,
 			});
 
-			// Invalidate only the sidebar list, not all 6 bootstrap endpoints.
-			// The conversation page load re-runs automatically as a new page.
-			await Promise.all([
-				invalidate(UrlDependency.ConversationList),
-				goto(`${base}/conversation/${conversationId}`),
-			]);
+			// Navigate first: a concurrent invalidate() re-renders this page and
+			// can cancel the navigation, leaving the pending message unsent.
+			await goto(`${base}/conversation/${conversationId}`);
+			// Then refresh only the sidebar list, not all 6 bootstrap endpoints.
+			await invalidate(UrlDependency.ConversationList);
 		} catch (err) {
 			error.set(ERROR_MESSAGES.default);
 			console.error(err);

--- a/src/routes/models/[...model]/+page.svelte
+++ b/src/routes/models/[...model]/+page.svelte
@@ -66,12 +66,12 @@
 			const pendingFilesNonce = files.length > 0 ? storePendingFiles(files) : undefined;
 
 			// Optimistically prepend the new conversation to the sidebar immediately so
-			// it appears before the first message starts streaming. The title is set to
-			// "" here; it will be updated to the real title via a Title SSE update once
-			// the LLM generates one.
+			// it appears before the first message starts streaming. "New Chat" matches
+			// the server-side default title; the real title arrives via a Title stream
+			// update once the LLM generates one.
 			convsStore.prepend({
 				id: conversationId,
-				title: "",
+				title: "New Chat",
 				model: modelId,
 				updatedAt: new Date(),
 			});

--- a/src/routes/models/[...model]/+page.svelte
+++ b/src/routes/models/[...model]/+page.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
 	import { page } from "$app/state";
 	import { base } from "$app/paths";
-	import { goto, replaceState } from "$app/navigation";
+	import { goto, invalidate, replaceState } from "$app/navigation";
+	import { UrlDependency } from "$lib/types/UrlDependency";
 	import { onMount, tick } from "svelte";
 	import { usePublicConfig } from "$lib/utils/PublicConfig.svelte";
 
@@ -62,8 +63,12 @@
 				files,
 			});
 
-			// invalidateAll to update list of conversations
-			await goto(`${base}/conversation/${conversationId}`, { invalidateAll: true });
+			// Invalidate only the sidebar list, not all 6 bootstrap endpoints.
+			// The conversation page load re-runs automatically as a new page.
+			await Promise.all([
+				invalidate(UrlDependency.ConversationList),
+				goto(`${base}/conversation/${conversationId}`),
+			]);
 		} catch (err) {
 			error.set(ERROR_MESSAGES.default);
 			console.error(err);

--- a/src/routes/models/[...model]/+page.svelte
+++ b/src/routes/models/[...model]/+page.svelte
@@ -2,21 +2,22 @@
 	import { page } from "$app/state";
 	import { base } from "$app/paths";
 	import { goto, replaceState } from "$app/navigation";
-	import { UrlDependency } from "$lib/types/UrlDependency";
-	import { safeInvalidate } from "$lib/utils/safeInvalidate";
 	import { onMount, tick } from "svelte";
 	import { usePublicConfig } from "$lib/utils/PublicConfig.svelte";
 
 	import ChatWindow from "$lib/components/chat/ChatWindow.svelte";
 	import { findCurrentModel } from "$lib/utils/models";
 	import { useSettingsStore } from "$lib/stores/settings";
+	import { useConversationsStore } from "$lib/stores/conversations.svelte";
 	import { ERROR_MESSAGES, error } from "$lib/stores/errors";
-	import { pendingMessage } from "$lib/stores/pendingMessage";
+	import { storePendingFiles } from "$lib/utils/pendingFiles";
 	import { sanitizeUrlParam } from "$lib/utils/urlParams";
 	import { loadAttachmentsFromUrls } from "$lib/utils/loadAttachmentsFromUrls";
 	import { requireAuthUser } from "$lib/utils/auth";
 
 	let { data } = $props();
+
+	const convsStore = useConversationsStore();
 
 	let loading = $state(false);
 	let files: File[] = $state([]);
@@ -58,19 +59,25 @@
 
 			const { conversationId } = await res.json();
 
-			// Ugly hack to use a store as temp storage, feel free to improve ^^
-			pendingMessage.set({
-				content: message,
-				files,
-			});
+			// Pass the first message text via SvelteKit history state (JSON-serializable).
+			// File objects are not serializable, so they are stored in a client-side Map
+			// keyed by a random nonce; the nonce travels with the history state and is
+			// consumed once by the conversation page.
+			const pendingFilesNonce = files.length > 0 ? storePendingFiles(files) : undefined;
 
-			// Refresh the sidebar list (only that, not all 6 bootstrap endpoints)
-			// BEFORE navigating. Refreshing after goto() would update layout data
-			// while the first message is streaming, and the conversation page's
-			// `$effect(() => { messages = data.messages })` would wipe the locally
-			// appended messages, blanking the conversation until the stream ends.
-			await safeInvalidate(UrlDependency.ConversationList);
-			await goto(`${base}/conversation/${conversationId}`);
+			// Optimistically prepend the new conversation to the sidebar immediately so
+			// it appears before the first message starts streaming. The title is set to
+			// "" here; it will be updated to the real title via a Title SSE update once
+			// the LLM generates one.
+			convsStore.prepend({
+				id: conversationId,
+				title: "",
+				model: modelId,
+				updatedAt: new Date(),
+			});
+			await goto(`${base}/conversation/${conversationId}`, {
+				state: { pendingMessage: message, pendingFilesNonce },
+			});
 		} catch (err) {
 			error.set(ERROR_MESSAGES.default);
 			console.error(err);


### PR DESCRIPTION
Re-lands #2321 (reverted in 6acd198f after breaking prod) with the root cause of the incident fixed and proven.

## What broke prod

Sent messages appeared for a moment, then the conversation went blank until streaming finished, then everything reappeared. Root cause: the message-resync effect in `conversation/[id]/+page.svelte` read `pending` as a tracked dependency. The first streaming token flips `pending` to false, and that flip itself re-ran the effect, overwriting the locally appended user and assistant messages with the stale page-load snapshot (just the system message for a new conversation, hence a fully blank screen). The stream kept mutating orphaned nodes, so nothing rendered until the post-stream invalidation restored server data.

Proof from an instrumented run: the sync fired 2ms before the wipe with `{convChanged: false, pending: false, dataLen: 1, localLen: 3}`.

## The fix (1fb2a332)

- `pending` is only read inside `untrack()`, so its flips can never re-run the effect.
- The effect syncs only when `data.messages` identity actually changed (post-stream invalidation) or the conversation changed (sidebar navigation). Any other re-run is a no-op.
- A mid-stream refresh while `pending` is true is intentionally skipped; the finally-block invalidation re-syncs after the stream ends.

## Why every pre-merge check missed it

The wipe window runs from first token to stream end. All earlier verification used one-word replies, which restored within the sampling gaps of the checks. Prod's slow thinking-model generations stretched the blank window across the whole response. The local repro needed nothing exotic: a fast model and a 50-word reply reproduced it on the first try.

## Verification

- Deterministic repro harness: `form.requestSubmit()` plus a MutationObserver visibility-timeline watcher. Before the fix: marker visible, wiped 3.5s later, on both the new-conversation and follow-up paths. After the fix: zero wipe events on both paths with long replies.
- `npm run lint` clean, `svelte-check` 0 errors, 313/313 server/SSR tests pass.
- No merge conflicts with current main (the #2329 pacing rework and #2327 thumbnails touch disjoint files).

## Also included (unchanged from the reviewed branch)

Everything from the previous review cycle: targeted invalidation + Cache-Control, safeInvalidate, client-owned conversations store, history-state pending message, SSE background-generation channel with hardened cursor parsing, the New Chat stub title, and the vite-build guard for the models fetch (which the revert also removed from main, so it rides along again).

## Regression-test gap (documented, not solved here)

No trustworthy automated seam exists for this bug class: the client browser vitest project is opt-in (`VITEST_BROWSER=true`) and currently fails to boot alongside the dev server, and no unit test can capture an effect's reactive dependency set. Until that harness is fixed, the pre-deploy check for this class is a long-reply E2E run with the visibility watcher. Follow-up: extract the sync into a testable rune module once the browser harness is reliable.