### PR TITLE
build(ci): drop github-slug-action, compute short SHA inline

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -63,7 +63,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@797d68864753cbceedc271349d402da4590e6302 # v4.5.0
+        run: echo "GITHUB_SHA_SHORT=${GITHUB_SHA:0:7}" >> $GITHUB_ENV
 
       - name: Build and Publish Docker Image with DB
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
@@ -124,7 +124,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@797d68864753cbceedc271349d402da4590e6302 # v4.5.0
+        run: echo "GITHUB_SHA_SHORT=${GITHUB_SHA:0:7}" >> $GITHUB_ENV
 
       - name: Build and Publish Docker Image without DB
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -27,7 +27,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4.5.0
+        run: echo "GITHUB_EVENT_PULL_REQUEST_HEAD_SHA_SHORT=$(echo ${{ github.event.pull_request.head.sha }} | cut -c 1-7)" >> $GITHUB_ENV
 
       - name: Set GITHUB_SHA_SHORT from PR
         if: env.GITHUB_EVENT_PULL_REQUEST_HEAD_SHA_SHORT != null

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -30,7 +30,7 @@ jobs:
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@797d68864753cbceedc271349d402da4590e6302 # v4.5.0
+        run: echo "GITHUB_SHA_SHORT=${GITHUB_SHA:0:7}" >> $GITHUB_ENV
 
       - name: Build and Publish HuggingChat image
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
@@ -54,7 +54,7 @@ jobs:
     needs: ["build-and-publish-huggingchat-image"]
     steps:
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@797d68864753cbceedc271349d402da4590e6302 # v4.5.0
+        run: echo "GITHUB_SHA_SHORT=${GITHUB_SHA:0:7}" >> $GITHUB_ENV
 
       - name: Gen values
         run: |


### PR DESCRIPTION
## Problem
`rlespinasse/github-slug-action` is dependent on other actions from its author, namely, `rlespinasse/slugify-value` and `rlespinasse/shortify-git-version`. Notably, the underlying actions are referenced by version tag, not by commit hash.

Not only does this mean the action has a significant footprint, it is also susceptible to supply-chain attacks through the version tagging of malicious actions, even by commit pinning `rlespinasse/github-slug-action`, since it does not pin the underlying actions.

Given that the action is only used to populate one particular env var, it might make sense to replace it with shell cmds.

## Solution

Replace `rlespinasse/github-slug-action` with inline shell to compute the 7-char short SHA, removing a CI supply-chain dependency.

- `build-image` and `deploy-prod` use `${GITHUB_SHA:0:7}` (the auto-injected default env var, no template interpolation)
- `deploy-dev` keeps the shell approach off github.event.pull_request.head.sha, since on pull_request triggers `GITHUB_SHA` is the merge commit, not the PR head