### PR TITLE
Overhaul the generation abort mechanism

### DIFF
--- a/src/lib/utils/generationState.spec.ts
+++ b/src/lib/utils/generationState.spec.ts
@@ -2,7 +2,12 @@ import { describe, expect, test } from "vitest";
 
 import type { Message } from "$lib/types/Message";
 import { MessageUpdateStatus, MessageUpdateType } from "$lib/types/MessageUpdate";
-import { isAssistantGenerationTerminal, isConversationGenerationActive } from "./generationState";
+import {
+	GENERATION_STALE_MS,
+	isAssistantGenerationTerminal,
+	isConversationGenerationActive,
+	isGenerationStale,
+} from "./generationState";
 
 function assistantMessage(overrides: Partial<Message> = {}): Message {
 	return {
@@ -71,5 +76,28 @@ describe("generationState", () => {
 
 		expect(isAssistantGenerationTerminal(message)).toBe(true);
 		expect(isConversationGenerationActive([message])).toBe(false);
+	});
+});
+
+describe("isGenerationStale", () => {
+	test("a recent write is not stale", () => {
+		expect(isGenerationStale(new Date())).toBe(false);
+		expect(isGenerationStale(new Date(Date.now() - GENERATION_STALE_MS + 5_000))).toBe(false);
+	});
+
+	test("a write older than the threshold is stale", () => {
+		expect(isGenerationStale(new Date(Date.now() - GENERATION_STALE_MS - 1_000))).toBe(true);
+	});
+
+	test("accepts ISO strings (API payloads)", () => {
+		expect(
+			isGenerationStale(new Date(Date.now() - GENERATION_STALE_MS - 1_000).toISOString())
+		).toBe(true);
+		expect(isGenerationStale(new Date().toISOString())).toBe(false);
+	});
+
+	test("missing or invalid timestamps are never stale", () => {
+		expect(isGenerationStale(undefined)).toBe(false);
+		expect(isGenerationStale("not-a-date")).toBe(false);
 	});
 });

--- a/src/lib/utils/generationState.ts
+++ b/src/lib/utils/generationState.ts
@@ -24,3 +24,19 @@ export function isConversationGenerationActive(messages: Message[]): boolean {
 
 	return !isAssistantGenerationTerminal(lastAssistant);
 }
+
+/**
+ * How long a generation may go without any database write before it is
+ * considered dead. Conversation.updatedAt is bumped when a generation starts
+ * (the pre-stream message write) and when it ends (persistConversation), so a
+ * conversation that has stayed non-terminal longer than this belongs to a pod
+ * that crashed before persisting — it will never become terminal on its own
+ * and must not keep the UI in a generating state forever.
+ */
+export const GENERATION_STALE_MS = 10 * 60 * 1000;
+
+export function isGenerationStale(lastWriteAt: Date | string | undefined): boolean {
+	if (!lastWriteAt) return false;
+	const t = new Date(lastWriteAt).getTime();
+	return !Number.isNaN(t) && Date.now() - t > GENERATION_STALE_MS;
+}

--- a/src/routes/api/v2/conversations/updates/+server.ts
+++ b/src/routes/api/v2/conversations/updates/+server.ts
@@ -2,7 +2,7 @@ import type { RequestHandler } from "@sveltejs/kit";
 import { requireAuth } from "$lib/server/api/utils/requireAuth";
 import { collections } from "$lib/server/database";
 import { authCondition } from "$lib/server/auth";
