### PR TITLE
fix(chat): drop ChatGPT-style scroll pin on mobile to stop end-of-stream jump

### DIFF
--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -376,6 +376,12 @@
 	function computeSpacerHeight(): number {
 		if (!chatContainer || !spacerEl) return MIN_SPACER_PX;
 
+		// Mobile/touch: skip the ChatGPT-style pin (user message scrolled to the top).
+		// On iOS, WebKit suppresses programmatic scrolls during touch/momentum, so the
+		// pin resolves as a jarring jump up when streaming ends. Keeping the spacer at
+		// its minimum means the view just scrolls to the bottom and follows the stream.
+		if (!window.matchMedia("(min-width: 768px)").matches) return MIN_SPACER_PX;
+
 		const userMsgs = chatContainer.querySelectorAll('[data-message-type="user"]');
 		const lastUserMsg = userMsgs[userMsgs.length - 1] as HTMLElement | undefined;
 		if (!lastUserMsg) return MIN_SPACER_PX;


### PR DESCRIPTION
## Problem

On iOS (phone), when the assistant's reply finishes streaming, the view jumps up so the user's own message snaps to the top of the screen. Reported as: "quand le message de l'assistant se termine, ça scroll en haut à la fin du message de l'utilisateur".

## Cause

This is the desktop "ChatGPT-style" pin misfiring. On send, `ChatWindow.svelte` inflates a tall bottom spacer and scrolls to the bottom, which lands the just-sent user message near the top of the viewport with room for the answer to stream in below. The scroll target stays "user message near top" for the whole stream.

On desktop this resolves instantly and invisibly. On iOS Safari, WebKit suppresses programmatic `scrollTo` during touch/momentum scrolling, so the repositioning is queued and only applies once the gesture and stream settle, which is right when generation ends. Result: one jarring jump up at the end.

## Fix

Cap the spacer at its minimum (`MIN_SPACER_PX`) below the `md` (768px) breakpoint, so mobile falls back to plain "scroll to bottom, then follow the stream" (classic mobile chat). One early-return in `computeSpacerHeight()`.

The spacer effect's `ResizeObserver` keeps running on mobile (it doubles as the stream-follower, since the `snapScrollToBottom` action observes the `h-full` container which does not grow with content), so autoscroll during generation is preserved. The spacer never inflates, so every scroll lands at the true bottom instead of "user message near top". Desktop is unchanged (guard only trips below `md`).

## Testing

- `npm run check`, `npm run lint` pass.
- Desktop: second/third messages still pin near the top (unchanged).
- Mobile (Safari responsive mode / real device): on send the view scrolls to bottom and follows the stream, no jump up when the reply finishes.