### PR TITLE
docs: add production deployment guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,3 +186,61 @@ npm run build
 You can preview the production build with `npm run preview`.
 
 > To deploy your app, you may need to install an [adapter](https://kit.svelte.dev/docs/adapters) for your target environment.
+
+## Production Deployment
+
+A minimal reference setup for running Chat UI in production with the default Node adapter, behind an Nginx reverse proxy.
+
+### Build-time vs runtime environment variables
+
+Most environment variables (model config, auth, MongoDB connection, etc.) can be set at runtime, e.g. via `-e` flags or your orchestrator's secrets/config. A few are **build-time only** because they're baked into the client bundle or read while `svelte.config.js` runs:
+
+- `APP_BASE` — the base path of the app (see [Subpath deployments](#subpath-deployments) below). Must be set before `npm run build` / the Docker build.
+- `PUBLIC_*` variables (e.g. `PUBLIC_APP_NAME`, `PUBLIC_APP_ASSETS`, `PUBLIC_ORIGIN`) — these are inlined into the client bundle at build time. If you need different values per environment, rebuild the image for each one.
+
+Everything else (`OPENAI_BASE_URL`, `OPENAI_API_KEY`, `MONGODB_URL`, `MCP_SERVERS`, etc.) is read at runtime and can be changed without rebuilding.
+
+### Subpath deployments
+
+To serve Chat UI under a path like `/chat` instead of the domain root:
+
+1. Set `APP_BASE=/chat` at **build time** (e.g. `docker build --build-arg APP_BASE=/chat ...` or `APP_BASE=/chat npm run build`).
+2. Set `PUBLIC_ORIGIN` to the full public URL of your deployment, e.g. `https://example.com`, so generated links (shared conversations, OpenGraph tags, etc.) are correct.
+3. Configure your reverse proxy to forward the `/chat` prefix to the container, as shown below.
+
+### Reverse proxy example (Nginx)
+
+```nginx
+server {
+    listen 80;
+    server_name example.com;
+
+    location /chat/ {
+        proxy_pass http://127.0.0.1:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Required for streamed chat responses
+        proxy_buffering off;
+        proxy_read_timeout 1h;
+    }
+}
+```
+
+If you deploy at the domain root instead, leave `APP_BASE` unset and use `location / { ... }` with the same proxy settings.
+
+### Required environment variables
+
+At minimum, a production deployment needs:
+
+```env
+OPENAI_BASE_URL=https://router.huggingface.co/v1
+OPENAI_API_KEY=hf_***
+MONGODB_URL=mongodb://user:pass@host:27017
+PUBLIC_ORIGIN=https://example.com
+```
+
+Without `MONGODB_URL`, Chat UI falls back to an in-memory database that is lost on restart — not suitable for production.

--- a/README.md
+++ b/README.md
@@ -193,12 +193,11 @@ A minimal reference setup for running Chat UI in production with the default Nod
 
 ### Build-time vs runtime environment variables
 
-Most environment variables (model config, auth, MongoDB connection, etc.) can be set at runtime, e.g. via `-e` flags or your orchestrator's secrets/config. A few are **build-time only** because they're baked into the client bundle or read while `svelte.config.js` runs:
+Most environment variables (model config, auth, MongoDB connection, `PUBLIC_*` vars, etc.) are read at runtime, e.g. via `-e` flags or your orchestrator's secrets/config. `APP_BASE` is the one **build-time-only** exception, since it's read while `svelte.config.js` runs:
 
 - `APP_BASE` — the base path of the app (see [Subpath deployments](#subpath-deployments) below). Must be set before `npm run build` / the Docker build.
-- `PUBLIC_*` variables (e.g. `PUBLIC_APP_NAME`, `PUBLIC_APP_ASSETS`, `PUBLIC_ORIGIN`) — these are inlined into the client bundle at build time. If you need different values per environment, rebuild the image for each one.
 
-Everything else (`OPENAI_BASE_URL`, `OPENAI_API_KEY`, `MONGODB_URL`, `MCP_SERVERS`, etc.) is read at runtime and can be changed without rebuilding.
+Everything else, including `PUBLIC_*` variables (e.g. `PUBLIC_APP_NAME`, `PUBLIC_APP_ASSETS`, `PUBLIC_ORIGIN`) and server-only vars (`OPENAI_BASE_URL`, `OPENAI_API_KEY`, `MONGODB_URL`, `MCP_SERVERS`, etc.), is read at server startup via SvelteKit's `$env/dynamic/public`/`$env/dynamic/private`. This means the same built image can be reused across environments — just set these vars when starting the container, restarting it to pick up any changes.
 
 ### Subpath deployments
 


### PR DESCRIPTION
## Summary
- Adds a "Production Deployment" section to the README covering a minimal reference setup with the default Node adapter behind an Nginx reverse proxy.
- Documents which env vars are build-time only (`APP_BASE`, `PUBLIC_*`) vs runtime-configurable, since this is a common source of confusion (e.g. asset paths and `manifest.json` breaking after a runtime-only env change).
- Documents subpath deployments (e.g. `/chat`) using `APP_BASE` + `PUBLIC_ORIGIN`, with a matching Nginx `location` block example (including streaming-friendly proxy settings).
- Lists the minimal required env vars for a production deployment, and notes that `MONGODB_URL` is required for persistence (otherwise Chat UI falls back to an in-memory DB).

This addresses #2067, which asked for a canonical production deployment example covering asset paths, build-time vs runtime env vars, reverse proxies, and subpath deployments.

## Test plan
- [x] Reviewed `svelte.config.js` and `.env` to confirm `APP_BASE` is build-time only and `PUBLIC_ORIGIN`/`PUBLIC_*` vars are inlined at build time
- [x] Verified the Nginx example matches the existing Docker run command's port (3000) and required headers for SSE/streaming responses

Closes #2067