### PR TITLE
Add social preview tags for home-page deep links (?q= / ?prompt=)

### DIFF
--- a/src/lib/components/PromptPreviewTags.svelte
+++ b/src/lib/components/PromptPreviewTags.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+	import { page } from "$app/state";
+	import { base } from "$app/paths";
+	import { usePublicConfig } from "$lib/utils/PublicConfig.svelte";
+	import { cleanTextForMeta } from "$lib/utils/sharePreviewText";
+
+	interface Props {
+		/** Sanitized prompt text from a ?q= / ?prompt= deep link (see promptFromLinkParams) */
+		prompt: string;
+	}
+
+	let { prompt }: Props = $props();
+
+	const publicConfig = usePublicConfig();
+
+	let urlBase = $derived(`${publicConfig.PUBLIC_ORIGIN || page.url.origin}${base}`);
+
+	let ogTitle = $derived(
+		`${cleanTextForMeta(prompt, 100) || "Chat with AI models"} - ${publicConfig.PUBLIC_APP_NAME}`
+	);
+	let ogDescription = $derived(
+		cleanTextForMeta(prompt, 200) || publicConfig.PUBLIC_APP_DESCRIPTION
+	);
+	// Canonical link the user actually shared (keeps the original query string).
+	let ogUrl = $derived(`${urlBase}/${page.url.search}`);
+	// The thumbnail endpoint accepts either param and renders the same card, so
+	// always pass ?q=. Cap the echoed text: the card only renders ~240 chars and
+	// over-long query strings get truncated by some crawlers.
+	let ogImage = $derived(
+		`${urlBase}/thumbnail.png?q=${encodeURIComponent(cleanTextForMeta(prompt, 240))}`
+	);
+</script>
+
+<svelte:head>
+	<meta property="og:title" content={ogTitle} />
+	<meta property="og:type" content="website" />
+	<meta property="og:description" content={ogDescription} />
+	<meta property="og:url" content={ogUrl} />
+	<meta property="og:image" content={ogImage} />
+	<meta property="og:image:width" content="1200" />
+	<meta property="og:image:height" content="648" />
+	<meta property="og:image:alt" content={ogTitle} />
+	<meta property="og:site_name" content={publicConfig.PUBLIC_APP_NAME} />
+	<meta property="og:locale" content="en_US" />
+	<meta name="twitter:card" content="summary_large_image" />
+	<meta name="twitter:title" content={ogTitle} />
+	<meta name="twitter:description" content={ogDescription} />
+	<meta name="twitter:image" content={ogImage} />
+	<meta name="twitter:image:alt" content={ogTitle} />
+</svelte:head>

--- a/src/lib/server/hooks/handle.ts
+++ b/src/lib/server/hooks/handle.ts
@@ -106,6 +106,7 @@ export async function handleRequest({ event, resolve }: HandleInput): Promise<Re
 						!event.url.pathname.startsWith(`${base}/r/`) &&
 						!event.url.pathname.startsWith(`${base}/conversation/`) &&
 						!event.url.pathname.startsWith(`${base}/models/`) &&
