### PR TITLE
Replace responsive breakpoints with container queries

### DIFF
--- a/src/lib/components/chat/ChatMessage.svelte
+++ b/src/lib/components/chat/ChatMessage.svelte
@@ -466,17 +466,17 @@
 		{#if message.routerMetadata || (!loading && message.content)}
 			<div
 				class="absolute -bottom-3.5 {message.routerMetadata && messageInfoWidth > messageWidth
-					? 'left-1 pl-1 lg:pl-7'
-					: 'right-1'} flex max-w-[calc(100dvw-40px)] items-center gap-0.5"
+					? 'left-1 pl-1 @2xl:pl-7'
+					: 'right-1'} flex max-w-[100cqw] items-center gap-0.5"
 				bind:offsetWidth={messageInfoWidth}
 			>
 				{#if message.routerMetadata && (message.routerMetadata.route || message.routerMetadata.model || message.routerMetadata.provider) && (!isLast || !loading)}
 					<div
-						class="mr-2 flex items-center gap-1.5 truncate text-[.65rem] whitespace-nowrap text-gray-400 sm:text-xs dark:text-gray-400 dark:opacity-50"
+						class="mr-2 flex items-center gap-1.5 truncate text-[.65rem] whitespace-nowrap text-gray-400 @xl:text-xs dark:text-gray-400 dark:opacity-50"
 					>
 						{#if message.routerMetadata.route && message.routerMetadata.model}
 							<span
-								class="truncate rounded-sm bg-gray-100 px-1 font-mono sm:py-px dark:bg-gray-800"
+								class="truncate rounded-sm bg-gray-100 px-1 font-mono @xl:py-px dark:bg-gray-800"
 							>
 								{message.routerMetadata.route}
 							</span>
@@ -484,13 +484,13 @@
 							{#if publicConfig.isHuggingChat}
 								<a
 									href="/chat/settings/{message.routerMetadata.model}"
-									class="flex items-center gap-1 truncate rounded-sm bg-gray-100 px-1 font-mono hover:text-gray-500 sm:py-px dark:bg-gray-800 dark:hover:text-gray-300"
+									class="flex items-center gap-1 truncate rounded-sm bg-gray-100 px-1 font-mono hover:text-gray-500 @xl:py-px dark:bg-gray-800 dark:hover:text-gray-300"
 								>
 									{message.routerMetadata.model.split("/").pop()}
 								</a>
 							{:else}
 								<span
-									class="truncate rounded-sm bg-gray-100 px-1.5 font-mono sm:py-px dark:bg-gray-800"
+									class="truncate rounded-sm bg-gray-100 px-1.5 font-mono @xl:py-px dark:bg-gray-800"
 								>
 									{message.routerMetadata.model.split("/").pop()}
 								</span>
@@ -498,11 +498,11 @@
 						{/if}
 						{#if message.routerMetadata.provider}
 							{@const hubOrg = PROVIDERS_HUB_ORGS[message.routerMetadata.provider]}
-							<span class="text-gray-500 max-sm:hidden">via</span>
+							<span class="text-gray-500 @max-xl:hidden">via</span>
 							<a
 								target="_blank"
 								href="https://huggingface.co/{hubOrg}"
-								class="flex items-center gap-1 truncate rounded-sm bg-gray-100 px-1 font-mono hover:text-gray-500 max-sm:hidden sm:py-px dark:bg-gray-800 dark:hover:text-gray-300"
+								class="flex items-center gap-1 truncate rounded-sm bg-gray-100 px-1 font-mono hover:text-gray-500 @max-xl:hidden @xl:py-px dark:bg-gray-800 dark:hover:text-gray-300"
 							>
 								<img
 									src="https://huggingface.co/api/avatars/{hubOrg}"

--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -650,8 +650,10 @@
 			use:snapScrollToBottom={scrollDependency}
 			bind:this={chatContainer}
 		>
+			<!-- @container: descendants (e.g. the per-message router-metadata row) adapt
+			     to the actual column width, which shrinks when the artifact panel is open -->
 			<div
-				class="mx-auto flex h-full max-w-3xl flex-col gap-6 px-5 pt-6 sm:gap-8 xl:max-w-4xl xl:pt-10"
+				class="@container mx-auto flex h-full max-w-3xl flex-col gap-6 px-5 pt-6 sm:gap-8 xl:max-w-4xl xl:pt-10"
 			>
 				{#if preprompt && preprompt != currentModel.preprompt}
 					<SystemPromptModal preprompt={preprompt ?? ""} />


### PR DESCRIPTION
## Summary
Migrates the ChatMessage component from Tailwind's screen-based responsive breakpoints (`sm:`, `lg:`, `max-sm:`) to container queries (`@xl:`, `@2xl:`, `@max-xl:`) to enable the router metadata row to adapt to the actual column width rather than viewport width. This is particularly important when the artifact panel is open, which shrinks the chat column.

## Key Changes
- **ChatMessage.svelte**: 
  - Replaced `lg:pl-7` with `@2xl:pl-7` for left padding on router metadata
  - Replaced `max-w-[calc(100dvw-40px)]` with `max-w-[100cqw]` to use container query width instead of viewport width
  - Replaced `sm:text-xs` with `@xl:text-xs` for router metadata text sizing
  - Replaced `sm:py-px` with `@xl:py-px` for vertical padding on metadata badges (4 instances)
  - Replaced `max-sm:hidden` with `@max-xl:hidden` for provider section visibility (2 instances)

- **ChatWindow.svelte**:
  - Added `@container` class to the main chat column wrapper to establish a container query context
  - Added explanatory comment documenting the purpose of the container query

## Implementation Details
The container query approach allows the router metadata display to respond to the actual available width in the chat column, which changes dynamically when the artifact panel opens/closes. This provides better responsive behavior than viewport-based breakpoints in this context.

https://claude.ai/code/session_01WjJqQryNGGcuAGSkXU2jph