### PR TITLE
Clamp interrupted messages to the client's stop point

### DIFF
--- a/src/lib/server/__tests__/conversation-stop-generating.spec.ts
+++ b/src/lib/server/__tests__/conversation-stop-generating.spec.ts
@@ -42,6 +42,52 @@ describe.sequential("POST /conversation/[id]/stop-generating", () => {
 		}
 	);
 
+	it("stores the stop point from the request body on the marker", async () => {
+		const { locals } = await createTestUser();
+		const conversation = await createTestConversation(locals);
+		const generationId = "22222222-2222-4222-8222-222222222222";
+
+		const response = await POST({
+			params: { id: conversation._id.toString() },
+			locals,
+			request: new Request("http://localhost/stop-generating", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ generationId, seenContentLength: 1234 }),
+			}),
+		} as never);
+
+		expect(response.status).toBe(200);
+		const marker = await collections.abortedGenerations.findOne({
+			conversationId: conversation._id,
+		});
+		expect(marker?.generationId).toBe(generationId);
+		expect(marker?.seenContentLength).toBe(1234);
+	});
+
+	it("ignores malformed stop-point bodies but still records the stop", async () => {
+		const { locals } = await createTestUser();
+		const conversation = await createTestConversation(locals);
+
+		const response = await POST({
+			params: { id: conversation._id.toString() },
+			locals,
+			request: new Request("http://localhost/stop-generating", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ generationId: "not-a-uuid", seenContentLength: -5 }),
+			}),
+		} as never);
+
+		expect(response.status).toBe(200);
+		const marker = await collections.abortedGenerations.findOne({
+			conversationId: conversation._id,
+		});
+		expect(marker).not.toBeNull();
+		expect(marker?.generationId).toBeUndefined();
+		expect(marker?.seenContentLength).toBeUndefined();
+	});
+
 	it("updates updatedAt while preserving createdAt on repeated stop", async () => {
 		const { locals } = await createTestUser();
 		const conversation = await createTestConversation(locals);

--- a/src/lib/server/__tests__/stopTruncation.spec.ts
+++ b/src/lib/server/__tests__/stopTruncation.spec.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+
+import { clampStoppedContent } from "$lib/server/stopTruncation";
+
+const GEN_ID = "11111111-1111-4111-8111-111111111111";
+const OTHER_GEN_ID = "22222222-2222-4222-8222-222222222222";
+
+describe("clampStoppedContent", () => {
+	it("clamps generated text to the reported stop point", () => {
+		expect(
+			clampStoppedContent({
+				content: "0123456789",
+				initialLength: 0,
+				generationId: GEN_ID,
+				marker: { generationId: GEN_ID, seenContentLength: 4 },
+			})
+		).toBe("0123");
+	});
+
+	it("never cuts into the pre-generation prefix (continue flows)", () => {
+		expect(
+			clampStoppedContent({
+				content: "prefix-and-more",
+				initialLength: 7,
+				generationId: GEN_ID,
+				marker: { generationId: GEN_ID, seenContentLength: 3 },
+			})
+		).toBe("prefix-");
+	});
+
+	it("leaves content unchanged when the stop point exceeds the generated text", () => {
+		expect(
+			clampStoppedContent({
+				content: "short",
+				initialLength: 0,
+				generationId: GEN_ID,
+				marker: { generationId: GEN_ID, seenContentLength: 50 },
+			})
+		).toBe("short");
+	});
+
+	it("ignores markers without a stop point (legacy stops)", () => {
+		expect(
+			clampStoppedContent({
+				content: "0123456789",
+				initialLength: 0,
+				generationId: GEN_ID,
+				marker: {},
+			})
+		).toBe("0123456789");
+	});
+
+	it("ignores stop points from another generation run", () => {
+		expect(
+			clampStoppedContent({
+				content: "0123456789",
+				initialLength: 0,
+				generationId: GEN_ID,
+				marker: { generationId: OTHER_GEN_ID, seenContentLength: 4 },
+			})
+		).toBe("0123456789");
+	});
+
+	it("ignores markers when the run has no generation id", () => {
+		expect(
+			clampStoppedContent({
+				content: "0123456789",
+				initialLength: 0,
+				generationId: undefined,
+				marker: { generationId: GEN_ID, seenContentLength: 4 },
+			})
+		).toBe("0123456789");
+	});
+
+	it("returns content unchanged without a marker", () => {
+		expect(
+			clampStoppedContent({
+				content: "0123456789",
+				initialLength: 0,
+				generationId: GEN_ID,
+				marker: null,
+			})
+		).toBe("0123456789");
+	});
+
+	it("floors fractional stop points and clamps negative ones to the prefix", () => {
+		expect(
+			clampStoppedContent({
+				content: "0123456789",
+				initialLength: 0,
+				generationId: GEN_ID,
+				marker: { generationId: GEN_ID, seenContentLength: 4.9 },
+			})
+		).toBe("0123");
+		expect(
+			clampStoppedContent({
+				content: "0123456789",
+				initialLength: 2,
+				generationId: GEN_ID,
+				marker: { generationId: GEN_ID, seenContentLength: -3 },
+			})
+		).toBe("01");
+	});
+
+	it("ignores non-finite stop points", () => {
+		expect(
+			clampStoppedContent({
+				content: "0123456789",
+				initialLength: 0,
+				generationId: GEN_ID,
+				marker: { generationId: GEN_ID, seenContentLength: Number.NaN },
+			})
+		).toBe("0123456789");
+	});
+});

--- a/src/lib/server/stopTruncation.ts
+++ b/src/lib/server/stopTruncation.ts
@@ -1,0 +1,36 @@
+import type { AbortedGeneration } from "$lib/types/AbortedGeneration";
+
+/**
+ * Content to persist for a user-stopped generation.
+ *
+ * The stopping client freezes its UI the moment Stop is clicked and reports
+ * the stop point (generation id + rendered character count) on the abort
+ * marker. Tokens keep arriving server-side until the marker is observed — or
+ * much longer when the stop request itself is delayed or retried — so without
+ * this clamp the interrupted message "grows back" past what the user saw on
+ * the next sync.
+ *
+ * The clamp is bounded below by the pre-generation prefix (continue flows
+ * append to existing content) and above by what was actually generated.
+ * Markers for another generation, legacy stop requests without a stop point,
+ * and non-finite lengths leave the content unchanged.
+ */
+export function clampStoppedContent(opts: {
+	content: string;
+	initialLength: number;
+	generationId: string | undefined;
+	marker: Pick<AbortedGeneration, "generationId" | "seenContentLength"> | null;
+}): string {
+	const { content, initialLength, generationId, marker } = opts;
+	const seen = marker?.seenContentLength;
+	if (
+		generationId === undefined ||
+		marker?.generationId !== generationId ||
+		typeof seen !== "number" ||
+		!Number.isFinite(seen)
+	) {
+		return content;
+	}
+	const keepUpTo = Math.max(initialLength, Math.min(content.length, Math.floor(seen)));
+	return content.slice(0, keepUpTo);
+}

--- a/src/lib/types/AbortedGeneration.ts
+++ b/src/lib/types/AbortedGeneration.ts
@@ -5,4 +5,11 @@ import type { Timestamps } from "./Timestamps";
 
 export interface AbortedGeneration extends Timestamps {
 	conversationId: Conversation["_id"];
+	// Stop point reported by the stopping client: which generation it was
+	// watching and how many characters of the streamed message it had on
+	// screen when Stop was clicked. Lets the generating pod clamp the
+	// persisted text to what the user saw rather than everything emitted
+	// before the marker was observed. Absent for legacy stop requests.
+	generationId?: string;
+	seenContentLength?: number;
 }

--- a/src/lib/utils/messageUpdates.ts
+++ b/src/lib/utils/messageUpdates.ts
@@ -19,6 +19,9 @@ type MessageUpdateRequestOptions = {
 	messageId?: string;
 	isRetry: boolean;
 	isContinue?: boolean;
+	// Client-chosen id for this generation run, echoed back by stop-generating
+	// so the server can match a stop point to the run it belongs to
+	generationId?: string;
 	files?: MessageFile[];
 	// Optional: pass selected MCP server names (client-side selection)
 	selectedMcpServerNames?: string[];
@@ -58,6 +61,7 @@ export async function fetchMessageUpdates(
 		id: opts.messageId,
 		is_retry: opts.isRetry,
 		is_continue: Boolean(opts.isContinue),
+		generationId: opts.generationId,
 		// Will be ignored server-side if unsupported
 		selectedMcpServerNames: opts.selectedMcpServerNames,
 		selectedMcpServers: opts.selectedMcpServers,

--- a/src/routes/conversation/[id]/+page.svelte
+++ b/src/routes/conversation/[id]/+page.svelte
@@ -381,8 +381,15 @@
 						messageToWriteTo.updates?.some((u) => u.type === MessageUpdateType.Tool) ?? false;
 
 					if (isInterrupted) {
-						// Preserve streamed content on abort. If we never streamed, fall back to finalText.
 						if (!messageToWriteTo.content) {
+							// We never streamed anything; fall back to finalText.
+							messageToWriteTo.content = finalText;
+						} else if (finalText && messageToWriteTo.content.startsWith(finalText)) {
+							// The server may have clamped the persisted text back to a
+							// reported stop point (see stop-generating). Adopt it when it
+							// is a prefix of what we streamed so this view matches what
+							// every other view will load; otherwise keep our streamed
+							// content (continue flows receive only the post-prefix text).
 							messageToWriteTo.content = finalText;
 						}
 					} else if (hadTools) {

--- a/src/routes/conversation/[id]/+page.svelte
+++ b/src/routes/conversation/[id]/+page.svelte
@@ -17,7 +17,7 @@
 	import { addChildren } from "$lib/utils/tree/addChildren";
 	import { addSibling } from "$lib/utils/tree/addSibling";
 	import { fetchMessageUpdates, resolveStreamingMode } from "$lib/utils/messageUpdates";
-	import type { v4 } from "uuid";
+	import { v4 } from "uuid";
 	import { useSettingsStore } from "$lib/stores/settings.js";
 	import { enabledServers, mcpServersLoaded } from "$lib/stores/mcpServers";
 	import { get } from "svelte/store";
@@ -55,6 +55,10 @@
 	// generation starts in this conversation.
 	let stopRequestedFor: string | null = $state(null);
 	let stopRequestPromise: Promise<void> | undefined;
+	// Id of the generation run this tab started, sent with the generation
+	// request and echoed in the stop request so the server can clamp the
+	// persisted text to the stop point of the run it belongs to.
+	let activeGenerationId: string | undefined;
 	// True while writeMessage runs; lets the generation-state effect skip the
 	// snapshot-staleness check for the generation streaming in this very tab.
 	let writeMessageInFlight = false;
@@ -135,6 +139,7 @@
 			// encoding or MCP hydration must abort THIS request, not whichever
 			// stale controller a previous generation left behind.
 			messageUpdatesAbortController = new AbortController();
+			activeGenerationId = v4();
 			const base64Files = await Promise.all(
 				(files ?? []).map((file) =>
 					file2base64(file).then((value) => ({
@@ -261,6 +266,7 @@
 					inputs: prompt,
 					messageId,
 					isRetry,
+					generationId: activeGenerationId,
 					files: isRetry ? userMessage?.files : base64Files,
 					selectedMcpServerNames: $enabledServers.map((s) => s.name),
 					selectedMcpServers: $enabledServers.map((s) => ({
@@ -468,6 +474,7 @@
 			console.error(err);
 		} finally {
 			writeMessageInFlight = false;
+			activeGenerationId = undefined;
 			$loading = false;
 			pending = false;
 			// Wait for the stop request to complete before refreshing data,
@@ -524,6 +531,17 @@
 	}
 
 	async function stopGeneration() {
+		// Snapshot the stop point first: the generation run this tab started
+		// (if any) and how many characters of the reply are on screen right
+		// now. The server clamps the persisted text back to this so the
+		// interrupted message cannot "grow back" past what the user saw while
+		// the abort marker was in flight.
+		const lastAssistant = messages.findLast((m) => m.from === "assistant");
+		const stopPoint =
+			activeGenerationId !== undefined && lastAssistant
+				? { generationId: activeGenerationId, seenContentLength: lastAssistant.content.length }
+				: undefined;
+
 		stopRequestedFor = convId;
 		$isAborted = true;
 		$loading = false;
@@ -532,7 +550,6 @@
 		// Mark the last assistant message as interrupted locally so
 		// isConversationGenerationActive() immediately returns false,
 		// removing the background poller and preventing $loading re-enable.
-		const lastAssistant = messages.findLast((m) => m.from === "assistant");
 		if (lastAssistant) {
 			lastAssistant.interrupted = true;
 		}
@@ -540,6 +557,10 @@
 		const sendStopRequest = async () => {
 			const response = await fetch(`${base}/conversation/${page.params.id}/stop-generating`, {
 				method: "POST",
+				...(stopPoint && {
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify(stopPoint),
+				}),
 			});
 			if (!response.ok) {
 				throw new Error(`Stop request failed: ${response.status}`);

--- a/src/routes/conversation/[id]/+server.ts
+++ b/src/routes/conversation/[id]/+server.ts
@@ -25,6 +25,7 @@ import { textGeneration } from "$lib/server/textGeneration";
 import type { TextGenerationContext } from "$lib/server/textGeneration/types";
 import { logger } from "$lib/server/logger.js";
 import { AbortRegistry } from "$lib/server/abortRegistry";
+import { clampStoppedContent } from "$lib/server/stopTruncation";
 import { MetricsServer } from "$lib/server/metrics";
 
 // How long a stop marker is protected from the pre-flight cleanup of a new
@@ -150,12 +151,16 @@ export async function POST({ request, locals, params, getClientAddress }) {
 		inputs: newPrompt,
 		id: messageId,
 		is_retry: isRetry,
+		generationId,
 		selectedMcpServerNames,
 		selectedMcpServers,
 		timezone,
 	} = z
 		.object({
 			id: z.string().uuid().refine(isMessageId).optional(), // parent message id to append to for a normal message, or the message id for a retry/continue
+			// client-chosen id for this generation run, echoed back by the stop
+			// request so a stop point can be matched to the run it belongs to
+			generationId: z.string().uuid().optional(),
 			inputs: z.optional(
 				z
 					.string()
@@ -602,6 +607,30 @@ export async function POST({ request, locals, params, getClientAddress }) {
 			let hasError = false;
 			const initialMessageContent = messageToWriteTo.content;
 
+			// Emit the streamed-so-far text as an interrupted final answer. The
+			// stopping client freezes its UI at the Stop click and reports its
+			// stop point on the abort marker, while tokens keep arriving here
+			// until the marker is observed (longer still when the stop request
+			// was delayed or retried). Clamp the text back to the stop point so
+			// the message persists exactly as the user last saw it instead of
+			// "growing back" on the next sync.
+			const emitInterruptedFinalAnswer = async () => {
+				const marker = await collections.abortedGenerations
+					.findOne({ conversationId: convId })
+					.catch(() => null);
+				messageToWriteTo.content = clampStoppedContent({
+					content: messageToWriteTo.content,
+					initialLength: initialMessageContent.length,
+					generationId,
+					marker,
+				});
+				await update({
+					type: MessageUpdateType.FinalAnswer,
+					text: messageToWriteTo.content.slice(initialMessageContent.length),
+					interrupted: true,
+				});
+			};
+
 			try {
 				// Fetch user settings once for all overrides and billing org
 				const userSettings = await collections.settings.findOne(authCondition(locals));
@@ -647,12 +676,7 @@ export async function POST({ request, locals, params, getClientAddress }) {
 					abortedByUser = true;
 				}
 				if (abortedByUser && !finalAnswerReceived) {
-					const partialText = messageToWriteTo.content.slice(initialMessageContent.length);
-					await update({
-						type: MessageUpdateType.FinalAnswer,
-						text: partialText,
-						interrupted: true,
-					});
+					await emitInterruptedFinalAnswer();
 				}
 			} catch (e) {
 				const err = e as Error;
@@ -667,12 +691,7 @@ export async function POST({ request, locals, params, getClientAddress }) {
 					abortedByUser = true;
 					logger.info({ conversationId: conversationKey }, "Generation aborted by user");
 					if (!finalAnswerReceived) {
-						const partialText = messageToWriteTo.content.slice(initialMessageContent.length);
-						await update({
-							type: MessageUpdateType.FinalAnswer,
-							text: partialText,
-							interrupted: true,
-						});
+						await emitInterruptedFinalAnswer();
 					}
 				} else {
 					hasError = true;

--- a/src/routes/conversation/[id]/stop-generating/+server.ts
+++ b/src/routes/conversation/[id]/stop-generating/+server.ts
@@ -3,11 +3,17 @@ import { collections } from "$lib/server/database";
 import { AbortRegistry } from "$lib/server/abortRegistry";
 import { error } from "@sveltejs/kit";
 import { ObjectId } from "mongodb";
+import { z } from "zod";
+
+const stopPointSchema = z.object({
+	generationId: z.string().uuid(),
+	seenContentLength: z.number().int().nonnegative(),
+});
 
 /**
  * Ideally, we'd be able to detect the client-side abort, see https://github.com/huggingface/chat-ui/pull/88#issuecomment-1523173850
  */
-export async function POST({ params, locals }) {
+export async function POST({ params, locals, request }) {
 	if (!locals.user && !locals.sessionId) {
 		error(401, "Unauthorized");
 	}
@@ -23,13 +29,28 @@ export async function POST({ params, locals }) {
 		error(404, "Conversation not found");
 	}
 
-	AbortRegistry.getInstance().abort(conversationId.toString());
+	// Optional stop point from the stopping client (see AbortedGeneration).
+	// Parsed leniently: a stop must succeed even with a missing or malformed
+	// body (legacy clients send none).
+	let stopPoint: z.infer<typeof stopPointSchema> | undefined;
+	try {
+		stopPoint = stopPointSchema.parse(await request.json());
+	} catch {
+		stopPoint = undefined;
+	}
 
+	// Write the marker before aborting the in-process registry so a finalize
+	// triggered by a same-pod abort always finds the stop point on it.
 	await collections.abortedGenerations.updateOne(
 		{ conversationId },
-		{ $set: { updatedAt: new Date() }, $setOnInsert: { createdAt: new Date() } },
+		{
+			$set: { updatedAt: new Date(), ...stopPoint },
+			$setOnInsert: { createdAt: new Date() },
+		},
 		{ upsert: true }
 	);
+
+	AbortRegistry.getInstance().abort(conversationId.toString());
 
 	return new Response();
 }


### PR DESCRIPTION
## Problem

Clicking Stop freezes the UI instantly, but the generating pod keeps streaming until it observes the abort marker. With fast providers, or when the stop request itself is delayed and retried, the persisted interrupted message ends up far longer than what the user saw, and the "stopped" reply visibly grows back on the next sync.

Observed on production during the post-release review: a stop-generating request hit a 503 and spent ~4.5s in the client retry backoff while fireworks kept streaming. A list stopped at item 22 was persisted with 75 items (`interrupted: true` was set correctly, but the content was far past the stop point). Tightening the 300ms marker watcher cannot fix that class of delay; anchoring the persisted text to what the user actually saw does.

## Fix

- The client tags each generation run with a `generationId` (sent in the generation request) and, on Stop, snapshots its stop point: the run id plus the rendered character count of the streaming reply. The count is frame-accurate since the smooth-stream pacer writes displayed text into `message.content`.
- `stop-generating` accepts an optional JSON body with that stop point. Parsing is lenient: stops without a body (legacy clients, re-attached tabs that did not start the run) keep the previous behavior, malformed bodies are ignored but the stop still lands.
- The endpoint now writes the marker before firing the in-process `AbortRegistry`, so a finalize triggered by a same-pod abort always finds the stop point on the marker.
- At finalize, the generation endpoint clamps the interrupted message through a new pure helper `clampStoppedContent`: bounded below by the pre-generation prefix (continue flows), above by the generated text, and only applied when the marker's `generationId` matches the run, so a stop from another tab or a stale marker can never truncate the wrong sibling.
- The two duplicated interrupted-FinalAnswer blocks in the conversation endpoint collapse into one `emitInterruptedFinalAnswer` helper. The tool-merge heuristics are unaffected (the clamped text passes the existing endsWith keep-as-is path).

## Validation

- 9 new unit tests for the clamp and 2 new endpoint tests for body handling (valid, malformed, absent), all passing alongside the existing suite.
- `npm run check` 0 errors, prettier and eslint clean, `messageUpdates` smoother suite still green.

## Known limitation

If the provider finishes before the marker is observed, the completed answer is kept untruncated (the stop arrived too late to matter). Retroactively cutting a finished answer felt worse than keeping it.