### PR TITLE
Fix chat auto-scroll on touch devices (iOS)

### DIFF
--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -337,7 +337,11 @@
 				last?.content === "";
 
 			if (userJustSentMessage) {
-				scrollBehavior = "smooth";
+				// Touch devices (iOS): a smooth programmatic scroll is suppressed during
+				// touch/momentum and only animates once the gesture/stream settle — i.e. the
+				// view visibly scrolls up right as the reply finishes. An instant scroll snaps
+				// to the bottom (revealing the freshly inflated spacer) immediately on send.
+				scrollBehavior = window.matchMedia("(pointer: coarse)").matches ? "instant" : "smooth";
 				forceReattach++;
 				// Only activate dynamic spacer after the first exchange
 				// (first user+assistant pair scrolls normally)

--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -341,7 +341,9 @@
 				// touch/momentum and only animates once the gesture/stream settle — i.e. the
 				// view visibly scrolls up right as the reply finishes. An instant scroll snaps
 				// to the bottom (revealing the freshly inflated spacer) immediately on send.
-				scrollBehavior = window.matchMedia("(pointer: coarse)").matches ? "instant" : "smooth";
+				// `any-pointer: coarse` so hybrid devices (touch laptop, iPad + trackpad) that
+				// can still touch-scroll snap instantly even when the primary pointer is fine.
+				scrollBehavior = window.matchMedia("(any-pointer: coarse)").matches ? "instant" : "smooth";
 				forceReattach++;
 				// Only activate dynamic spacer after the first exchange
 				// (first user+assistant pair scrolls normally)


### PR DESCRIPTION
## Summary
Fixes an issue where the chat window would not scroll to the bottom immediately when a user sends a message on touch devices (iOS). The smooth scroll animation was being suppressed during touch/momentum gestures, causing the UI to appear unresponsive until the gesture settled.

## Changes
- Modified the `scrollBehavior` assignment in `ChatWindow.svelte` to detect touch devices using `window.matchMedia("(pointer: coarse)")` and use `"instant"` scroll on touch devices instead of `"smooth"`
- Added explanatory comments documenting the iOS-specific behavior where programmatic smooth scrolls are deferred until touch gestures complete, whereas instant scrolls snap immediately to reveal the new content

## Implementation Details
The fix uses the CSS Media Queries `pointer: coarse` feature to detect touch input devices. On touch devices, an instant scroll snaps to the bottom immediately when the user sends a message, revealing the freshly inflated spacer and providing immediate visual feedback. On pointer devices (mouse/trackpad), the smooth scroll animation is preserved for a better visual experience.

https://claude.ai/code/session_01DZA6zBsc61PSuo8kg4yRB7