### PR TITLE
fix(textGeneration): stop saving max_tokens-truncated responses as complete

### DIFF
--- a/src/lib/server/endpoints/openai/openAIChatToTextGenerationStream.spec.ts
+++ b/src/lib/server/endpoints/openai/openAIChatToTextGenerationStream.spec.ts
@@ -39,6 +39,21 @@ describe("openAIChatToTextGenerationStream truncation handling", () => {
 		expect(final?.generated_text).toContain("<think>");
 	});
 
+	it("emits a terminal truncated output even when no content was produced", async () => {
+		// Hidden-reasoning models can burn the whole budget without surfacing any tokens,
+		// then terminate with finish_reason "length". The adapter must still yield a terminal
+		// output (generated_text "" rather than null) carrying truncated:true so the pipeline
+		// can finalize/flag it instead of silently dropping the empty completion.
+		const chunks = [{ choices: [{ index: 0, delta: {}, finish_reason: "length" }] }];
+
+		const outputs = await collect(openAIChatToTextGenerationStream(mockStream(chunks)));
+		const final = outputs.find((o) => o.generated_text !== null);
+
+		expect(final).toBeDefined();
+		expect(final?.generated_text).toBe("");
+		expect(final?.truncated).toBe(true);
+	});
+
 	it("does not flag truncated on a normal finish_reason 'stop'", async () => {
 		const chunks = [
 			{ choices: [{ index: 0, delta: { content: "Hello" } }] },

--- a/src/lib/server/endpoints/openai/openAIChatToTextGenerationStream.spec.ts
+++ b/src/lib/server/endpoints/openai/openAIChatToTextGenerationStream.spec.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import type OpenAI from "openai";
+import type { Stream } from "openai/streaming";
+import { openAIChatToTextGenerationStream } from "./openAIChatToTextGenerationStream";
+
+type Chunk = OpenAI.Chat.Completions.ChatCompletionChunk;
+
+function mockStream(chunks: unknown[]): Stream<Chunk> {
+	async function* gen() {
+		for (const c of chunks) yield c as Chunk;
+	}
+	return gen() as unknown as Stream<Chunk>;
+}
+
+type Output = { token: { special: boolean }; generated_text: string | null; truncated?: boolean };
+
+async function collect(stream: AsyncIterable<unknown>): Promise<Output[]> {
+	const out: Output[] = [];
+	for await (const o of stream) out.push(o as Output);
+	return out;
+}
+
+describe("openAIChatToTextGenerationStream truncation handling", () => {
+	it("flags truncated=true when the stream ends with finish_reason 'length'", async () => {
+		// Mimics a reasoning model (e.g. GLM-5.2) that spends its entire max_tokens budget on
+		// reasoning_content and hits the limit before ever emitting a final answer.
+		const chunks = [
+			{ choices: [{ index: 0, delta: { reasoning_content: "let me think about the kebab" } }] },
+			{ choices: [{ index: 0, delta: { reasoning_content: " a bit more, drafting code" } }] },
+			{ choices: [{ index: 0, delta: {}, finish_reason: "length" }] },
+		];
+
+		const outputs = await collect(openAIChatToTextGenerationStream(mockStream(chunks)));
+		const final = outputs.find((o) => o.generated_text !== null);
+
+		expect(final).toBeDefined();
+		expect(final?.truncated).toBe(true);
+		// The reasoning is still surfaced as an (unterminated) <think> block.
+		expect(final?.generated_text).toContain("<think>");
+	});
+
+	it("does not flag truncated on a normal finish_reason 'stop'", async () => {
+		const chunks = [
+			{ choices: [{ index: 0, delta: { content: "Hello" } }] },
+			{ choices: [{ index: 0, delta: { content: " world" }, finish_reason: "stop" }] },
+		];
+
+		const outputs = await collect(openAIChatToTextGenerationStream(mockStream(chunks)));
+		const final = outputs.find((o) => o.generated_text !== null);
+
+		expect(final?.generated_text).toBe("Hello world");
+		expect(final?.truncated).toBeFalsy();
+	});
+});

--- a/src/lib/server/endpoints/openai/openAIChatToTextGenerationStream.ts
+++ b/src/lib/server/endpoints/openai/openAIChatToTextGenerationStream.ts
@@ -124,7 +124,11 @@ export async function* openAIChatToTextGenerationStream(
 
 		// Accumulate the combined token into the full text
 		generatedText += combined;
-		const output: TextGenerationStreamOutput = {
+		// `finish_reason: "length"` means the model hit its max_tokens budget mid-generation
+		// (e.g. exhausted the budget while still reasoning). Surface it so the pipeline can flag
+		// the answer as interrupted instead of silently persisting a truncated message as complete.
+		const truncated = last && choices?.[0]?.finish_reason === "length";
+		const output: TextGenerationStreamOutput & { truncated?: boolean } = {
 			token: {
 				id: tokenId++,
 				text: combined,
@@ -133,6 +137,7 @@ export async function* openAIChatToTextGenerationStream(
 			},
 			generated_text: last ? generatedText : null,
 			details: null,
+			...(truncated ? { truncated: true } : {}),
 		};
 		yield output;
 
@@ -187,6 +192,8 @@ export async function* openAIChatToTextGenerationSingle(
 		content = `<think>${r}</think>` + content;
 	}
 	const tokenId = 0;
+	// Hit the max_tokens budget before completing (see streaming adapter above).
+	const truncated = completion.choices?.[0]?.finish_reason === "length";
 
 	// Yield the content as a single token
 	yield {
@@ -198,6 +205,7 @@ export async function* openAIChatToTextGenerationSingle(
 		},
 		generated_text: content,
 		details: null,
+		...(truncated ? { truncated: true } : {}),
 		...(getRouterMetadata
 			? (() => {
 					const metadata = getRouterMetadata();
@@ -207,6 +215,7 @@ export async function* openAIChatToTextGenerationSingle(
 				})()
 			: {}),
 	} as TextGenerationStreamOutput & {
+		truncated?: boolean;
 		routerMetadata?: { route?: string; model?: string; provider?: string };
 	};
 }

--- a/src/lib/server/endpoints/openai/openAICompletionToTextGenerationStream.ts
+++ b/src/lib/server/endpoints/openai/openAICompletionToTextGenerationStream.ts
@@ -17,7 +17,10 @@ export async function* openAICompletionToTextGenerationStream(
 		if (text) {
 			generatedText = generatedText + text;
 		}
-		const output: TextGenerationStreamOutput = {
+		// `finish_reason: "length"` => hit max_tokens before completing; surface it so the
+		// pipeline flags the answer as interrupted rather than persisting a truncated message.
+		const truncated = last && choices?.[0]?.finish_reason === "length";
+		const output: TextGenerationStreamOutput & { truncated?: boolean } = {
 			token: {
 				id: tokenId++,
 				text,
@@ -26,6 +29,7 @@ export async function* openAICompletionToTextGenerationStream(
 			},
 			generated_text: last ? generatedText : null,
 			details: null,
+			...(truncated ? { truncated: true } : {}),
 		};
 		yield output;
 	}

--- a/src/lib/server/textGeneration/generate.ts
+++ b/src/lib/server/textGeneration/generate.ts
@@ -86,8 +86,11 @@ export async function* generate(
 				continue;
 			}
 		}
-		// text generation completed
-		if (output.generated_text) {
+		// text generation completed. Use `!= null` (not truthiness) so a terminal output
+		// with empty text is still finalized: a model can hit finish_reason "length" before
+		// emitting any visible content (hidden-reasoning models, tiny budgets), and that
+		// truncation must still be flagged + logged rather than silently dropped.
+		if (output.generated_text != null) {
 			// If an abort happened just before final output, stop here and let
 			// the caller emit an interrupted final answer with partial text.
 			const abortTime = AbortedGenerations.getInstance().getAbortTime(conv._id.toString());

--- a/src/lib/server/textGeneration/generate.ts
+++ b/src/lib/server/textGeneration/generate.ts
@@ -109,6 +109,18 @@ export async function* generate(
 				text = text.slice(0, text.length - stopToken.length);
 			}
 
+			// `finish_reason: "length"` means the model hit its max_tokens budget mid-generation
+			// (e.g. exhausted the budget while still reasoning, never reaching the answer). The
+			// provider marks the final token as a normal stop, so flag it explicitly as interrupted
+			// and log it instead of silently saving a truncated answer as if it were complete.
+			if ((output as { truncated?: boolean }).truncated) {
+				interrupted = true;
+				logger.warn(
+					{ conversationId: conv._id.toString(), model: model.id, length: text.length },
+					"Generation truncated: model hit max_tokens (finish_reason=length) before completing"
+				);
+			}
+
 			let finalAnswer = text;
 			if (modelReasoning && modelReasoning.type === "regex" && modelReasoning.regex) {
 				const regex = new RegExp(modelReasoning.regex);

--- a/src/lib/server/textGeneration/mcp/runMcpFlow.ts
+++ b/src/lib/server/textGeneration/mcp/runMcpFlow.ts
@@ -508,8 +508,12 @@ export async function* runMcpFlow({
 			let firstToolDeltaLogged = false;
 			let sawToolCall = false;
 			let tokenCount = 0;
+			let finishReason: string | null = null;
 			for await (const chunk of completionStream) {
 				const choice = chunk.choices?.[0];
+				// Captured before the delta guard: the terminating chunk often carries the
+				// finish_reason with an empty/absent delta.
+				if (choice?.finish_reason) finishReason = choice.finish_reason;
 				const delta = choice?.delta;
 				if (!delta) continue;
 
@@ -744,13 +748,22 @@ export async function* runMcpFlow({
 			if (!streamedContent && lastAssistantContent.trim().length > 0) {
 				yield { type: MessageUpdateType.Stream, token: lastAssistantContent };
 			}
+			// `finish_reason: "length"` means the model hit its max_tokens budget before
+			// completing; flag it as interrupted instead of saving a truncated answer as complete.
+			const truncated = finishReason === "length";
+			if (truncated) {
+				logger.warn(
+					{ conversationId: conv._id.toString(), length: lastAssistantContent.length, loop },
+					"[mcp] generation truncated: model hit max_tokens (finish_reason=length) before completing"
+				);
+			}
 			yield {
 				type: MessageUpdateType.FinalAnswer,
 				text: lastAssistantContent,
-				interrupted: false,
+				interrupted: truncated,
 			};
 			logger.info(
-				{ length: lastAssistantContent.length, loop },
+				{ length: lastAssistantContent.length, loop, truncated },
 				"[mcp] final answer emitted (no tool_calls)"
 			);
 			return "completed";


### PR DESCRIPTION
## Problem

When a model hits its `max_tokens` budget, the provider returns `finish_reason: "length"`. The OpenAI stream adapters treated `"length"` identically to a clean `"stop"` (marking the final token `special: true`), so `generate.ts` computed `interrupted = false` and the **truncated message was persisted as if complete**. No log, no flag, no signal.

Most visible with reasoning models: GLM-5.2 spent its whole budget inside a `<think>` block and hit the limit before any answer, leaving the user with a ~160KB reasoning dump cut off mid-code, saved as a "finished" reply (e.g. `conversation/6a3bcad5a78f58a9cd8f8def`). Reproduced live: the model streamed only `reasoning_content`, emitted zero `content`, and terminated with `finish_reason: "length"`.

## Fix

- The stream adapters (`openAIChatToTextGenerationStream`, `openAICompletionToTextGenerationStream`, non-streaming single adapter) mark the final output `truncated: true` when `finish_reason === "length"`.
- `generate.ts` forces `interrupted = true` on a truncated output and logs a `warn`. It also gates the completion handling on `generated_text != null` (not truthiness) so empty truncated completions (hidden-reasoning models, tiny budgets) are still flagged + logged rather than silently dropped.
- The MCP flow (`runMcpFlow.ts`) tracks `finish_reason` and sets `interrupted` on its `FinalAnswer` accordingly, with a warning.
- Adds adapter tests (length vs stop, and the empty length-terminated stream).

This makes the persisted `interrupted` flag and the logs truthful. chat-ui has no dedicated "response was cut off" banner today, so this is backend correctness + ops visibility; a visible banner/continue affordance gated on this signal is a sensible follow-up.

## Test plan
- [x] `npx vitest run src/lib/server/endpoints/openai/openAIChatToTextGenerationStream.spec.ts` (3 passing)
- [x] `npm run check` (0 errors); ESLint + Prettier clean

Split from #2383 (this is the code half).