### PR TITLE
Send artifact error fix request directly instead of filling the input

### DIFF
--- a/src/lib/components/HtmlPreviewModal.svelte
+++ b/src/lib/components/HtmlPreviewModal.svelte
@@ -104,7 +104,7 @@
 				class="fixed right-4 bottom-4 z-50 btn flex items-center gap-2 rounded-full border-2 border-red-500/60 bg-red-800/90 px-4 py-1.5 text-sm text-white shadow-lg"
 				title="Send error to chat"
 				onclick={() => {
-					pendingChatInput.set(composeText());
+					pendingChatInput.set({ text: composeText() });
 					onclose?.();
 				}}
 			>

--- a/src/lib/components/chat/ArtifactPanel.svelte
+++ b/src/lib/components/chat/ArtifactPanel.svelte
@@ -284,11 +284,13 @@
 	function askToFixErrors() {
 		const lines = errors.map((e, i) => `${i + 1}. ${e.message}${e.stack ? `\n${e.stack}` : ""}`);
 		const summary = lines[0] ?? "Unknown error";
-		pendingChatInput.set(
-			errors.length > 1
-				? `it's not working: ${summary} (+${errors.length - 1} more) - can you fix it?`
-				: `it's not working: ${summary} - can you fix it?`
-		);
+		pendingChatInput.set({
+			text:
+				errors.length > 1
+					? `it's not working: ${summary} (+${errors.length - 1} more) - can you fix it?`
+					: `it's not working: ${summary} - can you fix it?`,
+			submit: true,
+		});
 	}
 
 	// ----- actions -----
@@ -605,7 +607,7 @@
 				<button
 					type="button"
 					class="btn flex items-center gap-1.5 rounded-full border border-red-300/60 bg-red-50 px-2.5 py-0.5 text-red-600 hover:bg-red-100 dark:border-red-500/40 dark:bg-red-500/10 dark:text-red-400 dark:hover:bg-red-500/20"
-					title="Send the error to the chat input"
+					title="Send the error to the chat"
 					onclick={askToFixErrors}
 				>
 					{errors.length} error{errors.length > 1 ? "s" : ""} — ask to fix

--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -148,7 +148,7 @@
 	let isTouchDevice = $derived(browser && navigator.maxTouchPoints > 0);
 
 	const handleSubmit = () => {
-		if (requireAuthUser() || loading || !draft) return;
+		if (requireAuthUser() || loading || isReadOnly || !draft) return;
 		tap();
 		onmessage?.(draft);
 		draft = "";
@@ -510,9 +510,12 @@
 			const { text, submit } = $pendingChatInput;
 			pendingChatInput.set(undefined);
 			draft = text;
-			// If handleSubmit bails (auth, generation in flight), the text stays
-			// in the input so nothing is lost
-			if (submit) handleSubmit();
+			// Submitting consumes the composer attachments, so files the user
+			// staged for another message must not be swept along by an
+			// auto-send: fall back to prefill and let them press send. Same if
+			// handleSubmit bails (auth, read-only, generation in flight) — the
+			// text stays in the input so nothing is lost.
+			if (submit && !files.length) handleSubmit();
 		}
 	});
 

--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -507,8 +507,12 @@
 
 	$effect(() => {
 		if ($pendingChatInput) {
-			draft = $pendingChatInput;
+			const { text, submit } = $pendingChatInput;
 			pendingChatInput.set(undefined);
+			draft = text;
+			// If handleSubmit bails (auth, generation in flight), the text stays
+			// in the input so nothing is lost
+			if (submit) handleSubmit();
 		}
 	});
 

--- a/src/lib/stores/pendingChatInput.ts
+++ b/src/lib/stores/pendingChatInput.ts
@@ -1,3 +1,9 @@
 import { writable } from "svelte/store";
 
-export const pendingChatInput = writable<string | undefined>(undefined);
+export interface PendingChatInput {
+	text: string;
+	/** Send the message immediately instead of only filling the chat input */
+	submit?: boolean;
+}
+
+export const pendingChatInput = writable<PendingChatInput | undefined>(undefined);


### PR DESCRIPTION
The artifact panel's "ask to fix" button used to only prefill the chat
input, leaving the user to press send. The pending chat input store now
carries an optional submit flag, and the artifact panel sets it so the
error message is sent immediately. If submission is blocked (auth needed,
generation in flight), the text stays in the input as before. The
fullscreen preview and code block preview keep the prefill behavior.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YXWhJSwjPnmtFisEwcbZ18