### PR TITLE
feat: deploy artifacts to a Hugging Face Space

### DIFF
--- a/.env
+++ b/.env
@@ -39,6 +39,9 @@ COUPLE_SESSION_WITH_COOKIE_NAME=
 # when OPEN_ID is configured, users are required to login after the welcome modal
 OPENID_CLIENT_ID="" # You can set to "__CIMD__" for automatic oauth app creation when deployed, see https://datatracker.ietf.org/doc/draft-ietf-oauth-client-id-metadata-document/
 OPENID_CLIENT_SECRET=
+# Add the "contribute-repos" scope to let users deploy artifacts to a Hugging Face Space
+# (the app can create Spaces and update only the ones it created). Requires the OAuth app to
+# permit that scope; only add it for Hugging Face OIDC, not generic providers that lack it.
 OPENID_SCOPES="openid profile inference-api read-mcp read-billing"
 USE_USER_TOKEN=
 AUTOMATIC_LOGIN=# if true authentication is required on all routes

--- a/chart/env/dev.yaml
+++ b/chart/env/dev.yaml
@@ -38,7 +38,7 @@ ingressInternal:
 envVars:
   TEST: "test"
   COUPLE_SESSION_WITH_COOKIE_NAME: "token"
-  OPENID_SCOPES: "openid profile inference-api read-mcp read-billing"
+  OPENID_SCOPES: "openid profile inference-api read-mcp read-billing contribute-repos"
   USE_USER_TOKEN: "true"
   MCP_FORWARD_HF_USER_TOKEN: "true"
   AUTOMATIC_LOGIN: "false"

--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -48,7 +48,7 @@ ingressInternal:
 
 envVars:
   COUPLE_SESSION_WITH_COOKIE_NAME: "token"
-  OPENID_SCOPES: "openid profile inference-api read-mcp read-billing"
+  OPENID_SCOPES: "openid profile inference-api read-mcp read-billing contribute-repos"
   USE_USER_TOKEN: "true"
   MCP_FORWARD_HF_USER_TOKEN: "true"
   AUTOMATIC_LOGIN: "false"

