### PR TITLE
Make the MCP tool-list cache effective: per-server entries, no per-request reset

### DIFF
--- a/src/lib/server/mcp/tools.test.ts
+++ b/src/lib/server/mcp/tools.test.ts
@@ -1,5 +1,48 @@
-import { describe, it, expect } from "vitest";
-import { sanitizeJsonSchema } from "./tools";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { sanitizeJsonSchema, getOpenAiToolsForMcp, resetMcpToolsCache } from "./tools";
+import type { McpServerConfig } from "./httpClient";
+
+// In-memory MCP servers keyed by URL: each listTools call is recorded so tests
+// can assert exactly which servers were (re-)listed vs served from the cache.
+const mcpMock = vi.hoisted(() => ({
+	listToolsCalls: [] as string[],
+	responses: new Map<string, { tools: unknown[] } | Error>(),
+}));
+
+vi.mock("@modelcontextprotocol/sdk/client", () => ({
+	Client: class {
+		private url = "";
+		async connect(transport: { url?: unknown }) {
+			this.url = String(transport.url ?? "");
+		}
+		async listTools() {
+			mcpMock.listToolsCalls.push(this.url);
+			const response = mcpMock.responses.get(this.url);
+			if (!response) return { tools: [] };
+			if (response instanceof Error) throw response;
+			return response;
+		}
+		async close() {}
+	},
+}));
+
+vi.mock("@modelcontextprotocol/sdk/client/streamableHttp.js", () => ({
+	StreamableHTTPClientTransport: class {
+		url: unknown;
+		constructor(url: unknown) {
+			this.url = url;
+		}
+	},
+}));
+
+vi.mock("@modelcontextprotocol/sdk/client/sse.js", () => ({
+	SSEClientTransport: class {
+		url: unknown;
+		constructor(url: unknown) {
+			this.url = url;
+		}
+	},
+}));
 
 // The real `write_file` inputSchema served today by hf.co/mcp. The properties
 // `private`, `revision`, `commit_message`, `commit_description` are shaped
