### PR TITLE
perf: compress dynamic SSR and API responses

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ USER user
 
 COPY --chown=1000 .env /app/.env
 COPY --chown=1000 entrypoint.sh /app/entrypoint.sh
+COPY --chown=1000 server.mjs /app/server.mjs
 COPY --chown=1000 package.json /app/package.json
 COPY --chown=1000 package-lock.json /app/package-lock.json
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,4 +16,4 @@ fi;
 
 export PUBLIC_VERSION=$(node -p "require('./package.json').version")
 
-dotenv -e /app/.env -c -- node --dns-result-order=ipv4first /app/build/index.js -- --host 0.0.0.0 --port 3000
+dotenv -e /app/.env -c -- node --dns-result-order=ipv4first /app/server.mjs

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
 				"@resvg/resvg-js": "^2.6.2",
 				"@tailwindcss/vite": "^4.3.0",
 				"bits-ui": "^2.14.2",
+				"compression": "^1.8.1",
 				"date-fns": "^2.29.3",
 				"file-type": "^21.3.1",
 				"handlebars": "^4.7.8",
@@ -4274,6 +4275,60 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/compressible": {
+			"version": "2.0.18",
+			"resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+			"integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+			"license": "MIT",
+			"dependencies": {
+				"mime-db": ">= 1.43.0 < 2"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/compression": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
+			"integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
+			"license": "MIT",
+			"dependencies": {
+				"bytes": "3.1.2",
+				"compressible": "~2.0.18",
+				"debug": "2.6.9",
+				"negotiator": "~0.6.4",
+				"on-headers": "~1.1.0",
+				"safe-buffer": "5.2.1",
+				"vary": "~1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/compression/node_modules/debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"license": "MIT",
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
+		"node_modules/compression/node_modules/ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+			"license": "MIT"
+		},
+		"node_modules/compression/node_modules/negotiator": {
+			"version": "0.6.4",
+			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+			"integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -7837,6 +7892,15 @@
 				"node": ">= 0.8"
 			}
 		},
+		"node_modules/on-headers": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+			"integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
 		"node_modules/once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -10297,7 +10361,7 @@
 			"version": "5.8.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
 			"integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-			"dev": true,
+			"devOptional": true,
 			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
 		"@resvg/resvg-js": "^2.6.2",
 		"@tailwindcss/vite": "^4.3.0",
 		"bits-ui": "^2.14.2",
+		"compression": "^1.8.1",
 		"date-fns": "^2.29.3",
 		"file-type": "^21.3.1",
 		"handlebars": "^4.7.8",

--- a/server.mjs
+++ b/server.mjs
@@ -1,0 +1,55 @@
+// Production server: wraps the adapter-node handler with response compression.
+//
+// adapter-node serves pre-compressed static assets (sirv finds the .gz/.br
+// files emitted at build time) but streams dynamic responses — SSR HTML and
+// API JSON — uncompressed. This wrapper gzip/brotli-encodes those.
+//
+// Streaming endpoints are explicitly excluded: the chat token stream
+// (application/jsonl, POST /conversation/[id]) and SSE
+// (text/event-stream, /api/v2/conversations/updates) must reach the client
+// chunk-by-chunk, and compression would buffer them, silently destroying
+// time-to-first-token.
+import { createServer } from "node:http";
+import { pathToFileURL } from "node:url";
+import compression from "compression";
+
+const STREAMING_CONTENT_TYPES = /^(?:text\/event-stream|application\/jsonl)\b/i;
+
+export function shouldCompress(req, res) {
+	const contentType = String(res.getHeader("Content-Type") ?? "");
+	if (STREAMING_CONTENT_TYPES.test(contentType)) return false;
+	return compression.filter(req, res);
+}
+
+export function createAppServer(handler) {
+	const compress = compression({ filter: shouldCompress });
+	return createServer((req, res) => {
+		compress(req, res, () =>
+			handler(req, res, () => {
+				res.statusCode = 404;
+				res.end("Not found");
+			})
+		);
+	});
+}
+
+const isMain =
+	process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isMain) {
+	const { handler } = await import("./build/handler.js");
+	const server = createAppServer(handler);
+	const port = parseInt(process.env.PORT ?? "3000", 10);
+	const host = process.env.HOST ?? "0.0.0.0";
+	server.listen(port, host, () => {
+		console.log(`Listening on http://${host}:${port}`);
+	});
+
+	const shutdown = () => {
+		server.close(() => process.exit(0));
+		const timeout = parseInt(process.env.SHUTDOWN_TIMEOUT ?? "30", 10);
+		setTimeout(() => process.exit(1), timeout * 1000).unref();
+	};
+	process.on("SIGTERM", shutdown);
+	process.on("SIGINT", shutdown);
+}


### PR DESCRIPTION
## What

Adds a thin production server (`server.mjs`) that wraps the adapter-node handler with `compression`, so dynamic responses (SSR HTML, `/api/v2/*` JSON) are served with brotli/gzip. Static assets were already pre-compressed at build time via sirv, but everything rendered at runtime went out raw.

Measured against hf.co/chat in production: the HTML document is 318-355 KB with no `content-encoding` on every page view, and every conversation-switch JSON payload (20-70 KB) is also uncompressed.

## Why streaming is excluded

The chat token stream (`POST /conversation/[id]`) responds with `Content-Type: application/jsonl`, and `/api/v2/conversations/updates` uses `text/event-stream`. A compression middleware buffers output, which would silently destroy time-to-first-token. Both content types are explicitly skipped, so token streaming behavior is unchanged.

## Deployment

- `entrypoint.sh` now starts `node /app/server.mjs` instead of `build/index.js` (PORT/HOST/SHUTDOWN_TIMEOUT env vars behave the same, body-size limiting stays inside the adapter handler)
- `Dockerfile` copies `server.mjs` into the image
- `npm run dev` / `vite preview` are unaffected

## Verification

- Behavioral test against the wrapper: HTML/JSON compressed (br), `application/jsonl` and `text/event-stream` pass through unencoded and unbuffered (first chunk arrives at ~100 ms of a ~500 ms stream, 5 distinct chunks received)
- Built the app and booted through `server.mjs`: `GET /chat/` went from 198,427 to 23,528 bytes transferred (-88%), `Content-Encoding: br`, `Vary: Accept-Encoding` set
- `npm run check`, `npm run lint`, `npm test` (392 tests) all pass
