### PR TITLE
Reduce model org avatar size in chat model switcher

### DIFF
--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -916,7 +916,7 @@
 										<img
 											src={currentModel.logoUrl}
 											alt=""
-											class="size-3.5 flex-none rounded-sm border bg-white dark:border-gray-700"
+											class="size-3 flex-none rounded-sm border bg-white dark:border-gray-700"
 										/>
 									{/if}
 									<span class="truncate">{currentModel.displayName}</span>


### PR DESCRIPTION
Follow-up to #2352. Reduces the model organization avatar in the **Model:** footer of the composer from `size-3.5` to `size-3` for a slightly more compact, subtle look.

### What changed
- `src/lib/components/chat/ChatWindow.svelte`: changed the avatar's Tailwind class from `size-3.5` to `size-3`.

https://claude.ai/code/session_01RVReHsgoKn6sDdkSsbaGxw

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVReHsgoKn6sDdkSsbaGxw)_