### PR TITLE
feat(offline): impl client chat store, service worker, UX 

### DIFF
--- a/src/lib/components/NavConversationItem.svelte
+++ b/src/lib/components/NavConversationItem.svelte
@@ -12,6 +12,9 @@
 	import EditConversationModal from "$lib/components/EditConversationModal.svelte";
 	import DeleteConversationModal from "$lib/components/DeleteConversationModal.svelte";
 	import { requireAuthUser } from "$lib/utils/auth";
+	import { useIsOnline } from "$lib/stores/isOnline.svelte";
+
+	const isOnline = useIsOnline();
 
 	interface Props {
 		conv: ConvSidebar;
@@ -57,7 +60,7 @@
 
 <div
 	class="group flex h-8 flex-none items-center gap-1.5 rounded-lg pr-1.5 pl-2 text-base text-gray-600 hover:bg-gray-100 max-sm:h-10 sm:text-sm dark:text-gray-300 dark:hover:bg-gray-700
-		{conv.id === page.params.id ? 'bg-gray-100 dark:bg-gray-700' : ''}"
+        {conv.id === page.params.id ? 'bg-gray-100 dark:bg-gray-700' : ''}"
 >
 	{#if inlineEditing}
 		<input
@@ -123,14 +126,26 @@
 					>
 						<DropdownMenu.Item
 							class="flex h-9 items-center gap-2 rounded-md px-2 text-sm text-gray-700 select-none focus-visible:outline-hidden data-highlighted:bg-gray-100 sm:h-8 dark:text-gray-200 dark:data-highlighted:bg-white/10"
-							onSelect={() => (renameOpen = true)}
+							disabled={!isOnline.value}
+							onSelect={() => {
+								if (!isOnline.value) return;
+								renameOpen = true;
+							}}
+							data-offline={!isOnline.value || undefined}
+							title={!isOnline.value ? "Rename requires an internet connection" : undefined}
 						>
 							<CarbonEdit class="size-4 opacity-90 dark:opacity-80" />
 							Rename
 						</DropdownMenu.Item>
 						<DropdownMenu.Item
 							class="flex h-9 items-center gap-2 rounded-md px-2 text-sm text-red-500 select-none focus-visible:outline-hidden data-highlighted:bg-red-50 data-highlighted:text-red-600 sm:h-8 dark:text-red-400 dark:data-highlighted:bg-red-500/10 dark:data-highlighted:text-red-400"
-							onSelect={() => (deleteOpen = true)}
+							disabled={!isOnline.value}
+							onSelect={() => {
+								if (!isOnline.value) return;
+								deleteOpen = true;
+							}}
+							data-offline={!isOnline.value || undefined}
+							title={!isOnline.value ? "Delete requires an internet connection" : undefined}
 						>
 							<CarbonTrashCan class="size-4 opacity-90 dark:opacity-80" />
 							Delete

--- a/src/lib/components/NavMenu.svelte
+++ b/src/lib/components/NavMenu.svelte
@@ -32,9 +32,11 @@
 	import { isPro } from "$lib/stores/isPro";
 	import IconPro from "$lib/components/icons/IconPro.svelte";
 	import MCPServerManager from "./mcp/MCPServerManager.svelte";
+	import { useIsOnline } from "$lib/stores/isOnline.svelte";
 
 	const publicConfig = usePublicConfig();
 	const client = useAPIClient();
+	const isOnline = useIsOnline();
 
 	interface Props {
 		conversations: ConvSidebar[];
@@ -143,7 +145,9 @@
 		href={`${base}/`}
 		onclick={handleNewChatClick}
 		class="flex rounded-lg border bg-white px-2 py-0.5 text-center whitespace-nowrap shadow-xs hover:shadow-none sm:text-smd dark:border-gray-600 dark:bg-gray-700"
-		title="Ctrl/Cmd + Shift + O"
+		class:pointer-events-none={!isOnline.value}
+		class:opacity-50={!isOnline.value}
+		title={!isOnline.value ? "New chat requires an internet connection" : "Ctrl/Cmd + Shift + O"}
 	>
 		New Chat
 	</a>

--- a/src/lib/components/chat/ChatInput.svelte
+++ b/src/lib/components/chat/ChatInput.svelte
@@ -27,6 +27,7 @@
 	} from "$lib/stores/mcpServers";
 	import { getMcpServerFaviconUrl } from "$lib/utils/favicon";
 	import { page } from "$app/state";
+	import { useIsOnline } from "$lib/stores/isOnline.svelte";
 
 	interface Props {
 		files?: File[];
@@ -60,6 +61,9 @@
 		focused = $bindable(false),
 		onsubmit,
 	}: Props = $props();
+
+	const isOnline = useIsOnline();
+	let offline = $derived(!isOnline.value);
 
 	const onFileChange = async (e: Event) => {
 		if (!e.target) return;
@@ -230,6 +234,9 @@
 	let selectedServers = $derived(
 		$allMcpServers.filter((server) => $selectedServerIds.has(server.id))
 	);
+
+	// Effective disabled: combine the prop with offline state
+	let effectiveDisabled = $derived(disabled || offline);
 </script>
 
 <div class="flex min-h-full flex-1 flex-col" onpaste={onPaste}>
@@ -238,14 +245,15 @@
 		tabindex="0"
 		inputmode="text"
 		class="scrollbar-custom max-h-[4lh] w-full resize-none overflow-x-hidden overflow-y-auto border-0 bg-transparent px-2.5 py-2.5 outline-hidden focus:ring-0 focus-visible:ring-0 sm:px-3 md:max-h-[8lh]"
-		class:text-gray-400={disabled}
+		class:text-gray-400={effectiveDisabled}
 		bind:value
 		bind:this={textareaElement}
 		onkeydown={handleKeydown}
 		oncompositionstart={() => (isCompositionOn = true)}
 		oncompositionend={() => (isCompositionOn = false)}
 		{placeholder}
-		{disabled}
+		disabled={effectiveDisabled}
+		title={offline ? "You need to be online to send messages" : placeholder}
 		onfocus={handleFocus}
 		onblur={handleBlur}
 		onbeforeinput={requireAuthUser}
@@ -261,7 +269,7 @@
 				<div class="flex items-center">
 					<input
 						bind:this={fileInputEl}
-						disabled={loading}
+						disabled={loading || offline}
 						class="absolute hidden size-0"
 						aria-label="Upload file"
 						type="file"
@@ -282,13 +290,18 @@
 								isDropdownOpen = false;
 								return;
 							}
+							if (open && offline) {
+								isDropdownOpen = false;
+								return;
+							}
 							isDropdownOpen = open;
 						}}
 					>
 						<DropdownMenu.Trigger
 							class="btn size-8 rounded-full border bg-white text-black shadow-sm transition-none enabled:hover:bg-white enabled:hover:shadow-inner sm:size-7 dark:border-transparent dark:bg-gray-600/50 dark:text-white dark:hover:enabled:bg-gray-600"
