### PR TITLE
Hide chat avatar when artifact panel is open

### DIFF
--- a/src/lib/components/chat/ChatMessage.svelte
+++ b/src/lib/components/chat/ChatMessage.svelte
@@ -28,6 +28,7 @@
 	import ImageLightbox from "./ImageLightbox.svelte";
 	import { splitArtifactSegments, stripArtifacts } from "$lib/utils/artifacts";
 	import type { ArtifactOperation } from "$lib/utils/artifacts";
+	import { artifactPanel } from "$lib/stores/artifactPanel.svelte";
 
 	interface Props {
 		message: Message;
@@ -384,8 +385,12 @@
 		onclick={() => (isTapped = !isTapped)}
 		onkeydown={() => (isTapped = !isTapped)}
 	>
+		<!-- Hidden while the artifact panel is open: the narrowed chat column
+		     reclaims the avatar's width (display:none also drops the flex gap) -->
 		<MessageAvatar
-			classNames="mt-5 size-3.5 flex-none select-none rounded-full shadow-lg max-sm:hidden"
+			classNames="mt-5 size-3.5 flex-none select-none rounded-full shadow-lg max-sm:hidden {artifactPanel.open
+				? 'hidden'
+				: ''}"
 			animating={isLast && loading}
 		/>
 		<div
@@ -472,7 +477,7 @@
 		{#if message.routerMetadata || (!loading && message.content)}
 			<div
 				class="absolute -bottom-3.5 {message.routerMetadata && messageInfoWidth > messageWidth
-					? 'left-1 pl-1 lg:pl-7'
+					? `left-1 pl-1 ${artifactPanel.open ? '' : 'lg:pl-7'}`
 					: 'right-1'} flex max-w-[calc(100dvw-40px)] items-center gap-0.5"
 				bind:offsetWidth={messageInfoWidth}
 			>


### PR DESCRIPTION
## Summary
Adjusts the chat message layout to hide the avatar and reclaim its width when the artifact panel is open, improving space utilization in the narrowed chat column.

## Changes
- Import `artifactPanel` store to access the panel's open state
- Hide `MessageAvatar` component when artifact panel is open by adding conditional `hidden` class
- Adjust message info positioning to remove the `lg:pl-7` padding when artifact panel is open, preventing unnecessary spacing in the narrowed layout

## Implementation Details
- The avatar is hidden using `display:none` which also drops the flex gap, allowing the chat column to reclaim the full width
- Message info positioning is conditionally adjusted using template literals to maintain proper alignment in both states

https://claude.ai/code/session_01QaonxT6apped581fFwSrQi