### PR TITLE
fix: apply truncate parameter to chat_completions message history

### DIFF
--- a/src/lib/server/endpoints/openai/endpointOai.spec.ts
+++ b/src/lib/server/endpoints/openai/endpointOai.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { getMessageContentLength } from "./endpointOai";
+
+describe("getMessageContentLength", () => {
+	it("returns the length of string content", () => {
+		expect(getMessageContentLength({ role: "user", content: "hello world" })).toBe(11);
+	});
+
+	it("returns 0 for empty/null content", () => {
+		expect(getMessageContentLength({ role: "assistant", content: null })).toBe(0);
+	});
+
+	it("sums text parts for multimodal array content, ignoring image parts", () => {
+		const largeText = "a".repeat(5000);
+		const message = {
+			role: "user" as const,
+			content: [
+				{ type: "text" as const, text: largeText },
+				{ type: "image_url" as const, image_url: { url: "data:image/png;base64,abcd" } },
+			],
+		};
+		expect(getMessageContentLength(message)).toBe(5000);
+	});
+
+	it("sums multiple text parts in multimodal array content", () => {
+		const message = {
+			role: "user" as const,
+			content: [
+				{ type: "text" as const, text: "first part " },
+				{ type: "image_url" as const, image_url: { url: "data:image/png;base64,abcd" } },
+				{ type: "text" as const, text: "second part" },
+			],
+		};
+		expect(getMessageContentLength(message)).toBe(22);
+	});
+});

--- a/src/lib/server/endpoints/openai/endpointOai.ts
+++ b/src/lib/server/endpoints/openai/endpointOai.ts
@@ -15,7 +15,19 @@ import type { Endpoint } from "../endpoints";
 import type OpenAI from "openai";
 import { createImageProcessorOptionsValidator, makeImageProcessor } from "../images";
 import { prepareMessagesWithFiles } from "$lib/server/textGeneration/utils/prepareFiles";
+import type { ChatCompletionMessageParam } from "openai/resources/chat/completions";
 // uuid import removed (no tool call ids)
+
+export function getMessageContentLength(message: ChatCompletionMessageParam): number {
+	if (typeof message.content === "string") return message.content.length;
+	if (Array.isArray(message.content)) {
+		return message.content.reduce(
+			(sum, part) => sum + (part.type === "text" ? part.text.length : 0),
+			0
+		);
+	}
+	return 0;
+}
 
 export const endpointOAIParametersSchema = z.object({
 	weight: z.number().int().positive().default(1),
@@ -209,12 +221,10 @@ export async function endpointOai(
 			// Uses a ~4 chars/token heuristic. System message and latest user turn are always kept.
 			if (parameters.truncate) {
 				const maxChars = parameters.truncate * 4;
-				const getContentLength = (m: OpenAI.Chat.Completions.ChatCompletionMessageParam): number =>
-					typeof m.content === "string" ? m.content.length : 0;
-				let totalChars = messagesOpenAI.reduce((sum, m) => sum + getContentLength(m), 0);
-				let i = messagesOpenAI[0]?.role === "system" ? 1 : 0;
+				let totalChars = messagesOpenAI.reduce((sum, m) => sum + getMessageContentLength(m), 0);
+				const i = messagesOpenAI[0]?.role === "system" ? 1 : 0;
 				while (totalChars > maxChars && i < messagesOpenAI.length - 1) {
-					totalChars -= getContentLength(messagesOpenAI[i]);
+					totalChars -= getMessageContentLength(messagesOpenAI[i]);
 					messagesOpenAI.splice(i, 1);
 				}
 			}

--- a/src/lib/server/endpoints/openai/endpointOai.ts
+++ b/src/lib/server/endpoints/openai/endpointOai.ts
@@ -205,6 +205,20 @@ export async function endpointOai(
 			// Combine model defaults with request-specific parameters
 			const parameters = { ...model.parameters, ...generateSettings };
 
+			// Trim message history to fit within the truncate token budget if set.
+			// Uses a ~4 chars/token heuristic. System message and latest user turn are always kept.
+			if (parameters.truncate) {
+				const maxChars = parameters.truncate * 4;
+				const getContentLength = (m: OpenAI.Chat.Completions.ChatCompletionMessageParam): number =>
+					typeof m.content === "string" ? m.content.length : 0;
+				let totalChars = messagesOpenAI.reduce((sum, m) => sum + getContentLength(m), 0);
+				let i = messagesOpenAI[0]?.role === "system" ? 1 : 0;
+				while (totalChars > maxChars && i < messagesOpenAI.length - 1) {
+					totalChars -= getContentLength(messagesOpenAI[i]);
+					messagesOpenAI.splice(i, 1);
+				}
+			}
+
 			// Build model ID with optional provider suffix (e.g., "model:fastest" or "model:together")
 			const baseModelId = model.id ?? model.name;
 			const modelId = provider && provider !== "auto" ? `${baseModelId}:${provider}` : baseModelId;


### PR DESCRIPTION
## Problem / Summary

The `parameters.truncate` field in model config is handled by `buildPrompt` which only applies to the legacy `completions` path. In the `chat_completions` path used by all modern models, `truncate` is silently ignored — the full message history is always sent, causing errors on models with small context windows when conversations grow long.

## Solution / Changes

- Before calling `openai.chat.completions.create` in `endpointOai.ts`, trim `messagesOpenAI` when `parameters.truncate` is set
- Uses a character-count heuristic (~4 chars/token) to estimate token usage
- Drops oldest non-system messages first, always preserving the system message and latest user turn

Closes #1765