+						event.url.pathname !== `${base}/thumbnail.png` &&
 						!event.url.pathname.startsWith(`${base}/api`)
 					) {
 						refreshSessionCookie(event.cookies, auth.secretSessionId);

--- a/src/lib/utils/urlParams.spec.ts
+++ b/src/lib/utils/urlParams.spec.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { promptFromLinkParams, sanitizeUrlParam, MAX_PARAM_LENGTH } from "./urlParams";
+
+const params = (init: Record<string, string>) => new URLSearchParams(init);
+
+describe("sanitizeUrlParam", () => {
+	it("trims surrounding whitespace", () => {
+		expect(sanitizeUrlParam("  hello  ")).toBe("hello");
+	});
+
+	it("returns null for null, empty, and whitespace-only input", () => {
+		expect(sanitizeUrlParam(null)).toBeNull();
+		expect(sanitizeUrlParam("")).toBeNull();
+		expect(sanitizeUrlParam("   ")).toBeNull();
+	});
+
+	it("returns null past the length cap", () => {
+		expect(sanitizeUrlParam("a".repeat(MAX_PARAM_LENGTH))).not.toBeNull();
+		expect(sanitizeUrlParam("a".repeat(MAX_PARAM_LENGTH + 1))).toBeNull();
+	});
+});
+
+describe("promptFromLinkParams", () => {
+	it("reads ?q=", () => {
+		expect(promptFromLinkParams(params({ q: "how do I bake bread?" }))).toBe(
+			"how do I bake bread?"
+		);
+	});
+
+	it("reads ?prompt=", () => {
+		expect(promptFromLinkParams(params({ prompt: "write me a poem" }))).toBe("write me a poem");
+	});
+
+	it("prefers ?q= over ?prompt= (matches the home page's consumption order)", () => {
+		expect(promptFromLinkParams(params({ q: "query wins", prompt: "ignored" }))).toBe("query wins");
+	});
+
+	it("falls back to ?prompt= when ?q= is blank", () => {
+		expect(promptFromLinkParams(params({ q: "   ", prompt: "fallback" }))).toBe("fallback");
+	});
+
+	it("trims the resolved value", () => {
+		expect(promptFromLinkParams(params({ q: "  spaced  " }))).toBe("spaced");
+	});
+
+	it("returns an empty string when neither param is usable", () => {
+		expect(promptFromLinkParams(params({}))).toBe("");
+		expect(promptFromLinkParams(params({ q: "", prompt: "  " }))).toBe("");
+		expect(promptFromLinkParams(params({ other: "x" }))).toBe("");
+	});
+
+	it("ignores over-long values", () => {
+		expect(promptFromLinkParams(params({ q: "a".repeat(MAX_PARAM_LENGTH + 1) }))).toBe("");
+	});
+});

--- a/src/lib/utils/urlParams.ts
+++ b/src/lib/utils/urlParams.ts
@@ -10,4 +10,16 @@ export function sanitizeUrlParam(value: string | null): string | null {
 	return trimmed;
 }
 
+/**
+ * Resolve the user prompt carried by a home-page deep link. `?q=` (auto-sent)
+ * takes precedence over `?prompt=` (prefilled draft), matching how the home
+ * page consumes them in onMount. Returns the sanitized text, or "" when neither
+ * param holds usable text. Drives the social-preview tags + thumbnail so that
+ * sharing a `?q=`/`?prompt=` link unfurls with the prompt instead of the
+ * generic app card.
+ */
+export function promptFromLinkParams(params: URLSearchParams): string {
+	return sanitizeUrlParam(params.get("q")) ?? sanitizeUrlParam(params.get("prompt")) ?? "";
+}
+
 export { MAX_PARAM_LENGTH };

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -23,6 +23,7 @@
 	import BackgroundGenerationPoller from "$lib/components/BackgroundGenerationPoller.svelte";
 	import { requireAuthUser } from "$lib/utils/auth";
 	import { createConversationsStore } from "$lib/stores/conversations.svelte";
+	import { promptFromLinkParams } from "$lib/utils/urlParams";
 
 	let { data = $bindable(), children } = $props();
 
@@ -199,6 +200,12 @@
 		page.route.id === "/r/[id]" ||
 			(page.route.id === "/conversation/[id]" && page.params.id?.length === 7)
 	);
+
+	// Home-page ?q= / ?prompt= deep links emit their own prompt-specific tags
+	// (see PromptPreviewTags.svelte), so skip the generic ones there too
+	let isPromptDeepLink = $derived(
+		page.route.id === "/" && Boolean(promptFromLinkParams(page.url.searchParams))
+	);
 </script>
 
 <svelte:head>
@@ -208,7 +215,7 @@
 
 	<!-- use those meta tags everywhere except on special listing pages -->
 	<!-- feel free to refacto if there's a better way -->
-	{#if !page.url.pathname.includes("/models/") && !isSharedConversationView}
+	{#if !page.url.pathname.includes("/models/") && !isSharedConversationView && !isPromptDeepLink}
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="{publicConfig.PUBLIC_APP_NAME} - Chat with AI models" />
 		<meta name="twitter:description" content={publicConfig.PUBLIC_APP_DESCRIPTION} />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -12,7 +12,8 @@
 	import { useSettingsStore } from "$lib/stores/settings.js";
 	import { useConversationsStore } from "$lib/stores/conversations.svelte";
 	import { findCurrentModel } from "$lib/utils/models";
-	import { sanitizeUrlParam } from "$lib/utils/urlParams";
+	import { sanitizeUrlParam, promptFromLinkParams } from "$lib/utils/urlParams";
+	import PromptPreviewTags from "$lib/components/PromptPreviewTags.svelte";
 	import { onMount, tick } from "svelte";
 	import { loading } from "$lib/stores/loading.js";
 	import { loadAttachmentsFromUrls } from "$lib/utils/loadAttachmentsFromUrls";
@@ -159,11 +160,20 @@
 	});
 
 	let currentModel = $derived(findCurrentModel(data.models, data.oldModels, $settings.activeModel));
