### PR TITLE
fix: sanitize invalid UTF-8 strings before MongoDB write

### DIFF
--- a/src/lib/server/sanitizeString.test.ts
+++ b/src/lib/server/sanitizeString.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { sanitizeUtf8 } from "./sanitizeString";
+import { sanitizeUtf8, sanitizeUtf8Deep } from "./sanitizeString";
 
 describe("sanitizeUtf8", () => {
 	it("passes through valid ASCII unchanged", () => {
@@ -46,5 +46,41 @@ describe("sanitizeUtf8", () => {
 		const mixed = "hello \uD800 world 😀";
 		const result = sanitizeUtf8(mixed);
 		expect(result).toBe("hello � world 😀");
+	});
+});
+
+describe("sanitizeUtf8Deep", () => {
+	it("sanitizes a lone surrogate buried in a nested array of update objects", () => {
+		const updates = [
+			{ type: "status", status: "started" },
+			{
+				type: "tool",
+				result: { content: "tool output \uD800 with surrogate", nested: ["a", "b\uDFFF"] },
+			},
+			{ type: "finalAnswer", text: "done\uD800" },
+		];
+		const result = sanitizeUtf8Deep(updates);
+		expect(result).toEqual([
+			{ type: "status", status: "started" },
+			{
+				type: "tool",
+				result: { content: "tool output � with surrogate", nested: ["a", "b�"] },
+			},
+			{ type: "finalAnswer", text: "done�" },
+		]);
+	});
+
+	it("passes through non-string primitives and Date instances unchanged", () => {
+		const date = new Date("2024-01-01T00:00:00.000Z");
+		const value = { count: 5, enabled: true, missing: null, when: date };
+		const result = sanitizeUtf8Deep(value);
+		expect(result).toEqual(value);
+		expect(result.when).toBe(date);
+	});
+
+	it("handles plain strings and empty arrays/objects", () => {
+		expect(sanitizeUtf8Deep("test\uD800")).toBe("test�");
+		expect(sanitizeUtf8Deep([])).toEqual([]);
+		expect(sanitizeUtf8Deep({})).toEqual({});
 	});
 });

--- a/src/lib/server/sanitizeString.test.ts
+++ b/src/lib/server/sanitizeString.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeUtf8 } from "./sanitizeString";
+
+describe("sanitizeUtf8", () => {
+	it("passes through valid ASCII unchanged", () => {
+		expect(sanitizeUtf8("hello world")).toBe("hello world");
+	});
+
+	it("passes through valid UTF-8 (Korean) unchanged", () => {
+		const korean = "안녕하세요";
+		expect(sanitizeUtf8(korean)).toBe(korean);
+	});
+
+	it("passes through valid emoji unchanged", () => {
+		const emoji = "🎉🤖";
+		expect(sanitizeUtf8(emoji)).toBe(emoji);
+	});
+
+	it("replaces a lone high surrogate with U+FFFD", () => {
+		// \uD800 is a lone (unpaired) high surrogate — invalid in UTF-16
+		const withSurrogate = "\uD800test";
+		const result = sanitizeUtf8(withSurrogate);
+		expect(result).not.toContain("\uD800");
+		// The surrogate is replaced with U+FFFD
+		expect(result).toBe("�test");
+	});
+
+	it("replaces a lone low surrogate with U+FFFD", () => {
+		const withSurrogate = "test\uDFFF";
+		const result = sanitizeUtf8(withSurrogate);
+		expect(result).not.toContain("\uDFFF");
+		expect(result).toBe("test�");
+	});
+
+	it("preserves a valid surrogate pair (emoji)", () => {
+		// U+1F600 GRINNING FACE — encoded as a surrogate pair in JS strings
+		const emoji = "😀";
+		expect(sanitizeUtf8(emoji)).toBe(emoji);
+	});
+
+	it("handles an empty string", () => {
+		expect(sanitizeUtf8("")).toBe("");
+	});
+
+	it("handles mixed valid and invalid sequences", () => {
+		const mixed = "hello \uD800 world 😀";
+		const result = sanitizeUtf8(mixed);
+		expect(result).toBe("hello � world 😀");
+	});
+});

--- a/src/lib/server/sanitizeString.ts
+++ b/src/lib/server/sanitizeString.ts
@@ -20,3 +20,26 @@ export function sanitizeUtf8(str: string): string {
 	const bytes = Buffer.from(str, "utf8");
 	return new TextDecoder("utf-8", { fatal: false }).decode(bytes);
 }
+
+/**
+ * Recursively applies `sanitizeUtf8` to every string found while walking an
+ * arbitrary value (objects, arrays, nested combinations). Used for
+ * unstructured data (e.g. stream update payloads) where invalid UTF-8 could
+ * be buried at any depth before a MongoDB write.
+ */
+export function sanitizeUtf8Deep<T>(value: T): T {
+	if (typeof value === "string") {
+		return sanitizeUtf8(value) as unknown as T;
+	}
+	if (Array.isArray(value)) {
+		return value.map((item) => sanitizeUtf8Deep(item)) as unknown as T;
+	}
+	if (value !== null && typeof value === "object" && !(value instanceof Date)) {
+		const result: Record<string, unknown> = {};
+		for (const [key, val] of Object.entries(value)) {
+			result[key] = sanitizeUtf8Deep(val);
+		}
+		return result as unknown as T;
+	}
+	return value;
+}

--- a/src/lib/server/sanitizeString.ts
+++ b/src/lib/server/sanitizeString.ts
@@ -1,0 +1,22 @@
+/**
+ * Replace any invalid UTF-8 byte sequences in `str` with the Unicode
+ * replacement character (U+FFFD).
+ *
+ * JavaScript strings are UTF-16 internally, but a string can still contain
+ * lone surrogates (e.g. \uD800–\uDFFF) that are not valid UTF-16 code-unit
+ * pairs.  When such a string is serialised to BSON, the driver encodes it as
+ * UTF-8 and the resulting byte sequence is rejected by MongoDB with:
+ *
+ *   BSONError: Invalid UTF-8 string in BSON document
+ *
+ * The round-trip through Buffer + TextDecoder normalises lone surrogates and
+ * any other ill-formed sequences to U+FFFD so the string is safe to store.
+ */
+export function sanitizeUtf8(str: string): string {
+	// Buffer.from encodes the JS string to bytes using UTF-8 (lone surrogates
+	// become the 3-byte replacement sequence EF BF BD / U+FFFD).
+	// TextDecoder with fatal:false then decodes those bytes back to a string,
+	// replacing any remaining invalid sequences with U+FFFD.
+	const bytes = Buffer.from(str, "utf8");
+	return new TextDecoder("utf-8", { fatal: false }).decode(bytes);
+}

--- a/src/routes/conversation/[id]/+server.ts
+++ b/src/routes/conversation/[id]/+server.ts
@@ -27,6 +27,7 @@ import { logger } from "$lib/server/logger.js";
 import { AbortRegistry } from "$lib/server/abortRegistry";
 import { clampStoppedContent } from "$lib/server/stopTruncation";
 import { MetricsServer } from "$lib/server/metrics";
+import { sanitizeUtf8 } from "$lib/server/sanitizeString";
 
 // How long a stop marker is protected from the pre-flight cleanup of a new
 // generation. A marker younger than this may still be awaiting observation by
@@ -165,7 +166,7 @@ export async function POST({ request, locals, params, getClientAddress }) {
 				z
 					.string()
 					.min(1)
-					.transform((s) => s.replace(/\r\n/g, "\n"))
+					.transform((s) => sanitizeUtf8(s.replace(/\r\n/g, "\n")))
 			),
 			is_retry: z.optional(z.boolean()),
 			selectedMcpServerNames: z.optional(z.array(z.string())),
@@ -382,7 +383,14 @@ export async function POST({ request, locals, params, getClientAddress }) {
 						return { type: MessageUpdateType.Stream, token: "", len } satisfies MessageStreamUpdate;
 					}) ?? [];
 
