### PR TITLE
Improve model list display with provider logos and icons

### DIFF
--- a/src/routes/settings/(nav)/+layout.svelte
+++ b/src/routes/settings/(nav)/+layout.svelte
@@ -184,6 +184,8 @@
 							<img
 								src={model.logoUrl}
 								alt=""
+								loading="lazy"
+								decoding="async"
 								class="size-3.5 flex-none rounded-sm border bg-white dark:border-gray-700"
 							/>
 						{:else}

--- a/src/routes/settings/(nav)/+layout.svelte
+++ b/src/routes/settings/(nav)/+layout.svelte
@@ -177,11 +177,21 @@
 					data-model-id={model.id}
 					aria-label="Configure {model.displayName}"
 				>
-					<div class="mr-auto flex items-center gap-1 truncate">
-						<span class="truncate">{model.displayName}</span>
+					<div class="mr-auto flex items-center gap-1.5 truncate">
 						{#if model.isRouter}
-							<IconOmni />
+							<IconOmni classNames="size-3.5 flex-none" />
+						{:else if model.logoUrl}
+							<img
+								src={model.logoUrl}
+								alt=""
+								class="size-3.5 flex-none rounded-sm border bg-white dark:border-gray-700"
+							/>
+						{:else}
+							<div
+								class="size-3.5 flex-none rounded-sm border border-transparent bg-gray-300 dark:bg-gray-800"
+							></div>
 						{/if}
+						<span class="truncate">{model.displayName}</span>
 					</div>
 
 					{#if publicConfig.isHuggingChat && !model.isRouter && $settings.providerOverrides?.[model.id] && $settings.providerOverrides[model.id] !== "auto"}


### PR DESCRIPTION
## Summary
Enhanced the settings model list UI to display provider logos and icons alongside model names, improving visual distinction between different model providers.

## Changes
- Updated the model list item layout to display provider branding:
  - Router models now show the Omni icon with consistent sizing (`size-3.5`)
  - Models with `logoUrl` display their provider logo as a rounded image with border styling
  - Models without logos show a placeholder colored box
- Adjusted spacing from `gap-1` to `gap-1.5` for better visual balance
- Reordered DOM elements to place the icon/logo before the model name for better visual hierarchy
- Applied consistent styling to all icon/logo variants with `flex-none` to prevent shrinking

## Implementation Details
- Icons and logos use `size-3.5` for consistent sizing across all variants
- Logo images include `rounded-sm border` styling with dark mode support (`dark:border-gray-700`)
- Placeholder divs use `border-transparent` to maintain layout consistency
- All icon/logo elements use `flex-none` to ensure they don't shrink in the flex container

https://claude.ai/code/session_01LS1JMMKR7vuXrD2WZe571L