--- a/src/lib/APIClient.ts
+++ b/src/lib/APIClient.ts
@@ -121,6 +121,9 @@ export function useAPIClient({
 			...endpoint(fetcher, `${baseUrl}/models`),
 			old: endpoint(fetcher, `${baseUrl}/models/old`),
 		},
+		spaces: {
+			deploy: endpoint(fetcher, `${baseUrl}/spaces/deploy`),
+		},
 		"public-config": endpoint(fetcher, `${baseUrl}/public-config`),
 		"feature-flags": endpoint(fetcher, `${baseUrl}/feature-flags`),
 		debug: {

--- a/src/lib/components/chat/ArtifactPanel.svelte
+++ b/src/lib/components/chat/ArtifactPanel.svelte
@@ -5,21 +5,25 @@
 	import type { ArtifactRegistry, ArtifactVersion } from "$lib/utils/artifacts";
 	import { artifactFileName, isPreviewableKind } from "$lib/utils/artifacts";
 	import { diffLines, diffStats, renderDiffHtml } from "$lib/utils/artifactDiff";
-	import { buildArtifactSrcdoc } from "$lib/utils/previewSrcdoc";
+	import { buildArtifactSrcdoc, isDeployableKind } from "$lib/utils/previewSrcdoc";
 	import { parseExternalUrl } from "$lib/utils/externalLink";
 	import { highlightCode } from "$lib/utils/marked";
 	import { artifactPanel, ARTIFACT_PANEL_DEFAULT_FRACTION } from "$lib/stores/artifactPanel.svelte";
 	import { pendingChatInput } from "$lib/stores/pendingChatInput";
+	import { usePublicConfig } from "$lib/utils/PublicConfig.svelte";
+	import { page } from "$app/state";
 
 	import MarkdownRenderer from "./MarkdownRenderer.svelte";
 	import CopyToClipBoardBtn from "../CopyToClipBoardBtn.svelte";
 	import ExternalLinkModal from "../ExternalLinkModal.svelte";
 	import HtmlPreviewModal from "../HtmlPreviewModal.svelte";
+	import DeployToSpaceModal from "./DeployToSpaceModal.svelte";
 
 	import CarbonCloseLarge from "~icons/carbon/close-large";
 	import CarbonChevronLeft from "~icons/carbon/chevron-left";
 	import CarbonChevronRight from "~icons/carbon/chevron-right";
 	import CarbonDownload from "~icons/carbon/download";
+	import CarbonRocket from "~icons/carbon/rocket";
 	import CarbonMaximize from "~icons/carbon/maximize";
 	import LucideWrapText from "~icons/lucide/wrap-text";
 	import LucideDiff from "~icons/lucide/diff";
@@ -312,6 +316,46 @@
 		artifactPanel.version = clamped >= totalVersions ? null : clamped;
 	}
 
+	// ----- deploy to a Hugging Face Space (HuggingChat only) -----
+	const publicConfig = usePublicConfig();
+	let conversationId = $derived(page.params?.id);
+	let deployModalOpen = $state(false);
+	// Deployments made this session, overlaid on the ones loaded with the page so
+	// the button flips to "Update" right after a successful first deploy. Keyed by
+	// conversation id first: ArtifactPanel is not remounted when only the route
+	// param changes, so a flat map would let a stale entry from one conversation
+	// mask another conversation's artifact that happens to share an identifier
+	// (e.g. the "untitled-artifact" fallback).
+	let sessionDeployments = $state<Record<string, Record<string, { repoId: string; url: string }>>>(
+		{}
+	);
+	let loadedDeployments = $derived(
+		(page.data as { deployedSpaces?: Record<string, { repoId: string }> })?.deployedSpaces ?? {}
+	);
+	let currentDeployment = $derived.by(() => {
+		const id = artifact?.identifier;
+		if (!id) return undefined;
+		const session = conversationId ? sessionDeployments[conversationId]?.[id] : undefined;
+		if (session) return session;
+		const loaded = loadedDeployments[id];
+		return loaded
+			? { repoId: loaded.repoId, url: `https://huggingface.co/spaces/${loaded.repoId}` }
+			: undefined;
+	});
+	function recordDeployment(deployment: { repoId: string; url: string }) {
+		const cid = conversationId;
+		const id = artifact?.identifier;
+		if (!cid || !id) return;
+		sessionDeployments[cid] = { ...(sessionDeployments[cid] ?? {}), [id]: deployment };
+	}
+	let canDeploy = $derived(
+		publicConfig.isHuggingChat &&
+			!!conversationId &&
+			!!version &&
+			version.complete &&
+			isDeployableKind(version.type)
+	);
+
 	function handleKeydown(e: KeyboardEvent) {
 		// An Escape already consumed by a modal (external-link confirm, fullscreen
 		// preview) must not also close the panel
@@ -406,6 +450,16 @@
 				>
 					<CarbonDownload />
 				</button>
+				{#if canDeploy}
+					<button
+						type="button"
+						class="btn rounded-md p-1.5 text-xs hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-800 dark:hover:text-gray-300"
+						title={currentDeployment ? "Update Space" : "Deploy to Space"}
+						onclick={() => (deployModalOpen = true)}
+					>
+						<CarbonRocket />
+					</button>
+				{/if}
 				{#if fullscreenSupported}
 					<button
 						type="button"
@@ -621,6 +675,19 @@
 
 {#if externalLinkUrl}
 	<ExternalLinkModal url={externalLinkUrl} onclose={() => (externalLinkUrl = null)} />
+{/if}
+
+{#if deployModalOpen && version && artifact && conversationId}
+	<DeployToSpaceModal
+		{conversationId}
+		artifactIdentifier={artifact.identifier}
+		title={version.title}
+		kind={version.type}
+		content={version.content}
+		existing={currentDeployment}
+		onclose={() => (deployModalOpen = false)}
+		ondeployed={recordDeployment}
+	/>
 {/if}
 
 <style>

--- a/src/lib/components/chat/DeployToSpaceModal.svelte
+++ b/src/lib/components/chat/DeployToSpaceModal.svelte
@@ -1,0 +1,251 @@
+<script lang="ts">
+	import { base } from "$app/paths";
+	import Modal from "$lib/components/Modal.svelte";
+	import { useAPIClient, handleResponse } from "$lib/APIClient";
+	import type { ArtifactKind } from "$lib/utils/artifacts";
+
+	import CarbonClose from "~icons/carbon/close";
+	import CarbonRocket from "~icons/carbon/rocket";
+	import CarbonArrowUpRight from "~icons/carbon/arrow-up-right";
+	import CarbonCheckmark from "~icons/carbon/checkmark";
+	import EosIconsLoading from "~icons/eos-icons/loading";
+
+	interface Existing {
+		repoId: string;
+		url: string;
+	}
+
+	interface Props {
+		conversationId: string;
+		artifactIdentifier: string;
+		title: string;
+		kind: ArtifactKind;
+		content: string;
+		existing?: Existing;
+		onclose?: () => void;
+		ondeployed?: (deployment: { repoId: string; url: string }) => void;
+	}
+
+	let {
+		conversationId,
+		artifactIdentifier,
+		title,
+		kind,
+		content,
+		existing,
+		onclose,
+		ondeployed,
+	}: Props = $props();
+
+	const client = useAPIClient();
+
+	// svelte-ignore state_referenced_locally
+	let spaceTitle = $state(title);
+	let visibility = $state<"public" | "private">("public");
+
+	type DeployState = "idle" | "deploying" | "success" | "error" | "reauth";
+	let deployState = $state<DeployState>("idle");
+	// svelte-ignore state_referenced_locally
+	let resultUrl = $state(existing?.url ?? "");
+	let errorMessage = $state("");
+
+	const isUpdate = $derived(!!existing);
+
+	function close() {
+		onclose?.();
+	}
+
+	async function deploy() {
+		deployState = "deploying";
+		errorMessage = "";
+		try {
+			const res = await client.spaces.deploy.post({
+				conversationId,
+				artifactIdentifier,
+				title: spaceTitle.trim() || title,
+				kind,
+				content,
+				visibility,
+			});
+
+			// 401/403 → the OAuth token lacks Space-creation permission (or there's no
+			// HF session yet); send the user through the OAuth flow to grant it.
+			if (res.status === 401 || res.status === 403) {
+				deployState = "reauth";
+				return;
+			}
+
+			const data = handleResponse(res) as { repoId: string; url: string; created: boolean };
+			resultUrl = data.url;
+			deployState = "success";
+			ondeployed?.({ repoId: data.repoId, url: data.url });
+		} catch (e) {
+			deployState = "error";
+			errorMessage = e instanceof Error ? e.message : "Something went wrong. Please try again.";
+		}
+	}
+
+	function reauthorize() {
+		const next = encodeURIComponent(window.location.pathname + window.location.search);
+		window.location.assign(`${base}/login?next=${next}`);
+	}
+</script>
+
+<Modal onclose={close} width="w-[90dvw] md:w-[480px]">
+	<div class="flex w-full flex-col gap-5 p-6">
+		<div class="flex items-start justify-between">
+			<h2 class="flex items-center gap-2 text-xl font-semibold text-gray-800 dark:text-gray-200">
+				<CarbonRocket class="text-lg text-gray-500 dark:text-gray-400" />
+				{isUpdate ? "Update Space" : "Deploy to a Space"}
+			</h2>
+			<button type="button" class="group outline-hidden" onclick={close} aria-label="Close">
+				<CarbonClose
+					class="size-5 text-gray-700 group-hover:text-gray-500 dark:text-gray-300 dark:group-hover:text-gray-400"
+				/>
+			</button>
+		</div>
+
+		{#if deployState === "success"}
+			<div class="flex flex-col gap-4">
+				<p class="flex items-center gap-2 text-sm font-medium text-green-700 dark:text-green-400">
+					<CarbonCheckmark class="size-4" />
+					{isUpdate ? "Your Space was updated." : "Your Space is live."}
+				</p>
+				<p class="text-sm text-gray-600 dark:text-gray-400">
+					It may take a few seconds for the Space to build. Public Spaces can be shared with anyone.
+				</p>
+				<div class="flex items-center justify-end gap-2">
+					<button
+						type="button"
+						class="inline-flex items-center rounded-xl border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-900 shadow-sm outline-hidden hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600"
+						onclick={close}
+					>
+						Done
+					</button>
+					<a
+						href={resultUrl}
+						target="_blank"
+						rel="noopener noreferrer"
+						class="inline-flex items-center gap-1.5 rounded-xl border border-gray-900 bg-gray-900 px-3 py-1.5 text-sm font-semibold text-white hover:bg-black focus:ring-2 focus:ring-gray-400 focus:ring-offset-2 focus:outline-hidden dark:border-gray-100 dark:bg-gray-100 dark:text-gray-900 dark:hover:bg-white dark:focus:ring-offset-gray-800"
+					>
+						Open Space
+						<CarbonArrowUpRight class="size-3.5" />
+					</a>
+				</div>
+			</div>
+		{:else if deployState === "reauth"}
+			<div class="flex flex-col gap-4">
+				<p class="text-sm text-gray-600 dark:text-gray-400">
+					To deploy artifacts, HuggingChat needs permission to create Spaces on your Hugging Face
+					account. Sign in again to grant it. It can only access Spaces it creates for you, not your
+					other repositories.
+				</p>
+				<div class="flex items-center justify-end gap-2">
+					<button
+						type="button"
+						class="inline-flex items-center rounded-xl border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-900 shadow-sm outline-hidden hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600"
+						onclick={close}
+					>
+						Cancel
+					</button>
+					<button
+						type="button"
+						class="inline-flex items-center gap-1.5 rounded-xl border border-gray-900 bg-gray-900 px-3 py-1.5 text-sm font-semibold text-white hover:bg-black focus:ring-2 focus:ring-gray-400 focus:ring-offset-2 focus:outline-hidden dark:border-gray-100 dark:bg-gray-100 dark:text-gray-900 dark:hover:bg-white dark:focus:ring-offset-gray-800"
+						onclick={reauthorize}
+					>
+						Sign in to continue
+					</button>
+				</div>
+			</div>
+		{:else}
+			<div class="flex flex-col gap-4">
+				<label class="flex flex-col gap-1.5">
+					<span class="text-sm font-medium text-gray-700 dark:text-gray-300">Space name</span>
+					<input
+						type="text"
+						bind:value={spaceTitle}
+						maxlength="100"
+						disabled={deployState === "deploying" || isUpdate}
+						placeholder="My artifact"
+						class="rounded-xl border border-gray-200 bg-white px-3.5 py-2 text-sm text-gray-800 outline-hidden focus:border-gray-400 disabled:opacity-60 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200"
+					/>
+					{#if isUpdate && existing}
+						<span class="font-mono text-xs text-gray-500 dark:text-gray-400">{existing.repoId}</span
+						>
+					{/if}
+				</label>
+
+				{#if !isUpdate}
+					<fieldset class="flex flex-col gap-2">
+						<span class="text-sm font-medium text-gray-700 dark:text-gray-300">Visibility</span>
+						<div class="flex gap-2">
+							<label
+								class="flex flex-1 cursor-pointer items-center gap-2 rounded-xl border px-3 py-2 text-sm {visibility ===
+								'public'
+									? 'border-gray-900 bg-gray-50 dark:border-gray-100 dark:bg-gray-800'
+									: 'border-gray-200 dark:border-gray-700'}"
+							>
+								<input
+									type="radio"
+									name="visibility"
+									value="public"
+									bind:group={visibility}
+									class="accent-gray-900 dark:accent-gray-100"
+								/>
+								<span class="text-gray-800 dark:text-gray-200">Public</span>
+							</label>
+							<label
+								class="flex flex-1 cursor-pointer items-center gap-2 rounded-xl border px-3 py-2 text-sm {visibility ===
+								'private'
+									? 'border-gray-900 bg-gray-50 dark:border-gray-100 dark:bg-gray-800'
+									: 'border-gray-200 dark:border-gray-700'}"
+							>
+								<input
+									type="radio"
+									name="visibility"
+									value="private"
+									bind:group={visibility}
+									class="accent-gray-900 dark:accent-gray-100"
+								/>
+								<span class="text-gray-800 dark:text-gray-200">Private</span>
+							</label>
+						</div>
+					</fieldset>
+				{/if}
+
+				{#if deployState === "error"}
+					<p
+						class="rounded-xl border border-red-300/60 bg-red-50 px-3.5 py-2.5 text-xs break-words text-red-600 dark:border-red-500/40 dark:bg-red-500/10 dark:text-red-400"
+					>
+						{errorMessage}
+					</p>
+				{/if}
+
+				<div class="flex items-center justify-end gap-2">
+					<button
+						type="button"
+						class="inline-flex items-center rounded-xl border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-900 shadow-sm outline-hidden hover:bg-gray-50 disabled:opacity-60 dark:border-gray-700 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600"
+						disabled={deployState === "deploying"}
+						onclick={close}
+					>
+						Cancel
+					</button>
+					<button
+						type="button"
+						class="inline-flex items-center gap-1.5 rounded-xl border border-gray-900 bg-gray-900 px-3 py-1.5 text-sm font-semibold text-white hover:bg-black focus:ring-2 focus:ring-gray-400 focus:ring-offset-2 focus:outline-hidden disabled:opacity-60 dark:border-gray-100 dark:bg-gray-100 dark:text-gray-900 dark:hover:bg-white dark:focus:ring-offset-gray-800"
+						disabled={deployState === "deploying"}
+						onclick={deploy}
+					>
+						{#if deployState === "deploying"}
+							<EosIconsLoading class="size-3.5" />
+							{isUpdate ? "Updating…" : "Deploying…"}
+						{:else}
+							<CarbonRocket class="size-3.5" />
+							{isUpdate ? "Update Space" : "Deploy"}
+						{/if}
+					</button>
+				</div>
+			</div>
+		{/if}
+	</div>
+</Modal>

--- a/src/lib/types/Conversation.ts
+++ b/src/lib/types/Conversation.ts
@@ -24,4 +24,25 @@ export interface Conversation extends Timestamps {
 	assistantId?: Assistant["_id"];
 
 	userAgent?: string;
+
+	/**
+	 * Spaces this conversation's artifacts have been deployed to, keyed by the
+	 * stable artifact `identifier`. Lets a re-deploy push a new commit to the same
+	 * Space instead of creating a new one. Only Spaces created through this app's
+	 * OAuth client are reachable (the `contribute-repos` scope), so every entry
+	 * here maps to an app-created Space.
+	 */
+	deployedSpaces?: Record<string, DeployedSpace>;
+}
+
+export interface DeployedSpace {
+	/** Full repo id, e.g. `username/my-artifact`. */
+	repoId: string;
+	createdAt: Date;
+	/**
+	 * Visibility the Space was created with, preserved so a recreate (after the
+	 * user deleted the Space on the Hub) doesn't silently flip a private Space to
+	 * public — the update modal hides the visibility control.
+	 */
+	private: boolean;
 }

--- a/src/lib/utils/deployableHtml.spec.ts
+++ b/src/lib/utils/deployableHtml.spec.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { buildDeployableHtml, isDeployableKind } from "$lib/utils/previewSrcdoc";
+
+describe("buildDeployableHtml", () => {
+	it("flags only self-contained kinds as deployable", () => {
+		expect(isDeployableKind("html")).toBe(true);
+		expect(isDeployableKind("svg")).toBe(true);
+		expect(isDeployableKind("react")).toBe(true);
+		expect(isDeployableKind("mermaid")).toBe(true);
+		expect(isDeployableKind("code")).toBe(false);
+		expect(isDeployableKind("markdown")).toBe(false);
+	});
+
+	it("ships raw HTML verbatim (no base tag or preview hook injected)", () => {
+		const html = `<!doctype html><html><head><title>App</title></head><body><a href="/page">x</a></body></html>`;
+		const out = buildDeployableHtml("html", html);
+		expect(out).toBe(html);
+		expect(out).not.toContain("base target");
+	});
+
+	// The deployed page has no parent window, so the postMessage hook (which the
+	// preview builders inject) must never ship to a Space.
+	it("never embeds the preview postMessage hook", () => {
+		const kinds = [
+			["svg", "<svg xmlns='http://www.w3.org/2000/svg'><rect width='10' height='10'/></svg>"],
+			["react", "export default function App(){ return <div>hi</div>; }"],
+			["mermaid", "graph TD; A-->B;"],
+		] as const;
+		for (const [kind, content] of kinds) {
+			const out = buildDeployableHtml(kind, content);
+			expect(out, kind).not.toContain("parent.postMessage");
+			expect(out, kind).not.toContain("chatui.preview");
+		}
+	});
+
+	it("wraps React with the React + Babel CDNs and embeds the source", () => {
+		const out = buildDeployableHtml(
+			"react",
+			"export default function App(){ return <div>hi</div>; }"
+		);
+		expect(out).toContain("unpkg.com/react@18");
+		expect(out).toContain("@babel/standalone");
+		expect(out).toContain("artifact-root");
+	});
+
+	it("wraps Mermaid with the Mermaid CDN", () => {
+		const out = buildDeployableHtml("mermaid", "graph TD; A-->B;");
+		expect(out).toContain("mermaid@11");
+		expect(out).toContain("graph TD");
+	});
+
+	it("wraps bare SVG into a full HTML document", () => {
+		const svg = "<svg xmlns='http://www.w3.org/2000/svg'><rect width='10' height='10'/></svg>";
+		const out = buildDeployableHtml("svg", svg);
+		expect(out).toContain("<!doctype html>");
+		expect(out).toContain("<svg");
+	});
+});

--- a/src/lib/utils/previewSrcdoc.ts
+++ b/src/lib/utils/previewSrcdoc.ts
@@ -21,6 +21,10 @@ import type { ArtifactKind } from "./artifacts";
 const END_SCRIPT_TAG = "</scr" + "ipt>";
 
 function buildPreviewHookScript(channel: string): string {
+	// Deployed artifacts (a static Space) pass an empty channel: there is no
+	// parent window to postMessage to, so the hook is omitted entirely and the
+	// shipped document is just the artifact itself.
+	if (!channel) return "";
 	return `\n<script>\n(function(){\n  function send(type, detail){\n    try{ parent.postMessage({ type: type, channel: '${channel}', detail: detail }, '*'); }catch(e){}\n  }\n  function nearestAnchor(node){\n    while (node && node !== document) {\n      if (node.tagName && node.tagName.toLowerCase() === 'a') return node;\n      node = node.parentNode;\n    }\n    return null;\n  }\n  function anchorHref(anchor){\n    var href = anchor.href;\n    if (typeof href === 'string') return href;\n    if (href && typeof href.baseVal === 'string') {\n      try { return new URL(href.baseVal, document.baseURI).href; } catch (err) { return ''; }\n    }\n    return '';\n  }\n  function scrollToFragment(raw){\n    var id = raw.slice(1);\n    try { id = decodeURIComponent(id); } catch (err) {}\n    var target = id ? document.getElementById(id) : null;\n    if (target && target.scrollIntoView) target.scrollIntoView();\n  }\n  function intercept(ev){\n    var anchor = nearestAnchor(ev.target);\n    if (!anchor) return;\n    ev.preventDefault();\n    ev.stopPropagation();\n    var raw = anchor.getAttribute('href') || anchor.getAttribute('xlink:href') || '';\n    if (raw.charAt(0) === '#') {\n      scrollToFragment(raw);\n      return;\n    }\n    if (!/^\\s*https?:/i.test(raw)) return;\n    var href = anchorHref(anchor);\n    if (/^https?:/i.test(href)) {\n      send('chatui.preview.openLink', { href: href });\n    }\n  }\n  window.addEventListener('click', intercept, true);\n  window.addEventListener('auxclick', intercept, true);\n  window.addEventListener('keydown', function(ev){\n    if (ev.key === 'Enter' || ev.key === ' ') {\n      intercept(ev);\n    }\n  }, true);\n  window.addEventListener('error', function(ev){\n    var msg = ev && ev.message ? ev.message : 'Script error';\n    var stack = ev && ev.error && ev.error.stack ? ev.error.stack : undefined;\n    send('chatui.preview.error', { message: msg, stack: stack });\n  });\n  window.addEventListener('unhandledrejection', function(ev){\n    var r = ev && ev.reason;\n    var msg = (typeof r === 'string') ? r : (r && r.message) ? r.message : 'Unhandled promise rejection';\n    var stack = r && r.stack ? r.stack : undefined;\n    send('chatui.preview.error', { message: msg, stack: stack });\n  });\n})();\n${END_SCRIPT_TAG}`;
 }
 
@@ -203,5 +207,31 @@ export function buildArtifactSrcdoc(kind: ArtifactKind, content: string, channel
 			return buildMermaidSrcdoc(content, channel);
 		default:
 			return buildHtmlSrcdoc(content, channel);
+	}
+}
+
+/** Kinds that can be shipped as a self-contained static page (an HF Space). */
+export function isDeployableKind(kind: ArtifactKind): boolean {
+	return kind === "html" || kind === "svg" || kind === "react" || kind === "mermaid";
+}
+
+/**
+ * Build the standalone `index.html` shipped to a deployed static Space. Unlike
+ * the preview builders this passes an empty channel, so the postMessage hook is
+ * stripped (a deployed page has no parent window to talk to). Raw HTML is shipped
+ * verbatim — it is already a complete self-contained page and we must not inject
+ * a `<base target="_blank">` that would rewrite its link behaviour. SVG/React/
+ * Mermaid reuse the same wrappers as the preview, minus the hook.
+ */
+export function buildDeployableHtml(kind: ArtifactKind, content: string): string {
+	switch (kind) {
+		case "react":
+			return buildReactSrcdoc(content, "");
+		case "mermaid":
+			return buildMermaidSrcdoc(content, "");
+		case "svg":
+			return buildHtmlSrcdoc(content, "");
+		default:
+			return content;
 	}
 }

--- a/src/routes/api/v2/conversations/[id]/+server.ts
+++ b/src/routes/api/v2/conversations/[id]/+server.ts
@@ -26,6 +26,7 @@ export const GET: RequestHandler = async ({ locals, params, url }) => {
 		updatedAt: conversation.updatedAt,
 		modelId: conversation.model,
 		shared: conversation.shared,
+		deployedSpaces: "deployedSpaces" in conversation ? conversation.deployedSpaces : undefined,
 	});
 };
 

--- a/src/routes/api/v2/spaces/deploy/+server.ts
+++ b/src/routes/api/v2/spaces/deploy/+server.ts
@@ -46,9 +46,14 @@ function slugify(title: string): string {
 }
 
 function buildReadme(title: string): string {
-	const safeTitle = title.replace(/"/g, "'").slice(0, 200);
+	const trimmed = title.slice(0, 200);
+	// YAML is a superset of JSON, so a JSON double-quoted string is a valid YAML
+	// double-quoted scalar with quotes, backslashes, control chars, and unicode
+	// all escaped correctly — avoids a stray `\` or `"` breaking the front matter.
+	const yamlTitle = JSON.stringify(trimmed);
+	const headingTitle = trimmed.replace(/[\r\n]+/g, " ");
 	return `---
-title: "${safeTitle}"
+title: ${yamlTitle}
 emoji: ${pick(SPACE_EMOJIS)}
 colorFrom: ${pick(SPACE_COLORS)}
 colorTo: ${pick(SPACE_COLORS)}
@@ -58,7 +63,7 @@ tags:
   - huggingchat
 ---
 
-# ${safeTitle}
+# ${headingTitle}
 
 Built with [HuggingChat](https://huggingface.co/chat).
 `;

--- a/src/routes/api/v2/spaces/deploy/+server.ts
+++ b/src/routes/api/v2/spaces/deploy/+server.ts
@@ -1,0 +1,228 @@
+import { error, type RequestHandler } from "@sveltejs/kit";
+import { z } from "zod";
+import { ObjectId } from "mongodb";
+import { createRepo, uploadFiles } from "@huggingface/hub";
+
+import { superjsonResponse } from "$lib/server/api/utils/superjsonResponse";
+import { requireAuth } from "$lib/server/api/utils/requireAuth";
+import { collections } from "$lib/server/database";
+import { authCondition } from "$lib/server/auth";
+import { config } from "$lib/server/config";
+import { buildDeployableHtml, isDeployableKind } from "$lib/utils/previewSrcdoc";
+import { logger } from "$lib/server/logger";
+
+const DEPLOYABLE_KINDS = ["html", "svg", "react", "mermaid"] as const;
+
+const bodySchema = z.object({
+	conversationId: z.string(),
+	// Keep the identifier safe as a MongoDB dot-path key (no `.`/`$`).
+	artifactIdentifier: z
+		.string()
+		.min(1)
+		.max(256)
+		.regex(/^[a-zA-Z0-9_-]+$/, "Invalid artifact identifier"),
+	title: z.string().min(1).max(200),
+	kind: z.enum(DEPLOYABLE_KINDS),
+	content: z.string().min(1),
+	visibility: z.enum(["public", "private"]).default("public"),
+});
+
+const SPACE_EMOJIS = ["🚀", "✨", "🎨", "🤗", "💡", "🧩", "🌈", "⚡️", "🪄", "🔮", "🛸", "🎯"];
+const SPACE_COLORS = ["red", "yellow", "green", "blue", "indigo", "purple", "pink", "gray"];
+
+function pick<T>(arr: readonly T[]): T {
+	return arr[Math.floor(Math.random() * arr.length)];
+}
+
+function slugify(title: string): string {
+	const slug = title
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "-")
+		.split("-")
+		.filter(Boolean)
+		.join("-")
+		.slice(0, 80);
+	return slug || "huggingchat-artifact";
+}
+
+function buildReadme(title: string): string {
+	const safeTitle = title.replace(/"/g, "'").slice(0, 200);
+	return `---
+title: "${safeTitle}"
+emoji: ${pick(SPACE_EMOJIS)}
+colorFrom: ${pick(SPACE_COLORS)}
+colorTo: ${pick(SPACE_COLORS)}
+sdk: static
+pinned: false
+tags:
+  - huggingchat
+---
+
+# ${safeTitle}
+
+Built with [HuggingChat](https://huggingface.co/chat).
+`;
+}
+
+function spaceUrl(repoId: string): string {
+	return `https://huggingface.co/spaces/${repoId}`;
+}
+
+function statusCodeOf(err: unknown): number | undefined {
+	if (err && typeof err === "object" && "statusCode" in err) {
+		const code = (err as { statusCode?: unknown }).statusCode;
+		return typeof code === "number" ? code : undefined;
+	}
+	return undefined;
+}
+
+/** 403 the client maps to a "grant Space permissions / sign in" prompt. */
+function reauthResponse(): Response {
+	return superjsonResponse(
+		{
+			code: "reauth-required",
+			message: "Grant Hugging Face permission to create Spaces, then try again.",
+		},
+		{ status: 403 }
+	);
+}
+
+export const POST: RequestHandler = async ({ locals, request }) => {
+	requireAuth(locals);
+
+	if (!config.isHuggingChat) {
+		error(403, "Deploying artifacts to a Space is not enabled on this instance.");
+	}
+
+	const accessToken = locals.token;
+	const username = locals.user?.username;
+	if (!accessToken || !username) {
+		// No HF OAuth token (e.g. anonymous session) — needs sign-in.
+		return reauthResponse();
+	}
+
+	const body = bodySchema.parse(await request.json());
+
+	if (!isDeployableKind(body.kind)) {
+		error(400, "This artifact type cannot be deployed to a Space.");
+	}
+
+	if (!ObjectId.isValid(body.conversationId)) {
+		error(400, "Invalid conversation ID");
+	}
+
+	const conversation = await collections.conversations.findOne({
+		_id: new ObjectId(body.conversationId),
+		...authCondition(locals),
+	});
+	if (!conversation) {
+		error(404, "Conversation not found");
+	}
+
+	const files = [
+		{
+			path: "index.html",
+			content: new Blob([buildDeployableHtml(body.kind, body.content)], { type: "text/html" }),
+		},
+		{
+			path: "README.md",
+			content: new Blob([buildReadme(body.title)], { type: "text/markdown" }),
+		},
+	];
+
+	const existing = conversation.deployedSpaces?.[body.artifactIdentifier];
+
+	// Re-deploy: push a new commit to the Space we created earlier.
+	if (existing) {
+		try {
+			await uploadFiles({
+				repo: { type: "space", name: existing.repoId },
+				accessToken,
+				files,
+				commitTitle: "Update from HuggingChat",
+			});
+			return superjsonResponse({
+				repoId: existing.repoId,
+				url: spaceUrl(existing.repoId),
+				created: false,
+			});
+		} catch (err) {
+			const status = statusCodeOf(err);
+			if (status === 401 || status === 403) {
+				return reauthResponse();
+			}
+			// 404 → the Space was deleted on the Hub; recreate it below.
+			if (status !== 404) {
+				logger.error(err, "Failed to update deployed Space");
+				error(502, "Failed to update the Space. Please try again.");
+			}
+		}
+	}
+
+	// First deploy (or recreate): make a fresh Space, retrying on name collisions.
+	// Preserve the original visibility when recreating a deleted Space — the update
+	// modal hides the visibility toggle, so body.visibility is the "public" default
+	// and would otherwise flip a previously-private Space to public.
+	const isPrivate = existing?.private ?? body.visibility === "private";
+	const baseSlug = slugify(body.title);
+	let repoId: string | undefined;
+	for (let attempt = 0; attempt < 4 && !repoId; attempt++) {
+		const slug = attempt === 0 ? baseSlug : `${baseSlug}-${Math.random().toString(36).slice(2, 7)}`;
+		const candidate = `${username}/${slug}`;
+		try {
+			await createRepo({
+				repo: { type: "space", name: candidate },
+				accessToken,
+				sdk: "static",
+				private: isPrivate,
+			});
+			repoId = candidate;
+		} catch (err) {
+			const status = statusCodeOf(err);
+			if (status === 401 || status === 403) {
+				return reauthResponse();
+			}
+			// 409 → name already taken; loop tries a suffixed slug.
+			if (status !== 409) {
+				logger.error(err, "Failed to create Space");
+				error(502, "Failed to create the Space. Please try again.");
+			}
+		}
+	}
+	if (!repoId) {
+		error(409, "Could not find an available Space name. Try renaming the artifact.");
+	}
+
+	// Persist the mapping right after creation so a failed upload still self-heals
+	// into an update on the next deploy instead of orphaning the Space.
+	await collections.conversations.updateOne(
+		{ _id: conversation._id, ...authCondition(locals) },
+		{
+			$set: {
+				[`deployedSpaces.${body.artifactIdentifier}`]: {
+					repoId,
+					createdAt: new Date(),
+					private: isPrivate,
+				},
+			},
+		}
+	);
+
+	try {
+		await uploadFiles({
+			repo: { type: "space", name: repoId },
+			accessToken,
+			files,
+			commitTitle: "Deploy from HuggingChat",
+		});
+	} catch (err) {
+		const status = statusCodeOf(err);
+		if (status === 401 || status === 403) {
+			return reauthResponse();
+		}
+		logger.error(err, "Failed to upload files to Space");
+		error(502, "The Space was created but uploading files failed. Try deploying again.");
+	}
+
+	return superjsonResponse({ repoId, url: spaceUrl(repoId), created: true });
+};

--- a/src/routes/conversation/[id]/+page.ts
+++ b/src/routes/conversation/[id]/+page.ts
@@ -4,6 +4,7 @@ import { redirect } from "@sveltejs/kit";
 import { base } from "$app/paths";
 import type { PageLoad } from "./$types";
 import type { Message } from "$lib/types/Message";
+import type { DeployedSpace } from "$lib/types/Conversation";
 
 interface ConversationData {
 	messages: Message[];
@@ -15,6 +16,7 @@ interface ConversationData {
 	updatedAt: Date;
 	modelId: string;
 	shared: boolean;
+	deployedSpaces?: Record<string, DeployedSpace>;
 }
 
 export const load: PageLoad = async ({ params, depends, fetch, url, parent }) => {


### PR DESCRIPTION
## What

Adds a one-click **Deploy to Space** action in the artifact panel. It publishes an artifact as a static Hugging Face Space owned by the logged-in user, and re-deploying pushes a new commit to the same Space (update in place).

Supported artifact kinds: HTML, SVG, React, and Mermaid. Each is shipped as a self-contained `index.html` (the preview-only `postMessage` hook is stripped so it never reaches a deployed page). Raw HTML is shipped verbatim.

## Permission model

Uses the **`contribute-repos`** OAuth scope: it can create repos and update only the ones it created, with no access to the user's other repositories. The target is always `sdk: static` (no backend, cannot enable `hf_oauth`), so a deployed artifact cannot run code or harvest tokens.

The feature is gated to HuggingChat (`isHuggingChat`) and uses the user's OAuth token (`locals.token`).

## How it works

- `buildDeployableHtml(kind, content)` in `previewSrcdoc.ts` produces the standalone page.
- `POST /api/v2/spaces/deploy` calls `createRepo` (sdk static) plus `uploadFiles` from `@huggingface/hub`, handling create-vs-update, slug collisions, deleted-Space recreation, and missing-scope (re-auth) responses.
- The artifact to Space mapping is persisted per conversation on `Conversation.deployedSpaces` (keyed by artifact identifier), so re-deploy targets the same Space. The recreate path preserves the original visibility.
- The deploy button and dialog (title, public/private toggle, success URL, re-auth prompt) live in `ArtifactPanel.svelte` and `DeployToSpaceModal.svelte`.

## Prerequisite (Hub side, not in this PR)

For this to work in production, HuggingChat's OAuth app must allow the `contribute-repos` scope (and ideally be auto-approved, like DeepSite), and `OPENID_SCOPES` in the prod config must include `contribute-repos`. Existing sessions need to re-authorize to get a token carrying the scope; the dialog handles the resulting 403 with a sign-in prompt.

## Testing

- Added `deployableHtml.spec.ts` (6 tests): deployable-kind detection, raw HTML verbatim, no preview hook leakage, and correct CDN wrappers for React/Mermaid/SVG.
- `npm run check`, `npm run lint`, and the new tests pass.