-							disabled={loading}
+							disabled={loading || offline}
 							aria-label="Add attachment"
+							title={offline ? "Attachments require an internet connection" : "Add attachment"}
 						>
 							<IconPlus class="text-base sm:text-sm" />
 						</DropdownMenu.Trigger>
@@ -425,7 +438,7 @@
 							class:cursor-help={!modelSupportsTools}
 							title={modelSupportsTools
 								? "MCP servers enabled"
-								: "Current model doesn’t support tools"}
+								: "Current model doesn't support tools"}
 						>
 							<button
 								class="inline-flex cursor-pointer items-center gap-1 bg-transparent p-0 leading-none whitespace-nowrap text-current select-none focus:outline-hidden"
@@ -480,8 +493,6 @@
 </div>
 
 <style>
-	/* In the base layer so utility classes (font-mono, text-xs, prose) keep
-	   winning over these element selectors, as they did before Tailwind v4 */
 	@layer base {
 		:global(pre),
 		:global(textarea) {

--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -63,6 +63,9 @@
 		isMessageToolResultUpdate,
 	} from "$lib/utils/messageUpdates";
 	import type { ToolFront } from "$lib/types/Tool";
+	import { useIsOnline } from "$lib/stores/isOnline.svelte";
+
+	const isOnline = useIsOnline();
 
 	interface Props {
 		messages?: Message[];
@@ -636,11 +639,11 @@
 		{/if}
 		{#if canShare}
 			<!-- Lives in the chat column (not the layout) so it stays visible when
-			     the artifact panel is open -->
+                 the artifact panel is open -->
 			<button
 				type="button"
 				class="hidden size-8 items-center justify-center gap-2 rounded-xl border border-gray-200 bg-white/90 text-sm font-medium text-gray-700 shadow-xs hover:bg-white/60 hover:text-gray-500 md:absolute md:top-5 md:right-6 md:z-10 md:flex dark:border-gray-700 dark:bg-gray-800/80 dark:text-gray-200 dark:hover:bg-gray-700
-					{loading ? 'cursor-not-allowed opacity-40' : ''}"
+                    {loading ? 'cursor-not-allowed opacity-40' : ''}"
 				onclick={() => shareModal.open()}
 				aria-label="Share conversation"
 				disabled={loading}
@@ -657,7 +660,7 @@
 			bind:this={chatContainer}
 		>
 			<!-- @container: descendants (e.g. the per-message router-metadata row) adapt
-			     to the actual column width, which shrinks when the artifact panel is open -->
+                 to the actual column width, which shrinks when the artifact panel is open -->
 			<div
 				class="@container mx-auto flex h-full max-w-3xl flex-col gap-6 px-5 pt-6 sm:gap-8 xl:max-w-4xl xl:pt-10"
 			>
@@ -728,10 +731,10 @@
 
 		<div
 			class="pointer-events-none absolute inset-x-0 bottom-0 z-0 mx-auto flex w-full
-			max-w-3xl flex-col items-center justify-center bg-linear-to-t from-white
-			via-white to-white/0 px-3.5 pt-2 *:pointer-events-auto
-			max-sm:py-0 sm:px-5
-			md:pb-4 xl:max-w-4xl dark:border-gray-800 dark:from-gray-900 dark:via-gray-900 dark:to-gray-900/0"
+            max-w-3xl flex-col items-center justify-center bg-linear-to-t from-white
+            via-white to-white/0 px-3.5 pt-2 *:pointer-events-auto
+            max-sm:py-0 sm:px-5
+            md:pb-4 xl:max-w-4xl dark:border-gray-800 dark:from-gray-900 dark:via-gray-900 dark:to-gray-900/0"
 		>
 			{#if !draft.length && !messages.length && !sources.length && !loading && (currentModel.isRouter || (modelSupportsTools && $allBaseServersEnabled)) && activeExamples.length && !hideRouterExamples && !lastIsError && $mcpServersLoaded}
 				<div
@@ -862,7 +865,10 @@
 									<button
 										type="button"
 										class="absolute right-10 bottom-2 mr-1.5 btn size-8 self-end rounded-full border bg-white/50 text-gray-500 transition-none hover:bg-gray-50 hover:text-gray-700 sm:right-9 sm:size-7 dark:border-transparent dark:bg-gray-600/50 dark:text-gray-300 dark:hover:bg-gray-500 dark:hover:text-white"
-										disabled={isReadOnly}
+										disabled={isReadOnly || !isOnline.value}
+										title={!isOnline.value
+											? "Voice recording requires an internet connection"
+											: undefined}
 										onclick={() => {
 											isRecording = true;
 										}}
@@ -873,10 +879,12 @@
 								{/if}
 								<button
 									class="absolute right-2 bottom-2 btn size-8 self-end rounded-full border bg-white text-black shadow transition-none enabled:hover:bg-white enabled:hover:shadow-inner sm:size-7 dark:border-transparent dark:bg-gray-600 dark:text-white dark:hover:enabled:bg-black {!draft ||
-									isReadOnly
+									isReadOnly ||
+									!isOnline.value
 										? ''
 										: 'bg-black! text-white! dark:bg-white! dark:text-black!'}"
-									disabled={!draft || isReadOnly}
+									disabled={!draft || isReadOnly || !isOnline.value}
+									title={!isOnline.value ? "You need to be online to send messages" : undefined}
 									type="submit"
 									aria-label="Send message"
 									name="submit"

--- a/src/lib/components/chat/UploadedFile.svelte
+++ b/src/lib/components/chat/UploadedFile.svelte
@@ -24,6 +24,20 @@
 	// Capture URL once at component creation to prevent reactive updates during navigation
 	let urlNotTrailing = page.url.pathname.replace(/\/$/, "");
 
+	// Trigger a fetch to cache attachment blobs in the service worker
+	$effect(() => {
+		if (
+			file.type === "hash" &&
+			"serviceWorker" in navigator &&
+			navigator.serviceWorker.controller
+		) {
+			const url = urlNotTrailing + "/output/" + file.value;
+			fetch(url).catch(() => {
+				// Silent - the SW will cache on success, offline fallback is fine
+			});
+		}
+	});
+
 	function truncateMiddle(text: string, maxLength: number): string {
 		if (text.length <= maxLength) {
 			return text;

--- a/src/lib/repositories/ConversationRepository.ts
+++ b/src/lib/repositories/ConversationRepository.ts
@@ -1,0 +1,179 @@
+/**
+ * Client-side repository for IndexedDB-backed persistence of conversations.
+ *
+ * Maintains two object stores:
+ *   - `conversations`        — sidebar list (ConvSidebar items)
+ *   - `conversation_details` — full message history (Conversation-like payloads)
+ *
+ * Consistency model: **server always wins**. Data returned from the server
+ * always overwrites local cache entries. Only fully-acknowledged messages
+ * (confirmed by the server) are persisted; optimistic/transient state lives
+ * exclusively in the UI stores.
+ */
+
+import { browser } from "$app/environment";
+import type { ConvSidebar } from "$lib/types/ConvSidebar";
+
+const DB_NAME = "chat-ui-cache";
+const DB_VERSION = 1;
+
+/** Lightweight serialisable shape for the sidebar list (mirrors ConvSidebar). */
+export interface StoredConversation {
+	id: string;
+	title: string;
+	updatedAt: string; // ISO string (Dates serialised for structured clone safety)
+	model?: string;
+}
+
+/** Lightweight serialisable shape for a full conversation payload. */
+export interface StoredConversationDetail {
+	id: string;
+	title: string;
+	model: string;
+	updatedAt: string; // ISO string
+	messages: string; // JSON-stringified Message[] (preserves Date etc. via superjson)
+	preprompt?: string;
+	rootMessageId?: string;
+	shared: boolean;
+	modelId: string;
+}
+
+function openDB(): Promise<IDBDatabase> {
+	return new Promise((resolve, reject) => {
+		const request = indexedDB.open(DB_NAME, DB_VERSION);
+		request.onupgradeneeded = () => {
+			const db = request.result;
+			if (!db.objectStoreNames.contains("conversations")) {
+				db.createObjectStore("conversations", { keyPath: "id" });
+			}
+			if (!db.objectStoreNames.contains("conversation_details")) {
+				db.createObjectStore("conversation_details", { keyPath: "id" });
+			}
+		};
+		request.onsuccess = () => resolve(request.result);
+		request.onerror = () => reject(request.error);
+	});
+}
+
+function getStore(db: IDBDatabase, storeName: string, mode: IDBTransactionMode): IDBObjectStore {
+	const tx = db.transaction(storeName, mode);
+	return tx.objectStore(storeName);
+}
+
+function promisifyRequest<T>(req: IDBRequest<T>): Promise<T> {
+	return new Promise((resolve, reject) => {
+		req.onsuccess = () => resolve(req.result);
+		req.onerror = () => reject(req.error);
+	});
+}
+
+export class ConversationRepository {
+	private dbPromise: Promise<IDBDatabase> | null = null;
+
+	private async ensureDB(): Promise<IDBDatabase> {
+		if (!this.dbPromise) {
+			this.dbPromise = openDB();
+		}
+		return this.dbPromise;
+	}
+
+	// ---------------------------------------------------------------------------
+	// Conversations (sidebar list)
+	// ---------------------------------------------------------------------------
+
+	/** Replace the entire sidebar list in one transaction. */
+	async setConversations(items: ConvSidebar[]): Promise<void> {
+		if (!browser) return;
+		const db = await this.ensureDB();
+		const store = getStore(db, "conversations", "readwrite");
+		// Clear and re-insert for a full replace
+		await promisifyRequest(store.clear());
+		for (const item of items) {
+			store.put(this.toStoredConversation(item));
+		}
+	}
+
+	/** Return all cached sidebar conversations, newest first. */
+	async getConversations(): Promise<ConvSidebar[]> {
+		if (!browser) return [];
+		const db = await this.ensureDB();
+		const store = getStore(db, "conversations", "readonly");
+		const all = await promisifyRequest(store.getAll());
+		return (all ?? [])
+			.map((s) => this.fromStoredConversation(s))
+			.sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
+	}
+
+	// ---------------------------------------------------------------------------
+	// Conversation details (full message history)
+	// ---------------------------------------------------------------------------
+
+	/** Store (overwrite) a full conversation detail. */
+	async setConversationDetail(
+		id: string,
+		detail: Omit<StoredConversationDetail, "id">
+	): Promise<void> {
+		if (!browser) return;
+		const db = await this.ensureDB();
+		const store = getStore(db, "conversation_details", "readwrite");
+		await promisifyRequest(store.put({ id, ...detail }));
+	}
+
+	/** Retrieve a full conversation detail by id. */
+	async getConversationDetail(id: string): Promise<StoredConversationDetail | undefined> {
+		if (!browser) return undefined;
+		const db = await this.ensureDB();
+		const store = getStore(db, "conversation_details", "readonly");
+		return promisifyRequest(store.get(id));
+	}
+
+	/** Remove a conversation detail by id. */
+	async removeConversationDetail(id: string): Promise<void> {
+		if (!browser) return;
+		const db = await this.ensureDB();
+		const store = getStore(db, "conversation_details", "readwrite");
+		await promisifyRequest(store.delete(id));
+	}
+
+	// ---------------------------------------------------------------------------
+	// Bulk operations
+	// ---------------------------------------------------------------------------
+
+	/** Clear all cached data (called on logout). */
+	async clearAll(): Promise<void> {
+		if (!browser) return;
+		const db = await this.ensureDB();
+		const tx = db.transaction(["conversations", "conversation_details"], "readwrite");
+		tx.objectStore("conversations").clear();
+		tx.objectStore("conversation_details").clear();
+		return new Promise((resolve, reject) => {
+			tx.oncomplete = () => resolve();
+			tx.onerror = () => reject(tx.error);
+		});
+	}
+
+	// ---------------------------------------------------------------------------
+	// Serialisation helpers
+	// ---------------------------------------------------------------------------
+
+	private toStoredConversation(item: ConvSidebar): StoredConversation {
+		return {
+			id: String(item.id),
+			title: item.title,
+			updatedAt: item.updatedAt.toISOString(),
+			model: item.model,
+		};
+	}
+
+	private fromStoredConversation(s: StoredConversation): ConvSidebar {
+		return {
+			id: s.id,
+			title: s.title,
+			updatedAt: new Date(s.updatedAt),
+			model: s.model,
+		};
+	}
+}
+
+/** Singleton instance — the single source of truth for IndexedDB access. */
+export const conversationRepository = new ConversationRepository();

--- a/src/lib/stores/conversations.svelte.ts
+++ b/src/lib/stores/conversations.svelte.ts
@@ -24,6 +24,7 @@ import { browser } from "$app/environment";
 import { getContext, setContext } from "svelte";
 import type { ConvSidebar } from "$lib/types/ConvSidebar";
 import { useAPIClient, handleResponse } from "$lib/APIClient";
+import { conversationRepository } from "$lib/repositories/ConversationRepository";
 
 export const CONVERSATIONS_CONTEXT_KEY = "conversationsStore";
 
@@ -44,6 +45,8 @@ class ConversationsStore {
 	/** Replace the entire list (called from layout when data.conversations changes). */
 	init(conversations: ConvSidebar[]): void {
 		this.#list = conversations;
+		// Persist the server-confirmed list to IndexedDB for offline fallback.
+		void conversationRepository.setConversations(conversations);
 	}
 
 	/**
@@ -88,9 +91,19 @@ class ConversationsStore {
 				updatedAt: new Date(conv.updatedAt),
 			}));
 			this.#list = freshList;
+			// Persist the server-confirmed list to IndexedDB.
+			void conversationRepository.setConversations(freshList);
 		} catch (err) {
 			// Non-fatal: keep the existing list rather than blanking the sidebar.
 			console.error("[conversationsStore] refresh failed", err);
+		}
+	}
+
+	/** Clear all locally cached data (called on user logout). */
+	async clearCache(): Promise<void> {
+		this.#list = [];
+		if (browser) {
+			await conversationRepository.clearAll();
 		}
 	}
 }

--- a/src/lib/stores/isOnline.svelte.ts
+++ b/src/lib/stores/isOnline.svelte.ts
@@ -1,0 +1,93 @@
+/**
+ * Reactive connectivity store using Svelte 5 runes.
+ *
+ * `navigator.onLine` is only reliable when it reports `false` (definitely
+ * offline); a `true` value merely means a network interface exists, not that
+ * requests actually reach the server. It also fails to flip under DevTools'
+ * Network "Offline" emulation once a service worker is controlling the page.
+ *
+ * So we probe once at startup to establish ground truth past that unreliable
+ * initial value, then drive off the `online`/`offline` events (which fire
+ * reliably on real transitions). The probe is a lightweight fetch to the
+ * same-origin `/healthcheck` endpoint; the service worker serves that route
+ * network-first, so it reflects real reachability (200 online, 503/throw
+ * offline).
+ */
+import { browser } from "$app/environment";
+import { base } from "$app/paths";
+
+const PROBE_TIMEOUT_MS = 5_000;
+
+class IsOnlineStore {
+	#online = $state<boolean>(browser ? navigator.onLine : true);
+	#probing = false;
+
+	constructor() {
+		if (!browser) return;
+
+		// `offline` is trustworthy on its own; react immediately.
+		window.addEventListener("offline", () => {
+			this.#online = false;
+		});
+		// `online` only hints that connectivity *might* be back — verify it.
+		window.addEventListener("online", () => void this.probe());
+
+		// Re-check when the tab regains focus, in case state changed while hidden.
+		document.addEventListener("visibilitychange", () => {
+			if (document.visibilityState === "visible") void this.probe();
+		});
+
+		// One probe at startup to correct navigator.onLine's unreliable initial
+		// value; transitions after that come from the events above.
+		void this.probe();
+	}
+
+	/** Actively verify reachability by hitting the same-origin healthcheck. */
+	async probe(): Promise<void> {
+		if (!browser || this.#probing) return;
+
+		// `navigator.onLine === false` is a reliable offline signal — skip the
+		// round-trip and avoid a doomed fetch.
+		if (!navigator.onLine) {
+			this.#online = false;
+			return;
+		}
+
+		this.#probing = true;
+		const controller = new AbortController();
+		const timeout = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS);
+		try {
+			const res = await fetch(`${base}/healthcheck`, {
+				method: "GET",
+				cache: "no-store",
+				signal: controller.signal,
+			});
+			this.#online = res.ok;
+		} catch {
+			this.#online = false;
+		} finally {
+			clearTimeout(timeout);
+			this.#probing = false;
+		}
+	}
+
+	get value(): boolean {
+		return this.#online;
+	}
+}
+
+let store: IsOnlineStore | undefined;
+
+export function createIsOnlineStore(): IsOnlineStore {
+	if (!store) {
+		store = new IsOnlineStore();
+	}
+	return store;
+}
+
+export function useIsOnline(): IsOnlineStore {
+	if (!store) {
+		store = new IsOnlineStore();
+	}
+	return store;
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -24,6 +24,7 @@
 	import BackgroundGenerationPoller from "$lib/components/BackgroundGenerationPoller.svelte";
 	import { requireAuthUser } from "$lib/utils/auth";
 	import { createConversationsStore } from "$lib/stores/conversations.svelte";
+	import { useIsOnline } from "$lib/stores/isOnline.svelte";
 
 	let { data = $bindable(), children } = $props();
 
@@ -33,24 +34,23 @@
 	const client = useAPIClient();
 
 	const convsStore = createConversationsStore();
-	// Synchronous seed for SSR: $effect is stripped by the server-side compiler,
-	// so we must call init() immediately to populate the list on first paint.
-	// The $effect below handles client-side resyncs when data.conversations
-	// reference changes after subsequent invalidations.
-	// Last-write-wins from server is acceptable; see conversations.svelte.ts.
 	convsStore.init(data.conversations);
 
 	$effect(() => {
 		convsStore.init(data.conversations);
 	});
 
+	const isOnline = useIsOnline();
+
 	let isNavCollapsed = $state(false);
+
+	// Measured height of the stacked top banners; used to offset the chat content.
+	let bannerHeight = $state(0);
 
 	let errorToastTimeout: ReturnType<typeof setTimeout>;
 	let currentError: string | undefined = $state();
 
 	async function onError() {
-		// If a new different error comes, wait for the current error to hide first
 		if ($error && currentError && $error !== currentError) {
 			clearTimeout(errorToastTimeout);
 			currentError = undefined;
@@ -133,14 +133,10 @@
 		setHapticsEnabled($settings.hapticsEnabled);
 	});
 
+	// Service worker update handling
+	let swUpdateAvailable = $state(false);
+
 	onMount(async () => {
-		// Seed the MCP store from the SSR payload before anything else runs.
-		// onMount never fires during SSR, so this matches the server-rendered HTML
-		// (stores at defaults) and avoids hydration mismatches in NavMenu / ChatWindow.
-		// The layout onMount fires after child onMounts (Svelte 5 order), but that
-		// is fine: writeMessage's mcpServersLoaded gate is an async Promise/subscriber,
-		// so when initWithServers sets mcpServersLoaded=true synchronously here, the
-		// subscriber resolves immediately without any added network latency.
 		initWithServers(data.mcpBaseServers ?? []);
 
 		if (publicConfig.isHuggingChat && data.user?.username) {
@@ -150,7 +146,7 @@
 					isPro.set(userData.isPro ?? false);
 				})
 				.catch(() => {
-					// Keep isPro as null on error - don't show any badge if status is unknown
+					// keep isPro as null on error
 				});
 		}
 
@@ -179,8 +175,48 @@
 			});
 		}
 
+		// Register service worker and listen for updates
+		if ("serviceWorker" in navigator) {
+			const registration = await navigator.serviceWorker.getRegistration();
+
+			if (registration) {
+				// A new SW is waiting to activate
+				if (registration.waiting) {
+					swUpdateAvailable = true;
+				}
+
+				// Listen for new SW installations
+				registration.addEventListener("updatefound", () => {
+					const newWorker = registration.installing;
+					if (newWorker) {
+						newWorker.addEventListener("statechange", () => {
+							if (newWorker.state === "installed" && navigator.serviceWorker.controller) {
+								swUpdateAvailable = true;
+							}
+						});
+					}
+				});
+			}
+
+			// When the SW takes control, reload to activate the new version
+			navigator.serviceWorker.addEventListener("controllerchange", () => {
+				window.location.reload();
+			});
+		}
+
 		window.addEventListener("keydown", onKeydown, { capture: true });
 	});
+
+	function handleUpdateNow() {
+		swUpdateAvailable = false;
+		if ("serviceWorker" in navigator) {
+			navigator.serviceWorker.getRegistration().then((registration) => {
+				if (registration?.waiting) {
+					registration.waiting.postMessage({ type: "SKIP_WAITING" });
+				}
+			});
+		}
+	}
 
 	let mobileNavTitle = $derived(
 		["/models", "/privacy"].includes(page.route.id ?? "")
@@ -262,10 +298,42 @@
 
 <BackgroundGenerationPoller />
 
+<!-- Top banners pinned to the very top across all viewports. bannerHeight is
+	measured so the app shell below can be offset by exactly the stacked banner
+	height, keeping both the navbar and the page content clear of the banners. -->
+<div
+	bind:clientHeight={bannerHeight}
+	class="fixed top-0 right-0 left-0 z-50 flex flex-col"
+>
+	{#if browser && !isOnline.value}
+		<div
+			class="flex items-center justify-center gap-2 bg-amber-500 px-4 py-2 text-sm font-medium text-white shadow-md"
+		>
+			<span class="inline-block size-2 rounded-full bg-white/60"></span>
+			You are currently offline. Some features may be unavailable.
+		</div>
+	{/if}
+
+	{#if swUpdateAvailable}
+		<div
+			class="flex items-center justify-center gap-3 bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-md"
+		>
+			<span>A new version of {publicConfig.PUBLIC_APP_NAME} is available.</span>
+			<button
+				class="rounded-lg bg-white px-3 py-1 text-sm font-semibold text-blue-700 hover:bg-blue-50"
+				onclick={handleUpdateNow}
+			>
+				Update Now
+			</button>
+		</div>
+	{/if}
+</div>
+
 <div
 	class="fixed grid h-dvh w-screen grid-cols-1 grid-rows-[auto_1fr] overflow-hidden text-smd {!isNavCollapsed
 		? 'md:grid-cols-[260px_1fr]'
 		: 'md:grid-cols-[0px_1fr]'} transition-[300ms] [transition-property:grid-template-columns] md:grid-rows-[1fr] dark:text-gray-300"
+	style:padding-top={bannerHeight ? `${bannerHeight}px` : undefined}
 >
 	<ExpandNavigation
 		isCollapsed={isNavCollapsed}

--- a/src/routes/conversation/[id]/+page.svelte
+++ b/src/routes/conversation/[id]/+page.svelte
@@ -37,6 +37,10 @@
 	import { useAPIClient, handleResponse } from "$lib/APIClient";
 	import SharePreviewTags from "$lib/components/SharePreviewTags.svelte";
 
+	// IndexedDB persistence for offline fallback
+	import { conversationRepository } from "$lib/repositories/ConversationRepository";
+	import superjson from "superjson";
+
 	let { data } = $props();
 
 	// Obtain the conversations store during component init (context must be read
@@ -694,6 +698,24 @@
 			rootMessageId = data.rootMessageId;
 			_lastSyncedConvId = currentConvId;
 			_lastSyncedMessages = newMessages;
+
+			// Persist the server-confirmed conversation to IndexedDB.
+			// This fires whenever the load function returns fresh data (page
+			// navigation or post-stream invalidation). Optimistic/transient
+			// messages that haven't been acknowledged by the server are never
+			// persisted — they remain only in the local `messages` state.
+			if (browser && currentConvId) {
+				void conversationRepository.setConversationDetail(currentConvId, {
+					title: data.title,
+					model: data.model,
+					updatedAt: data.updatedAt.toISOString(),
+					messages: superjson.stringify(newMessages),
+					preprompt: data.preprompt,
+					rootMessageId: data.rootMessageId,
+					shared: data.shared,
+					modelId: data.modelId,
+				});
+			}
 		}
 	});
 