+
+	// Social-preview text for ?q= / ?prompt= deep links. Server-rendered so link
+	// unfurlers (which don't run the onMount that consumes these params) see the
+	// prompt-specific card; the layout suppresses its generic tags in this case.
+	let previewPrompt = $derived(promptFromLinkParams(page.url.searchParams));
 </script>
 
 <svelte:head>
 	<title>{publicConfig.PUBLIC_APP_NAME}</title>
 </svelte:head>
+
+{#if previewPrompt}
+	<PromptPreviewTags prompt={previewPrompt} />
+{/if}
 
 {#if hasModels}
 	<ChatWindow

--- a/src/routes/thumbnail.png/+server.ts
+++ b/src/routes/thumbnail.png/+server.ts
@@ -1,0 +1,38 @@
+import { type RequestHandler } from "@sveltejs/kit";
+
+import { config } from "$lib/server/config";
+import { getShareThumbnailPng } from "$lib/server/shareThumbnail/shareThumbnail";
+import { renderableThumbnailText } from "$lib/utils/sharePreviewText";
+import { promptFromLinkParams } from "$lib/utils/urlParams";
+
+// Social-preview thumbnail for home-page deep links (?q= / ?prompt=). The same
+// card the shared-conversation endpoint renders, but the prompt comes straight
+// from the query string instead of a stored conversation.
+//
+// The prompt text is fully attacker-controllable here, but the render pipeline
+// treats it as inert text: it is sanitized and length-capped by
+// renderableThumbnailText, the satori element tree is built from plain objects
+// (never parsed as HTML), and no network calls happen at render time — so
+// rendering query-string text is as safe as rendering a stored share
+// (see shareThumbnail.ts / sharePreviewText.ts). Distinct prompts are bounded
+// by an LRU cache shared with the share endpoint; an empty/non-renderable
+// prompt falls back to the generic card.
+export const GET: RequestHandler = (async ({ url }) => {
+	const prompt = renderableThumbnailText(promptFromLinkParams(url.searchParams), 240);
+
+	const png = await getShareThumbnailPng({
+		prompt,
+		isHuggingChat: config.isHuggingChat,
+		appName: config.PUBLIC_APP_NAME,
+	});
+
+	// The card is a pure function of the (sanitized) prompt in the URL, so the
+	// same link always yields the same image — long cache lifetimes are safe and
+	// let link unfurlers hit the CDN instead of re-rendering.
+	return new Response(png, {
+		headers: {
+			"Content-Type": "image/png",
+			"Cache-Control": "public, max-age=86400, s-maxage=604800, stale-while-revalidate=604800",
+		},
+	});
+}) satisfies RequestHandler;


### PR DESCRIPTION
## Summary

Adds support for generating social-preview cards (Open Graph / Twitter meta tags) when sharing home-page deep links with `?q=` or `?prompt=` query parameters. This allows shared links to unfurl with the prompt text instead of the generic app card.

## Key Changes

- **New utility function `promptFromLinkParams()`** (`src/lib/utils/urlParams.ts`): Extracts and sanitizes the prompt from `?q=` or `?prompt=` parameters, with `?q=` taking precedence. Includes comprehensive test coverage.

- **New component `PromptPreviewTags.svelte`**: Renders Open Graph and Twitter meta tags dynamically based on the prompt text. Generates a social-preview thumbnail via the new `/thumbnail.png` endpoint, with text capped at 240 characters for optimal card rendering.

- **New endpoint `GET /thumbnail.png`** (`src/routes/thumbnail.png/+server.ts`): Generates PNG social-preview cards on-demand from query-string prompts. Reuses the existing share-thumbnail rendering pipeline with aggressive caching (24h public, 7d CDN) since the card is a pure function of the sanitized prompt.

- **Updated home page** (`src/routes/+page.svelte`): Conditionally renders `PromptPreviewTags` when a prompt deep link is detected, enabling server-side rendering of preview tags for link unfurlers.

- **Updated layout** (`src/routes/+layout.svelte`): Suppresses generic meta tags when rendering a prompt-specific deep link to avoid tag duplication.

## Implementation Details

- The prompt text is fully attacker-controllable via the query string, but the render pipeline treats it as inert text: it's sanitized and length-capped by `renderableThumbnailText()`, the satori element tree is built from plain objects (never parsed as HTML), and no network calls happen at render time — making it as safe as rendering stored shares.
- Distinct prompts are bounded by an LRU cache shared with the existing share endpoint.
- Empty or non-renderable prompts fall back to the generic app card.

https://claude.ai/code/session_016eCeQ68BbXXSbyBTukpSqD