### PR TITLE
perf(chat): share a markdown worker pool instead of one worker per message

### DIFF
--- a/src/lib/components/chat/MarkdownRenderer.svelte
+++ b/src/lib/components/chat/MarkdownRenderer.svelte
@@ -1,10 +1,14 @@
 <script lang="ts">
-	import { fallbackBlocks, processBlocks, type BlockToken } from "$lib/utils/marked";
-	import MarkdownWorker from "$lib/workers/markdownWorker?worker";
+	import { fallbackBlocks, type BlockToken } from "$lib/utils/marked";
+	import {
+		acquireMarkdownClientId,
+		cancelMarkdownClient,
+		renderMarkdownBlocks,
+	} from "$lib/utils/markdownWorkerPool";
 	import MarkdownBlock from "./MarkdownBlock.svelte";
 	import { browser } from "$app/environment";
 
-	import { onMount, onDestroy } from "svelte";
+	import { onDestroy } from "svelte";
 	import { updateDebouncer } from "$lib/utils/updates";
 
 	interface Props {
@@ -16,13 +20,15 @@
 	let { content, sources = [], loading = false }: Props = $props();
 
 	// Lightweight blocks used for SSR and the initial client render. Full markdown
-	// rendering is deferred to the worker (or async processBlocks) on mount, so the
-	// heavy synchronous pipeline never runs on the server event loop. See fallbackBlocks.
+	// rendering is deferred to the shared worker pool (or async processBlocks fallback)
+	// on the client, so the heavy synchronous pipeline never runs on the server event
+	// loop. See fallbackBlocks.
 	let fallback = $derived(fallbackBlocks(content));
 	let workerBlocks: BlockToken[] | null = $state(null);
 	let blocks = $derived(workerBlocks ?? fallback);
 
-	let worker: Worker | null = null;
+	// Stable id so the pool can coalesce this instance's successive (streaming) renders.
+	const clientId = acquireMarkdownClientId();
 	let latestRequestId = 0;
 
 	function handleBlocks(result: BlockToken[], requestId: number) {
@@ -33,36 +39,12 @@
 
 	$effect(() => {
 		if (!browser) return;
-
-		const requestId = ++latestRequestId;
-
-		if (worker) {
-			updateDebouncer.startRender();
-			worker.postMessage({ type: "process", content, sources, requestId, streaming: loading });
-			return;
-		}
-
-		(async () => {
-			updateDebouncer.startRender();
-			const processed = await processBlocks(content, sources, loading);
-			handleBlocks(processed, requestId);
-		})();
-	});
-
-	onMount(() => {
-		if (typeof Worker !== "undefined") {
-			worker = new MarkdownWorker();
-			worker.onmessage = (event: MessageEvent) => {
-				const data = event.data as { type?: string; blocks?: BlockToken[]; requestId?: number };
-				if (data?.type !== "processed" || !data.blocks || data.requestId === undefined) return;
-				handleBlocks(data.blocks, data.requestId);
-			};
-		}
+		updateDebouncer.startRender();
+		latestRequestId = renderMarkdownBlocks(clientId, content, sources, loading, handleBlocks);
 	});
 
 	onDestroy(() => {
-		worker?.terminate();
-		worker = null;
+		cancelMarkdownClient(clientId);
 	});
 </script>
 

--- a/src/lib/utils/markdownWorkerPool.ts
+++ b/src/lib/utils/markdownWorkerPool.ts
@@ -1,0 +1,154 @@
+import { browser } from "$app/environment";
+import MarkdownWorker from "$lib/workers/markdownWorker?worker";
+import { processBlocks, type BlockToken } from "$lib/utils/marked";
+
+type Source = { title?: string; link: string };
+type ResultCallback = (blocks: BlockToken[], requestId: number) => void;
+
+interface Job {
+	clientId: number;
+	requestId: number;
+	content: string;
+	sources: Source[];
+	streaming: boolean;
+	onResult: ResultCallback;
+}
+
+// The full markdown pipeline (katex + highlight.js + marked + DOMPurify) is loaded into
+// every worker's JS VM, so the pool is deliberately tiny: a couple of workers shared
+// across every MarkdownRenderer instance, instead of one worker per message. The old
+// per-instance design spawned hundreds of worker VMs in a long thread, which exhausted
+// mobile WebKit's ~2 GB per-tab renderer memory cap and got the tab jetsam-killed.
+const POOL_SIZE = browser ? Math.max(1, Math.min(2, (navigator.hardwareConcurrency || 2) - 1)) : 0;
+
+const canUseWorker = browser && typeof Worker !== "undefined";
+
+let nextRequestId = 1;
+let nextClientId = 1;
+
+const idle: Worker[] = [];
+let createdWorkers = 0;
+
+// Latest queued job per client. Older queued jobs for the same client are coalesced away
+// (only the most recent content matters), which keeps a fast-streaming message from
+// flooding the pool with superseded work.
+const pending = new Map<number, Job>();
+const queue: number[] = [];
+const queued = new Set<number>();
+
+// Jobs handed to a worker and awaiting its reply, keyed by requestId.
+const inFlight = new Map<
+	number,
+	{ clientId: number; onResult: ResultCallback; cancelled: boolean }
+>();
+// Clients currently occupying a worker. Used to serialize per client so a newer request
+// never races ahead of (or runs concurrently with) the one already in flight.
+const inFlightClients = new Set<number>();
+
+function ensureWorker() {
+	if (idle.length > 0 || createdWorkers >= POOL_SIZE) return;
+	const worker = new MarkdownWorker();
+	worker.onmessage = (event: MessageEvent) => onWorkerMessage(worker, event);
+	createdWorkers++;
+	idle.push(worker);
+}
+
+function onWorkerMessage(worker: Worker, event: MessageEvent) {
+	const data = event.data as { type?: string; blocks?: BlockToken[]; requestId?: number };
+	if (data?.type !== "processed" || data.requestId === undefined) return;
+
+	idle.push(worker);
+	const entry = inFlight.get(data.requestId);
+	inFlight.delete(data.requestId);
+	if (entry) {
+		inFlightClients.delete(entry.clientId);
+		if (!entry.cancelled) entry.onResult(data.blocks ?? [], data.requestId);
+	}
+	pump();
+}
+
+function pump() {
+	while (queue.length > 0) {
+		if (idle.length === 0) ensureWorker();
+		if (idle.length === 0) return; // every worker busy and pool at capacity
+		// First queued client that isn't already running (one job at a time per client).
+		const idx = queue.findIndex((clientId) => !inFlightClients.has(clientId));
+		if (idx === -1) return; // all waiting clients are mid-flight; wait for a reply
+		const clientId = queue.splice(idx, 1)[0];
+		queued.delete(clientId);
+		const job = pending.get(clientId);
+		pending.delete(clientId);
+		if (!job) continue;
+
+		const worker = idle.pop() as Worker;
+		inFlightClients.add(clientId);
+		inFlight.set(job.requestId, { clientId, onResult: job.onResult, cancelled: false });
+		worker.postMessage({
+			type: "process",
+			content: job.content,
+			sources: job.sources,
+			requestId: job.requestId,
+			streaming: job.streaming,
+		});
+	}
+}
+
+/** Stable id for one MarkdownRenderer instance, used to coalesce its successive renders. */
+export function acquireMarkdownClientId(): number {
+	return nextClientId++;
+}
+
+/**
+ * Queue a markdown render for `clientId` on the shared worker pool. Returns the requestId;
+ * the caller should treat only the highest requestId it has issued as current and ignore
+ * late/stale callbacks. Falls back to async main-thread processing when workers aren't
+ * available (SSR, or a browser without Worker support).
+ */
+export function renderMarkdownBlocks(
+	clientId: number,
+	content: string,
+	sources: Source[],
+	streaming: boolean,
+	onResult: ResultCallback
+): number {
+	const requestId = nextRequestId++;
+
+	if (!canUseWorker) {
+		void processBlocks(content, sources, streaming).then((blocks) => onResult(blocks, requestId));
+		return requestId;
+	}
+
+	pending.set(clientId, { clientId, requestId, content, sources, streaming, onResult });
+	if (!queued.has(clientId)) {
+		queued.add(clientId);
+		queue.push(clientId);
+	}
+	pump();
+	return requestId;
+}
+
+/** Drop any queued/in-flight work for a client that is going away (component destroyed). */
+export function cancelMarkdownClient(clientId: number): void {
+	pending.delete(clientId);
+	if (queued.delete(clientId)) {
+		const i = queue.indexOf(clientId);
+		if (i !== -1) queue.splice(i, 1);
+	}
+	for (const entry of inFlight.values()) {
+		if (entry.clientId === clientId) entry.cancelled = true;
+	}
+}
+
+// Debug hook: read `__mdWorkerPool.workers()` in the console to confirm the live worker
+// count stays at most POOL_SIZE regardless of conversation length. Before pooling, that
+// count equaled the number of mounted MarkdownRenderer instances (hundreds in a long
+// thread), which is what exhausted the mobile renderer's memory.
+if (browser) {
+	(globalThis as unknown as { __mdWorkerPool?: unknown }).__mdWorkerPool = {
+		poolSize: POOL_SIZE,
+		workers: () => createdWorkers,
+		idle: () => idle.length,
+		queued: () => queue.length,
+		inFlight: () => inFlight.size,
+	};
+}

--- a/src/lib/utils/markdownWorkerPool.ts
+++ b/src/lib/utils/markdownWorkerPool.ts
@@ -1,6 +1,6 @@
 import { browser } from "$app/environment";
 import MarkdownWorker from "$lib/workers/markdownWorker?worker";
-import { processBlocks, type BlockToken } from "$lib/utils/marked";
+import { fallbackBlocks, processBlocks, type BlockToken } from "$lib/utils/marked";
 
 type Source = { title?: string; link: string };
 type ResultCallback = (blocks: BlockToken[], requestId: number) => void;
@@ -14,6 +14,15 @@ interface Job {
 	onResult: ResultCallback;
 }
 
+interface InFlight {
+	requestId: number;
+	clientId: number;
+	content: string;
+	worker: Worker;
+	onResult: ResultCallback;
+	cancelled: boolean;
+}
+
 // The full markdown pipeline (katex + highlight.js + marked + DOMPurify) is loaded into
 // every worker's JS VM, so the pool is deliberately tiny: a couple of workers shared
 // across every MarkdownRenderer instance, instead of one worker per message. The old
@@ -21,7 +30,21 @@ interface Job {
 // mobile WebKit's ~2 GB per-tab renderer memory cap and got the tab jetsam-killed.
 const POOL_SIZE = browser ? Math.max(1, Math.min(2, (navigator.hardwareConcurrency || 2) - 1)) : 0;
 
-const canUseWorker = browser && typeof Worker !== "undefined";
+const hasWorkerSupport = browser && typeof Worker !== "undefined";
+
+// Flips permanently to true if the Worker constructor throws (strict CSP `worker-src`,
+// sandboxed iframe, Safari Lockdown Mode, quota denial) or if workers keep dying on
+// startup. `typeof Worker !== "undefined"` only proves the global exists, not that
+// construction succeeds, so we also need this runtime guard. Once set, every render
+// degrades to the async main-thread path instead of going silent on the fallback.
+let workersBroken = false;
+const canUseWorker = () => hasWorkerSupport && !workersBroken;
+
+// A worker that dies before ever replying triggers a recreate; cap how many times in a
+// row that can happen before we give up on workers entirely (avoids a recreate storm if
+// the worker module itself fails to initialize). Reset on any successful reply.
+const MAX_CONSECUTIVE_DEATHS = 3;
+let consecutiveDeaths = 0;
 
 let nextRequestId = 1;
 let nextClientId = 1;
@@ -37,26 +60,97 @@ const queue: number[] = [];
 const queued = new Set<number>();
 
 // Jobs handed to a worker and awaiting its reply, keyed by requestId.
-const inFlight = new Map<
-	number,
-	{ clientId: number; onResult: ResultCallback; cancelled: boolean }
->();
+const inFlight = new Map<number, InFlight>();
 // Clients currently occupying a worker. Used to serialize per client so a newer request
 // never races ahead of (or runs concurrently with) the one already in flight.
 const inFlightClients = new Set<number>();
 
+function runOnMainThread(job: {
+	content: string;
+	sources: Source[];
+	streaming: boolean;
+	requestId: number;
+	onResult: ResultCallback;
+}) {
+	void processBlocks(job.content, job.sources, job.streaming)
+		.then((blocks) => job.onResult(blocks, job.requestId))
+		// Symmetry with the worker path ("never go silent"): on a parse error still
+		// resolve the render with the lightweight fallback instead of leaking an
+		// unhandled rejection and stranding the renderer on escaped plaintext.
+		.catch(() => job.onResult(fallbackBlocks(job.content), job.requestId));
+}
+
+// Workers became unavailable: flush everything still queued to the main-thread path so no
+// render is left stranded.
+function drainToMainThread() {
+	for (const job of pending.values()) runOnMainThread(job);
+	pending.clear();
+	queue.length = 0;
+	queued.clear();
+}
+
 function ensureWorker() {
 	if (idle.length > 0 || createdWorkers >= POOL_SIZE) return;
-	const worker = new MarkdownWorker();
+	let worker: Worker;
+	try {
+		worker = new MarkdownWorker();
+	} catch {
+		// Construction itself failed (CSP / Lockdown Mode / sandbox). Give up on workers
+		// for the session and degrade gracefully.
+		workersBroken = true;
+		drainToMainThread();
+		return;
+	}
 	worker.onmessage = (event: MessageEvent) => onWorkerMessage(worker, event);
+	worker.onerror = () => handleWorkerDeath(worker);
+	worker.onmessageerror = () => handleWorkerDeath(worker);
 	createdWorkers++;
 	idle.push(worker);
+}
+
+// Detach a worker from the pool, freeing its slot so a replacement can be created. Returns
+// the in-flight entries that were attached to it for the caller to resolve or discard.
+function dropWorker(worker: Worker): InFlight[] {
+	const i = idle.indexOf(worker);
+	if (i !== -1) idle.splice(i, 1);
+	if (createdWorkers > 0) createdWorkers--;
+	const orphaned: InFlight[] = [];
+	for (const entry of inFlight.values()) {
+		if (entry.worker === worker) orphaned.push(entry);
+	}
+	for (const entry of orphaned) {
+		inFlight.delete(entry.requestId);
+		inFlightClients.delete(entry.clientId);
+	}
+	return orphaned;
+}
+
+// A worker crashed without replying (top-level error, structured-clone messageerror, or
+// the OS reclaiming it). Don't strand its render or wedge the pool: deliver the fallback,
+// free the slot, and retry queued work on a fresh worker.
+function handleWorkerDeath(worker: Worker) {
+	worker.onmessage = null;
+	worker.onerror = null;
+	worker.onmessageerror = null;
+	const orphaned = dropWorker(worker);
+	worker.terminate();
+	for (const entry of orphaned) {
+		if (!entry.cancelled) entry.onResult(fallbackBlocks(entry.content), entry.requestId);
+	}
+	consecutiveDeaths++;
+	if (consecutiveDeaths >= MAX_CONSECUTIVE_DEATHS) {
+		workersBroken = true;
+		drainToMainThread();
+		return;
+	}
+	pump();
 }
 
 function onWorkerMessage(worker: Worker, event: MessageEvent) {
 	const data = event.data as { type?: string; blocks?: BlockToken[]; requestId?: number };
 	if (data?.type !== "processed" || data.requestId === undefined) return;
 
+	consecutiveDeaths = 0;
 	idle.push(worker);
 	const entry = inFlight.get(data.requestId);
 	inFlight.delete(data.requestId);
@@ -70,7 +164,7 @@ function onWorkerMessage(worker: Worker, event: MessageEvent) {
 function pump() {
 	while (queue.length > 0) {
 		if (idle.length === 0) ensureWorker();
-		if (idle.length === 0) return; // every worker busy and pool at capacity
+		if (idle.length === 0) return; // every worker busy and pool at capacity (or broken)
 		// First queued client that isn't already running (one job at a time per client).
 		const idx = queue.findIndex((clientId) => !inFlightClients.has(clientId));
 		if (idx === -1) return; // all waiting clients are mid-flight; wait for a reply
@@ -82,7 +176,14 @@ function pump() {
 
 		const worker = idle.pop() as Worker;
 		inFlightClients.add(clientId);
-		inFlight.set(job.requestId, { clientId, onResult: job.onResult, cancelled: false });
+		inFlight.set(job.requestId, {
+			requestId: job.requestId,
+			clientId,
+			content: job.content,
+			worker,
+			onResult: job.onResult,
+			cancelled: false,
+		});
 		worker.postMessage({
 			type: "process",
 			content: job.content,
@@ -102,7 +203,7 @@ export function acquireMarkdownClientId(): number {
  * Queue a markdown render for `clientId` on the shared worker pool. Returns the requestId;
  * the caller should treat only the highest requestId it has issued as current and ignore
  * late/stale callbacks. Falls back to async main-thread processing when workers aren't
- * available (SSR, or a browser without Worker support).
+ * available (SSR, no Worker support, or workers that failed at runtime).
  */
 export function renderMarkdownBlocks(
 	clientId: number,
@@ -113,8 +214,8 @@ export function renderMarkdownBlocks(
 ): number {
 	const requestId = nextRequestId++;
 
-	if (!canUseWorker) {
-		void processBlocks(content, sources, streaming).then((blocks) => onResult(blocks, requestId));
+	if (!canUseWorker()) {
+		runOnMainThread({ content, sources, streaming, requestId, onResult });
 		return requestId;
 	}
 
@@ -134,8 +235,27 @@ export function cancelMarkdownClient(clientId: number): void {
 		const i = queue.indexOf(clientId);
 		if (i !== -1) queue.splice(i, 1);
 	}
+
+	// If a render is already running for this client, abort it: the component is gone, so
+	// terminate its worker (truly stopping the obsolete parse, rather than letting it hold
+	// a scarce pool slot) and free the slot. A fresh worker is created lazily on the next
+	// pump for whatever view is now active. At most one in-flight job per client (renders
+	// are serialized per client), so this terminates at most one worker.
+	let abortedWorker: Worker | undefined;
 	for (const entry of inFlight.values()) {
-		if (entry.clientId === clientId) entry.cancelled = true;
+		if (entry.clientId === clientId) {
+			entry.cancelled = true;
+			abortedWorker = entry.worker;
+			break;
+		}
+	}
+	if (abortedWorker) {
+		abortedWorker.onmessage = null;
+		abortedWorker.onerror = null;
+		abortedWorker.onmessageerror = null;
+		dropWorker(abortedWorker);
+		abortedWorker.terminate();
+		pump();
 	}
 }
 
@@ -150,5 +270,6 @@ if (browser) {
 		idle: () => idle.length,
 		queued: () => queue.length,
 		inFlight: () => inFlight.size,
+		broken: () => workersBroken,
 	};
 }

--- a/src/lib/utils/marked.ts
+++ b/src/lib/utils/marked.ts
@@ -436,6 +436,21 @@ type TextToken = {
 
 const blockCache = new Map<string, BlockToken>();
 
+// The markdown worker pool keeps a small number of long-lived workers alive for the whole
+// session, so their blockCache no longer dies with a per-message worker. Bound it (Map
+// preserves insertion order, so deleting the first key evicts the oldest entry) to keep
+// memory flat across very long / many conversations. Comfortably larger than any single
+// conversation, so normal usage still gets full cache hits.
+const BLOCK_CACHE_MAX = 2000;
+
+function rememberBlock(key: string, block: BlockToken) {
+	blockCache.set(key, block);
+	if (blockCache.size > BLOCK_CACHE_MAX) {
+		const oldest = blockCache.keys().next().value;
+		if (oldest !== undefined) blockCache.delete(oldest);
+	}
+}
+
 function cacheKey(index: number, blockContent: string, sources: SimpleSource[]) {
 	const sourceKey = sources.map((s) => s.link).join("|");
 	return `${index}-${hashString(blockContent)}|${sourceKey}`;
@@ -534,7 +549,7 @@ export async function processBlocks(
 				content: blockContent,
 				tokens,
 			};
-			blockCache.set(key, block);
+			rememberBlock(key, block);
 			return block;
 		})
 	);
@@ -594,7 +609,7 @@ export function processBlocksSync(
 			content: blockContent,
 			tokens,
 		};
-		blockCache.set(key, block);
+		rememberBlock(key, block);
 		return block;
 	});
 }

--- a/src/lib/workers/markdownWorker.ts
+++ b/src/lib/workers/markdownWorker.ts
@@ -3,7 +3,7 @@ type SimpleSource = {
 	title?: string;
 	link: string;
 };
-import { processBlocks, type BlockToken } from "$lib/utils/marked";
+import { processBlocks, fallbackBlocks, type BlockToken } from "$lib/utils/marked";
 
 export type IncomingMessage = {
 	type: "process";
@@ -19,44 +19,28 @@ export type OutgoingMessage = {
 	requestId: number;
 };
 
-// Flag to track if the worker is currently processing a message
-let isProcessing = false;
-
-// Buffer to store the latest incoming message
-let latestMessage: IncomingMessage | null = null;
-
-// Helper function to safely handle the latest message
-async function processMessage() {
-	if (latestMessage) {
-		const nextMessage = latestMessage;
-
-		latestMessage = null;
-		isProcessing = true;
-
-		try {
-			const { content, sources, requestId, streaming } = nextMessage;
-			const processedBlocks = await processBlocks(content, sources, streaming ?? false);
-			postMessage(
-				JSON.parse(JSON.stringify({ type: "processed", blocks: processedBlocks, requestId }))
-			);
-		} finally {
-			isProcessing = false;
-
-			// After processing, check if a new message was buffered
-			await new Promise((resolve) => setTimeout(resolve, 100));
-			processMessage();
-		}
-	}
-}
-
-onmessage = (event) => {
-	if (event.data.type !== "process") {
+// Stateless request/response. All flow control (one job at a time per worker, per-client
+// coalescing) lives in the shared pool (markdownWorkerPool.ts), so the worker just
+// processes whatever it is handed and replies once. The pool never posts a second job to
+// a busy worker, hence no internal queue/buffer here.
+onmessage = async (event) => {
+	const data = event.data as IncomingMessage;
+	if (data.type !== "process") {
 		return;
 	}
 
-	latestMessage = event.data as IncomingMessage;
+	const { content, sources, requestId, streaming } = data;
 
-	if (!isProcessing && latestMessage) {
-		processMessage();
+	let blocks: BlockToken[];
+	try {
+		blocks = await processBlocks(content, sources ?? [], streaming ?? false);
+	} catch {
+		// Never strand the pool: it waits for a reply to free this worker, so on failure
+		// degrade to the lightweight fallback rendering instead of going silent.
+		blocks = fallbackBlocks(content);
 	}
+
+	postMessage(
+		JSON.parse(JSON.stringify({ type: "processed", blocks, requestId })) as OutgoingMessage
+	);
 };

--- a/src/lib/workers/markdownWorker.ts
+++ b/src/lib/workers/markdownWorker.ts
@@ -40,7 +40,18 @@ onmessage = async (event) => {
 		blocks = fallbackBlocks(content);
 	}
 
-	postMessage(
-		JSON.parse(JSON.stringify({ type: "processed", blocks, requestId })) as OutgoingMessage
-	);
+	try {
+		postMessage(
+			JSON.parse(JSON.stringify({ type: "processed", blocks, requestId })) as OutgoingMessage
+		);
+	} catch {
+		// A block somehow isn't JSON/structured-clone safe. Reply with the fallback so the
+		// pool always gets a reply and the shared worker is never left wedged. fallbackBlocks
+		// output is plain data and always serializes.
+		postMessage({
+			type: "processed",
+			blocks: fallbackBlocks(content),
+			requestId,
+		} as OutgoingMessage);
+	}
 };


### PR DESCRIPTION
## Problem

Long conversations OOM-crash mobile Safari ("A problem repeatedly occurred"): the WebContent renderer process is jetsam-killed at its ~2 GB per-tab cap. PR #2391 (`content-visibility`) did not fix it and was reverted.

## Root cause

`MarkdownRenderer` spawned a dedicated Web Worker on every mount (`new MarkdownWorker()`), with no pooling. It is mounted per text unit, not per message: each assistant message renders one per text unit (`ChatMessage`), plus up to two more for the reasoning panel (`OpenReasoningResults`). A long thread therefore creates hundreds of workers.

Every worker loads the full markdown pipeline into its own JS VM: katex + mhchem, highlight.js core + 20 language grammars, marked, htmlparser2, isomorphic-dompurify. On iOS these dedicated workers are threads inside the same WebContent process, so all those heaps and thread stacks count against the same ~2 GB cap. The cost scales linearly with conversation length, which matches the symptom.

This is also why earlier fixes missed it. `content-visibility` only skips layout/paint of DOM, the workers stay alive while the component is mounted regardless of on/off-screen. And the cost is largely hidden from desktop DevTools' "JS heap" number (which measures the main page heap, not the sum of worker heaps), which is why desktop looked fine at ~130 MB.

## Fix

Share a tiny pool of workers (at most 2, `min(2, cores - 1)`) across every `MarkdownRenderer` instead of one per instance. Requests are routed by a global requestId and results dispatched back to each instance's callback.

- **New `src/lib/utils/markdownWorkerPool.ts`**: the pool. Per-client coalescing (only a client's latest queued render is kept, so a fast-streaming message cannot flood the pool with superseded work) and per-client serialization (a newer request never races ahead of, or runs concurrently with, that client's in-flight one). The old single-`latestMessage` worker buffer assumed one client and would drop other clients' jobs, this does not.
- **`markdownWorker.ts`**: simplified to stateless request/response (the pool owns all flow control). Added a try/catch that degrades to `fallbackBlocks` on parse failure, so a thrown job cannot strand a pooled worker.
- **`MarkdownRenderer.svelte`**: drops the per-instance worker, acquires a clientId, submits via the pool, cancels on destroy. The SSR / no-Worker fallback to async `processBlocks` is preserved.
- **`marked.ts`**: bounds the worker-side `blockCache` (FIFO cap 2000), since pooled workers now live for the whole session instead of dying with each message.

Net effect: hundreds of worker VMs collapse to at most 2, and the heavy libraries load twice total instead of once per message.

## Validation

- `svelte-check`: 0 errors (1 pre-existing, unrelated warning). `marked.spec.ts`: 35/35 pass. prettier + eslint clean.
- Local smoke test (Chrome, dev build): the pool loads in-app, stays capped at 2 workers with multiple concurrent clients, and round-trips markdown through the shared workers with highlight.js and KaTeX both rendering. In-flight count drains to 0, no console errors.
- Debug hook `window.__mdWorkerPool.workers()` reports the live worker count. It stays at most 2 regardless of conversation length (it previously equaled the mounted `MarkdownRenderer` count, in the hundreds on a long thread). Useful for confirming on a device via Safari Web Inspector.
- The client `.svelte.test.ts` (opt-in chromium harness) could not boot locally (pre-existing flaky harness), it will run in CI.

## Notes

- Client-side change to the markdown rendering path only, no markup or server changes.
- `content-visibility` is complementary and can be reintroduced separately, but this addresses the actual memory bottleneck.
