### PR TITLE
feat: make TEXT_MIME_ALLOWLIST extendable via env var

### DIFF
--- a/.env
+++ b/.env
@@ -28,6 +28,10 @@ PUBLIC_SHARE_PREFIX=
 PUBLIC_GOOGLE_ANALYTICS_ID=
 PUBLIC_PLAUSIBLE_SCRIPT_URL=
 PUBLIC_APPLE_APP_ID=
+# Comma-separated list of extra MIME types (or "type/*" patterns) to treat as text-uploadable
+# files, in addition to the built-in TEXT_MIME_ALLOWLIST (text/*, application/json,
+# application/xml, application/csv). Example: PUBLIC_TEXT_MIME_ALLOWLIST_EXTRA=application/typescript,application/x-python
+PUBLIC_TEXT_MIME_ALLOWLIST_EXTRA=
 # Feature announcements shown as a toast on the home screen (no conversation open).
 # JSON5 array of { title, description, link?, maxDate? }; the last valid entry is shown.
 # maxDate auto-hides the announcement after that date; a date-only value like "2026-12-31"

--- a/src/lib/components/chat/ChatInput.svelte
+++ b/src/lib/components/chat/ChatInput.svelte
@@ -12,7 +12,7 @@
 	import CarbonChevronRight from "~icons/carbon/chevron-right";
 	import CarbonClose from "~icons/carbon/close";
 	import UrlFetchModal from "./UrlFetchModal.svelte";
-	import { TEXT_MIME_ALLOWLIST, IMAGE_MIME_ALLOWLIST_DEFAULT } from "$lib/constants/mime";
+	import { getTextMimeAllowlist, IMAGE_MIME_ALLOWLIST_DEFAULT } from "$lib/constants/mime";
 	import MCPServerManager from "$lib/components/mcp/MCPServerManager.svelte";
 	import IconMCP from "$lib/components/icons/IconMCP.svelte";
 
@@ -91,7 +91,7 @@
 	function openFilePickerText() {
 		const textAccept =
 			mimeTypes.filter((m) => !(m === "image/*" || m.startsWith("image/"))).join(",") ||
-			TEXT_MIME_ALLOWLIST.join(",");
+			getTextMimeAllowlist().join(",");
 		openPickerWithAccept(textAccept);
 	}
 

--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -444,12 +444,12 @@
 	);
 
 	// Always allow common text-like files; add images only when model is multimodal
-	import { TEXT_MIME_ALLOWLIST, IMAGE_MIME_ALLOWLIST_DEFAULT } from "$lib/constants/mime";
+	import { getTextMimeAllowlist, IMAGE_MIME_ALLOWLIST_DEFAULT } from "$lib/constants/mime";
 
 	let activeMimeTypes = $derived(
 		Array.from(
 			new Set([
-				...TEXT_MIME_ALLOWLIST,
+				...getTextMimeAllowlist(),
 				...(modelIsMultimodal
 					? (currentModel.multimodalAcceptedMimetypes ?? [...IMAGE_MIME_ALLOWLIST_DEFAULT])
 					: []),

--- a/src/lib/components/chat/UploadedFile.svelte
+++ b/src/lib/components/chat/UploadedFile.svelte
@@ -9,7 +9,7 @@
 	import AudioPlayer from "../players/AudioPlayer.svelte";
 	import EosIconsLoading from "~icons/eos-icons/loading";
 	import { base } from "$app/paths";
-	import { TEXT_MIME_ALLOWLIST } from "$lib/constants/mime";
+	import { getTextMimeAllowlist } from "$lib/constants/mime";
 
 	interface Props {
 		file: MessageFile;
@@ -58,7 +58,7 @@
 	}
 
 	const isPlainText = (mime: string) =>
-		mime === "application/vnd.chatui.clipboard" || matchesAllowed(mime, TEXT_MIME_ALLOWLIST);
+		mime === "application/vnd.chatui.clipboard" || matchesAllowed(mime, getTextMimeAllowlist());
 
 	let isClickable = $derived(isImage(file.mime) || isPlainText(file.mime));
 </script>

--- a/src/lib/constants/mime.ts
+++ b/src/lib/constants/mime.ts
@@ -1,3 +1,5 @@
+import { env as publicEnv } from "$env/dynamic/public";
+
 // Centralized MIME allowlists used across client and server
 // Keep these lists minimal and consistent with server processing.
 
@@ -9,3 +11,14 @@ export const TEXT_MIME_ALLOWLIST = [
 ] as const;
 
 export const IMAGE_MIME_ALLOWLIST_DEFAULT = ["image/jpeg", "image/png"] as const;
+
+// Allows deployments to accept additional text-like MIME types (e.g. "application/typescript")
+// via a comma-separated PUBLIC_TEXT_MIME_ALLOWLIST_EXTRA env var.
+export function getTextMimeAllowlist(): readonly string[] {
+	const extra =
+		publicEnv.PUBLIC_TEXT_MIME_ALLOWLIST_EXTRA?.split(",")
+			.map((mime) => mime.trim())
+			.filter(Boolean) ?? [];
+
+	return [...TEXT_MIME_ALLOWLIST, ...extra];
+}

--- a/src/lib/server/textGeneration/utils/prepareFiles.ts
+++ b/src/lib/server/textGeneration/utils/prepareFiles.ts
@@ -1,7 +1,7 @@
 import type { MessageFile } from "$lib/types/Message";
 import type { EndpointMessage } from "$lib/server/endpoints/endpoints";
 import type { OpenAI } from "openai";
-import { TEXT_MIME_ALLOWLIST } from "$lib/constants/mime";
+import { getTextMimeAllowlist } from "$lib/constants/mime";
 import type { makeImageProcessor } from "$lib/server/endpoints/images";
 
 /**
@@ -53,7 +53,7 @@ async function prepareFiles(
 	const textFiles = files.filter((file) => {
 		const mime = (file.mime || "").toLowerCase();
 		const [fileType, fileSubtype] = mime.split("/");
-		return TEXT_MIME_ALLOWLIST.some((allowed) => {
+		return getTextMimeAllowlist().some((allowed) => {
 			const [type, subtype] = allowed.toLowerCase().split("/");
 			const typeOk = type === "*" || type === fileType;
 			const subOk = subtype === "*" || subtype === fileSubtype;


### PR DESCRIPTION
## Summary
- Adds a new `PUBLIC_TEXT_MIME_ALLOWLIST_EXTRA` env var that lets self-hosted deployments extend the built-in `TEXT_MIME_ALLOWLIST` (`text/*`, `application/json`, `application/xml`, `application/csv`) with additional comma-separated MIME types or `type/*` patterns (e.g. `application/typescript,application/x-python`).
- Introduces `getTextMimeAllowlist()` in `src/lib/constants/mime.ts`, which merges the base allowlist with the configured extras, and updates all consumers (file picker accept types, upload preview/clickability, and server-side text-file injection) to use it.
- Documents the new env var in `.env`.

This addresses the request in #2194 to make the text MIME allowlist configurable via an environment variable, so files like TypeScript source that are otherwise rejected with "Some file type not supported" can be uploaded after configuring the relevant MIME type(s).

## Test plan
- [x] `npm run check` — 0 errors
- [x] Verified `getTextMimeAllowlist()` merges `TEXT_MIME_ALLOWLIST` with parsed, trimmed, non-empty entries from `PUBLIC_TEXT_MIME_ALLOWLIST_EXTRA`
- [x] Confirmed all prior usages of `TEXT_MIME_ALLOWLIST` (file picker, upload preview, server-side text injection) now go through `getTextMimeAllowlist()`

Closes #2194