### PR TITLE
Document sandbox restrictions for live previews

### DIFF
--- a/src/lib/server/textGeneration/artifacts.ts
+++ b/src/lib/server/textGeneration/artifacts.ts
@@ -26,6 +26,8 @@ Allowed type values:
 - "code": code in any programming language; add language="..." to the tag. Shown with syntax highlighting, not executed.
 - "markdown": a formatted document (README, essay, report, guide). Rendered as rich text.
 
+Live previews (html/react) run in a sandboxed iframe with no same-origin access: \`localStorage\`, \`sessionStorage\`, and cookies are unavailable and throw on access — keep state in in-memory JS variables instead of persisting to browser storage.
+
 Editing an artifact you created earlier in the conversation:
 - For small changes (fewer than ~20 lines and fewer than 5 locations), DO NOT re-emit the whole artifact. Emit a targeted update with find/replace pairs:
 


### PR DESCRIPTION
## Summary
Added documentation clarifying the sandbox restrictions for live preview artifacts (HTML/React). This helps users understand why certain browser APIs are unavailable in previews and provides guidance on alternative approaches.

## Changes
- Added a note to the artifact generation instructions explaining that live previews run in a sandboxed iframe with no same-origin access
- Documented that `localStorage`, `sessionStorage`, and cookies are unavailable and will throw on access
- Recommended using in-memory JavaScript variables for state management instead of persisting to browser storage

## Details
This documentation update is placed in the artifact type definitions section of `src/lib/server/textGeneration/artifacts.ts`, making it visible to the LLM when generating live preview artifacts. This helps prevent users from writing code that relies on unavailable browser storage APIs and guides them toward appropriate alternatives.

https://claude.ai/code/session_013RmkpGzSwM4pRCwaKGKKBQ