--- a/src/routes/conversation/[id]/+page.ts
+++ b/src/routes/conversation/[id]/+page.ts
@@ -53,13 +53,31 @@ export const load: PageLoad = async ({ params, depends, fetch, url, parent }) =>
 		}
 	}
 
-	// Cache-aside: try server first, fall back to IndexedDB on failure.
-	// Server-confirmed data always overwrites local cache entries.
-	try {
-		const data = (await client
-			.conversations({ id: params.id })
-			.get({ query: { fromShare: url.searchParams.get("fromShare") ?? undefined } })
-			.then(handleResponse)) as ConversationData;
+	// Cache-aside: try server first, fall back to IndexedDB only on offline/network
+	// failures. A definitive server response (403/404/etc.) must be honored — we
+	// must not render a deleted or now-forbidden conversation from local cache.
+	const response = await client
+		.conversations({ id: params.id })
+		.get({ query: { fromShare: url.searchParams.get("fromShare") ?? undefined } })
+		.catch((fetchErr) => {
+			// The fetch itself threw (true network failure, e.g. offline with no SW).
+			console.error("[conversation] network request threw for", params.id, fetchErr);
+			return undefined;
+		});
+
+	// Treat a thrown fetch and the service worker's 503 (or status 0) as "offline".
+	// Any other error status is a definitive answer from the server.
+	const isOffline = !response || response.status === 503 || response.status === 0;
+
+	if (response && !isOffline) {
+		// A definitive server error (deleted / forbidden / etc.) — honor it and
+		// redirect home rather than serving a stale or private copy from cache.
+		if (response.error) {
+			console.error("[conversation] server rejected", params.id, response.status, response.error);
+			redirect(302, `${base}/`);
+		}
+
+		const data = handleResponse(response) as ConversationData;
 
 		// Persist server-confirmed data to IndexedDB for offline fallback.
 		if (browser) {
@@ -76,32 +94,32 @@ export const load: PageLoad = async ({ params, depends, fetch, url, parent }) =>
 		}
 
 		return data;
-	} catch (serverErr) {
-		// Network request failed; attempt to serve from IndexedDB cache.
-		if (browser) {
-			try {
-				const cached = await conversationRepository.getConversationDetail(params.id);
-				if (cached) {
-					console.info("[conversation] serving from IndexedDB fallback for", params.id);
-					return {
-						id: cached.id,
-						title: cached.title,
-						model: cached.model,
-						updatedAt: new Date(cached.updatedAt),
-						messages: superjson.parse(cached.messages) as Message[],
-						preprompt: cached.preprompt,
-						rootMessageId: cached.rootMessageId,
-						shared: cached.shared,
-						modelId: cached.modelId,
-					} satisfies ConversationData;
-				}
-			} catch (cacheErr) {
-				console.error("[conversation] IndexedDB fallback also failed", cacheErr);
-			}
-		}
-
-		// No cache available either — redirect home.
-		console.error("[conversation] load failed for", params.id, serverErr);
-		redirect(302, `${base}/`);
 	}
+
+	// Offline (or network failure): attempt to serve from IndexedDB cache.
+	if (browser) {
+		try {
+			const cached = await conversationRepository.getConversationDetail(params.id);
+			if (cached) {
+				console.info("[conversation] serving from IndexedDB fallback for", params.id);
+				return {
+					id: cached.id,
+					title: cached.title,
+					model: cached.model,
+					updatedAt: new Date(cached.updatedAt),
+					messages: superjson.parse(cached.messages) as Message[],
+					preprompt: cached.preprompt,
+					rootMessageId: cached.rootMessageId,
+					shared: cached.shared,
+					modelId: cached.modelId,
+				} satisfies ConversationData;
+			}
+		} catch (cacheErr) {
+			console.error("[conversation] IndexedDB fallback also failed", cacheErr);
+		}
+	}
+
+	// No cache available either — redirect home.
+	console.error("[conversation] load failed for", params.id);
+	redirect(302, `${base}/`);
 };

