### PR TITLE
fix(artifacts): add a worked edit example to reduce empty update blocks

### DIFF
--- a/src/lib/server/textGeneration/artifacts.ts
+++ b/src/lib/server/textGeneration/artifacts.ts
@@ -36,7 +36,15 @@ Editing an artifact you created earlier in the conversation:
 <new_str>replacement text</new_str>
 </artifact>
 
+For example, to recolor a button in an existing "signup-form" artifact, emit exactly:
+
+<artifact identifier="signup-form" type="update">
+<old_str>background: #16a34a;</old_str>
+<new_str>background: #2563eb;</new_str>
+</artifact>
+
 - Each old_str must match the latest version EXACTLY (including whitespace/indentation) and must be unique within it. Copy it verbatim from the latest version; do not retype, reformat, or re-indent it.
+- Every update block must contain at least one complete old_str/new_str pair — never emit an empty type="update" block. If you can't produce exact old_str text, re-emit the full artifact instead (same identifier).
 - Emit at most ONE update block per reply, with all the pairs (up to 4) inside that single block — never one block per pair.
 - For larger changes, re-emit the full artifact with the SAME identifier (this creates a new version).
 - Keep the identifier BYTE-IDENTICAL across every version, even when the title or content changes (renaming a green button to blue keeps the same identifier). Use a new identifier only for a genuinely different artifact.


### PR DESCRIPTION
Follow-up to #2379. An N=70 artifact-edit eval (GLM-5.2) found the dominant *actionable* failure isn't the matching algorithm — it's that ~11% of edit turns emit a bare `<artifact type="update"></artifact>` with **no pairs** inside (the "no-pairs" case). The model correctly decides an update is needed but doesn't produce any `old_str`/`new_str`.

The system prompt only showed the placeholder *schema*, never a filled-in example. This adds:

1. A concrete worked example (recoloring a button) with real `old_str`/`new_str` content.
2. An explicit rule: an update block must contain at least one complete pair; if exact `old_str` text can't be produced, re-emit the full artifact with the same identifier instead.

Prompt-only change. `npm run check` and `npm run lint` pass.

Note: the eval also confirmed two pi-mono ideas were correctly **not** ported in #2379 — "match-all-against-original" diverged in 0/70 runs (we re-search per pair, so no stale-offset bug), and identifier drift / typography normalization are model-dependent safety nets (GLM-5.2 copies verbatim; other routed models like Kimi-K2.6 drift).