-			return { ...msg, updates: filteredUpdates };
+			// Sanitize free-form text fields to avoid BSONError on invalid UTF-8
+			// sequences (e.g. lone surrogates from mis-encoded Windows clipboard input).
+			return {
+				...msg,
+				content: sanitizeUtf8(msg.content),
+				...(msg.reasoning !== undefined && { reasoning: sanitizeUtf8(msg.reasoning) }),
+				updates: filteredUpdates,
+			};
 		});
 
 		await collections.conversations.updateOne(

--- a/src/routes/conversation/[id]/+server.ts
+++ b/src/routes/conversation/[id]/+server.ts
@@ -27,7 +27,7 @@ import { logger } from "$lib/server/logger.js";
 import { AbortRegistry } from "$lib/server/abortRegistry";
 import { clampStoppedContent } from "$lib/server/stopTruncation";
 import { MetricsServer } from "$lib/server/metrics";
-import { sanitizeUtf8 } from "$lib/server/sanitizeString";
+import { sanitizeUtf8, sanitizeUtf8Deep } from "$lib/server/sanitizeString";
 
 // How long a stop marker is protected from the pre-flight cleanup of a new
 // generation. A marker younger than this may still be awaiting observation by
@@ -385,11 +385,13 @@ export async function POST({ request, locals, params, getClientAddress }) {
 
 			// Sanitize free-form text fields to avoid BSONError on invalid UTF-8
 			// sequences (e.g. lone surrogates from mis-encoded Windows clipboard input).
+			// filteredUpdates can carry arbitrary nested strings (tool results,
+			// status text, titles, etc.), so it needs the deep variant.
 			return {
 				...msg,
 				content: sanitizeUtf8(msg.content),
 				...(msg.reasoning !== undefined && { reasoning: sanitizeUtf8(msg.reasoning) }),
-				updates: filteredUpdates,
+				updates: sanitizeUtf8Deep(filteredUpdates),
 			};
 		});
 