--- a/src/routes/conversation/[id]/+page.ts
+++ b/src/routes/conversation/[id]/+page.ts
@@ -1,3 +1,4 @@
+import { browser } from "$app/environment";
 import { useAPIClient, handleResponse } from "$lib/APIClient";
 import { UrlDependency } from "$lib/types/UrlDependency";
 import { redirect } from "@sveltejs/kit";
@@ -5,6 +6,8 @@ import { base } from "$app/paths";
 import type { PageLoad } from "./$types";
 import type { Message } from "$lib/types/Message";
 import type { DeployedSpace } from "$lib/types/Conversation";
+import { conversationRepository } from "$lib/repositories/ConversationRepository";
+import superjson from "superjson";
 
 interface ConversationData {
 	messages: Message[];
@@ -50,13 +53,55 @@ export const load: PageLoad = async ({ params, depends, fetch, url, parent }) =>
 		}
 	}
 
-	// Load conversation (works for both owned and shared conversations)
+	// Cache-aside: try server first, fall back to IndexedDB on failure.
+	// Server-confirmed data always overwrites local cache entries.
 	try {
-		return (await client
+		const data = (await client
 			.conversations({ id: params.id })
 			.get({ query: { fromShare: url.searchParams.get("fromShare") ?? undefined } })
 			.then(handleResponse)) as ConversationData;
-	} catch {
+
+		// Persist server-confirmed data to IndexedDB for offline fallback.
+		if (browser) {
+			void conversationRepository.setConversationDetail(params.id, {
+				title: data.title,
+				model: data.model,
+				updatedAt: data.updatedAt.toISOString(),
+				messages: superjson.stringify(data.messages),
+				preprompt: data.preprompt,
+				rootMessageId: data.rootMessageId,
+				shared: data.shared,
+				modelId: data.modelId,
+			});
+		}
+
+		return data;
+	} catch (serverErr) {
+		// Network request failed; attempt to serve from IndexedDB cache.
+		if (browser) {
+			try {
+				const cached = await conversationRepository.getConversationDetail(params.id);
+				if (cached) {
+					console.info("[conversation] serving from IndexedDB fallback for", params.id);
+					return {
+						id: cached.id,
+						title: cached.title,
+						model: cached.model,
+						updatedAt: new Date(cached.updatedAt),
+						messages: superjson.parse(cached.messages) as Message[],
+						preprompt: cached.preprompt,
+						rootMessageId: cached.rootMessageId,
+						shared: cached.shared,
+						modelId: cached.modelId,
+					} satisfies ConversationData;
+				}
+			} catch (cacheErr) {
+				console.error("[conversation] IndexedDB fallback also failed", cacheErr);
+			}
+		}
+
+		// No cache available either — redirect home.
+		console.error("[conversation] load failed for", params.id, serverErr);
 		redirect(302, `${base}/`);
 	}
 };

