### PR TITLE
fix(message): properly config svelte-ignore

### DIFF
--- a/src/lib/components/chat/ChatMessage.svelte
+++ b/src/lib/components/chat/ChatMessage.svelte
@@ -399,7 +399,8 @@
 				</div>
 			{/if}
 
-			<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+			<!-- svelte-ignore a11y_no_static_element_interactions -->
+			<!-- svelte-ignore a11y_click_events_have_key_events -->
 			<div bind:this={contentEl} oncopy={handleCopy} onclick={handleContentClick}>
 				{#if isLast && loading && blocks.length === 0}
 					<IconLoading classNames="loading inline ml-2 first:ml-0" />


### PR DESCRIPTION
This pull request makes a minor update to the accessibility linting comments in the `ChatMessage.svelte` component. The change separates the `svelte-ignore` directives for better clarity and maintainability, but does not affect the component's functionality.