### PR TITLE
Adjust sidebar width from 290px to 260px

### DIFF
--- a/src/lib/components/NavMenu.svelte
+++ b/src/lib/components/NavMenu.svelte
@@ -185,12 +185,11 @@
 					href="https://huggingface.co/{user.username}"
 					target="_blank"
 					rel="noopener noreferrer"
-					class="flex flex-none shrink items-center gap-1.5 truncate pr-2 text-gray-500 hover:underline dark:text-gray-400"
+					class="min-w-0 truncate pr-2 text-gray-500 hover:underline dark:text-gray-400"
 					>{user.username}</a
 				>
 			{:else}
-				<span
-					class="flex flex-none shrink items-center gap-1.5 truncate pr-2 text-gray-500 dark:text-gray-400"
+				<span class="min-w-0 truncate pr-2 text-gray-500 dark:text-gray-400"
 					>{user?.username || user?.email}</span
 				>
 			{/if}
@@ -200,14 +199,14 @@
 					href="https://huggingface.co/subscribe/pro?from=HuggingChat"
 					target="_blank"
 					rel="noopener noreferrer"
-					class="ml-auto flex h-[20px] items-center gap-1 px-1.5 py-0.5 text-xs text-gray-500 dark:text-gray-400"
+					class="ml-auto flex h-[20px] shrink-0 items-center gap-1 px-1.5 py-0.5 text-xs text-gray-500 dark:text-gray-400"
 				>
 					<IconPro />
 					Get PRO
 				</a>
 			{:else if publicConfig.isHuggingChat && $isPro === true}
 				<span
-					class="ml-auto flex h-[20px] items-center gap-1 px-1.5 py-0.5 text-xs text-gray-500 dark:text-gray-400"
+					class="ml-auto flex h-[20px] shrink-0 items-center gap-1 px-1.5 py-0.5 text-xs text-gray-500 dark:text-gray-400"
 				>
 					<IconPro />
 					PRO

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -263,14 +263,14 @@
 
 <div
 	class="fixed grid h-dvh w-screen grid-cols-1 grid-rows-[auto,1fr] overflow-hidden text-smd {!isNavCollapsed
-		? 'md:grid-cols-[290px,1fr]'
+		? 'md:grid-cols-[261px,1fr]'
 		: 'md:grid-cols-[0px,1fr]'} transition-[300ms] [transition-property:grid-template-columns] dark:text-gray-300 md:grid-rows-[1fr]"
 >
 	<ExpandNavigation
 		isCollapsed={isNavCollapsed}
 		onClick={() => (isNavCollapsed = !isNavCollapsed)}
 		classNames="absolute inset-y-0 z-10 my-auto {!isNavCollapsed
-			? 'left-[290px]'
+			? 'left-[261px]'
 			: 'left-0'} *:transition-transform"
 	/>
 
@@ -283,7 +283,7 @@
 		/>
 	</MobileNav>
 	<nav
-		class="grid max-h-dvh grid-cols-1 grid-rows-[auto,1fr,auto] overflow-hidden *:w-[290px] max-md:hidden"
+		class="grid max-h-dvh grid-cols-1 grid-rows-[auto,1fr,auto] overflow-hidden *:w-[261px] max-md:hidden"
 	>
 		<NavMenu
 			conversations={convsStore.list}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -263,14 +263,14 @@
 
 <div
 	class="fixed grid h-dvh w-screen grid-cols-1 grid-rows-[auto,1fr] overflow-hidden text-smd {!isNavCollapsed
-		? 'md:grid-cols-[261px,1fr]'
+		? 'md:grid-cols-[260px,1fr]'
 		: 'md:grid-cols-[0px,1fr]'} transition-[300ms] [transition-property:grid-template-columns] dark:text-gray-300 md:grid-rows-[1fr]"
 >
 	<ExpandNavigation
 		isCollapsed={isNavCollapsed}
 		onClick={() => (isNavCollapsed = !isNavCollapsed)}
 		classNames="absolute inset-y-0 z-10 my-auto {!isNavCollapsed
-			? 'left-[261px]'
+			? 'left-[260px]'
 			: 'left-0'} *:transition-transform"
 	/>
 
@@ -283,7 +283,7 @@
 		/>
 	</MobileNav>
 	<nav
-		class="grid max-h-dvh grid-cols-1 grid-rows-[auto,1fr,auto] overflow-hidden *:w-[261px] max-md:hidden"
+		class="grid max-h-dvh grid-cols-1 grid-rows-[auto,1fr,auto] overflow-hidden *:w-[260px] max-md:hidden"
 	>
 		<NavMenu
 			conversations={convsStore.list}


### PR DESCRIPTION
## Summary
Reduces the navigation sidebar width from 290px to 260px across the layout component.

## Changes
- Updated grid column template width for expanded navigation state from `290px` to `260px`
- Adjusted navigation button position (`left-[290px]` → `left-[260px]`) to align with new sidebar width
- Updated navigation menu width constraint from `*:w-[290px]` to `*:w-[260px]`

## Details
This change affects the responsive layout in `src/routes/+layout.svelte`, specifically:
- The main grid layout's `md:grid-cols` value when navigation is expanded
- The `ExpandNavigation` button's left positioning
- The navigation menu's width on desktop viewports

The adjustment maintains the existing responsive behavior while reducing the sidebar footprint by 30px.

https://claude.ai/code/session_011A9ammohYzuz1QmWurCn16