--- a/src/routes/settings/(nav)/+layout.svelte
+++ b/src/routes/settings/(nav)/+layout.svelte
@@ -44,7 +44,7 @@
 		if (!currentModelId) return;
 		const buttons = container.querySelectorAll<HTMLButtonElement>("button[data-model-id]");
 		let target: HTMLElement | null = null;
-		for (const btn of buttons) {
+		for (const btn of Array.from(buttons)) {
 			if (btn.dataset.modelId === currentModelId) {
 				target = btn;
 				break;

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -1,0 +1,143 @@
+/// <reference types="@sveltejs/kit" />
+/// <reference no-default-lib="true"/>
+/// <reference lib="esnext" />
+/// <reference lib="webworker" />
+
+import { base, build, files, version } from "$service-worker";
+
+const sw = self as unknown as ServiceWorkerGlobalScope;
+
+// Create a unique cache name for this deployment
+const CACHE_NAME = `chat-ui-${version}`;
+
+// Assets to precache (app shell)
+const ASSETS = [...build, ...files];
+
+// Install: precache the app shell
+sw.addEventListener("install", (event: ExtendableEvent) => {
+	async function precache() {
+		const cache = await caches.open(CACHE_NAME);
+		await cache.addAll(ASSETS);
+		// Seed a neutral "/" shell so an offline navigation to an uncached route
+		// has a real app shell to fall back to (best-effort: a failure here must
+		// not abort the install).
+		try {
+			await cache.add(`${base}/`);
+		} catch {
+			// ignore — the shell will be populated on the first online "/" visit
+		}
+		// Note: we intentionally do NOT skipWaiting() here. A new worker stays in
+		// "waiting" so +layout.svelte can surface the "Update Now" banner; it only
+		// activates once the client posts SKIP_WAITING (see the message handler),
+		// avoiding an unprompted reload that would discard in-progress drafts.
+	}
+	event.waitUntil(precache());
+});
+
+// Activate: clean up old caches
+sw.addEventListener("activate", (event: ExtendableEvent) => {
+	async function cleanup() {
+		const keys = await caches.keys();
+		const oldKeys = keys.filter((key) => key !== CACHE_NAME);
+		await Promise.all(oldKeys.map((key) => caches.delete(key)));
+		// Take control of all clients immediately
+		await sw.clients.claim();
+	}
+	event.waitUntil(cleanup());
+});
+
+// Fetch: serve cached assets, network-first for API calls
+sw.addEventListener("fetch", (event: FetchEvent) => {
+	const url = new URL(event.request.url);
+	const isAttachment = url.pathname.match(/\/output\/[a-f0-9]{64}/);
+	const isAPI = url.pathname.startsWith("/api/");
+	const isAsset = ASSETS.some((asset) => url.pathname === asset);
+
+	// Cache-first for app shell assets
+	if (isAsset) {
+		event.respondWith(
+			caches.match(event.request).then((cached) => {
+				return cached ?? fetch(event.request);
+			})
+		);
+		return;
+	}
+
+	// Cache-first for attachment blobs (GET /output/[sha256])
+	if (isAttachment && event.request.method === "GET") {
+		event.respondWith(
+			caches.open(CACHE_NAME).then((cache) => {
+				return cache.match(event.request).then((cached) => {
+					if (cached) return cached;
+					return fetch(event.request).then((response) => {
+						if (response.ok) {
+							cache.put(event.request, response.clone());
+						}
+						return response;
+					});
+				});
+			})
+		);
+		return;
+	}
+
+	// Network-first for API calls
+	if (isAPI) {
+		event.respondWith(
+			fetch(event.request).catch(() => {
+				return caches.match(event.request).then((cached) => {
+					if (cached) return cached;
+					return new Response(null, { status: 503, statusText: "Offline" });
+				});
+			})
+		);
+		return;
+	}
+
+	// Navigation requests: network-first, but cache successful responses so the
+	// app shell is available offline. SSR pages are never in the precache, so
+	// without this write-through an offline reload has no HTML to serve.
+	if (event.request.mode === "navigate") {
+		event.respondWith(
+			fetch(event.request)
+				.then((response) => {
+					if (response.ok) {
+						// Cache each route under its OWN url so an offline reload of that
+						// page works. We deliberately do not clone this into the "/" shell:
+						// route-specific SSR (e.g. /conversation/:id) embeds private/stale
+						// data, and serving it as the generic fallback would leak the wrong
+						// conversation. The neutral "/" shell is seeded at install instead.
+						const copy = response.clone();
+						void caches.open(CACHE_NAME).then((cache) => cache.put(event.request, copy));
+					}
+					return response;
+				})
+				.catch(() =>
+					caches.match(event.request).then((cached) => {
+						if (cached) return cached;
+						return caches
+							.match(`${base}/`)
+							.then((root) => root ?? new Response(null, { status: 503, statusText: "Offline" }));
+					})
+				)
+		);
+		return;
+	}
+
+	// For all other requests, try network first, fall back to cached
+	event.respondWith(
+		fetch(event.request).catch(() => {
+			return caches.match(event.request).then((cached) => {
+				if (cached) return cached;
+				return new Response(null, { status: 503, statusText: "Offline" });
+			});
+		})
+	);
+});
+
+// Listen for SKIP_WAITING message from the client
+sw.addEventListener("message", (event: ExtendableMessageEvent) => {
+	if (event.data?.type === "SKIP_WAITING") {
+		void sw.skipWaiting();
+	}
+});


### PR DESCRIPTION

<img width="1499" height="636" alt="image" src="https://github.com/user-attachments/assets/98b15684-29a6-4319-a255-13af9e83ee1c" />


This pull request introduces robust offline support to the chat UI by implementing a new IndexedDB-backed caching layer for conversations and a reliable online/offline detection mechanism. The UI is now aware of connectivity status, disabling actions that require a network connection and providing clear feedback to users. The most significant changes are grouped below.

**Offline detection and UI adaptation:**

- Introduced a new `isOnline` store (`useIsOnline`) that reliably detects real connectivity by probing a healthcheck endpoint, improving on the limitations of `navigator.onLine`. UI components now reactively use this store to enable or disable actions depending on online status, and provide tooltips explaining why actions are unavailable when offline.

- Updated UI elements—including chat input, file uploads, attachments, new chat button, conversation rename/delete, and voice recording—to be disabled when offline, with appropriate visual cues and accessibility titles.

Closes #2344 