### PR TITLE
fix(markdown): stop blocking the Node event loop with SSR markdown rendering

### DIFF
--- a/src/lib/components/chat/MarkdownRenderer.svelte
+++ b/src/lib/components/chat/MarkdownRenderer.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { processBlocks, processBlocksSync, type BlockToken } from "$lib/utils/marked";
+	import { fallbackBlocks, processBlocks, type BlockToken } from "$lib/utils/marked";
 	import MarkdownWorker from "$lib/workers/markdownWorker?worker";
 	import MarkdownBlock from "./MarkdownBlock.svelte";
 	import { browser } from "$app/environment";
@@ -15,10 +15,12 @@
 
 	let { content, sources = [], loading = false }: Props = $props();
 
-	// Sync-computed blocks used as fallback and for SSR (where effects don't run)
-	let syncBlocks = $derived(processBlocksSync(content, sources, loading));
+	// Lightweight blocks used for SSR and the initial client render. Full markdown
+	// rendering is deferred to the worker (or async processBlocks) on mount, so the
+	// heavy synchronous pipeline never runs on the server event loop. See fallbackBlocks.
+	let fallback = $derived(fallbackBlocks(content));
 	let workerBlocks: BlockToken[] | null = $state(null);
-	let blocks = $derived(workerBlocks ?? syncBlocks);
+	let blocks = $derived(workerBlocks ?? fallback);
 
 	let worker: Worker | null = null;
 	let latestRequestId = 0;

