### PR TITLE
perf: trim API payloads and fix client hot paths

### DIFF
--- a/src/lib/components/InfiniteScroll.svelte
+++ b/src/lib/components/InfiniteScroll.svelte
@@ -1,48 +1,45 @@
 <script lang="ts">
 	import { onMount } from "svelte";
 	interface Props {
-		onvisible?: () => void;
+		onvisible?: () => void | Promise<void>;
 	}
 
 	let { onvisible }: Props = $props();
 
 	let loader: HTMLDivElement | undefined = $state();
 	let observer: IntersectionObserver;
-	let intervalId: ReturnType<typeof setInterval> | undefined;
 
 	onMount(() => {
 		if (!loader) {
 			return;
 		}
 
-		observer = new IntersectionObserver((entries) => {
-			entries.forEach((entry) => {
-				if (entry.isIntersecting) {
-					// Clear any existing interval
-					if (intervalId) {
-						clearInterval(intervalId);
-					}
-					// Start new interval that dispatches every 250ms
-					intervalId = setInterval(() => {
-						onvisible?.();
-					}, 250);
-				} else {
-					// Clear interval when not intersecting
-					if (intervalId) {
-						clearInterval(intervalId);
-						intervalId = undefined;
-					}
+		let busy = false;
+
+		observer = new IntersectionObserver(async (entries) => {
+			if (busy || !entries.some((entry) => entry.isIntersecting)) {
+				return;
+			}
+			busy = true;
+			try {
+				await onvisible?.();
+			} finally {
+				busy = false;
+				// Re-observe so the observer delivers a fresh entry against the
+				// updated layout: if the sentinel is still visible after the new
+				// content rendered, this triggers the next load; otherwise it
+				// re-arms for the next scroll into view.
+				if (loader) {
+					observer.unobserve(loader);
+					observer.observe(loader);
 				}
-			});
+			}
 		});
 
 		observer.observe(loader);
 
 		return () => {
 			observer.disconnect();
-			if (intervalId) {
-				clearInterval(intervalId);
-			}
 		};
 	});
 </script>

--- a/src/lib/server/api/__tests__/conversations-id.spec.ts
+++ b/src/lib/server/api/__tests__/conversations-id.spec.ts
@@ -2,6 +2,13 @@ import { describe, expect, it, afterEach } from "vitest";
 import { ObjectId } from "mongodb";
 import superjson from "superjson";
 import { collections } from "$lib/server/database";
+import type { Message } from "$lib/types/Message";
+import {
+	MessageUpdateType,
+	MessageUpdateStatus,
+	MessageReasoningUpdateType,
+	MessageToolUpdateType,
+} from "$lib/types/MessageUpdate";
 import {
 	createTestLocals,
 	createTestUser,
@@ -112,6 +119,126 @@ describe.sequential("GET /api/v2/conversations/[id]", () => {
 		} catch (e: unknown) {
 			expect((e as { status: number }).status).toBe(400);
 		}
+	});
+
+	it("trims unread payload from tool-less messages", { timeout: 15000 }, async () => {
+		const { locals } = await createTestUser();
+		const content = "Hello world response";
+		const conv = await createTestConversation(locals, {
+			messages: [
+				{
+					id: crypto.randomUUID(),
+					from: "assistant",
+					content,
+					reasoning: "chain of thought",
+					updates: [
+						{ type: MessageUpdateType.Status, status: MessageUpdateStatus.Started },
+						{ type: MessageUpdateType.Stream, token: "", len: 12 },
+						{ type: MessageUpdateType.Stream, token: "", len: 8 },
+						{
+							type: MessageUpdateType.Reasoning,
+							subtype: MessageReasoningUpdateType.Stream,
+							token: "chain of thought",
+						},
+						{
+							type: MessageUpdateType.Reasoning,
+							subtype: MessageReasoningUpdateType.Status,
+							status: "Done in 2s",
+						},
+						{ type: MessageUpdateType.FinalAnswer, text: content, interrupted: false },
+						{ type: MessageUpdateType.Title, title: "A title" },
+					],
+					ancestors: [],
+					children: [],
+				},
+			],
+		});
+
+		const res = await GET({
+			locals,
+			params: { id: conv._id.toString() },
+			url: mockUrl(),
+		} as never);
+
+		const data = await parseResponse<{ messages: Message[] }>(res);
+		const message = data.messages.find((m) => m.from === "assistant");
+		expect(message).toBeDefined();
+		if (!message) return;
+		const updates = message.updates ?? [];
+
+		// content is authoritative and untouched
+		expect(message.content).toBe(content);
+		// server-side reasoning accumulator and raw reasoning tokens are not shipped
+		expect(message.reasoning).toBeUndefined();
+		expect(
+			updates.some(
+				(u) =>
+					u.type === MessageUpdateType.Reasoning && u.subtype === MessageReasoningUpdateType.Stream
+			)
+		).toBe(false);
+		// tool-less messages drop stream markers and the FinalAnswer text duplicate
+		expect(updates.some((u) => u.type === MessageUpdateType.Stream)).toBe(false);
+		const finalAnswer = updates.find((u) => u.type === MessageUpdateType.FinalAnswer);
+		expect(finalAnswer).toMatchObject({ text: "", interrupted: false });
+		// generation-state signals survive
+		expect(updates.some((u) => u.type === MessageUpdateType.Status)).toBe(true);
+		expect(updates.some((u) => u.type === MessageUpdateType.Title)).toBe(true);
+	});
+
+	it("keeps stream markers and FinalAnswer text for messages with tool calls", async () => {
+		const { locals } = await createTestUser();
+		const conv = await createTestConversation(locals, {
+			messages: [
+				{
+					id: crypto.randomUUID(),
+					from: "assistant",
+					content: "text before tool. text after tool.",
+					updates: [
+						{ type: MessageUpdateType.Stream, token: "", len: 17 },
+						{
+							type: MessageUpdateType.Tool,
+							subtype: MessageToolUpdateType.Call,
+							uuid: "tool-1",
+							call: { name: "search", parameters: {} },
+						},
+						{
+							type: MessageUpdateType.Reasoning,
+							subtype: MessageReasoningUpdateType.Stream,
+							token: "thinking",
+						},
+						{
+							type: MessageUpdateType.FinalAnswer,
+							text: "text after tool.",
+							interrupted: false,
+						},
+					],
+					ancestors: [],
+					children: [],
+				},
+			],
+		});
+
+		const res = await GET({
+			locals,
+			params: { id: conv._id.toString() },
+			url: mockUrl(),
+		} as never);
+
+		const data = await parseResponse<{ messages: Message[] }>(res);
+		const updates = data.messages.find((m) => m.from === "assistant")?.updates ?? [];
+
+		// tool messages need markers + final text to interleave text between tool blocks
+		expect(updates.some((u) => u.type === MessageUpdateType.Stream)).toBe(true);
+		const finalAnswer = updates.find((u) => u.type === MessageUpdateType.FinalAnswer);
+		expect(finalAnswer).toMatchObject({ text: "text after tool." });
+		expect(updates.some((u) => u.type === MessageUpdateType.Tool)).toBe(true);
+		// raw reasoning tokens are dropped regardless of tools
+		expect(
+			updates.some(
+				(u) =>
+					u.type === MessageUpdateType.Reasoning && u.subtype === MessageReasoningUpdateType.Stream
+			)
+		).toBe(false);
 	});
 });
 

--- a/src/lib/server/api/types.ts
+++ b/src/lib/server/api/types.ts
@@ -1,5 +1,3 @@
-import type { BackendModel } from "$lib/server/models";
-
 export type GETModelsResponse = Array<{
 	id: string;
 	name: string;
@@ -11,8 +9,6 @@ export type GETModelsResponse = Array<{
 	description?: string;
 	logoUrl?: string;
 	providers?: Array<{ provider: string } & Record<string, unknown>>;
-	promptExamples?: { title: string; prompt: string }[];
-	parameters: BackendModel["parameters"];
 	preprompt?: string;
 	multimodal: boolean;
 	multimodalAcceptedMimetypes?: string[];

--- a/src/lib/server/endpoints/endpoints.ts
+++ b/src/lib/server/endpoints/endpoints.ts
@@ -7,7 +7,7 @@ import type {
 } from "@huggingface/inference";
 import { z } from "zod";
 import { endpointOAIParametersSchema, endpointOai } from "./openai/endpointOai";
-import type { Model } from "$lib/types/Model";
+import type { BackendModel } from "$lib/server/models";
 import type { ObjectId } from "mongodb";
 
 export type EndpointMessage = Omit<Message, "id">;
@@ -16,7 +16,7 @@ export type EndpointMessage = Omit<Message, "id">;
 export interface EndpointParameters {
 	messages: EndpointMessage[];
 	preprompt?: Conversation["preprompt"];
-	generateSettings?: Partial<Model["parameters"]>;
+	generateSettings?: Partial<BackendModel["parameters"]>;
 	isMultimodal?: boolean;
 	conversationId?: ObjectId;
 	locals: App.Locals | undefined;

--- a/src/lib/server/hooks/handle.ts
+++ b/src/lib/server/hooks/handle.ts
@@ -161,10 +161,14 @@ export async function handleRequest({ event, resolve }: HandleInput): Promise<Re
 				// if the request is a POST request or login-related we refresh the cookie
 				refreshSessionCookie(event.cookies, auth.secretSessionId);
 
-				await collections.sessions.updateOne(
-					{ sessionId: auth.sessionId },
-					{ $set: { updatedAt: new Date(), expiresAt: addWeeks(new Date(), 2) } }
-				);
+				// Rolling-expiry extension is best-effort: don't hold up the request
+				// on a MongoDB round-trip for it.
+				collections.sessions
+					.updateOne(
+						{ sessionId: auth.sessionId },
+						{ $set: { updatedAt: new Date(), expiresAt: addWeeks(new Date(), 2) } }
+					)
+					.catch((err) => logger.error(err, "Failed to extend session expiry"));
 			}
 
 			if (

--- a/src/lib/types/Model.ts
+++ b/src/lib/types/Model.ts
@@ -8,8 +8,6 @@ export type Model = Pick<
 	| "isRouter"
 	| "websiteUrl"
 	| "datasetName"
-	| "promptExamples"
-	| "parameters"
 	| "description"
 	| "logoUrl"
 	| "modelUrl"

--- a/src/lib/utils/markdownWorkerPool.ts
+++ b/src/lib/utils/markdownWorkerPool.ts
@@ -236,26 +236,17 @@ export function cancelMarkdownClient(clientId: number): void {
 		if (i !== -1) queue.splice(i, 1);
 	}
 
-	// If a render is already running for this client, abort it: the component is gone, so
-	// terminate its worker (truly stopping the obsolete parse, rather than letting it hold
-	// a scarce pool slot) and free the slot. A fresh worker is created lazily on the next
-	// pump for whatever view is now active. At most one in-flight job per client (renders
-	// are serialized per client), so this terminates at most one worker.
-	let abortedWorker: Worker | undefined;
+	// If a render is already running for this client, just flag it: onWorkerMessage
+	// discards the stale result and recycles the worker to the idle pool. Terminating
+	// the worker here would make the next conversation pay a full respawn (bundle
+	// re-eval + katex/hljs init, ~50-200ms) on every switch away from a mid-render
+	// view, which costs far more than letting the in-flight parse run out. At most
+	// one in-flight job per client (renders are serialized per client).
 	for (const entry of inFlight.values()) {
 		if (entry.clientId === clientId) {
 			entry.cancelled = true;
-			abortedWorker = entry.worker;
 			break;
 		}
-	}
-	if (abortedWorker) {
-		abortedWorker.onmessage = null;
-		abortedWorker.onerror = null;
-		abortedWorker.onmessageerror = null;
-		dropWorker(abortedWorker);
-		abortedWorker.terminate();
-		pump();
 	}
 }
 

--- a/src/routes/api/v2/conversations/[id]/+server.ts
+++ b/src/routes/api/v2/conversations/[id]/+server.ts
@@ -6,6 +6,36 @@ import { collections } from "$lib/server/database";
 import { authCondition } from "$lib/server/auth";
 import { ObjectId } from "mongodb";
 import { validModelIdSchema } from "$lib/server/models";
+import type { Message } from "$lib/types/Message";
+import { MessageUpdateType, MessageReasoningUpdateType } from "$lib/types/MessageUpdate";
+
+/**
+ * Drop persisted message data the client never reads before sending it over
+ * the wire: the server-side `reasoning` accumulator, raw reasoning stream
+ * tokens, and — for tool-less messages — the per-token stream markers and the
+ * FinalAnswer text (a duplicate of `message.content`). ChatMessage rebuilds
+ * tool-less messages from `message.content` alone, while messages with tool
+ * calls need the stream markers and FinalAnswer text to interleave text
+ * between tool blocks, so their updates are kept.
+ *
+ * Read-path only: MongoDB keeps the full document (the legacy
+ * /api/conversation/[id] endpoint still exposes complete updates).
+ */
+function trimMessageForResponse(message: Message): Message {
+	const trimmed = { ...message };
+	delete trimmed.reasoning;
+	const updates = trimmed.updates;
+	if (!updates?.length) return trimmed;
+	const hasTool = updates.some((u) => u.type === MessageUpdateType.Tool);
+	trimmed.updates = updates
+		.filter(
+			(u) =>
+				!(u.type === MessageUpdateType.Reasoning && u.subtype === MessageReasoningUpdateType.Stream)
+		)
+		.filter((u) => hasTool || u.type !== MessageUpdateType.Stream)
+		.map((u) => (!hasTool && u.type === MessageUpdateType.FinalAnswer ? { ...u, text: "" } : u));
+	return trimmed;
+}
 
 export const GET: RequestHandler = async ({ locals, params, url }) => {
 	requireAuth(locals);
@@ -17,7 +47,7 @@ export const GET: RequestHandler = async ({ locals, params, url }) => {
 	);
 
 	return superjsonResponse({
-		messages: conversation.messages,
+		messages: conversation.messages.map(trimMessageForResponse),
 		title: conversation.title,
 		model: conversation.model,
 		preprompt: conversation.preprompt,

--- a/src/routes/api/v2/models/+server.ts
+++ b/src/routes/api/v2/models/+server.ts
@@ -26,8 +26,6 @@ export const GET: RequestHandler = async () => {
 					providers: model.providers as unknown as Array<
 						{ provider: string } & Record<string, unknown>
 					>,
-					promptExamples: model.promptExamples,
-					parameters: model.parameters,
 					preprompt: model.preprompt,
 					multimodal: model.multimodal,
 					multimodalAcceptedMimetypes: model.multimodalAcceptedMimetypes,


### PR DESCRIPTION
Payload and hot-path fixes from profiling hf.co/chat user journeys (initial load, conversation switching, new conversation, streaming) with Chrome instrumentation, then verifying each candidate fix against the code.

## Conversation GET payload trim

`GET /api/v2/conversations/[id]` returned everything MongoDB stores. Measured on prod: a fresh conversation with a single 4.5 KB assistant answer shipped as 20.9 KB of JSON, and the same payload is embedded a second time in the SSR document.

The response now drops, per message:

- `reasoning`: server-side accumulator, zero client reads (rendering parses `<think>` blocks from `message.content`)
- reasoning stream token updates: never rendered from `updates`
- for tool-less messages only: per-token stream markers and the `FinalAnswer.text` duplicate of `message.content`. `ChatMessage` rebuilds tool-less messages from `message.content` via its existing fallbacks; messages with tool calls keep their markers and final text since those drive text/tool interleaving.

`Status` and `FinalAnswer` entries stay (blanked text) because `generationState` checks their presence. This is read-path only: stored documents are untouched, and the legacy `/api/conversation/[id]` endpoint still returns full updates. Notably the trim is deliberately not in `resolveConversation`, because the message-delete endpoint writes `conversation.messages` back to MongoDB after passing through it.

Two new tests cover the trim (tool-less) and the preservation (tool messages).

## Models API trim

`/api/v2/models` is fetched in the root layout and embedded in every page (181 KB of the 318 KB prod HTML document). Removed:

- `promptExamples`: never read client-side, the landing chips come from hardcoded constants
- `parameters`: only used server-side (`buildPrompt`)

`providers`, `preprompt` and `multimodalAcceptedMimetypes` stay (settings page, ChatWindow). The legacy `/api/models` endpoint is unchanged for external consumers. One server file (`endpoints.ts`) typed `generateSettings` against the frontend `Model` type and now uses `BackendModel`.

## Hot-path fixes

- **Session hook**: the rolling-expiry `sessions.updateOne` was awaited before `resolve()` on every POST, adding a serial MongoDB round-trip to message sends. Now fire-and-forget with error logging.
- **InfiniteScroll**: the 250 ms `setInterval` could trigger duplicate page fetches while one was in flight (`handleVisible` has no concurrency guard). Replaced with a busy-guarded, once-per-intersection observer that re-arms after each load, so pagination still continues when the sentinel remains visible after new items render.
- **Markdown worker pool**: navigating away mid-render terminated the in-flight worker, forcing a full respawn (bundle re-eval, katex/hljs init) on the next conversation. The existing `cancelled` flag already discards stale results, so the worker is now recycled instead.

## Verification

`npm run check` (0 errors), `npm run lint`, `npm test`: 392 tests pass including the 2 new ones.
