### PR TITLE
docs: add quickstart examples with common .env.local configurations

### DIFF
--- a/docs/source/configuration/common-issues.md
+++ b/docs/source/configuration/common-issues.md
@@ -28,6 +28,24 @@ If models aren't appearing in the UI:
 2. Check that `OPENAI_API_KEY` is valid
 3. Ensure the endpoint returns models at `${OPENAI_BASE_URL}/models`
 
+### `MODELS` variable not parsed correctly
+
+If you customise the model list via the `MODELS` variable and models don't appear, check that you are using the backtick multiline syntax correctly:
+
+```ini
+# Correct — backtick immediately after = on the opening line,
+# closing backtick alone on the last line
+MODELS=`[
+  { "id": "my-model", "name": "My Model" }
+]`
+```
+
+Common mistakes:
+
+- Missing the opening or closing backtick entirely
+- Putting a space between `=` and the opening backtick (`MODELS= \`[` is invalid)
+- Editing `.env` directly instead of `.env.local` (your change gets overwritten on `git pull`)
+
 ## Database connection errors
 
 For development, you can skip MongoDB entirely - Chat UI will use an embedded database.

--- a/docs/source/installation/docker.md
+++ b/docs/source/installation/docker.md
@@ -41,7 +41,7 @@ docker run -p 3000:3000 \
   ghcr.io/huggingface/chat-ui-db
 ```
 
-On Linux, append `--add-host=host.docker.internal:host-gateway` to the command so Docker can resolve the hostname.
+On Linux, append `--add-host=host.docker.internal:host-gateway` to the command so Docker can resolve the hostname. Ollama also binds to `127.0.0.1:11434` by default on Linux, so the host-gateway address still won't be reachable until you start it with `OLLAMA_HOST=0.0.0.0:11434 ollama serve` (or set `OLLAMA_HOST` in its service config) to accept connections from outside the host.
 
 ## Using an Environment File
 
@@ -49,12 +49,12 @@ For more configuration options, use `--env-file` to avoid leaking secrets in she
 
 ```bash
 docker run -p 3000:3000 \
-  --env-file .env.local \
+  --env-file .env.docker \
   -v chat-ui-data:/data \
   ghcr.io/huggingface/chat-ui-db
 ```
 
 > [!TIP]
-> Use `--env-file .env.local` rather than multiple `-e` flags. This keeps your tokens out of shell history and makes it easy to reuse the same configuration file you use for local development.
+> Use `--env-file` rather than multiple `-e` flags to keep your tokens out of shell history. Don't point it directly at your local `.env.local`, though: Docker's env-file format treats `#` as a comment only at the start of a line, so placeholder values like `MONGODB_URL=#your mongodb URL here...` are read as literal strings and will override the image's bundled MongoDB URL. Instead, copy it to a dedicated file (e.g. `cp .env.local .env.docker`) and remove or fill in any placeholder lines before using it with `--env-file`.
 
 See the [configuration overview](../configuration/overview) for all available environment variables.

--- a/docs/source/installation/docker.md
+++ b/docs/source/installation/docker.md
@@ -29,6 +29,20 @@ docker run -p 3000:3000 \
 
 Use `host.docker.internal` to reach MongoDB running on your host machine, or provide your MongoDB Atlas connection string.
 
+## With a Local Ollama Instance
+
+To connect Docker-hosted Chat UI to Ollama running on your host machine, use `host.docker.internal` instead of `localhost` (Linux users: add `--add-host=host.docker.internal:host-gateway`):
+
+```bash
+docker run -p 3000:3000 \
+  -e OPENAI_BASE_URL=http://host.docker.internal:11434/v1 \
+  -e OPENAI_API_KEY=ollama \
+  -v chat-ui-data:/data \
+  ghcr.io/huggingface/chat-ui-db
+```
+
+On Linux, append `--add-host=host.docker.internal:host-gateway` to the command so Docker can resolve the hostname.
+
 ## Using an Environment File
 
 For more configuration options, use `--env-file` to avoid leaking secrets in shell history:
