### PR TITLE
Handle OAuth callback in different browser with retry guard

### DIFF
--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -67,7 +67,7 @@ export const sameSite = z
 	.default(!secure || dev || config.ALLOW_INSECURE_COOKIES === "true" ? "lax" : "none")
 	.parse(config.COOKIE_SAMESITE === "" ? undefined : config.COOKIE_SAMESITE);
 
-function sanitizeReturnPath(path: string | undefined | null): string | undefined {
+export function sanitizeReturnPath(path: string | undefined | null): string | undefined {
 	if (!path) {
 		return undefined;
 	}
@@ -78,6 +78,32 @@ function sanitizeReturnPath(path: string | undefined | null): string | undefined
 		return undefined;
 	}
 	return path;
+}
+
+/**
+ * One-shot guard used when restarting the OAuth flow after a callback that was started
+ * in another browser (e.g. "Open in Safari" from an in-app browser). Prevents redirect loops.
+ */
+const loginRetryCookieName = "hfChat-loginRetry";
+
+export function hasLoginRetryCookie(cookies: Cookies): boolean {
+	return cookies.get(loginRetryCookieName) === "1";
+}
+
+export function setLoginRetryCookie(cookies: Cookies) {
+	cookies.set(loginRetryCookieName, "1", {
+		path: "/",
+		// `strict` would keep this cookie from being sent on the cross-site IdP -> callback
+		// navigation, which is exactly where the loop guard must be observable
+		sameSite: sameSite === "strict" ? "lax" : sameSite,
+		secure,
+		httpOnly: true,
+		maxAge: 5 * 60,
+	});
+}
+
+export function clearLoginRetryCookie(cookies: Cookies) {
+	cookies.delete(loginRetryCookieName, { path: "/" });
 }
 
 export function refreshSessionCookie(cookies: Cookies, sessionId: string) {

--- a/src/routes/login/callback/+server.ts
+++ b/src/routes/login/callback/+server.ts
@@ -64,16 +64,28 @@ export async function GET({ url, locals, cookies, request, getClientAddress }) {
 		if (!hasLoginRetryCookie(cookies)) {
 			setLoginRetryCookie(cookies);
 
-			// Best-effort recovery of the return path from the (unverified) state payload;
-			// it is re-sanitized to an in-app absolute path before use.
-			let next: string | undefined;
+			// Best-effort recovery of the return path and redirect URI from the (unverified)
+			// state payload; the path is re-sanitized and the redirect URI is checked against
+			// ALTERNATIVE_REDIRECT_URLS both here and again in triggerOauthFlow before use.
+			const retryParams = new URLSearchParams();
 			try {
-				next = sanitizeReturnPath(JSON.parse(csrfToken)?.data?.next);
+				const data = JSON.parse(csrfToken)?.data;
+				const next = sanitizeReturnPath(data?.next);
+				if (next) {
+					retryParams.set("next", next);
+				}
+				if (
+					typeof data?.redirectUrl === "string" &&
+					config.ALTERNATIVE_REDIRECT_URLS.includes(data.redirectUrl)
+				) {
+					retryParams.set("callback", data.redirectUrl);
+				}
 			} catch {
-				next = undefined;
+				// Malformed state: retry without a return path or alternate redirect URI.
 			}
 
-			return redirect(302, `${base}/login${next ? `?next=${encodeURIComponent(next)}` : ""}`);
+			const retryQuery = retryParams.toString();
+			return redirect(302, `${base}/login${retryQuery ? `?${retryQuery}` : ""}`);
 		}
 
 		throw error(

--- a/src/routes/login/callback/+server.ts
+++ b/src/routes/login/callback/+server.ts
@@ -1,5 +1,12 @@
 import { error, redirect } from "@sveltejs/kit";
-import { getOIDCUserData, validateAndParseCsrfToken } from "$lib/server/auth";
+import {
+	clearLoginRetryCookie,
+	getOIDCUserData,
+	hasLoginRetryCookie,
+	sanitizeReturnPath,
+	setLoginRetryCookie,
+	validateAndParseCsrfToken,
+} from "$lib/server/auth";
 import { z } from "zod";
 import { base } from "$app/paths";
 import { config } from "$lib/server/config";
@@ -47,14 +54,32 @@ export async function GET({ url, locals, cookies, request, getClientAddress }) {
 	const csrfToken = Buffer.from(state, "base64").toString("utf-8");
 
 	const validatedToken = await validateAndParseCsrfToken(csrfToken, locals.sessionId);
-
-	if (!validatedToken) {
-		throw error(403, "Invalid or expired CSRF token");
-	}
-
 	const codeVerifier = cookies.get("hfChat-codeVerifier");
-	if (!codeVerifier) {
-		throw error(403, "Code verifier cookie not found");
+
+	if (!validatedToken || !codeVerifier) {
+		// The `state` token and PKCE code verifier are bound to the browser that started the
+		// login flow, so either check can fail on its own; when the callback lands in a
+		// different browser (e.g. "Open in Safari" from an in-app browser) both do. Restart
+		// the flow once in this browser instead of dead-ending on a 403.
+		if (!hasLoginRetryCookie(cookies)) {
+			setLoginRetryCookie(cookies);
+
+			// Best-effort recovery of the return path from the (unverified) state payload;
+			// it is re-sanitized to an in-app absolute path before use.
+			let next: string | undefined;
+			try {
+				next = sanitizeReturnPath(JSON.parse(csrfToken)?.data?.next);
+			} catch {
+				next = undefined;
+			}
+
+			return redirect(302, `${base}/login${next ? `?next=${encodeURIComponent(next)}` : ""}`);
+		}
+
+		throw error(
+			403,
+			validatedToken ? "Code verifier cookie not found" : "Invalid or expired CSRF token"
+		);
 	}
 
 	const { userData, token } = await getOIDCUserData(
@@ -92,6 +117,8 @@ export async function GET({ url, locals, cookies, request, getClientAddress }) {
 		userAgent: request.headers.get("user-agent") ?? undefined,
 		ip: getClientAddress(),
 	});
+
+	clearLoginRetryCookie(cookies);
 
 	// Prefer returning the user to their original in-app path when provided.
 	// `validatedToken.next` is sanitized server-side to avoid protocol-relative redirects.


### PR DESCRIPTION
## Summary

Improves OAuth login flow resilience when the callback is received in a different browser than the one that initiated the login (e.g., "Open in Safari" from an in-app browser). Instead of failing with a 403 error, the flow now restarts in the current browser while preserving the intended return path.

## Key Changes

- **Added retry guard mechanism**: Introduced `hfChat-loginRetry` cookie to prevent infinite redirect loops when restarting the OAuth flow
  - `hasLoginRetryCookie()`: Check if retry has already been attempted
  - `setLoginRetryCookie()`: Set one-shot guard cookie (5 minute expiry)
  - `clearLoginRetryCookie()`: Clear guard after successful login

- **Enhanced callback validation**: Modified error handling in `/login/callback` to gracefully recover from cross-browser scenarios
  - When CSRF token or code verifier validation fails, check if this is a retry attempt
  - If not retried yet, redirect back to `/login` with the sanitized return path preserved
  - If already retried, throw 403 with appropriate error message

- **Exported `sanitizeReturnPath()`**: Made the path sanitization function public so it can be reused in the callback handler to recover the intended destination from the unverified state payload

## Implementation Details

- The retry cookie uses `sameSite: "lax"` (even when strict is configured) to ensure it's sent on the cross-site IdP → callback navigation where the loop guard must be observable
- Return path recovery is best-effort with try-catch to handle malformed state tokens gracefully
- Error messages distinguish between CSRF token and code verifier failures to aid debugging

https://claude.ai/code/session_01QWamsbC2xoGRoQazysMEVp