### PR TITLE
feat: add per-user setting to disable KaTeX rendering

### DIFF
--- a/src/lib/components/chat/MarkdownRenderer.svelte
+++ b/src/lib/components/chat/MarkdownRenderer.svelte
@@ -6,6 +6,7 @@
 
 	import { onMount, onDestroy } from "svelte";
 	import { updateDebouncer } from "$lib/utils/updates";
+	import { useSettingsStore } from "$lib/stores/settings";
 
 	interface Props {
 		content: string;
@@ -14,6 +15,9 @@
 	}
 
 	let { content, sources = [], loading = false }: Props = $props();
+
+	const settings = useSettingsStore();
+	let disableKatex = $derived($settings.disableKatex ?? false);
 
 	// Lightweight blocks used for SSR and the initial client render. Full markdown
 	// rendering is deferred to the worker (or async processBlocks) on mount, so the
@@ -38,13 +42,20 @@
 
 		if (worker) {
 			updateDebouncer.startRender();
-			worker.postMessage({ type: "process", content, sources, requestId, streaming: loading });
+			worker.postMessage({
+				type: "process",
+				content,
+				sources,
+				requestId,
+				streaming: loading,
+				disableKatex,
+			});
 			return;
 		}
 
 		(async () => {
 			updateDebouncer.startRender();
-			const processed = await processBlocks(content, sources, loading);
+			const processed = await processBlocks(content, sources, loading, disableKatex);
 			handleBlocks(processed, requestId);
 		})();
 	});

--- a/src/lib/components/chat/MarkdownRenderer.svelte
+++ b/src/lib/components/chat/MarkdownRenderer.svelte
@@ -17,7 +17,8 @@
 	let { content, sources = [], loading = false }: Props = $props();
 
 	const settings = useSettingsStore();
-	let disableKatex = $derived($settings.disableKatex ?? false);
+	// Guard against missing settings context (e.g. component rendered directly in tests)
+	let disableKatex = $derived(settings ? ($settings.disableKatex ?? false) : false);
 
 	// Lightweight blocks used for SSR and the initial client render. Full markdown
 	// rendering is deferred to the worker (or async processBlocks) on mount, so the