@@ -39,5 +53,8 @@ docker run -p 3000:3000 \
   -v chat-ui-data:/data \
   ghcr.io/huggingface/chat-ui-db
 ```
+
+> [!TIP]
+> Use `--env-file .env.local` rather than multiple `-e` flags. This keeps your tokens out of shell history and makes it easy to reuse the same configuration file you use for local development.
 
 See the [configuration overview](../configuration/overview) for all available environment variables.

--- a/docs/source/installation/local.md
+++ b/docs/source/installation/local.md
@@ -1,12 +1,17 @@
 # Running Locally
 
+> [!IMPORTANT]
+> Always create a `.env.local` file for your own configuration. **Never edit `.env` directly** — it is the default template checked into the repository and will be overwritten when you pull updates. Copy it as a starting point: `cp .env .env.local`
+
 ## Quick Start
 
-1. Create a `.env.local` file with your API credentials:
+1. Create `.env.local` with your API credentials:
 
 ```ini
 OPENAI_BASE_URL=https://router.huggingface.co/v1
-OPENAI_API_KEY=hf_************************
+OPENAI_API_KEY=hf_your_token_here
+# MONGODB_URL is optional for local dev — omit it to use the embedded in-memory DB
+# that persists chat history to the ./db folder automatically
 ```
 
 2. Install and run:
@@ -17,6 +22,51 @@ npm run dev -- --open
 ```
 
 That's it! Chat UI will discover available models automatically from your endpoint.
+
+## Common Setup Patterns
+
+### Pattern 1: Hugging Face router (no MongoDB needed)
+
+The fastest setup: uses the HF inference router and the embedded in-memory database.
+
+```ini
+# .env.local
+OPENAI_BASE_URL=https://router.huggingface.co/v1
+OPENAI_API_KEY=hf_your_token_here
+```
+
+Get your token at [hf.co/settings/tokens](https://huggingface.co/settings/tokens). Chat history persists to `./db` between restarts.
+
+### Pattern 2: Local Ollama instance
+
+First start Ollama (`ollama serve` runs on port 11434 by default), then:
+
+```ini
+# .env.local
+OPENAI_BASE_URL=http://127.0.0.1:11434/v1
+OPENAI_API_KEY=ollama
+```
+
+### Pattern 3: Customising models with the `MODELS` variable
+
+The `MODELS` variable uses **JSON5 syntax wrapped in backticks**. The backticks are required — they allow multiline values in `.env` files. A missing backtick is the most common cause of a blank model list.
+
+```ini
+# .env.local
+OPENAI_BASE_URL=https://router.huggingface.co/v1
+OPENAI_API_KEY=hf_your_token_here
+MODELS=`[
+  {
+    "id": "meta-llama/Llama-3.3-70B-Instruct",
+    "name": "Llama 3.3 70B",
+    "multimodal": false,
+    "supportsTools": true
+  }
+]`
+```
+
+> [!NOTE]
+> The opening backtick goes directly after `MODELS=` on the same line. The closing backtick goes on its own line after the `]`. Both are part of the value syntax, not shell syntax.
 
 ## Configuration
 


### PR DESCRIPTION
## Problem / Summary

New self-hosters frequently struggle to get chat-ui running. Issues #1819, #1633, and #1458 all trace back to underdocumented setup patterns:

- **#1819**: The `MODELS=` env var uses backtick multiline JSON5 syntax that is not documented clearly — a missing backtick silently breaks the model list
- **#1633**: Docker `run` command examples did not cover the common Ollama + Docker combination
- **#1458**: Users editing `.env` directly instead of `.env.local` lose their config on every `git pull`

## Solution / Changes

- **`docs/source/installation/local.md`**: Add a "Common Setup Patterns" section with three concrete `.env.local` examples (HF router + in-memory DB, local Ollama, and `MODELS` variable with correct backtick syntax). Add a prominent warning about `.env` vs `.env.local`.
- **`docs/source/installation/docker.md`**: Add a "With a Local Ollama Instance" section showing the `host.docker.internal` hostname and the Linux `--add-host` flag. Add a tip about using `--env-file .env.local` to keep tokens out of shell history.
- **`docs/source/configuration/common-issues.md`**: Add a sub-section under "Models not loading" documenting the three most common `MODELS` variable mistakes (missing backtick, space before backtick, editing `.env` directly).

Closes #1774