### PR TITLE
Slim the models list payload and harden per-model endpoints

### DIFF
--- a/src/lib/APIClient.ts
+++ b/src/lib/APIClient.ts
@@ -117,10 +117,15 @@ export function useAPIClient({
 			reports: endpoint(fetcher, `${baseUrl}/user/reports`),
 			"billing-orgs": endpoint(fetcher, `${baseUrl}/user/billing-orgs`),
 		},
-		models: {
-			...endpoint(fetcher, `${baseUrl}/models`),
-			old: endpoint(fetcher, `${baseUrl}/models/old`),
-		},
+		models: Object.assign(
+			// client.models({ id: "org/name" }) — per-model detail (providers, parameters).
+			// Model ids may contain a slash; the path resolves to /models/[namespace]([/model]).
+			(params: { id: string }) => endpoint(fetcher, `${baseUrl}/models/${params.id}`),
+			{
+				...endpoint(fetcher, `${baseUrl}/models`),
+				old: endpoint(fetcher, `${baseUrl}/models/old`),
+			}
+		),
 		spaces: {
 			deploy: endpoint(fetcher, `${baseUrl}/spaces/deploy`),
 		},

--- a/src/lib/server/api/types.ts
+++ b/src/lib/server/api/types.ts
@@ -1,5 +1,8 @@
 import type { BackendModel } from "$lib/server/models";
 
+// List shape: intentionally excludes `providers` (~60KB across all models) and
+// `parameters` — no list consumer reads them, and the whole list is SSR-inlined
+// into every page. They are served by the per-model detail endpoint instead.
 export type GETModelsResponse = Array<{
 	id: string;
 	name: string;
@@ -10,9 +13,7 @@ export type GETModelsResponse = Array<{
 	displayName: string;
 	description?: string;
 	logoUrl?: string;
-	providers?: Array<{ provider: string } & Record<string, unknown>>;
 	promptExamples?: { title: string; prompt: string }[];
-	parameters: BackendModel["parameters"];
 	preprompt?: string;
 	multimodal: boolean;
 	multimodalAcceptedMimetypes?: string[];
@@ -23,6 +24,11 @@ export type GETModelsResponse = Array<{
 	hasInferenceAPI: boolean;
 	isRouter: boolean;
 }>;
+
+export type GETModelResponse = GETModelsResponse[number] & {
+	providers?: Array<{ provider: string } & Record<string, unknown>>;
+	parameters: BackendModel["parameters"];
+};
 
 export type GETOldModelsResponse = Array<{
 	id: string;

--- a/src/lib/server/api/utils/serializeModel.ts
+++ b/src/lib/server/api/utils/serializeModel.ts
@@ -1,0 +1,44 @@
+import type { ProcessedModel } from "$lib/server/models";
+import type { GETModelResponse, GETModelsResponse } from "$lib/server/api/types";
+
+// API responses must never serialize a model object directly: the raw
+// ProcessedModel carries server-only configuration (an `endpoints` array that
+// can hold per-model API keys for self-hosted deployments, prompt render
+// functions, etc.). Every field that leaves the server is listed explicitly.
+
+export function serializeModelSummary(model: ProcessedModel): GETModelsResponse[number] {
+	return {
+		id: model.id,
+		name: model.name,
+		websiteUrl: model.websiteUrl,
+		modelUrl: model.modelUrl,
+		datasetName: model.datasetName,
+		datasetUrl: model.datasetUrl,
+		displayName: model.displayName,
+		description: model.description,
+		logoUrl: model.logoUrl,
+		promptExamples: model.promptExamples,
+		preprompt: model.preprompt,
+		multimodal: model.multimodal,
+		multimodalAcceptedMimetypes: model.multimodalAcceptedMimetypes,
+		supportsTools: (model as unknown as { supportsTools?: boolean }).supportsTools ?? false,
+		supportsReasoning:
+			(model as unknown as { supportsReasoning?: boolean }).supportsReasoning ?? false,
+		supportsArtifacts:
+			(model as unknown as { supportsArtifacts?: boolean }).supportsArtifacts ?? false,
+		unlisted: model.unlisted,
+		hasInferenceAPI: model.hasInferenceAPI,
+		isRouter: model.isRouter,
+	};
+}
+
+// Detail shape for GET /models/[namespace]([/model]): the summary plus the
+// heavyweight fields (providers is ~60KB across all models) that only the
+// per-model settings page needs, fetched on demand.
+export function serializeModelDetail(model: ProcessedModel): GETModelResponse {
+	return {
+		...serializeModelSummary(model),
+		providers: model.providers as unknown as Array<{ provider: string } & Record<string, unknown>>,
+		parameters: model.parameters,
+	};
+}

--- a/src/lib/server/endpoints/endpoints.ts
+++ b/src/lib/server/endpoints/endpoints.ts
@@ -7,7 +7,7 @@ import type {
 } from "@huggingface/inference";
 import { z } from "zod";
 import { endpointOAIParametersSchema, endpointOai } from "./openai/endpointOai";
-import type { Model } from "$lib/types/Model";
+import type { BackendModel } from "$lib/server/models";
 import type { ObjectId } from "mongodb";
 
 export type EndpointMessage = Omit<Message, "id">;
@@ -16,7 +16,7 @@ export type EndpointMessage = Omit<Message, "id">;
 export interface EndpointParameters {
 	messages: EndpointMessage[];
 	preprompt?: Conversation["preprompt"];
-	generateSettings?: Partial<Model["parameters"]>;
+	generateSettings?: Partial<BackendModel["parameters"]>;
 	isMultimodal?: boolean;
 	conversationId?: ObjectId;
 	locals: App.Locals | undefined;

--- a/src/lib/types/Model.ts
+++ b/src/lib/types/Model.ts
@@ -1,5 +1,8 @@
 import type { BackendModel } from "$lib/server/models";
 
+// Client-side model shape, mirroring the models LIST payload
+// (GETModelsResponse): `providers` and `parameters` are intentionally absent —
+// they are heavyweight and only served by the per-model detail endpoint.
 export type Model = Pick<
 	BackendModel,
 	| "id"
@@ -9,7 +12,6 @@ export type Model = Pick<
 	| "websiteUrl"
 	| "datasetName"
 	| "promptExamples"
-	| "parameters"
 	| "description"
 	| "logoUrl"
 	| "modelUrl"
@@ -19,7 +21,6 @@ export type Model = Pick<
 	| "multimodalAcceptedMimetypes"
 	| "unlisted"
 	| "hasInferenceAPI"
-	| "providers"
 	| "supportsTools"
 	| "supportsReasoning"
 	| "supportsArtifacts"

--- a/src/routes/api/v2/models/+server.ts
+++ b/src/routes/api/v2/models/+server.ts
@@ -1,5 +1,6 @@
 import type { RequestHandler } from "@sveltejs/kit";
 import { superjsonResponse } from "$lib/server/api/utils/superjsonResponse";
+import { serializeModelSummary } from "$lib/server/api/utils/serializeModel";
 import type { GETModelsResponse } from "$lib/server/api/types";
 
 // Models are loaded once at server startup; new models appear on redeploy.
@@ -13,33 +14,7 @@ export const GET: RequestHandler = async () => {
 		return superjsonResponse(
 			models
 				.filter((m) => m.unlisted == false)
-				.map((model) => ({
-					id: model.id,
-					name: model.name,
-					websiteUrl: model.websiteUrl,
-					modelUrl: model.modelUrl,
-					datasetName: model.datasetName,
-					datasetUrl: model.datasetUrl,
-					displayName: model.displayName,
-					description: model.description,
-					logoUrl: model.logoUrl,
-					providers: model.providers as unknown as Array<
-						{ provider: string } & Record<string, unknown>
-					>,
-					promptExamples: model.promptExamples,
-					parameters: model.parameters,
-					preprompt: model.preprompt,
-					multimodal: model.multimodal,
-					multimodalAcceptedMimetypes: model.multimodalAcceptedMimetypes,
-					supportsTools: (model as unknown as { supportsTools?: boolean }).supportsTools ?? false,
-					supportsReasoning:
-						(model as unknown as { supportsReasoning?: boolean }).supportsReasoning ?? false,
-					supportsArtifacts:
-						(model as unknown as { supportsArtifacts?: boolean }).supportsArtifacts ?? false,
-					unlisted: model.unlisted,
-					hasInferenceAPI: model.hasInferenceAPI,
-					isRouter: model.isRouter,
-				})) satisfies GETModelsResponse,
+				.map(serializeModelSummary) satisfies GETModelsResponse,
 			{ headers: MODELS_CACHE_HEADERS }
 		);
 	} catch {

--- a/src/routes/api/v2/models/[namespace]/+server.ts
+++ b/src/routes/api/v2/models/[namespace]/+server.ts
@@ -1,8 +1,11 @@
 import type { RequestHandler } from "@sveltejs/kit";
 import { superjsonResponse } from "$lib/server/api/utils/superjsonResponse";
+import { serializeModelDetail } from "$lib/server/api/utils/serializeModel";
 import { resolveModel } from "$lib/server/api/utils/resolveModel";
 
 export const GET: RequestHandler = async ({ params }) => {
 	const model = await resolveModel(params.namespace ?? "");
-	return superjsonResponse(model);
+	// Serialize an explicit field list — the raw model object carries
+	// server-only endpoint configuration that must never reach the client.
+	return superjsonResponse(serializeModelDetail(model));
 };

--- a/src/routes/api/v2/models/[namespace]/[model]/+server.ts
+++ b/src/routes/api/v2/models/[namespace]/[model]/+server.ts
@@ -1,8 +1,11 @@
 import type { RequestHandler } from "@sveltejs/kit";
 import { superjsonResponse } from "$lib/server/api/utils/superjsonResponse";
+import { serializeModelDetail } from "$lib/server/api/utils/serializeModel";
 import { resolveModel } from "$lib/server/api/utils/resolveModel";
 
 export const GET: RequestHandler = async ({ params }) => {
 	const model = await resolveModel(params.namespace ?? "", params.model ?? "");
-	return superjsonResponse(model);
+	// Serialize an explicit field list — the raw model object carries
+	// server-only endpoint configuration that must never reach the client.
+	return superjsonResponse(serializeModelDetail(model));
 };

--- a/src/routes/settings/(nav)/[...model]/+page.svelte
+++ b/src/routes/settings/(nav)/[...model]/+page.svelte
@@ -21,10 +21,12 @@
 
 	import { goto } from "$app/navigation";
 	import { usePublicConfig } from "$lib/utils/PublicConfig.svelte";
+	import { useAPIClient, handleResponse } from "$lib/APIClient";
 	import Switch from "$lib/components/Switch.svelte";
 
 	const publicConfig = usePublicConfig();
 	const settings = useSettingsStore();
+	const client = useAPIClient();
 	const modelId = $derived(page.params.model ?? "");
 
 	// Functional bindings for nested settings (Svelte 5):
@@ -123,7 +125,36 @@
 	);
 
 	let model = $derived(page.data.models.find((el: BackendModel) => el.id === modelId));
-	let providerList: RouterProvider[] = $derived((model?.providers ?? []) as RouterProvider[]);
+
+	// Providers are excluded from the models list payload (they are ~60KB
+	// across all models and this page is their only reader); fetch them for
+	// the current model on demand from the per-model detail endpoint.
+	let providerList: RouterProvider[] = $state([]);
+	let providersLoading = $state(false);
+	$effect(() => {
+		providerList = [];
+		if (!publicConfig.isHuggingChat || !model || model.isRouter) {
+			providersLoading = false;
+			return;
+		}
+		const requestedId = modelId;
+		providersLoading = true;
+		client
+			.models({ id: requestedId })
+			.get()
+			.then(handleResponse)
+			.then((detail: { providers?: RouterProvider[] } | null) => {
+				if (requestedId !== modelId) return; // stale response for a previous model
+				providerList = detail?.providers ?? [];
+			})
+			.catch(() => {
+				// No providers section is rendered on failure; the selection-mode
+				// options (auto/fastest/cheapest) still work via settings.
+			})
+			.finally(() => {
+				if (requestedId === modelId) providersLoading = false;
+			});
+	});
 
 	// multimodalOverrides/toolsOverrides intentionally have no initValue: getters fall back
 	// to the model's advertised capability, so upstream capability changes flow through.
@@ -407,7 +438,7 @@
 				</div>
 			</div>
 
-			{#if publicConfig.isHuggingChat && model.providers?.length && !model?.isRouter}
+			{#if publicConfig.isHuggingChat && !model?.isRouter && (providersLoading || providerList.length > 0)}
 				<div
 					class="mt-3 flex flex-col items-start gap-2.5 rounded-xl border border-gray-200 bg-white px-3 py-3 shadow-xs dark:border-gray-700 dark:bg-gray-800"
 				>


### PR DESCRIPTION
## What

The full 123-model registry is fetched in the root layout and SSR-inlined into every page as a ~181KB `data-sveltekit-fetched` script. Most of that weight is fields no list consumer reads: `providers` is ~59KB and is only used by the per-model settings page (one string field), and `parameters` has no client consumer at all.

This PR:

- removes `providers` and `parameters` from `GET /api/v2/models` (list) and from the client `Model` type
- serves them from the per-model detail endpoints instead, via a new `GETModelResponse` shape
- makes the settings model page fetch providers lazily with a loading state (new `client.models({ id })` accessor)
- replaces the raw model serialization in the per-model endpoints with an explicit field map

That last point is also a hardening fix: `GET /api/v2/models/[namespace]([/model])` previously returned the entire server-side model object. For self-hosted deployments that configure per-model `endpoints` with an `apiKey` in the `MODELS` env var, that serialized secrets into an unauthenticated response. Nothing in the app called those routes, which is why it went unnoticed. They now share the same explicit serializer as the list.

`src/lib/server/endpoints/endpoints.ts` switches its `generateSettings` type from the client `Model` type to `BackendModel`, which it should have used all along.

## Measured

Models list payload drops from 164KB to 95KB raw (with compression on top where available). The SSR HTML document shrinks accordingly on every page load.

## Verification

- svelte-check catches all consumers; the only client reader of `providers` was the settings page, updated here
- Both id shapes exercised against a running build: `/api/v2/models/omni` and `/api/v2/models/zai-org/GLM-5.2` return providers and parameters with no server-only fields
- Provider dropdown on the settings page verified working with the lazy fetch

---
Part of a performance series measured from a live profile of hf.co/chat. Each PR is file-disjoint and merges independently, in any order: #2409 (compression), #2410 (models payload), #2411 (markdown pipeline), #2412 (conversation switching), #2413 (stream update batching), #2414 (send handler DB), #2415 (sidebar hydration).
