### PR TITLE
feat(ChatWindow): make caveat configurable

### DIFF
--- a/.env
+++ b/.env
@@ -28,6 +28,9 @@ PUBLIC_SHARE_PREFIX=
 PUBLIC_GOOGLE_ANALYTICS_ID=
 PUBLIC_PLAUSIBLE_SCRIPT_URL=
 PUBLIC_APPLE_APP_ID=
+# Caveat text shown below the chat input on new chats.
+# Defaults to "Generated content may be inaccurate or false." if unset.
+PUBLIC_CAVEAT=
 # Feature announcements shown as a toast on the home screen (no conversation open).
 # JSON5 array of { title, description, link?, cta?, maxDate? }; the last valid entry is shown.
 # cta overrides the link label (defaults to "Learn more").

--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -984,7 +984,9 @@
 						</span>
 					{/if}
 					{#if !messages.length && !loading}
-						<span class="max-sm:hidden">Generated content may be inaccurate or false.</span>
+						<span class="max-sm:hidden"
+							>{publicConfig.PUBLIC_CAVEAT || "Generated content may be inaccurate or false."}</span
+						>
 					{/if}
 					{#if $settings.reasoningOverrides?.[currentModel.id] ?? currentModel.supportsReasoning}
 						<div class="ml-auto">


### PR DESCRIPTION
<img width="749" height="166" alt="image" src="https://github.com/user-attachments/assets/1629df1d-7e87-416b-a1f5-30ad540f5b83" />

## Motivation

Sysadmins who deploy this application (or derivatives) may wish to tailor the caveat found at the bottom of the chat window, to emphasize certain aspects of the deployed application. This may include warnings to not upload sensitive information, or reminders of the kind of content that is permitted.

## Changes

This pull request introduces a configurable caveat message below the chat input for new chats. The caveat text can now be set via the `PUBLIC_CAVEAT` environment variable, falling back to the default message if unset.

Configuration improvements:

* Added `PUBLIC_CAVEAT` to the `.env` file, allowing customization of the caveat text shown below the chat input on new chats. If unset, it defaults to "Generated content may be inaccurate or false."
* Updated `ChatWindow.svelte` to display the value of `PUBLIC_CAVEAT` or the default caveat message if the variable is not set.