### PR TITLE
fix(layout): silence spurious error

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -2,6 +2,7 @@
 	import "../styles/main.css";
 
 	import { onDestroy, onMount } from "svelte";
+	import { browser } from "$app/environment";
 	import { goto } from "$app/navigation";
 	import { base } from "$app/paths";
 	import { page } from "$app/state";
@@ -101,8 +102,25 @@
 		settings.set({ welcomeModalSeen: true });
 	}
 
+	// Global keyboard shortcut: New Chat (Ctrl/Cmd + Shift + O)
+	const onKeydown = (e: KeyboardEvent) => {
+		// Ignore when a modal has focus (app is inert)
+		const appEl = document.getElementById("app");
+		if (appEl?.hasAttribute("inert")) return;
+
+		const oPressed = e.key?.toLowerCase() === "o";
+		const metaOrCtrl = e.metaKey || e.ctrlKey;
+		if (oPressed && e.shiftKey && metaOrCtrl) {
+			e.preventDefault();
+			isAborted.set(true);
+			if (requireAuthUser()) return;
+			goto(`${base}/`, { invalidateAll: true });
+		}
+	};
+
 	onDestroy(() => {
 		clearTimeout(errorToastTimeout);
+		if (browser) window.removeEventListener("keydown", onKeydown, { capture: true });
 	});
 
 	$effect(() => {
@@ -161,24 +179,7 @@
 			});
 		}
 
-		// Global keyboard shortcut: New Chat (Ctrl/Cmd + Shift + O)
-		const onKeydown = (e: KeyboardEvent) => {
-			// Ignore when a modal has focus (app is inert)
-			const appEl = document.getElementById("app");
-			if (appEl?.hasAttribute("inert")) return;
-
-			const oPressed = e.key?.toLowerCase() === "o";
-			const metaOrCtrl = e.metaKey || e.ctrlKey;
-			if (oPressed && e.shiftKey && metaOrCtrl) {
-				e.preventDefault();
-				isAborted.set(true);
-				if (requireAuthUser()) return;
-				goto(`${base}/`, { invalidateAll: true });
-			}
-		};
-
 		window.addEventListener("keydown", onKeydown, { capture: true });
-		onDestroy(() => window.removeEventListener("keydown", onKeydown, { capture: true }));
 	});
 
 	let mobileNavTitle = $derived(


### PR DESCRIPTION
This pull request refactors how the global keyboard shortcut for "New Chat" (Ctrl/Cmd + Shift + O) is handled in the `src/routes/+layout.svelte` file. The main change moves the definition of the `onKeydown` event handler outside of a reactive statement and ensures proper cleanup of the event listener when the component is destroyed.

**Keyboard shortcut handling improvements:**

* Moved the `onKeydown` keyboard event handler definition to the top-level of the script, outside of the reactive `$effect` block, to prevent redefinition on each reactive run.
* Ensured the global "New Chat" keyboard shortcut (Ctrl/Cmd + Shift + O) is consistently registered and properly cleaned up by adding the event listener in the `$effect` block and removing it in the `onDestroy` lifecycle hook. [[1]](diffhunk://#diff-cc69d6a97e4f62578028d872b8d5032f2786fe1eaa65735429286b375234168dR104-R122) [[2]](diffhunk://#diff-cc69d6a97e4f62578028d872b8d5032f2786fe1eaa65735429286b375234168dL164-L181)

Fixes #2394 