### PR TITLE
fix: exclude nested node_modules dirs from Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,10 @@
-Dockerfile
+﻿Dockerfile
 .vscode/
 .idea
 .gitignore
 LICENSE
 README.md
-node_modules/
+**/node_modules/
 .svelte-kit/
 .env*
 !.env


### PR DESCRIPTION
## Problem / Summary

The `.dockerignore` file uses `node_modules/` on line 7, which per Docker's `.dockerignore` spec only matches a top-level `node_modules` directory (unlike `.gitignore` which matches at any depth). Nested `node_modules` directories (e.g. from workspaces or sub-packages) are included in the build context, bloating image build times.

## Solution / Changes

- Change `node_modules/` → `**/node_modules/` to match nested copies at any depth, consistent with Docker's glob spec.

Closes #1920