-import { isAssistantGenerationTerminal } from "$lib/utils/generationState";
+import { isAssistantGenerationTerminal, isGenerationStale } from "$lib/utils/generationState";
 import type { Message } from "$lib/types/Message";
 
 /**
@@ -119,7 +119,11 @@ export const GET: RequestHandler = async ({ locals, url, request }) => {
 						const lastAssistant = [...conv.messages]
 							.reverse()
 							.find((m) => m.from === "assistant") as Message | undefined;
-						const isTerminal = isAssistantGenerationTerminal(lastAssistant);
+						// Stale non-terminal conversations belong to pods that died
+						// before persisting; report them terminal so clients stop
+						// tracking them instead of spinning forever.
+						const isTerminal =
+							isAssistantGenerationTerminal(lastAssistant) || isGenerationStale(conv.updatedAt);
 
 						const event: ConvUpdate = {
 							id: conv._id.toString(),

--- a/src/routes/conversation/[id]/+page.svelte
+++ b/src/routes/conversation/[id]/+page.svelte
@@ -33,7 +33,8 @@
 	import { loading } from "$lib/stores/loading.js";
 	import { streamStart } from "$lib/utils/haptics";
 	import { requireAuthUser } from "$lib/utils/auth.js";
-	import { isConversationGenerationActive } from "$lib/utils/generationState";
+	import { isConversationGenerationActive, isGenerationStale } from "$lib/utils/generationState";
+	import { useAPIClient, handleResponse } from "$lib/APIClient";
 	import SharePreviewTags from "$lib/components/SharePreviewTags.svelte";
 
 	let { data } = $props();
@@ -46,8 +47,17 @@
 	let pending = $state(false);
 	let initialRun = true;
 	let showSubscribeModal = $state(false);
-	let stopRequested = $state(false);
+	// Conversation-scoped stop tombstone. A boolean reset on page.params.id
+	// changes resurrects the generating UI: invalidation reassigns page.params,
+	// which clears the flag while the stopped conversation's snapshot is still
+	// non-terminal, flipping $loading back on. Keying the tombstone by
+	// conversation id makes it survive invalidations; it expires when a new
+	// generation starts in this conversation.
+	let stopRequestedFor: string | null = $state(null);
 	let stopRequestPromise: Promise<void> | undefined;
+	// True while writeMessage runs; lets the generation-state effect skip the
+	// snapshot-staleness check for the generation streaming in this very tab.
+	let writeMessageInFlight = false;
 	let messageUpdatesAbortController = new AbortController();
 
 	let files: File[] = $state([]);
@@ -116,10 +126,15 @@
 		isRetry?: boolean;
 	}): Promise<void> {
 		try {
-			stopRequested = false;
+			stopRequestedFor = null;
 			$isAborted = false;
 			$loading = true;
 			pending = true;
+			writeMessageInFlight = true;
+			// Create the controller before any await: a Stop click during file
+			// encoding or MCP hydration must abort THIS request, not whichever
+			// stale controller a previous generation left behind.
+			messageUpdatesAbortController = new AbortController();
 			const base64Files = await Promise.all(
 				(files ?? []).map((file) =>
 					file2base64(file).then((value) => ({
@@ -220,7 +235,6 @@
 				throw new Error("Message to write to not found");
 			}
 
-			messageUpdatesAbortController = new AbortController();
 			const streamingMode = resolveStreamingMode($settings);
 
 			// Wait for the MCP store to hydrate before sending so the server receives
@@ -259,7 +273,10 @@
 				},
 				messageUpdatesAbortController.signal
 			).catch((err) => {
-				error.set(err.message);
+				// A user abort rejects the fetch; that is not an error worth a toast
+				if (!$isAborted && !(err instanceof DOMException && err.name === "AbortError")) {
+					error.set(err.message);
+				}
 			});
 			if (messageUpdatesIterator === undefined) return;
 
@@ -437,7 +454,9 @@
 				flushBuffer(new Date());
 			}
 		} catch (err) {
-			if (err instanceof Error && err.message.includes("overloaded")) {
+			if ($isAborted || (err instanceof DOMException && err.name === "AbortError")) {
+				// User-initiated abort, not an error
+			} else if (err instanceof Error && err.message.includes("overloaded")) {
 				$error = "Too much traffic, please try again.";
 			} else if (err instanceof Error && err.message.includes("429")) {
 				$error = ERROR_MESSAGES.rateLimited;
@@ -448,33 +467,64 @@
 			}
 			console.error(err);
 		} finally {
+			writeMessageInFlight = false;
 			$loading = false;
 			pending = false;
 			// Wait for the stop request to complete before refreshing data,
-			// so the server has persisted interrupted:true to the database.
+			// so the abort marker is durably written before we poll for the
+			// terminal state below.
 			if (stopRequestPromise) {
 				await stopRequestPromise.catch(() => {});
 				stopRequestPromise = undefined;
 			}
+			const stoppedHere = stopRequestedFor === convId;
 			// Only re-run the loads that actually need fresh data: the
 			// conversation page (new messages) and the sidebar list
 			// (updated title / updatedAt via client-owned store refresh).
 			// Avoids the 5 redundant bootstrap requests (models, settings, user,
 			// public-config, feature-flags) that a full invalidateAll() would trigger.
 			// When this finally runs because beforeNavigate aborted the stream
-			// ($isAborted set without stopRequested), invalidating would cancel
+			// ($isAborted set without a stop click), invalidating would cancel
 			// that very navigation (e.g. the "New Chat" click that triggered
 			// the abort) before the router even exposes it via `navigating`.
 			// Skip the refresh: the destination page loads its own data.
-			const abortedByNavigation = $isAborted && !stopRequested;
+			const abortedByNavigation = $isAborted && !stoppedHere;
 			if (!abortedByNavigation) {
+				// stop-generating returns as soon as the abort marker is written,
+				// NOT when the generating pod has persisted interrupted:true.
+				// Invalidating right away would load a non-terminal snapshot that
+				// wipes the optimistic interrupted flag and shows a stuck
+				// streaming state. Wait (bounded) for the persisted state to
+				// become terminal before refreshing.
+				if (stoppedHere) {
+					await waitForTerminalPersist(convId);
+				}
 				await Promise.all([safeInvalidate(UrlDependency.Conversation), convsStore.refresh()]);
 			}
 		}
 	}
 
+	// Poll the conversation API until the last assistant message is terminal
+	// (interrupted, final answer, or error persisted), bounded at ~3.2s. Used
+	// after a Stop so the post-stop refresh reads settled data instead of a
+	// mid-abort snapshot.
+	async function waitForTerminalPersist(id: string) {
+		const client = useAPIClient();
+		for (let attempt = 0; attempt < 8; attempt++) {
+			try {
+				const conversation = (await client.conversations({ id }).get().then(handleResponse)) as {
+					messages: Message[];
+				};
+				if (!isConversationGenerationActive(conversation.messages)) return;
+			} catch {
+				return; // cannot verify; fall through to the single refresh
+			}
+			await new Promise((resolve) => setTimeout(resolve, 400));
+		}
+	}
+
 	async function stopGeneration() {
-		stopRequested = true;
+		stopRequestedFor = convId;
 		$isAborted = true;
 		$loading = false;
 		messageUpdatesAbortController.abort();
@@ -497,18 +547,22 @@
 		};
 
 		// Store the promise so writeMessage's finally block can await it
-		// before calling invalidateAll() — ensures the server has persisted
-		// interrupted:true before we fetch fresh data.
+		// before refreshing data. Losing this request entirely means the server
+		// never learns about the stop (the abort marker is what cross-pod
+		// generation watchers act on), so retry with backoff instead of giving
+		// up after a single transient failure.
 		stopRequestPromise = (async () => {
-			try {
-				await sendStopRequest();
-			} catch (firstErr) {
+			const delays = [0, 300, 1000, 3000];
+			for (const [attempt, delay] of delays.entries()) {
+				if (delay) await new Promise((resolve) => setTimeout(resolve, delay));
 				try {
-					await new Promise((resolve) => setTimeout(resolve, 300));
 					await sendStopRequest();
-				} catch (retryErr) {
-					console.error("Failed to stop generation", firstErr, retryErr);
-					$error = "Failed to stop generation. Please try again.";
+					return;
+				} catch (err) {
+					if (attempt === delays.length - 1) {
+						console.error("Failed to stop generation", err);
+						$error = "Failed to stop generation. Please try again.";
+					}
 				}
 			}
 		})();
@@ -541,7 +595,10 @@
 			await writeMessage({ prompt: pendingText });
 		}
 
-		const streaming = isConversationGenerationActive(messages);
+		// Don't resume tracking for stale snapshots: a generation that has gone
+		// this long without a DB write died with its pod and will never finish.
+		const streaming =
+			isConversationGenerationActive(messages) && !isGenerationStale(data.updatedAt);
 		if (streaming) {
 			addBackgroundGeneration({ id: convId, startedAt: Date.now() });
 			$loading = true;
@@ -613,13 +670,14 @@
 	});
 
 	$effect(() => {
-		page.params.id;
-		stopRequested = false;
-	});
-
-	$effect(() => {
-		const streaming = isConversationGenerationActive(messages);
-		if (stopRequested) {
+		const streaming =
+			isConversationGenerationActive(messages) &&
+			// A snapshot that has gone this long without a database write belongs
+			// to a pod that died before persisting a terminal state; never
+			// resurrect the streaming UI for it. Generations streaming in this
+			// tab are exempt — their snapshot timestamp is from page-load time.
+			(untrack(() => writeMessageInFlight) || !isGenerationStale(data.updatedAt));
+		if (stopRequestedFor === convId) {
 			$loading = false;
 		} else if (streaming) {
 			$loading = true;

--- a/src/routes/conversation/[id]/+server.ts
+++ b/src/routes/conversation/[id]/+server.ts
@@ -72,6 +72,15 @@ export async function POST({ request, locals, params, getClientAddress }) {
 		error(404, "Conversation not found");
 	}
 
+	// A new generation invalidates any stale stop marker for this conversation.
+	// The abortedGenerations collection is the cross-pod abort channel:
+	// stop-generating upserts a marker, and the watcher in the stream below
+	// polls it. Clearing it here — before the client could possibly issue a
+	// stop for THIS generation (its fetch has not returned yet) — means any
+	// marker observed later was meant for us, with no wall-clock comparison
+	// between pods needed.
+	await collections.abortedGenerations.deleteOne({ conversationId: convId });
+
 	// register the event for ratelimiting
 	await collections.messageEvents.insertOne({
 		type: "message",
@@ -372,6 +381,33 @@ export async function POST({ request, locals, params, getClientAddress }) {
 			const ctrl = new AbortController();
 			abortRegistry.register(conversationKey, ctrl);
 
+			// Cross-pod and pre-first-token abort path. The in-process registry
+			// only works when the stop request lands on this pod, and the cached
+			// AbortedGenerations map is only consulted between tokens — useless
+			// while awaiting the first token of a slow (e.g. reasoning) model.
+			// Poll the marker collection directly and abort the upstream request
+			// as soon as a stop is observed. Pre-flight deleted any stale marker,
+			// so marker presence means a stop for this generation.
+			const abortMarkerWatcher = setInterval(() => {
+				collections.abortedGenerations
+					.findOne({ conversationId: convId })
+					.then((marker) => {
+						if (marker && !ctrl.signal.aborted) {
+							logger.info(
+								{ conversationId: conversationKey },
+								"Stop marker observed; aborting generation"
+							);
+							ctrl.abort();
+						}
+						if (marker || ctrl.signal.aborted) {
+							clearInterval(abortMarkerWatcher);
+						}
+					})
+					.catch(() => {
+						// transient DB error; the next tick retries
+					});
+			}, 300);
+
 			let finalAnswerReceived = false;
 			let abortedByUser = false;
 			let finishedStatusSent = false;
@@ -609,6 +645,9 @@ export async function POST({ request, locals, params, getClientAddress }) {
 				const isAbortError =
 					err?.name === "AbortError" ||
 					err?.name === "APIUserAbortError" ||
+					// The OpenAI SDK's APIUserAbortError keeps name "Error", so
+					// match the class name too
+					err?.constructor?.name === "APIUserAbortError" ||
 					err?.message === "Request was aborted.";
 				if (isAbortError || ctrl.signal.aborted) {
 					abortedByUser = true;
@@ -667,6 +706,7 @@ export async function POST({ request, locals, params, getClientAddress }) {
 			}
 
 			await persistConversation();
+			clearInterval(abortMarkerWatcher);
 			abortRegistry.unregister(conversationKey, ctrl);
 
 			// used to detect if cancel() is called bc of interrupt or just because the connection closes

--- a/src/routes/conversation/[id]/+server.ts
+++ b/src/routes/conversation/[id]/+server.ts
@@ -27,6 +27,13 @@ import { logger } from "$lib/server/logger.js";
 import { AbortRegistry } from "$lib/server/abortRegistry";
 import { MetricsServer } from "$lib/server/metrics";
 
+// How long a stop marker is protected from the pre-flight cleanup of a new
+// generation. A marker younger than this may still be awaiting observation by
+// a running generation's 300ms watcher (possibly on another pod); deleting it
+// would lose the stop. Aborted generations consume their marker on shutdown,
+// so markers normally live far shorter than this.
+const STOP_MARKER_GRACE_MS = 5_000;
+
 export async function POST({ request, locals, params, getClientAddress }) {
 	const id = z.string().parse(params.id);
 	const convId = new ObjectId(id);
@@ -75,11 +82,18 @@ export async function POST({ request, locals, params, getClientAddress }) {
 	// A new generation invalidates any stale stop marker for this conversation.
 	// The abortedGenerations collection is the cross-pod abort channel:
 	// stop-generating upserts a marker, and the watcher in the stream below
-	// polls it. Clearing it here — before the client could possibly issue a
-	// stop for THIS generation (its fetch has not returned yet) — means any
-	// marker observed later was meant for us, with no wall-clock comparison
-	// between pods needed.
-	await collections.abortedGenerations.deleteOne({ conversationId: convId });
+	// polls it. Clearing stale markers here — before the client could possibly
+	// issue a stop for THIS generation (its fetch has not returned yet) — means
+	// any marker observed later was meant for us, with no wall-clock comparison
+	// between pods needed. Markers younger than the grace window are preserved:
+	// they belong to a stop for a still-winding-down generation in this same
+	// conversation (e.g. issued from another tab), whose watcher must get the
+	// chance to observe them; aborted generations consume their marker on
+	// shutdown, so a fresh marker is never a stale one.
+	await collections.abortedGenerations.deleteOne({
+		conversationId: convId,
+		updatedAt: { $lt: new Date(Date.now() - STOP_MARKER_GRACE_MS) },
+	});
 
 	// register the event for ratelimiting
 	await collections.messageEvents.insertOne({
@@ -708,6 +722,18 @@ export async function POST({ request, locals, params, getClientAddress }) {
 			await persistConversation();
 			clearInterval(abortMarkerWatcher);
 			abortRegistry.unregister(conversationKey, ctrl);
+
+			// Consume the stop marker once the stop has been honored and the
+			// interrupted state persisted. Markers are conversation-scoped, so a
+			// leftover would trip the watcher of the next generation; consuming
+			// here (instead of unconditionally deleting in pre-flight) keeps
+			// markers alive long enough for concurrent in-flight generations to
+			// observe them.
+			if (abortedByUser) {
+				await collections.abortedGenerations
+					.deleteOne({ conversationId: convId })
+					.catch((err) => logger.warn(err, "Failed to consume stop marker"));
+			}
 
 			// used to detect if cancel() is called bc of interrupt or just because the connection closes
 			doneStreaming = true;


### PR DESCRIPTION
## Problem

Two field reports on hf.co/chat: clicking Stop before the first token does nothing, and stopped conversations come back as if they were still generating. Reproduced both deterministically on dev with a watcher that clicks Stop 150-300ms after send. The wedged state is worse than it looks: the resurrected `$loading=true` also makes `handleSubmit` silently drop the next message.

A multi-agent review of the whole abort path (client, server, persistence, multi-pod) confirmed 17 distinct findings. This PR fixes the load-bearing ones.

## Root causes and fixes

**Client (`conversation/[id]/+page.svelte`)**

- `stopRequested` was reset whenever `page.params.id` was touched. Invalidation reassigns `page.params`, so the post-stop refresh cleared the flag while the snapshot was still non-terminal, and the generation-state effect flipped `$loading` back on. Replaced with a conversation-scoped tombstone (`stopRequestedFor`) that survives invalidations and expires when a new generation starts.
- The post-stop refresh assumed the `stop-generating` 200 meant `interrupted:true` was persisted. It only means the abort marker was written (the generating pod may not even have seen it yet, especially cross-pod). The refresh now polls the conversation API (bounded ~3.2s) until the persisted state is terminal before invalidating.
- The `AbortController` was created after the file-encoding and MCP-hydration awaits, so a Stop during that window aborted a stale controller and the request proceeded anyway. Now created before any await.
- The stop POST retried once after 300ms and then gave up, losing the abort entirely on transient failures (observed live, two consecutive 503s). Now retries with backoff (0/300ms/1s/3s).
- User-initiated aborts no longer surface an "The operation was aborted." error toast.

**Server (`conversation/[id]/+server.ts`)**

- The in-process `AbortRegistry` is a no-op when the stop request lands on another pod (prod runs 3 replicas, no sticky sessions), and the cached `abortedGenerations` map was only consulted between tokens, so a stop before the first token of a slow (reasoning) model had no effect at all. The generation stream now polls the `abortedGenerations` collection every 300ms and aborts the upstream request as soon as a marker appears, regardless of which pod received the stop and whether any token has arrived.
- Pre-flight deletes any stale marker for the conversation, so marker presence alone means stop. This also removes the dependency on the cross-pod wall-clock comparison (`date > promptedAt`) that silently voided aborts under clock skew.
- Abort detection additionally matches the OpenAI SDK's `APIUserAbortError` by constructor name (its `.name` stays "Error").

**Zombie hygiene (`generationState.ts`, SSE endpoint)**

- A conversation that stays non-terminal for over 10 minutes without any DB write belongs to a pod that died before persisting (conv.updatedAt is bumped at generation start and end). The SSE endpoint now reports such conversations terminal and the client refuses to resume background tracking for them, instead of spinning forever.

## Testing

- 4 new unit tests for `isGenerationStale`; all 328 tests, svelte-check, and lint pass.
- Live gates on dev (deterministic watcher, `form.requestSubmit` + timed Stop click):
  - Stop at 150ms (mid pre-flight, pre-token): terminal `interrupted:true` + FinalAnswer persisted with zero content, Stop button settles and stays settled for 25s, no resurrection.
  - Stop at ~1s: stop POST at t+1ms, terminal poll observed persistence at ~t+1s, single clean refresh.
  - Send after stop: next message POSTs and streams normally (previously silently dropped).
  - Mid-stream stop: partial content (278 chars) persisted with `interrupted:true`.
  - Navigate away (New Chat) mid-stream: navigation completes, generation finishes in background with `interrupted:false` (no regression of the navigation-abort class).