### PR TITLE
Stop artifact cards from spinning forever after an aborted generation

### DIFF
--- a/src/lib/components/chat/ArtifactCard.svelte
+++ b/src/lib/components/chat/ArtifactCard.svelte
@@ -61,6 +61,11 @@
 				? `Code · ${version.language}`
 				: KIND_LABELS[version.type];
 		const versionLabel = (artifact?.versions.length ?? 0) > 1 ? ` · v${version.version}` : "";
+		if (version.interrupted) {
+			return version.op === "update"
+				? `Edit interrupted${versionLabel}`
+				: `Interrupted · ${kindLabel}${versionLabel}`;
+		}
 		if (version.op === "update") {
 			return version.failedPairs
 				? `Edited, ${version.failedPairs} change${version.failedPairs > 1 ? "s" : ""} didn't apply${versionLabel}`

--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -115,7 +115,11 @@
 
 	// Artifacts: fold <artifact> operations from the visible message path into a
 	// versioned registry, shared with the inline cards and the side panel.
-	let artifactRegistry = $derived(collectArtifacts(messages));
+	// Only the message currently receiving tokens can have a streaming artifact;
+	// unclosed tags anywhere else are interrupted generations, not live ones.
+	let artifactRegistry = $derived(
+		collectArtifacts(messages, loading ? messages.at(-1)?.id : undefined)
+	);
 	setArtifactsContext({
 		get registry() {
 			return artifactRegistry;

--- a/src/lib/utils/artifacts.spec.ts
+++ b/src/lib/utils/artifacts.spec.ts
@@ -201,12 +201,44 @@ describe("collectArtifacts", () => {
 		});
 	});
 
-	it("marks the streaming version", () => {
+	it("marks the streaming version while its message is live", () => {
+		const registry = collectArtifacts(
+			[msg("m1", `<artifact identifier="app" type="html" title="App">stream`)],
+			"m1"
+		);
+		expect(registry.streaming).toEqual({ identifier: "app", version: 1 });
+		expect(registry.artifacts.get("app")?.versions[0].complete).toBe(false);
+	});
+
+	it("finalizes an unclosed artifact whose message is no longer generating", () => {
+		// Aborted/interrupted generations leave the tag unterminated forever; the
+		// version must not read as streaming once nothing can append to it.
 		const registry = collectArtifacts([
 			msg("m1", `<artifact identifier="app" type="html" title="App">stream`),
 		]);
-		expect(registry.streaming).toEqual({ identifier: "app", version: 1 });
-		expect(registry.artifacts.get("app")?.versions[0].complete).toBe(false);
+		expect(registry.streaming).toBeUndefined();
+		expect(registry.artifacts.get("app")?.versions[0]).toMatchObject({
+			complete: true,
+			interrupted: true,
+			content: "stream",
+		});
+	});
+
+	it("finalizes an unclosed artifact in an earlier message even while another is live", () => {
+		const registry = collectArtifacts(
+			[
+				msg("m1", `<artifact identifier="app" type="html" title="App">partial`),
+				msg("m2", "continue", "user"),
+				msg("m3", `<artifact identifier="app" type="html" title="App">fresh`),
+			],
+			"m3"
+		);
+		expect(registry.artifacts.get("app")?.versions[0]).toMatchObject({
+			complete: true,
+			interrupted: true,
+		});
+		expect(registry.artifacts.get("app")?.versions[1].complete).toBe(false);
+		expect(registry.streaming).toEqual({ identifier: "app", version: 2 });
 	});
 
 	it("flags updates that reference unknown artifacts", () => {
@@ -221,6 +253,23 @@ describe("collectArtifacts", () => {
 	});
 
 	it("applies streaming update pairs progressively", () => {
+		const registry = collectArtifacts(
+			[
+				msg("m1", `<artifact identifier="app" type="html" title="App">alpha beta</artifact>`),
+				msg(
+					"m2",
+					`<artifact identifier="app" type="update"><old_str>alpha</old_str><new_str>gamma</new_str><old_str>be`
+				),
+			],
+			"m2"
+		);
+		const version = registry.artifacts.get("app")?.versions[1];
+		expect(version?.content).toBe("gamma beta");
+		expect(version?.complete).toBe(false);
+		expect(registry.streaming).toEqual({ identifier: "app", version: 2 });
+	});
+
+	it("finalizes an interrupted update op", () => {
 		const registry = collectArtifacts([
 			msg("m1", `<artifact identifier="app" type="html" title="App">alpha beta</artifact>`),
 			msg(
@@ -230,8 +279,8 @@ describe("collectArtifacts", () => {
 		]);
 		const version = registry.artifacts.get("app")?.versions[1];
 		expect(version?.content).toBe("gamma beta");
-		expect(version?.complete).toBe(false);
-		expect(registry.streaming).toEqual({ identifier: "app", version: 2 });
+		expect(version).toMatchObject({ complete: true, interrupted: true });
+		expect(registry.streaming).toBeUndefined();
 	});
 
 	it("ignores artifacts in user messages", () => {
@@ -393,18 +442,21 @@ describe("zero-pair updates are flagged", () => {
 	});
 
 	it("does not flag a still-streaming update with no pairs yet", () => {
-		const registry = collectArtifacts([
-			{
-				id: "m1",
-				from: "assistant",
-				content: `<artifact identifier="app" type="html" title="App">hello</artifact>`,
-			},
-			{
-				id: "m2",
-				from: "assistant",
-				content: `<artifact identifier="app" type="update">\n<old_str>hel`,
-			},
-		]);
+		const registry = collectArtifacts(
+			[
+				{
+					id: "m1",
+					from: "assistant",
+					content: `<artifact identifier="app" type="html" title="App">hello</artifact>`,
+				},
+				{
+					id: "m2",
+					from: "assistant",
+					content: `<artifact identifier="app" type="update">\n<old_str>hel`,
+				},
+			],
+			"m2"
+		);
 		const v2 = registry.artifacts.get("app")?.versions[1];
 		expect(v2?.complete).toBe(false);
 		expect(v2?.failedPairs).toBe(0);

--- a/src/lib/utils/artifacts.ts
+++ b/src/lib/utils/artifacts.ts
@@ -274,6 +274,8 @@ export interface ArtifactVersion {
 	language?: string;
 	content: string;
 	complete: boolean;
+	/** Generation ended (abort/error) before the closing tag arrived */
+	interrupted?: boolean;
 	op: ArtifactOpLabel;
 	/** 1-based version number within the artifact */
 	version: number;
@@ -309,9 +311,15 @@ export function artifactOpKey(messageId: Message["id"], opIndex: number): string
  * Walk the active conversation path and fold artifact operations into
  * versioned artifacts. Updates apply onto the latest version of the same
  * identifier; re-emitting a known identifier counts as a rewrite.
+ *
+ * `liveMessageId` is the message currently receiving tokens, if any. An
+ * unclosed tag only means "still streaming" there; anywhere else nothing can
+ * append to the content anymore (aborted or errored generation), so the
+ * version is final and flagged `interrupted` instead of spinning forever.
  */
 export function collectArtifacts(
-	messages: Array<Pick<Message, "id" | "from" | "content">>
+	messages: Array<Pick<Message, "id" | "from" | "content">>,
+	liveMessageId?: Message["id"]
 ): ArtifactRegistry {
 	const artifacts = new Map<string, Artifact>();
 	const byMessageOp = new Map<string, ArtifactCardRef>();
@@ -334,6 +342,8 @@ export function collectArtifacts(
 			opIndex += 1;
 
 			let artifact = artifacts.get(op.identifier);
+			const isLive = !op.closed && message.id === liveMessageId;
+			const interrupted = !op.closed && !isLive;
 
 			if (op.kind === "create") {
 				if (!artifact) {
@@ -346,14 +356,15 @@ export function collectArtifacts(
 					title: op.title,
 					language: op.language,
 					content: op.content,
-					complete: op.closed,
+					complete: !isLive,
+					interrupted,
 					op: artifact.versions.length > 0 ? "rewrite" : "create",
 					version: artifact.versions.length + 1,
 					messageId: message.id,
 				};
 				artifact.versions.push(version);
 				byMessageOp.set(key, { identifier: op.identifier, version: version.version });
-				if (!op.closed) {
+				if (isLive) {
 					streaming = { identifier: op.identifier, version: version.version };
 				}
 				continue;
@@ -373,18 +384,19 @@ export function collectArtifacts(
 				title: op.title || base.title,
 				language: base.language,
 				content: result.content,
-				complete: op.closed,
+				complete: !isLive,
+				interrupted,
 				op: "update",
 				version: artifact.versions.length + 1,
 				messageId: message.id,
 				// A finished update with zero parsed pairs is a no-op the model
 				// didn't intend — surface it as a failed edit instead of silently
 				// showing "Edited" with unchanged content.
-				failedPairs: Math.max(result.failed, op.closed && op.pairs.length === 0 ? 1 : 0),
+				failedPairs: Math.max(result.failed, !isLive && op.pairs.length === 0 ? 1 : 0),
 			};
 			artifact.versions.push(version);
 			byMessageOp.set(key, { identifier: op.identifier, version: version.version });
-			if (!op.closed) {
+			if (isLive) {
 				streaming = { identifier: op.identifier, version: version.version };
 			}
 		}


### PR DESCRIPTION
## Problem

Aborting (or erroring out of) a generation mid-artifact left the inline artifact card stuck on "Generating…" with a spinner, permanently. The side panel stayed locked in streaming mode too: no preview, no download, view pinned to the bottom.

Cause: `collectArtifacts` derived completeness purely from the presence of the closing `</artifact>` tag in the message content. An interrupted generation never delivers that tag, and nothing can ever append to the message afterwards, so the version read as "streaming" forever.

## Fix

- `collectArtifacts(messages, liveMessageId?)` now takes the id of the message currently receiving tokens (passed by `ChatWindow` as the last message of the visible path while `loading`). An unclosed tag only means "still streaming" on that message. Anywhere else the version is final (`complete: true`) and flagged `interrupted`.
- `ArtifactCard` renders interrupted versions with the kind icon and an honest subtitle ("Interrupted · SVG image", or "Edit interrupted" for update ops) instead of the spinner.
- Because the version is now final, the panel naturally unlocks preview/code/download for the partial content.

## Testing

- 4 new regression tests at the `collectArtifacts` seam (unclosed op in a non-live message, unclosed op in an earlier message while another streams, interrupted update op, streaming still works for the live message). Written first and watched fail.
- All 327 tests and lint pass.
- Verified live on dev: auto-clicked Stop 2ms after a card entered "Generating…". The card settled to "Interrupted · SVG image". After a full page reload the completed artifact still reads "SVG image", the aborted one reads "Interrupted · SVG image", and clicking it opens the panel with the partial code visible.