### PR TITLE
Expand single tool calls in chat messages

### DIFF
--- a/src/lib/components/chat/ChatMessage.svelte
+++ b/src/lib/components/chat/ChatMessage.svelte
@@ -444,17 +444,19 @@
 							<ArtifactCard op={unit.op} messageId={message.id} opIndex={unit.opIndex} />
 						{:else if unit.kind === "group"}
 							<div data-exclude-from-copy class="not-last:mb-1 has-[+.prose]:mb-2! [.prose+&]:mt-3">
-								{#if unit.blocks.length > 1}
-									<!-- Collapse the whole run into a single summary -->
+								{#if unit.blocks.length > 1 && unit.toolCount !== 1}
+									<!-- Collapse multi-tool or pure-thinking runs into a single summary -->
 									<ToolCallsSummary blocks={unit.blocks} toolCount={unit.toolCount} />
 								{:else}
-									<!-- A lone process block stays standalone -->
-									{@const only = unit.blocks[0]}
-									{#if only.type === "think"}
-										<OpenReasoningResults content={only.content} loading={false} />
-									{:else}
-										<ToolUpdate tool={only.updates} loading={false} />
-									{/if}
+									<!-- A lone block, or a single tool call (optionally alongside thinking),
+									     stays expanded so the tool that ran is visible without an extra click -->
+									{#each unit.blocks as block, blockIndex (block.type === "tool" ? `tool-${block.uuid}-${blockIndex}` : `think-${blockIndex}`)}
+										{#if block.type === "think"}
+											<OpenReasoningResults content={block.content} loading={false} />
+										{:else}
+											<ToolUpdate tool={block.updates} loading={false} />
+										{/if}
+									{/each}
 								{/if}
 							</div>
 						{/if}


### PR DESCRIPTION
## Summary
Modified the chat message rendering logic to expand single tool calls alongside thinking blocks, rather than collapsing them into a summary. This improves visibility of tool execution results without requiring an extra click.

## Key Changes
- Updated the condition for collapsing message blocks: now only collapses when there are multiple blocks AND it's not a single tool call (`unit.blocks.length > 1 && unit.toolCount !== 1`)
- Changed the else branch from rendering only the first block to iterating through all blocks with `{#each}`, allowing multiple blocks (e.g., thinking + tool call) to display expanded
- Added proper key generation for each block to maintain Svelte's reactivity (`tool-${block.uuid}-${blockIndex}` for tools, `think-${blockIndex}` for thinking blocks)
- Updated comments to clarify the new behavior: single tool calls stay expanded for visibility, while multi-tool or pure-thinking runs are collapsed into a summary

## Implementation Details
The change preserves the existing `ToolCallsSummary` component for complex scenarios (multiple tools or thinking-only blocks) while expanding the simple case of a single tool call, optionally with thinking blocks. This provides better UX by showing tool results immediately without hiding them behind a collapsible summary.

https://claude.ai/code/session_01S8ttPBmjJF1iYMQjYxsVE8