### PR DESCRIPTION
## Problem / Summary

Pasting text containing invalid UTF-8 byte sequences (e.g. mis-encoded Korean characters from a Windows clipboard) causes a `BSONError: Invalid UTF-8 string in BSON document` crash when the message is saved to MongoDB, losing the conversation state.

JavaScript strings are UTF-16 internally but can carry lone surrogates (`\uD800`–`\uDFFF`) that have no valid UTF-8 encoding. When BSON serialises such a string it produces an ill-formed byte sequence that MongoDB rejects.

## Solution / Changes

- Add `src/lib/server/sanitizeString.ts` — a `sanitizeUtf8` utility that round-trips the string through `Buffer.from(s, "utf8")` + `TextDecoder` with `fatal: false`, replacing any invalid sequences with U+FFFD (the standard Unicode replacement character).
- Apply the sanitizer at **two** points in the database write boundary in `src/routes/conversation/[id]/+server.ts`:
  1. The zod `inputs` transform, so user message text is clean before it is added to the in-memory conversation object (and before the initial `updateOne`).
  2. `persistConversation`, where `content` and `reasoning` are sanitized on every message immediately before each `updateOne` call — guarding assistant output too.
- Add `src/lib/server/sanitizeString.test.ts` with 8 unit tests covering valid ASCII, valid Korean, emoji, lone high/low surrogates, valid surrogate pairs, empty strings, and mixed inputs.

## Test plan

- [ ] `npx vitest run src/lib/server/sanitizeString.test.ts` — all 8 tests pass
- [ ] `npm run check` — no type errors
- [ ] `npx eslint src/lib/server/sanitizeString.ts src/lib/server/sanitizeString.test.ts 'src/routes/conversation/[id]/+server.ts'` — no ESLint errors
- [ ] Manual: paste a string containing `\uD800` (lone surrogate) into the chat input and verify it saves without a BSONError; the replacement character U+FFFD appears in place of the invalid sequence

Closes #1745

🤖 Generated with [Claude Code](https://claude.com/claude-code)