--- a/src/lib/components/chat/MarkdownRenderer.svelte.test.ts
+++ b/src/lib/components/chat/MarkdownRenderer.svelte.test.ts
@@ -2,101 +2,116 @@ import MarkdownRenderer from "./MarkdownRenderer.svelte";
 import { render } from "vitest-browser-svelte";
 import { page } from "@vitest/browser/context";
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+// Rich markdown rendering is deferred to the markdown worker (or async processBlocks)
+// on mount; the first paint shows a lightweight escaped-text fallback. Assertions on
+// the rendered output therefore wait for the asynchronous upgrade.
 
 describe("MarkdownRenderer", () => {
-	it("renders", () => {
+	it("renders", async () => {
 		render(MarkdownRenderer, { content: "Hello, world!" });
-		expect(page.getByText("Hello, world!")).toBeInTheDocument();
+		await expect.element(page.getByText("Hello, world!")).toBeInTheDocument();
 	});
-	it("renders headings", () => {
+	it("renders headings", async () => {
 		render(MarkdownRenderer, { content: "# Hello, world!" });
-		expect(page.getByRole("heading", { level: 1 })).toBeInTheDocument();
+		await expect.element(page.getByRole("heading", { level: 1 })).toBeInTheDocument();
 	});
-	it("renders links", () => {
+	it("renders links", async () => {
 		render(MarkdownRenderer, { content: "[Hello, world!](https://example.com)" });
 		const link = page.getByRole("link", { name: "Hello, world!" });
-		expect(link).toBeInTheDocument();
-		expect(link).toHaveAttribute("href", "https://example.com");
-		expect(link).toHaveAttribute("target", "_blank");
-		expect(link).toHaveAttribute("rel", "noreferrer");
+		await expect.element(link).toBeInTheDocument();
+		await expect.element(link).toHaveAttribute("href", "https://example.com");
+		await expect.element(link).toHaveAttribute("target", "_blank");
+		await expect.element(link).toHaveAttribute("rel", "noreferrer");
 	});
-	it("renders inline codespans", () => {
+	it("renders inline codespans", async () => {
 		render(MarkdownRenderer, { content: "`foobar`" });
-		expect(page.getByRole("code")).toHaveTextContent("foobar");
+		await expect.element(page.getByRole("code")).toHaveTextContent("foobar");
 	});
-	it("renders block codes", () => {
+	it("renders block codes", async () => {
 		render(MarkdownRenderer, { content: "```foobar```" });
-		expect(page.getByRole("code")).toHaveTextContent("foobar");
+		await expect.element(page.getByRole("code")).toHaveTextContent("foobar");
 	});
-	it("doesnt render raw html directly", () => {
+	it("doesnt render raw html directly", async () => {
 		render(MarkdownRenderer, { content: "<button>Click me</button>" });
-		expect(page.getByRole("button").elements).toHaveLength(0);
-		// htmlparser2 escapes disallowed tags
-		expect(page.getByRole("paragraph")).toHaveTextContent("<button>Click me</button>");
+		await expect
+			.element(page.getByRole("paragraph"))
+			.toHaveTextContent("<button>Click me</button>");
+		expect(page.getByRole("button").elements()).toHaveLength(0);
 	});
-	it("renders latex", () => {
+	it("renders latex", async () => {
 		const { baseElement } = render(MarkdownRenderer, { content: "$(oo)^2$" });
-		expect(baseElement.querySelectorAll(".katex")).toHaveLength(1);
+		await vi.waitFor(() => expect(baseElement.querySelectorAll(".katex")).toHaveLength(1));
 	});
-	it("does not render latex in code blocks", () => {
+	it("does not render latex in code blocks", async () => {
 		const { baseElement } = render(MarkdownRenderer, { content: "```\n$(oo)^2$\n```" });
+		await expect.element(page.getByRole("code")).toBeInTheDocument();
 		expect(baseElement.querySelectorAll(".katex")).toHaveLength(0);
 	});
-	it("does not render latex in inline codes", () => {
+	it("does not render latex in inline codes", async () => {
 		const { baseElement } = render(MarkdownRenderer, { content: "`$oo` and `$bar`" });
+		await expect.element(page.getByText("oo").first()).toBeInTheDocument();
 		expect(baseElement.querySelectorAll(".katex")).toHaveLength(0);
 	});
-	it("does not render latex across multiple lines", () => {
+	it("does not render latex across multiple lines", async () => {
 		const { baseElement } = render(MarkdownRenderer, { content: "* $oo \n* $aa" });
+		await expect.element(page.getByRole("listitem").first()).toBeInTheDocument();
 		expect(baseElement.querySelectorAll(".katex")).toHaveLength(0);
 	});
-	it("renders latex with some < and > symbols", () => {
+	it("renders latex with some < and > symbols", async () => {
 		const { baseElement } = render(MarkdownRenderer, { content: "$foo < bar > baz$" });
-		expect(baseElement.querySelectorAll(".katex")).toHaveLength(1);
+		await vi.waitFor(() => expect(baseElement.querySelectorAll(".katex")).toHaveLength(1));
 	});
 });
 
 describe("MarkdownRenderer streaming", () => {
-	it("renders an incomplete link as an inert anchor without href", () => {
+	it("renders an incomplete link as an inert anchor without href", async () => {
 		const { baseElement } = render(MarkdownRenderer, {
 			content: "Check [the docs](https://exam",
 			loading: true,
 		});
-		const anchor = baseElement.querySelector("a[data-incomplete-link]");
-		expect(anchor).not.toBeNull();
-		expect(anchor?.getAttribute("href")).toBeNull();
-		expect(anchor?.textContent).toBe("the docs");
+		await vi.waitFor(() => {
+			const anchor = baseElement.querySelector("a[data-incomplete-link]");
+			expect(anchor).not.toBeNull();
+			expect(anchor?.getAttribute("href")).toBeNull();
+			expect(anchor?.textContent).toBe("the docs");
+		});
 	});
 
-	it("renders incomplete bold as bold while streaming", () => {
+	it("renders incomplete bold as bold while streaming", async () => {
 		const { baseElement } = render(MarkdownRenderer, {
 			content: "Some **important tex",
 			loading: true,
 		});
-		const strong = baseElement.querySelector("strong");
-		expect(strong?.textContent).toBe("important tex");
+		await vi.waitFor(() => {
+			const strong = baseElement.querySelector("strong");
+			expect(strong?.textContent).toBe("important tex");
+		});
 	});
 
-	it("does not flash a heading while a list item streams in", () => {
+	it("does not flash a heading while a list item streams in", async () => {
 		const { baseElement } = render(MarkdownRenderer, {
 			content: "Shopping list:\n-",
 			loading: true,
 		});
+		await expect.element(page.getByText("Shopping list:")).toBeInTheDocument();
 		expect(baseElement.querySelector("h2")).toBeNull();
 	});
 
-	it("does not merge paragraphs after a <br> into one block", () => {
+	it("does not merge paragraphs after a <br> into one block", async () => {
 		const { baseElement } = render(MarkdownRenderer, {
 			content: "First paragraph.\n\n<br>\n\nSecond paragraph.\n\nThird paragraph.",
 		});
-		expect(baseElement.textContent).toContain("Second paragraph.");
-		expect(baseElement.textContent).toContain("Third paragraph.");
+		await vi.waitFor(() => {
+			expect(baseElement.textContent).toContain("Second paragraph.");
+			expect(baseElement.textContent).toContain("Third paragraph.");
+		});
 	});
 
-	it("renders a trailing setext heading in completed messages", () => {
+	it("renders a trailing setext heading in completed messages", async () => {
 		// Streaming repairs must not apply when loading is false
 		const { baseElement } = render(MarkdownRenderer, { content: "Title\n-" });
-		expect(baseElement.querySelector("h2")?.textContent).toBe("Title");
+		await vi.waitFor(() => expect(baseElement.querySelector("h2")?.textContent).toBe("Title"));
 	});
 });

--- a/src/lib/utils/marked.spec.ts
+++ b/src/lib/utils/marked.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { processBlocksSync, processTokensSync } from "./marked";
+import { fallbackBlocks, highlightCode, processBlocksSync, processTokensSync } from "./marked";
 
 function renderHtml(md: string): string {
 	const tokens = processTokensSync(md, []);
@@ -205,5 +205,75 @@ describe("processBlocksSync streaming behavior", () => {
 		// Mid-stream render: third paragraph still arriving, repairs active
 		const partialIds = processBlocksSync(`${full.slice(0, -10)}`, [], true).map((b) => b.id);
 		expect(partialIds.slice(0, -1)).toEqual(fullIds.slice(0, partialIds.length - 1));
+	});
+});
+
+describe("event-loop guards for oversized inputs (SSR)", () => {
+	test("small code with a known language is highlighted normally", () => {
+		const html = highlightCode("const x = 1;", "javascript");
+		expect(html).toContain('class="hljs');
+	});
+
+	test("very large code blocks are not highlighted (escaped plain text)", () => {
+		const huge = "<x>".repeat(20_000); // 60k chars, > MAX_HIGHLIGHT_LENGTH
+		const html = highlightCode(huge, "javascript");
+		expect(html).not.toContain('class="hljs');
+		expect(html).toContain("&lt;x&gt;");
+	});
+
+	test("medium unlabeled code blocks skip expensive auto-detection (escaped plain text)", () => {
+		const medium = "<y>".repeat(2_000); // 6k chars, > MAX_AUTO_HIGHLIGHT_LENGTH, no language
+		const html = highlightCode(medium);
+		expect(html).not.toContain('class="hljs');
+		expect(html).toContain("&lt;y&gt;");
+	});
+
+	test("huge katex blocks are not rendered with katex (escaped raw)", () => {
+		const huge = `$$${"a".repeat(11_000)}$$`; // > MAX_KATEX_LENGTH
+		const html = processTokensSync(huge, [])
+			.map((token) => (token.type === "text" && typeof token.html === "string" ? token.html : ""))
+			.join("");
+		expect(html).not.toContain("katex");
+	});
+});
+
+describe("fallbackBlocks (SSR / initial render)", () => {
+	test("does not run highlight.js, katex or produce code tokens", () => {
+		const content = [
+			"# Title",
+			"",
+			"Some **text** with math $x^2$ and a code block:",
+			"",
+			"```python",
+			"print('hello')",
+			"```",
+		].join("\n");
+		const blocks = fallbackBlocks(content);
+		expect(blocks).toHaveLength(1);
+		const tokens = blocks[0].tokens;
+		// Single text token, no code tokens (CodeBlock => DOMPurify/jsdom on the server)
+		expect(tokens).toHaveLength(1);
+		expect(tokens[0].type).toBe("text");
+		const html =
+			tokens[0].type === "text" && typeof tokens[0].html === "string" ? tokens[0].html : "";
+		expect(html).not.toContain("hljs");
+		expect(html).not.toContain("katex");
+	});
+
+	test("escapes html so raw markdown content is inert", () => {
+		const blocks = fallbackBlocks("<img src=x onerror=alert(1)>");
+		const html =
+			blocks[0].tokens[0].type === "text" && typeof blocks[0].tokens[0].html === "string"
+				? blocks[0].tokens[0].html
+				: "";
+		expect(html).not.toContain("<img");
+		expect(html).toContain("&lt;img");
+	});
+
+	test("is deterministic (stable id and html) for identical content", () => {
+		const a = fallbackBlocks("hello world");
+		const b = fallbackBlocks("hello world");
+		expect(a[0].id).toBe(b[0].id);
+		expect(a[0].tokens).toEqual(b[0].tokens);
 	});
 });

--- a/src/lib/utils/marked.ts
+++ b/src/lib/utils/marked.ts
@@ -123,6 +123,16 @@ interface katexInlineToken extends Tokens.Generic {
 	displayMode: false;
 }
 
+function renderKatex(token: katexBlockToken | katexInlineToken): string {
+	if (token.text.length > MAX_KATEX_LENGTH) {
+		return escapeHTML(token.raw);
+	}
+	return katex.renderToString(token.text, {
+		throwOnError: false,
+		displayMode: token.displayMode,
+	});
+}
+
 export const katexBlockExtension: TokenizerExtension & RendererExtension = {
 	name: "katexBlock",
 	level: "block",
@@ -164,13 +174,7 @@ export const katexBlockExtension: TokenizerExtension & RendererExtension = {
 
 	renderer(token) {
 		if (token.type === "katexBlock") {
-			if (token.text.length > MAX_KATEX_LENGTH) {
-				return escapeHTML(token.raw);
-			}
-			return katex.renderToString(token.text, {
-				throwOnError: false,
-				displayMode: token.displayMode,
-			});
+			return renderKatex(token as katexBlockToken);
 		}
 		return undefined;
 	},
@@ -217,13 +221,7 @@ const katexInlineExtension: TokenizerExtension & RendererExtension = {
 
 	renderer(token) {
 		if (token.type === "katexInline") {
-			if (token.text.length > MAX_KATEX_LENGTH) {
-				return escapeHTML(token.raw);
-			}
-			return katex.renderToString(token.text, {
-				throwOnError: false,
-				displayMode: token.displayMode,
-			});
+			return renderKatex(token as katexInlineToken);
 		}
 		return undefined;
 	},
@@ -557,9 +555,11 @@ export async function processBlocks(
  * arrives.
  */
 export function fallbackBlocks(content: string): BlockToken[] {
+	// Static id: it is only used as the {#each} key for this single throwaway block and
+	// has no semantic meaning, so there is no need to hash the (potentially large) content.
 	return [
 		{
-			id: `fallback-${hashString(content)}`,
+			id: "fallback",
 			content,
 			tokens: [
 				{

--- a/src/lib/utils/marked.ts
+++ b/src/lib/utils/marked.ts
@@ -57,6 +57,18 @@ const bundledLanguages: [string, LanguageFn][] = [
 
 bundledLanguages.forEach(([name, language]) => hljs.registerLanguage(name, language));
 
+// highlight.js and KaTeX run synchronously and can block their thread for a long time
+// on large or pathological inputs (e.g. a model dumping a huge unlabeled code block or
+// a giant math expression). SSR no longer runs this pipeline (see fallbackBlocks), but
+// these caps still protect the markdown worker and the async processBlocks fallback.
+// Output is unchanged for normal content and only degrades gracefully (escaped text)
+// past these sizes.
+const MAX_HIGHLIGHT_LENGTH = 50_000;
+// Auto-detection tries every registered language, so it is far more expensive than
+// single-language highlighting and gets a tighter cap.
+const MAX_AUTO_HIGHLIGHT_LENGTH = 5_000;
+const MAX_KATEX_LENGTH = 10_000;
+
 // Media URL detection
 const VIDEO_EXTENSIONS = /\.(mp4|webm|ogg|mov|m4v)([?#]|$)/i;
 const AUDIO_EXTENSIONS = /\.(mp3|wav|m4a|aac|flac)([?#]|$)/i;
@@ -152,6 +164,9 @@ export const katexBlockExtension: TokenizerExtension & RendererExtension = {
 
 	renderer(token) {
 		if (token.type === "katexBlock") {
+			if (token.text.length > MAX_KATEX_LENGTH) {
+				return escapeHTML(token.raw);
+			}
 			return katex.renderToString(token.text, {
 				throwOnError: false,
 				displayMode: token.displayMode,
@@ -202,6 +217,9 @@ const katexInlineExtension: TokenizerExtension & RendererExtension = {
 
 	renderer(token) {
 		if (token.type === "katexInline") {
+			if (token.text.length > MAX_KATEX_LENGTH) {
+				return escapeHTML(token.raw);
+			}
 			return katex.renderToString(token.text, {
 				throwOnError: false,
 				displayMode: token.displayMode,
@@ -256,12 +274,22 @@ function sanitizeHref(href?: string | null): string | undefined {
 }
 
 export function highlightCode(text: string, lang?: string): string {
+	// Very large blocks would block the event loop for too long; render them as
+	// escaped plain text instead.
+	if (text.length > MAX_HIGHLIGHT_LENGTH) {
+		return escapeHTML(text);
+	}
 	if (lang && hljs.getLanguage(lang)) {
 		try {
 			return hljs.highlight(text, { language: lang, ignoreIllegals: true }).value;
 		} catch {
 			// fall through to auto-detect
 		}
+	}
+	// Auto-detection runs every grammar over the input and is the most expensive path;
+	// skip it for larger blocks rather than stalling the event loop.
+	if (text.length > MAX_AUTO_HIGHLIGHT_LENGTH) {
+		return escapeHTML(text);
 	}
 	return hljs.highlightAuto(text).value;
 }
@@ -515,7 +543,37 @@ export async function processBlocks(
 }
 
 /**
- * Synchronous version of processBlocks for SSR
+ * Cheap, allocation-light blocks used for SSR and the initial client render.
+ *
+ * Rich markdown rendering (marked + highlight.js + KaTeX + DOMPurify/jsdom) is
+ * intentionally NOT run here: it executes synchronously on the single Node event loop
+ * during SSR and, summed across every message of a conversation, can block the loop
+ * long enough to fail liveness/readiness health checks (observed event-loop stalls up
+ * to ~1.5s). The browser upgrades each message to fully rendered markdown via the
+ * markdown worker (or async processBlocks fallback) on mount.
+ *
+ * The output is deterministic and identical on server and client, so hydration is not
+ * affected; only the first paint shows lightly-formatted text before the worker result
+ * arrives.
+ */
+export function fallbackBlocks(content: string): BlockToken[] {
+	return [
+		{
+			id: `fallback-${hashString(content)}`,
+			content,
+			tokens: [
+				{
+					type: "text",
+					html: `<div style="white-space:pre-wrap;overflow-wrap:anywhere">${escapeHTML(content)}</div>`,
+				},
+			],
+		},
+	];
+}
+
+/**
+ * Synchronous version of processBlocks. Kept for non-SSR callers and tests; it is no
+ * longer used on the SSR render path (see fallbackBlocks).
  */
 export function processBlocksSync(
 	content: string,


### PR DESCRIPTION
## Problem

Loading `/conversation/[id]` for a large conversation could stall the Node event loop for up to ~1.5s (measured on prod via `nodejs_eventloop_lag_max_seconds`). Because the liveness/readiness probes hit `/chat/healthcheck` with a tight timeout, these stalls failed the probes, kubelet restarted the pods in a loop, the ALB lost healthy targets, and users got 504s on hf.co/chat.

CPU and memory were nearly idle the whole time (CPU ~2%, mem ~5% of limit, no OOMKills, CPU throttling ~0.5%), which ruled out resource exhaustion. The stalls were pure synchronous main-thread blocking.

## Root cause

`MarkdownRenderer.svelte` computes `processBlocksSync(content, ...)` for **every message** during SSR. That synchronously runs the full pipeline on the single Node event loop:

- `marked` lexing + parsing
- `highlight.js` (including `highlightAuto`, which tries every registered grammar) for every code block
- `katex.renderToString` for every math expression
- `DOMPurify.sanitize` via `isomorphic-dompurify`, which is jsdom-backed and heavy on the server, for every code block (`CodeBlock.svelte`)

Per-operation cost is small, but summed across all messages of a long conversation it adds up to hundreds of ms to >1s, and a single pathological block (e.g. a model dumping a huge unlabeled code block, which forces the expensive `highlightAuto`) can spike it further. The client already offloads all of this to a Web Worker, so only the server path was unprotected.

Rough local numbers: `highlightAuto` on a large unlabeled block ~70ms, jsdom `DOMPurify.sanitize` ~100ms for 120 blocks, vs the new escaped-text fallback ~0.5ms.

## Fix

1. **Defer rich markdown rendering to the client.** SSR and the initial client render now emit a lightweight, escaped-text fallback (`fallbackBlocks`) instead of the full pipeline. The browser upgrades each message to fully rendered markdown via the existing markdown worker (or the async `processBlocks` fallback) on mount. Server and client produce identical fallback output, so hydration is not affected; only the first paint shows lightly-formatted text for a moment before the worker result arrives. The heavy pipeline no longer touches the server event loop at all.

2. **Cap highlight.js and KaTeX by input size** as defense in depth, so a single pathological block can no longer block the markdown worker or the async fallback either. `highlightAuto` (the most expensive path) gets a tighter cap than single-language highlighting. Output is unchanged for normal content and only degrades gracefully (escaped text) past the caps.

## Tradeoff to confirm

Deferring SSR rendering means no-JS clients and crawlers see lightly-formatted text instead of fully rendered markdown (this includes public shared conversations under `/r/[id]`). For the authenticated chat this is a non-issue. If we want to keep rich SSR for share pages specifically, the alternative is moving rendering to a server-side worker-thread pool, which is a much larger change. Flagging for a call.

## Tests

- `marked.spec.ts`: added coverage for `fallbackBlocks` (no highlight/katex/code tokens, escaped output, deterministic) and for the highlight/katex size caps.
- `MarkdownRenderer.svelte.test.ts`: updated to await the asynchronous worker upgrade (rendering is no longer synchronous on first paint). All 16 browser tests pass.
- Full `server` + `ssr` suites pass, `lint`, `check`, and `build` are green.