### PR TITLE
Center the model name in model thumbnails

### DIFF
--- a/src/routes/models/[...model]/thumbnail.png/ModelThumbnail.svelte
+++ b/src/routes/models/[...model]/thumbnail.png/ModelThumbnail.svelte
@@ -10,11 +10,15 @@
 	let { name, isHuggingChat = false }: Props = $props();
 </script>
 
+<!-- This is rendered to an image by satori, which honors inline styles but not the
+	Tailwind classes, so the centering has to be inline (and the <h1> below must not be
+	w-full, or it stretches and the name sticks to the left edge). The classes are kept
+	so the markup still reads correctly. -->
 <div
 	class=" flex h-[648px] w-full flex-col items-center justify-center bg-black px-16 text-center text-white"
-	style="background-image: url(https://cdn-uploads.huggingface.co/production/uploads/5f17f0a0925b9863e28ad517/L4XVRJ7MsfFDD7ROx_geO.png);"
+	style="background-image: url(https://cdn-uploads.huggingface.co/production/uploads/5f17f0a0925b9863e28ad517/L4XVRJ7MsfFDD7ROx_geO.png); display: flex; flex-direction: column; align-items: center; justify-content: center;"
 >
-	<h1 class="mb-8 w-full text-center text-7xl font-bold text-white">
+	<h1 class="mb-8 text-7xl font-bold text-white">
 		{name.split("/")[1]}
 	</h1>
 


### PR DESCRIPTION
The model social-preview card relied on Tailwind classes
(items-center/justify-center/text-center) for centering, but satori only
honors inline styles when rasterizing, so the name rendered stuck to the
left edge. Center via inline flex styles and drop w-full from the <h1> so
it shrink-wraps instead of stretching left.

https://claude.ai/code/session_01LvCYKJurLD6jEW2SHyJLRv