@@ -132,5 +175,120 @@ describe("sanitizeJsonSchema", () => {
 		const before = JSON.stringify(writeFileSchema);
 		sanitizeJsonSchema(writeFileSchema);
 		expect(JSON.stringify(writeFileSchema)).toBe(before);
+	});
+});
+
+const SERVER_A: McpServerConfig = { name: "Server A", url: "https://a.example/mcp" };
+const SERVER_B: McpServerConfig = { name: "Server B", url: "https://b.example/mcp" };
+
+const searchTool = {
+	name: "search",
+	description: "Search things",
+	inputSchema: { type: "object", properties: { q: { type: "string" } } },
+};
+const fetchTool = {
+	name: "fetch_page",
+	description: "Fetch a page",
+	inputSchema: { type: "object", properties: { url: { type: "string" } } },
+};
+
+describe("getOpenAiToolsForMcp per-server cache", () => {
+	beforeEach(() => {
+		resetMcpToolsCache();
+		mcpMock.listToolsCalls.length = 0;
+		mcpMock.responses.clear();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("serves repeat requests from the cache instead of re-listing", async () => {
+		mcpMock.responses.set(SERVER_A.url, { tools: [searchTool] });
+
+		const first = await getOpenAiToolsForMcp([SERVER_A]);
+		const second = await getOpenAiToolsForMcp([SERVER_A]);
+
+		expect(mcpMock.listToolsCalls).toEqual([SERVER_A.url]);
+		expect(first.tools.map((t) => t.function.name)).toEqual(["search"]);
+		expect(first.tools[0].function.parameters).toMatchObject({ type: "object" });
+		expect(second.tools.map((t) => t.function.name)).toEqual(["search"]);
+		expect(second.mapping.search).toEqual({
+			fnName: "search",
+			server: "Server A",
+			tool: "search",
+		});
+	});
+
+	it("fetches only servers missing from the cache when the selection grows", async () => {
+		mcpMock.responses.set(SERVER_A.url, { tools: [searchTool] });
+		mcpMock.responses.set(SERVER_B.url, { tools: [fetchTool] });
+
+		await getOpenAiToolsForMcp([SERVER_A]);
+		const merged = await getOpenAiToolsForMcp([SERVER_A, SERVER_B]);
+
+		expect(mcpMock.listToolsCalls).toEqual([SERVER_A.url, SERVER_B.url]);
+		expect(merged.tools.map((t) => t.function.name)).toEqual(["search", "fetch_page"]);
+	});
+
+	it("re-lists a server after its entry expires", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-06-11T12:00:00Z"));
+		mcpMock.responses.set(SERVER_A.url, { tools: [searchTool] });
+
+		await getOpenAiToolsForMcp([SERVER_A]);
+		vi.setSystemTime(new Date("2026-06-11T12:01:01Z")); // past the 60s TTL
+		await getOpenAiToolsForMcp([SERVER_A]);
+
+		expect(mcpMock.listToolsCalls).toEqual([SERVER_A.url, SERVER_A.url]);
+	});
+
+	it("does not cache a failed listing and retries it on the next request", async () => {
+		mcpMock.responses.set(SERVER_A.url, new Error("boom"));
+		mcpMock.responses.set(SERVER_B.url, { tools: [fetchTool] });
+
+		const first = await getOpenAiToolsForMcp([SERVER_A, SERVER_B]);
+		expect(first.tools.map((t) => t.function.name)).toEqual(["fetch_page"]);
+
+		mcpMock.responses.set(SERVER_A.url, { tools: [searchTool] });
+		const second = await getOpenAiToolsForMcp([SERVER_A, SERVER_B]);
+
+		expect(second.tools.map((t) => t.function.name)).toEqual(["search", "fetch_page"]);
+		// A listed twice (failure not cached), B listed once (success cached)
+		expect(mcpMock.listToolsCalls.filter((u) => u === SERVER_A.url)).toHaveLength(2);
+		expect(mcpMock.listToolsCalls.filter((u) => u === SERVER_B.url)).toHaveLength(1);
+	});
+
+	it("keys entries by headers so per-user auth does not share a cache entry", async () => {
+		mcpMock.responses.set(SERVER_A.url, { tools: [searchTool] });
+		const asUser1 = { ...SERVER_A, headers: { Authorization: "Bearer hf_user1" } };
+		const asUser2 = { ...SERVER_A, headers: { Authorization: "Bearer hf_user2" } };
+
+		await getOpenAiToolsForMcp([asUser1]);
+		await getOpenAiToolsForMcp([asUser2]);
+		await getOpenAiToolsForMcp([asUser1]);
+
+		expect(mcpMock.listToolsCalls).toEqual([SERVER_A.url, SERVER_A.url]);
+	});
+
+	it("hits the cache when only the display name changes, mapping to the new name", async () => {
+		mcpMock.responses.set(SERVER_A.url, { tools: [searchTool] });
+
+		await getOpenAiToolsForMcp([SERVER_A]);
+		const renamed = await getOpenAiToolsForMcp([{ ...SERVER_A, name: "Renamed" }]);
+
+		expect(mcpMock.listToolsCalls).toEqual([SERVER_A.url]);
+		expect(renamed.mapping.search?.server).toBe("Renamed");
+	});
+
+	it("suffixes colliding tool names with the server name", async () => {
+		mcpMock.responses.set(SERVER_A.url, { tools: [searchTool] });
+		mcpMock.responses.set(SERVER_B.url, { tools: [searchTool] });
+
+		const { tools, mapping } = await getOpenAiToolsForMcp([SERVER_A, SERVER_B]);
+
+		expect(tools.map((t) => t.function.name)).toEqual(["search", "search_Server_B"]);
+		expect(mapping.search.server).toBe("Server A");
+		expect(mapping.search_Server_B.server).toBe("Server B");
 	});
 });

--- a/src/lib/server/mcp/tools.ts
+++ b/src/lib/server/mcp/tools.ts
@@ -17,15 +17,26 @@ export interface McpToolMapping {
 	tool: string;
 }
 
-interface CacheEntry {
+// Tool listings are cached per server (url + headers), not per server set, so
+// toggling one server never invalidates the others' entries. Headers are part
+// of the key because they change what a server returns (e.g. the forwarded HF
+// user token yields a per-user tool list on hf.co/mcp); that also means the key
+// space grows with active users, hence the size cap.
+type CachedServerTool = {
+	name: string;
+	description?: string;
+	parameters?: Record<string, unknown>;
+};
+
+interface ServerCacheEntry {
 	fetchedAt: number;
 	ttlMs: number;
-	tools: OpenAiTool[];
-	mapping: Record<string, McpToolMapping>;
+	tools: CachedServerTool[];
 }
 
 const DEFAULT_TTL_MS = 60_000;
-const cache = new Map<string, CacheEntry>();
+const MAX_CACHE_ENTRIES = 1_000;
+const cache = new Map<string, ServerCacheEntry>();
 
 // Per OpenAI tool/function name guidelines most providers enforce:
 //   ^[a-zA-Z0-9_-]{1,64}$
@@ -106,24 +117,27 @@ export function sanitizeJsonSchema(schema: Record<string, unknown>): Record<stri
 	return out;
 }
 
-function buildCacheKey(servers: McpServerConfig[]): string {
-	const normalized = servers
-		.map((server) => ({
-			name: server.name,
-			url: server.url,
-			headers: server.headers
-				? Object.entries(server.headers)
-						.sort(([a], [b]) => a.localeCompare(b))
-						.map(([key, value]) => [key, value])
-				: [],
-		}))
-		.sort((a, b) => {
-			const byName = a.name.localeCompare(b.name);
-			if (byName !== 0) return byName;
-			return a.url.localeCompare(b.url);
-		});
+function serverCacheKey(server: McpServerConfig): string {
+	const headers = server.headers
+		? Object.entries(server.headers).sort(([a], [b]) => a.localeCompare(b))
+		: [];
+	return JSON.stringify([server.url, headers]);
+}
 
-	return JSON.stringify(normalized);
+function evictExpired(now: number) {
+	for (const [key, entry] of cache) {
+		if (now - entry.fetchedAt >= entry.ttlMs) {
+			cache.delete(key);
+		}
+	}
+}
+
+function enforceCacheCap() {
+	if (cache.size <= MAX_CACHE_ENTRIES) return;
+	const oldestFirst = [...cache.entries()].sort((a, b) => a[1].fetchedAt - b[1].fetchedAt);
+	for (const [key] of oldestFirst.slice(0, cache.size - MAX_CACHE_ENTRIES)) {
+		cache.delete(key);
+	}
 }
 
 type ListedTool = {
@@ -177,17 +191,62 @@ async function listServerTools(
 	}
 }
 
+async function fetchServerTools(
+	server: McpServerConfig,
+	opts: { signal?: AbortSignal } = {}
+): Promise<CachedServerTool[]> {
+	const raw = await listServerTools(server, opts);
+	const normalized: CachedServerTool[] = [];
+	for (const tool of raw) {
+		if (typeof tool.name !== "string" || tool.name.trim().length === 0) {
+			continue;
+		}
+		normalized.push({
+			name: tool.name,
+			description: tool.description ?? tool.annotations?.title,
+			parameters: isPlainObject(tool.inputSchema)
+				? sanitizeJsonSchema(tool.inputSchema)
+				: undefined,
+		});
+	}
+	return normalized;
+}
+
 export async function getOpenAiToolsForMcp(
 	servers: McpServerConfig[],
 	{ ttlMs = DEFAULT_TTL_MS, signal }: { ttlMs?: number; signal?: AbortSignal } = {}
 ): Promise<{ tools: OpenAiTool[]; mapping: Record<string, McpToolMapping> }> {
 	const now = Date.now();
-	const cacheKey = buildCacheKey(servers);
-	const cached = cache.get(cacheKey);
-	if (cached && now - cached.fetchedAt < cached.ttlMs) {
-		return { tools: cached.tools, mapping: cached.mapping };
-	}
+	evictExpired(now);
 
+	// Resolve each server's tools from the per-server cache; only cold servers
+	// are fetched, in parallel. A failed listing contributes no tools and caches
+	// nothing, so the next request retries that server.
+	const listed = await Promise.all(
+		servers.map(async (server): Promise<CachedServerTool[]> => {
+			const key = serverCacheKey(server);
+			const cached = cache.get(key);
+			if (cached) {
+				return cached.tools;
+			}
+			try {
+				const tools = await fetchServerTools(server, { signal });
+				cache.set(key, { fetchedAt: now, ttlMs, tools });
+				return tools;
+			} catch (err) {
+				logger.debug(
+					{ server: server.name, url: server.url, err: String(err) },
+					"[mcp] failed to list tools for server"
+				);
+				return [];
+			}
+		})
+	);
+	enforceCacheCap();
+
+	// Function names depend on the request's server combination (collision
+	// suffixes), so definitions and mapping are rebuilt per request from the
+	// cached per-server listings.
 	const tools: OpenAiTool[] = [];
 	const mapping: Record<string, McpToolMapping> = {};
 
@@ -210,59 +269,36 @@ export async function getOpenAiToolsForMcp(
 		seenNames.add(name);
 	};
 
-	// Fetch tools in parallel; tolerate individual failures
-	const tasks = servers.map((server) => listServerTools(server, { signal }));
-	const results = await Promise.allSettled(tasks);
-
-	for (let i = 0; i < results.length; i++) {
-		const server = servers[i];
-		const r = results[i];
-		if (r.status === "fulfilled") {
-			const serverTools = r.value;
-			for (const tool of serverTools) {
-				if (typeof tool.name !== "string" || tool.name.trim().length === 0) {
-					continue;
-				}
-
-				const parameters = isPlainObject(tool.inputSchema)
-					? sanitizeJsonSchema(tool.inputSchema)
-					: undefined;
-				const description = tool.description ?? tool.annotations?.title;
-				const toolName = tool.name;
-
-				// Emit a collision-aware function name.
-				// Prefer the plain tool name; on conflict, suffix with server name.
-				let plainName = sanitizeName(toolName);
-				if (plainName in mapping) {
-					const suffix = sanitizeName(server.name);
-					const candidate = `${plainName}_${suffix}`.slice(0, 64);
-					if (!(candidate in mapping)) {
-						plainName = candidate;
-					} else {
-						let i = 2;
-						let next = `${candidate}_${i}`;
-						while (i < 10 && next in mapping) {
-							i += 1;
-							next = `${candidate}_${i}`;
-						}
-						plainName = next.slice(0, 64);
+	for (const [index, server] of servers.entries()) {
+		for (const tool of listed[index]) {
+			// Emit a collision-aware function name.
+			// Prefer the plain tool name; on conflict, suffix with server name.
+			let plainName = sanitizeName(tool.name);
+			if (plainName in mapping) {
+				const suffix = sanitizeName(server.name);
+				const candidate = `${plainName}_${suffix}`.slice(0, 64);
+				if (!(candidate in mapping)) {
+					plainName = candidate;
+				} else {
+					let n = 2;
+					let next = `${candidate}_${n}`;
+					while (n < 10 && next in mapping) {
+						n += 1;
+						next = `${candidate}_${n}`;
 					}
+					plainName = next.slice(0, 64);
 				}
-
-				pushToolDefinition(plainName, description, parameters);
-				mapping[plainName] = {
-					fnName: plainName,
-					server: server.name,
-					tool: toolName,
-				};
 			}
-		} else {
-			// ignore failure for this server
-			continue;
+
+			pushToolDefinition(plainName, tool.description, tool.parameters);
+			mapping[plainName] = {
+				fnName: plainName,
+				server: server.name,
+				tool: tool.name,
+			};
 		}
 	}
 
-	cache.set(cacheKey, { fetchedAt: now, ttlMs, tools, mapping });
 	return { tools, mapping };
 }
 

--- a/src/lib/server/textGeneration/mcp/runMcpFlow.ts
+++ b/src/lib/server/textGeneration/mcp/runMcpFlow.ts
@@ -2,7 +2,6 @@ import { config } from "$lib/server/config";
 import { MessageUpdateType, type MessageUpdate } from "$lib/types/MessageUpdate";
 import { getMcpServers } from "$lib/server/mcp/registry";
 import { isValidUrl } from "$lib/server/urlSafety";
-import { resetMcpToolsCache } from "$lib/server/mcp/tools";
 import { getOpenAiToolsForMcp } from "$lib/server/mcp/tools";
 import type {
 	ChatCompletionChunk,
@@ -99,8 +98,6 @@ export async function* runMcpFlow({
 		)?.mcp;
 		const custom = Array.isArray(reqMcp?.selectedServers) ? reqMcp?.selectedServers : [];
 		if (custom.length > 0) {
-			// Invalidate cached tool list when the set of servers changes at request-time
-			resetMcpToolsCache();
 			// Deduplicate by server name (request takes precedence)
 			const byName = new Map<
 				string,


### PR DESCRIPTION
## Problem

`getOpenAiToolsForMcp` has a 60s TTL cache for MCP tool listings, but it has been dead in production since the original MCP PR (#1981): `runMcpFlow` calls `resetMcpToolsCache()` whenever the request carries `selectedServers`, and the client sends all enabled servers on every message. So every MCP message from every user wiped the global cache before checking it, then paid connect (initialize round-trip, plus an HTTP-to-SSE fallback retry for SSE-only servers) and `listTools` to every enabled server before the first LLM token. That is roughly 1s per message, gated on the slowest enabled server.

The reset never provided correctness. The cache key already encodes the full server config (url and headers), so any change in selection naturally produces a different key and misses.

## Changes

- Remove the per-request `resetMcpToolsCache()` call in `runMcpFlow.ts`.
- Cache tool listings per server (keyed on url plus sorted headers) instead of per server set. Toggling one server no longer invalidates the others, and per-user auth headers (the forwarded HF token on hf.co/mcp) only shard the entry of the server they apply to.
- Cache the normalized per-server tool list (sanitized schema, description). OpenAI function names and the name-to-server mapping are rebuilt per request, since collision suffixes depend on the request's server combination.
- Failed listings cache nothing and are retried on the next request, matching the previous tolerate-failures behavior.
- Add eviction: expired entries are swept on each call, and the map is capped at 1000 entries (oldest evicted first), since per-user keys now accumulate instead of being wiped every message.

## Impact

With the default 60s TTL, the per-message `listTools` tax disappears for any message within the window, and changing the selection only fetches servers that are not already cached. Cold start and TTL expiry behave as before. Tool-list freshness is bounded by the same 60s the cache was always designed for.

## Tests

Seven new tests in `tools.test.ts` (mocked MCP SDK client, listings recorded per URL): cache hit on repeat requests, cold-only fetching when the selection grows, TTL expiry, failure retry without cache poisoning, per-user header sharding, display-name changes not busting the cache, and collision suffixing across servers. Full suite passes (361 tests), `npm run check` and `npm run lint` are clean.