--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -23,6 +23,7 @@ type SettingsStore = {
 	directPaste: boolean;
 	hapticsEnabled: boolean;
 	billingOrganization?: string;
+	disableKatex?: boolean;
 };
 
 type SettingsStoreWritable = Writable<SettingsStore> & {

--- a/src/lib/types/Settings.ts
+++ b/src/lib/types/Settings.ts
@@ -87,6 +87,12 @@ export interface Settings extends Timestamps {
 	 * Stores the org's preferred_username. If empty/undefined, bills to personal account.
 	 */
 	billingOrganization?: string;
+
+	/**
+	 * When true, KaTeX block and inline extensions are omitted from the markdown
+	 * pipeline so that `$` patterns are never rendered as math.
+	 */
+	disableKatex?: boolean;
 }
 
 export type SettingsEditable = Omit<Settings, "welcomeModalSeenAt" | "createdAt" | "updatedAt">;
@@ -107,4 +113,5 @@ export const DEFAULT_SETTINGS = {
 	streamingMode: "smooth",
 	directPaste: false,
 	hapticsEnabled: true,
+	disableKatex: false,
 } satisfies SettingsEditable;

--- a/src/lib/utils/marked.ts
+++ b/src/lib/utils/marked.ts
@@ -368,12 +368,12 @@ function sanitizeHtmlForMultimedia(html: string): string {
 	return sanitized;
 }
 
-function createMarkedInstance(sources: SimpleSource[]): Marked {
+function createMarkedInstance(sources: SimpleSource[], disableKatex = false): Marked {
 	return new Marked({
 		hooks: {
 			postprocess: (html) => addInlineCitations(html, sources),
 		},
-		extensions: [katexBlockExtension, katexInlineExtension],
+		extensions: disableKatex ? [] : [katexBlockExtension, katexInlineExtension],
 		renderer: {
 			link: (href, title, text) => {
 				// Placeholder emitted by parseIncompleteMarkdown while a link's URL is
@@ -441,8 +441,12 @@ function cacheKey(index: number, blockContent: string, sources: SimpleSource[]) 
 	return `${index}-${hashString(blockContent)}|${sourceKey}`;
 }
 
-export async function processTokens(content: string, sources: SimpleSource[]): Promise<Token[]> {
-	const marked = createMarkedInstance(sources);
+export async function processTokens(
+	content: string,
+	sources: SimpleSource[],
+	disableKatex = false
+): Promise<Token[]> {
+	const marked = createMarkedInstance(sources, disableKatex);
 	const tokens = marked.lexer(content);
 
 	const processedTokens = await Promise.all(
@@ -467,8 +471,12 @@ export async function processTokens(content: string, sources: SimpleSource[]): P
 	return processedTokens;
 }
 
-export function processTokensSync(content: string, sources: SimpleSource[]): Token[] {
-	const marked = createMarkedInstance(sources);
+export function processTokensSync(
+	content: string,
+	sources: SimpleSource[],
+	disableKatex = false
+): Token[] {
+	const marked = createMarkedInstance(sources, disableKatex);
 	const tokens = marked.lexer(content);
 	return tokens.map((token) => {
 		if (token.type === "code") {
@@ -517,7 +525,8 @@ function hashString(str: string): string {
 export async function processBlocks(
 	content: string,
 	sources: SimpleSource[] = [],
-	streaming = false
+	streaming = false,
+	disableKatex = false
 ): Promise<BlockToken[]> {
 	const processedContent = streaming ? parseIncompleteMarkdown(content) : content;
 	const blocks = parseMarkdownIntoBlocks(processedContent);
@@ -526,15 +535,15 @@ export async function processBlocks(
 		blocks.map(async (blockContent, index) => {
 			const key = cacheKey(index, blockContent, sources);
 			const cached = blockCache.get(key);
-			if (cached) return cached;
+			if (cached && !disableKatex) return cached;
 
-			const tokens = await processTokens(blockContent, sources);
+			const tokens = await processTokens(blockContent, sources, disableKatex);
 			const block: BlockToken = {
 				id: `${index}-${hashString(blockContent)}`,
 				content: blockContent,
 				tokens,
 			};
-			blockCache.set(key, block);
+			if (!disableKatex) blockCache.set(key, block);
 			return block;
 		})
 	);
@@ -578,7 +587,8 @@ export function fallbackBlocks(content: string): BlockToken[] {
 export function processBlocksSync(
 	content: string,
 	sources: SimpleSource[] = [],
-	streaming = false
+	streaming = false,
+	disableKatex = false
 ): BlockToken[] {
 	const processedContent = streaming ? parseIncompleteMarkdown(content) : content;
 	const blocks = parseMarkdownIntoBlocks(processedContent);
@@ -586,15 +596,15 @@ export function processBlocksSync(
 	return blocks.map((blockContent, index) => {
 		const key = cacheKey(index, blockContent, sources);
 		const cached = blockCache.get(key);
-		if (cached) return cached;
+		if (cached && !disableKatex) return cached;
 
-		const tokens = processTokensSync(blockContent, sources);
+		const tokens = processTokensSync(blockContent, sources, disableKatex);
 		const block: BlockToken = {
 			id: `${index}-${hashString(blockContent)}`,
 			content: blockContent,
 			tokens,
 		};
-		blockCache.set(key, block);
+		if (!disableKatex) blockCache.set(key, block);
 		return block;
 	});
 }

--- a/src/lib/workers/markdownWorker.ts
+++ b/src/lib/workers/markdownWorker.ts
@@ -11,6 +11,7 @@ export type IncomingMessage = {
 	sources: SimpleSource[];
 	requestId: number;
 	streaming?: boolean;
+	disableKatex?: boolean;
 };
 
 export type OutgoingMessage = {
@@ -34,8 +35,13 @@ async function processMessage() {
 		isProcessing = true;
 
 		try {
-			const { content, sources, requestId, streaming } = nextMessage;
-			const processedBlocks = await processBlocks(content, sources, streaming ?? false);
+			const { content, sources, requestId, streaming, disableKatex } = nextMessage;
+			const processedBlocks = await processBlocks(
+				content,
+				sources,
+				streaming ?? false,
+				disableKatex ?? false
+			);
 			postMessage(
 				JSON.parse(JSON.stringify({ type: "processed", blocks: processedBlocks, requestId }))
 			);

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -38,6 +38,7 @@ interface SettingsResponse {
 	reasoningEffortOverrides: Record<string, "low" | "medium" | "high">;
 	reasoningOverrides: Record<string, boolean>;
 	billingOrganization?: string;
+	disableKatex?: boolean;
 }
 
 export const load = async ({ fetch, url }) => {

--- a/src/routes/api/v2/user/settings/+server.ts
+++ b/src/routes/api/v2/user/settings/+server.ts
@@ -28,6 +28,7 @@ const settingsSchema = z.object({
 	hapticsEnabled: z.boolean().default(true),
 	hidePromptExamples: z.record(z.boolean()).default({}),
 	billingOrganization: z.string().optional(),
+	disableKatex: z.boolean().default(false),
 });
 
 export const GET: RequestHandler = async ({ locals }) => {
@@ -79,6 +80,7 @@ export const GET: RequestHandler = async ({ locals }) => {
 		reasoningEffortOverrides: settings?.reasoningEffortOverrides ?? {},
 		reasoningOverrides: config.isHuggingChat ? {} : (settings?.reasoningOverrides ?? {}),
 		billingOrganization: settings?.billingOrganization ?? undefined,
+		disableKatex: settings?.disableKatex ?? DEFAULT_SETTINGS.disableKatex,
 	});
 };
 

--- a/src/routes/settings/(nav)/+server.ts
+++ b/src/routes/settings/(nav)/+server.ts
@@ -24,6 +24,7 @@ const settingsSchema = z.object({
 	hapticsEnabled: z.boolean().default(true),
 	hidePromptExamples: z.record(z.boolean()).default({}),
 	billingOrganization: z.string().optional(),
+	disableKatex: z.boolean().default(false),
 });
 
 export async function POST({ request, locals }) {

--- a/src/routes/settings/(nav)/application/+page.svelte
+++ b/src/routes/settings/(nav)/application/+page.svelte
@@ -46,6 +46,12 @@
 	function setHapticsEnabled(v: boolean) {
 		settings.update((s) => ({ ...s, hapticsEnabled: v }));
 	}
+	function getDisableKatex() {
+		return $settings.disableKatex ?? false;
+	}
+	function setDisableKatex(v: boolean) {
+		settings.update((s) => ({ ...s, disableKatex: v }));
+	}
 
 	const client = useAPIClient();
 
@@ -204,6 +210,19 @@
 						<Switch name="hapticsEnabled" bind:checked={getHapticsEnabled, setHapticsEnabled} />
 					</div>
 				{/if}
+
+				<div class="flex items-start justify-between py-3">
+					<div>
+						<div class="text-[13px] font-medium text-gray-800 dark:text-gray-200">
+							Disable LaTeX rendering
+						</div>
+						<p class="text-[12px] text-gray-500 dark:text-gray-400">
+							Stop rendering <code class="font-mono">$</code> patterns as math. Useful when working
+							with code containing variables like <code class="font-mono">$foo</code>.
+						</p>
+					</div>
+					<Switch name="disableKatex" bind:checked={getDisableKatex, setDisableKatex} />
+				</div>
 
 				<!-- Theme selector -->
 				<div class="flex items-start justify-between py-3">


### PR DESCRIPTION
## Problem / Summary

KaTeX renders `$` patterns in model output — including PHP variable syntax (`$foo`), shell variables, and other `$`-prefixed text — as LaTeX math even when no math is intended. Users who work with code-heavy models or PHP have no way to opt out.

## Solution / Changes

- Add `disableKatex: boolean` field (default `false`) to `Settings.ts` and `DEFAULT_SETTINGS`
- Modify `marked.ts` to conditionally skip KaTeX block/inline extensions when disabled; also threads the flag through `processTokens`, `processTokensSync`, `processBlocks`, and `processBlocksSync`
- Update `markdownWorker.ts` to accept and forward the `disableKatex` flag
- Read `$settings.disableKatex` in `MarkdownRenderer.svelte` and pass it to the markdown pipeline and the web worker
- Allow the new field in both settings PATCH endpoints (`/settings` and `/api/v2/user/settings`)
- Add a "Disable LaTeX rendering" toggle in the application settings UI

Closes #1645