### PR TITLE
Instant conversation switching: client cache, create-response seed, loading bar

### DIFF
--- a/src/lib/components/NavigationLoadingBar.svelte
+++ b/src/lib/components/NavigationLoadingBar.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+	import { navigating } from "$app/state";
+
+	// Conversation switches block on the conversation fetch before the page
+	// swaps, so give the user immediate feedback. The delay keeps fast
+	// navigations (warm cache, quick network) from flashing the bar.
+	const SHOW_DELAY_MS = 150;
+
+	let visible = $state(false);
+
+	$effect(() => {
+		if (navigating.to?.route.id === "/conversation/[id]") {
+			const timer = setTimeout(() => (visible = true), SHOW_DELAY_MS);
+			return () => {
+				clearTimeout(timer);
+				visible = false;
+			};
+		}
+		visible = false;
+	});
+</script>
+
+{#if visible}
+	<div
+		class="fixed inset-x-0 top-0 z-50 h-[3px] overflow-hidden"
+		role="progressbar"
+		aria-label="Loading conversation"
+	>
+		<div class="loading-bar h-full w-2/5 rounded-r-full bg-black/70 dark:bg-white/60"></div>
+	</div>
+{/if}
+
+<style>
+	.loading-bar {
+		animation: slide 1.2s cubic-bezier(0.4, 0, 0.2, 1) infinite;
+	}
+	@keyframes slide {
+		0% {
+			transform: translateX(-100%);
+		}
+		100% {
+			transform: translateX(350%);
+		}
+	}
+	@media (prefers-reduced-motion: reduce) {
+		.loading-bar {
+			animation: none;
+			width: 100%;
+			opacity: 0.4;
+		}
+	}
+</style>

--- a/src/lib/utils/conversationCache.ts
+++ b/src/lib/utils/conversationCache.ts
@@ -1,0 +1,73 @@
+import { browser } from "$app/environment";
+import superjson from "superjson";
+import type { Message } from "$lib/types/Message";
+import type { DeployedSpace } from "$lib/types/Conversation";
+
+// Payload shape of GET /api/v2/conversations/[id] (post superjson-parse),
+// shared by the page load, this cache, and the create-conversation seed.
+export interface ConversationData {
+	messages: Message[];
+	title: string;
+	model: string;
+	preprompt?: string;
+	rootMessageId?: string;
+	id: string;
+	updatedAt: Date;
+	modelId: string;
+	shared: boolean;
+	deployedSpaces?: Record<string, DeployedSpace>;
+}
+
+interface CacheEntry {
+	data: ConversationData;
+	fetchedAt: number;
+}
+
+// Browser-only stale-while-revalidate cache of visited conversations, so
+// switching back to a recently viewed chat renders instantly instead of
+// re-downloading its full history. Must never be populated during SSR: module
+// state on the server is shared across requests, i.e. across users.
+//
+// Correctness contract (enforced by the conversation page load):
+// - a load for a DIFFERENT conversation than the previous load is a
+//   navigation and may serve this cache (revalidating in the background);
+// - a load for the SAME conversation is an explicit invalidate() (stream
+//   finished, model switched, generation poller) and must bypass the cache.
+const MAX_ENTRIES = 8;
+
+// A cache entry younger than this is served without a background revalidate.
+// Covers the two hot paths where a refetch is pure waste: the create-flow
+// seed (the entry was just built from the insert we performed) and the
+// immediate re-load after a revalidation already replaced the entry.
+export const CONVERSATION_CACHE_FRESH_MS = 2_000;
+
+const cache = new Map<string, CacheEntry>();
+
+export function getCachedConversation(id: string): CacheEntry | undefined {
+	if (!browser) return undefined;
+	const entry = cache.get(id);
+	if (!entry) return undefined;
+	// Refresh LRU position
+	cache.delete(id);
+	cache.set(id, entry);
+	return entry;
+}
+
+export function setCachedConversation(id: string, data: ConversationData): void {
+	if (!browser) return;
+	cache.delete(id);
+	cache.set(id, { data, fetchedAt: Date.now() });
+	if (cache.size > MAX_ENTRIES) {
+		const oldest = cache.keys().next().value;
+		if (oldest !== undefined) cache.delete(oldest);
+	}
+}
+
+export function invalidateCachedConversation(id: string): void {
+	cache.delete(id);
+}
+
+/** Stable serialization for change detection between cached and fresh data. */
+export function conversationFingerprint(data: ConversationData): string {
+	return JSON.stringify(superjson.serialize(data));
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -14,6 +14,7 @@
 
 	import Toast from "$lib/components/Toast.svelte";
 	import NavMenu from "$lib/components/NavMenu.svelte";
+	import NavigationLoadingBar from "$lib/components/NavigationLoadingBar.svelte";
 	import MobileNav from "$lib/components/MobileNav.svelte";
 	import WelcomeModal from "$lib/components/WelcomeModal.svelte";
 	import ExpandNavigation from "$lib/components/ExpandNavigation.svelte";
@@ -24,6 +25,7 @@
 	import BackgroundGenerationPoller from "$lib/components/BackgroundGenerationPoller.svelte";
 	import { requireAuthUser } from "$lib/utils/auth";
 	import { createConversationsStore } from "$lib/stores/conversations.svelte";
+	import { invalidateCachedConversation } from "$lib/utils/conversationCache";
 
 	let { data = $bindable(), children } = $props();
 
@@ -72,6 +74,9 @@
 			.then(handleResponse)
 			.then(async () => {
 				convsStore.remove(id);
+				// Drop any cached copy so a back-navigation to the deleted
+				// conversation cannot render it from cache.
+				invalidateCachedConversation(id);
 
 				if (page.params.id === id) {
 					await goto(`${base}/`, { invalidateAll: true });
@@ -261,6 +266,8 @@
 {/if}
 
 <BackgroundGenerationPoller />
+
+<NavigationLoadingBar />
 
 <div
 	class="fixed grid h-dvh w-screen grid-cols-1 grid-rows-[auto_1fr] overflow-hidden text-smd {!isNavCollapsed

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -9,6 +9,8 @@
 	import ChatWindow from "$lib/components/chat/ChatWindow.svelte";
 	import { ERROR_MESSAGES, error } from "$lib/stores/errors";
 	import { storePendingFiles } from "$lib/utils/pendingFiles";
+	import superjson from "superjson";
+	import { setCachedConversation, type ConversationData } from "$lib/utils/conversationCache";
 	import { useSettingsStore } from "$lib/stores/settings.js";
 	import { useConversationsStore } from "$lib/stores/conversations.svelte";
 	import { findCurrentModel } from "$lib/utils/models";
@@ -74,7 +76,18 @@
 				return;
 			}
 
-			const { conversationId } = await res.json();
+			const { conversationId, conversation } = await res.json();
+
+			// The create response embeds the conversation payload; seed the client
+			// cache with it so the conversation page load skips its GET and the
+			// first generation request starts one round-trip sooner.
+			if (typeof conversation === "string") {
+				try {
+					setCachedConversation(conversationId, superjson.parse<ConversationData>(conversation));
+				} catch {
+					// Malformed seed: the page load falls back to a normal fetch.
+				}
+			}
 
 			// Pass the first message text via SvelteKit history state (JSON-serializable).
 			// File objects are not serializable, so they are stored in a client-side Map

--- a/src/routes/conversation/+server.ts
+++ b/src/routes/conversation/+server.ts
@@ -10,6 +10,7 @@ import { v4 } from "uuid";
 import { authCondition } from "$lib/server/auth";
 import { usageLimits } from "$lib/server/usageLimits";
 import { MetricsServer } from "$lib/server/metrics";
+import superjson from "superjson";
 
 export const POST: RequestHandler = async ({ locals, request }) => {
 	const body = await request.text();
@@ -83,16 +84,19 @@ export const POST: RequestHandler = async ({ locals, request }) => {
 		messages[0].content = values.preprompt;
 	}
 
+	// Always store sanitized titles
+	const storedTitle = (title || "New Chat").replace(/<\/?think>/gi, "").trim();
+	const now = new Date();
+
 	const res = await collections.conversations.insertOne({
 		_id: new ObjectId(),
-		// Always store sanitized titles
-		title: (title || "New Chat").replace(/<\/?think>/gi, "").trim(),
+		title: storedTitle,
 		rootMessageId,
 		messages,
 		model: values.model,
 		preprompt: values.preprompt,
-		createdAt: new Date(),
-		updatedAt: new Date(),
+		createdAt: now,
+		updatedAt: now,
 		userAgent: request.headers.get("User-Agent") ?? undefined,
 		...(locals.user ? { userId: locals.user._id } : { sessionId: locals.sessionId }),
 		...(values.fromShare ? { meta: { fromShareId: values.fromShare } } : {}),
@@ -102,9 +106,31 @@ export const POST: RequestHandler = async ({ locals, request }) => {
 		MetricsServer.getMetrics().model.conversationsTotal.inc({ model: values.model });
 	}
 
+	// Alongside the id (the stable public shape of this legacy endpoint), embed
+	// the same payload GET /api/v2/conversations/[id] would return, so the
+	// client can seed its conversation cache and skip the follow-up GET that
+	// otherwise sits between conversation creation and the first generation
+	// request. superjson-encoded (as a string field) to preserve Dates exactly
+	// like the v2 endpoint does.
+	const conversationId = res.insertedId.toString();
 	return new Response(
 		JSON.stringify({
-			conversationId: res.insertedId.toString(),
+			conversationId,
+			conversation: superjson.stringify({
+				messages,
+				title: storedTitle,
+				model: values.model,
+				preprompt: values.preprompt,
+				rootMessageId,
+				id: conversationId,
+				updatedAt: now,
+				modelId: values.model,
+				// Matches what GET /api/v2/conversations/[id] returns for the normal
+				// post-create navigation (no fromShare query param): resolveConversation
+				// only reports shared=true when the viewing URL's fromShare matches.
+				shared: false,
+				deployedSpaces: undefined,
+			}),
 		}),
 		{ headers: { "Content-Type": "application/json" } }
 	);

--- a/src/routes/conversation/[id]/+page.ts
+++ b/src/routes/conversation/[id]/+page.ts
@@ -40,8 +40,20 @@ function revalidateInBackground(
 	fromShare: string | undefined,
 	served: ConversationData
 ) {
-	void fetchConversation(client, id, fromShare)
-		.then((fresh) => {
+	void client
+		.conversations({ id })
+		.get({ query: { fromShare } })
+		.then((response) => {
+			// The conversation is gone or this session can no longer read it
+			// (deleted in another tab, revoked access, expired session): drop the
+			// entry and re-run the load so the page takes its real error path
+			// (redirect home) instead of keeping the stale view on screen.
+			if (response.status === 401 || response.status === 403 || response.status === 404) {
+				invalidateCachedConversation(id);
+				return safeInvalidate(UrlDependency.Conversation);
+			}
+			// Throws on remaining errors (5xx etc.), handled as transient below.
+			const fresh = handleResponse(response) as ConversationData;
 			if (conversationFingerprint(fresh) === conversationFingerprint(served)) return;
 			setCachedConversation(id, fresh);
 			// safeInvalidate, not invalidate: a raw invalidate() fired from this
@@ -50,11 +62,10 @@ function revalidateInBackground(
 			return safeInvalidate(UrlDependency.Conversation);
 		})
 		.catch(() => {
-			// Could be a transient network failure just as well as a deleted or
-			// inaccessible conversation — we cannot tell them apart here. Only
-			// drop the cache entry; the next real navigation refetches and takes
-			// the genuine error path. Forcing a reload here would bounce the user
-			// to the homepage on a mere network blip.
+			// Transient failure (network blip, server error): only drop the cache
+			// entry; the next real navigation refetches and takes the genuine
+			// error path. Forcing a reload here would bounce the user to the
+			// homepage on a mere network hiccup.
 			invalidateCachedConversation(id);
 		});
 }

--- a/src/routes/conversation/[id]/+page.ts
+++ b/src/routes/conversation/[id]/+page.ts
@@ -2,21 +2,61 @@ import { useAPIClient, handleResponse } from "$lib/APIClient";
 import { UrlDependency } from "$lib/types/UrlDependency";
 import { redirect } from "@sveltejs/kit";
 import { base } from "$app/paths";
+import { browser } from "$app/environment";
+import { safeInvalidate } from "$lib/utils/safeInvalidate";
 import type { PageLoad } from "./$types";
-import type { Message } from "$lib/types/Message";
-import type { DeployedSpace } from "$lib/types/Conversation";
+import {
+	CONVERSATION_CACHE_FRESH_MS,
+	conversationFingerprint,
+	getCachedConversation,
+	invalidateCachedConversation,
+	setCachedConversation,
+	type ConversationData,
+} from "$lib/utils/conversationCache";
 
-interface ConversationData {
-	messages: Message[];
-	title: string;
-	model: string;
-	preprompt?: string;
-	rootMessageId?: string;
-	id: string;
-	updatedAt: Date;
-	modelId: string;
-	shared: boolean;
-	deployedSpaces?: Record<string, DeployedSpace>;
+// Id of the conversation the previous load() call served. A repeat load for
+// the same id means invalidate(UrlDependency.Conversation) ran (stream
+// finished, model switch, background poller) and fresh data is expected; only
+// a load for a different id is a navigation that may be served from cache.
+let lastLoadedId: string | undefined;
+
+async function fetchConversation(
+	client: ReturnType<typeof useAPIClient>,
+	id: string,
+	fromShare: string | undefined
+): Promise<ConversationData> {
+	return (await client
+		.conversations({ id })
+		.get({ query: { fromShare } })
+		.then(handleResponse)) as ConversationData;
+}
+
+// Serve-stale-then-revalidate: fetch fresh data off the critical path and, if
+// it differs from what the cache (and thus the page) currently shows, refresh
+// the cache and re-run the load — which then hits the updated, fresh entry.
+function revalidateInBackground(
+	client: ReturnType<typeof useAPIClient>,
+	id: string,
+	fromShare: string | undefined,
+	served: ConversationData
+) {
+	void fetchConversation(client, id, fromShare)
+		.then((fresh) => {
+			if (conversationFingerprint(fresh) === conversationFingerprint(served)) return;
+			setCachedConversation(id, fresh);
+			// safeInvalidate, not invalidate: a raw invalidate() fired from this
+			// background task can cancel an in-flight navigation the user just
+			// started (see safeInvalidate.ts).
+			return safeInvalidate(UrlDependency.Conversation);
+		})
+		.catch(() => {
+			// Could be a transient network failure just as well as a deleted or
+			// inaccessible conversation — we cannot tell them apart here. Only
+			// drop the cache entry; the next real navigation refetches and takes
+			// the genuine error path. Forcing a reload here would bounce the user
+			// to the homepage on a mere network blip.
+			invalidateCachedConversation(id);
+		});
 }
 
 export const load: PageLoad = async ({ params, depends, fetch, url, parent }) => {
@@ -50,12 +90,29 @@ export const load: PageLoad = async ({ params, depends, fetch, url, parent }) =>
 		}
 	}
 
+	const fromShare = url.searchParams.get("fromShare") ?? undefined;
+	const isNavigation = lastLoadedId !== params.id;
+	lastLoadedId = params.id;
+
+	// Share views bypass the cache entirely: their payload depends on the
+	// fromShare parameter, not just the conversation id.
+	if (browser && isNavigation && !fromShare) {
+		const cached = getCachedConversation(params.id);
+		if (cached) {
+			if (Date.now() - cached.fetchedAt > CONVERSATION_CACHE_FRESH_MS) {
+				revalidateInBackground(client, params.id, fromShare, cached.data);
+			}
+			return cached.data;
+		}
+	}
+
 	// Load conversation (works for both owned and shared conversations)
 	try {
-		return (await client
-			.conversations({ id: params.id })
-			.get({ query: { fromShare: url.searchParams.get("fromShare") ?? undefined } })
-			.then(handleResponse)) as ConversationData;
+		const data = await fetchConversation(client, params.id, fromShare);
+		if (browser && !fromShare) {
+			setCachedConversation(params.id, data);
+		}
+		return data;
 	} catch {
 		redirect(302, `${base}/`);
 	}


### PR DESCRIPTION
## What

Two related costs in conversation navigation:

1. Every switch refetches the full conversation, including switching back to one visited seconds ago. Measured at 280-400ms per switch, all of it blocking the page swap, with no loading feedback.
2. Sending the first message of a new chat is a 3-request waterfall: create POST, then a GET of the conversation that was just created, then the generation POST. Roughly 560ms to first token, vs ~276ms for a follow-up message.

This PR:

- adds a small browser-only LRU cache of visited conversations (`conversationCache.ts`, 8 entries, stale-while-revalidate). A load for a different conversation than the previous load serves the cache and revalidates in the background with `safeInvalidate`; a repeat load for the same id means an explicit `invalidate()` (stream finished, model switch, poller) and always bypasses the cache. Share views (`fromShare`) bypass entirely. SSR never touches the cache (module state on the server is cross-request).
- has `POST /conversation` embed the same payload `GET /api/v2/conversations/[id]` returns (superjson-encoded, additive field, existing `conversationId` shape unchanged), and seeds the cache from it before `goto()`, which removes the middle GET from the new-chat waterfall
- deletes the cache entry when a conversation is deleted
- background revalidation failures only drop the cache entry, they never force a reload (a transient network error should not bounce the user to the homepage)
- adds a thin top loading bar driven by `navigating`, scoped to the conversation route, delayed 150ms so fast switches never flash it

## Measured

- New chat send: 2 requests instead of 3, confirmed in the network log against a local production build
- Revisiting a cached conversation renders with zero network wait; revalidation runs in the background and re-renders only if the data actually changed (fingerprint compare)

## Notes

The seeded `shared` flag matches what a fresh GET returns for the normal post-create navigation. The `updatedAt` freshness window (2s) exists so the create-seed and revalidation-refresh paths do not immediately refetch what they just wrote.

---
Part of a performance series measured from a live profile of hf.co/chat. Each PR is file-disjoint and merges independently, in any order: #2409 (compression), #2410 (models payload), #2411 (markdown pipeline), #2412 (conversation switching), #2413 (stream update batching), #2414 (send handler DB), #2415 (sidebar hydration).
