### PR TITLE
Key the sidebar conversation list and lazy-mount the mobile drawer

### DIFF
--- a/src/lib/components/MobileNav.svelte
+++ b/src/lib/components/MobileNav.svelte
@@ -35,6 +35,17 @@
 	let closeEl: HTMLButtonElement | undefined = $state();
 	let openEl: HTMLButtonElement | undefined = $state();
 
+	// The drawer's content (a second full NavMenu) is expensive to SSR and
+	// hydrate, and most page views never open the drawer. Mount it on first
+	// open (or swipe) and keep it mounted afterward so the slide animation
+	// and inner scroll position survive subsequent open/close cycles.
+	let hasOpenedDrawer = $state(false);
+	$effect(() => {
+		if (isOpen || isDragging) {
+			hasOpenedDrawer = true;
+		}
+	});
+
 	const isHuggingChat = $derived(Boolean(page.data?.publicConfig?.isHuggingChat));
 	const canShare = $derived(
 		isHuggingChat &&
@@ -296,5 +307,7 @@
 	class="fixed top-0 bottom-0 left-0 z-30 grid max-h-dvh grid-cols-1
 	grid-rows-[auto_1fr_auto_auto] rounded-r-xl bg-white pt-4 md:hidden dark:bg-gray-900"
 >
-	{@render children?.()}
+	{#if hasOpenedDrawer}
+		{@render children?.()}
+	{/if}
 </nav>

--- a/src/lib/components/NavMenu.svelte
+++ b/src/lib/components/NavMenu.svelte
@@ -158,7 +158,7 @@
 				<h4 class="mt-4 mb-1.5 pl-0.5 text-xs text-gray-400 first:mt-0 dark:text-gray-500">
 					{titles[group]}
 				</h4>
-				{#each convs as conv}
+				{#each convs as conv (String(conv.id))}
 					<NavConversationItem {conv} {oneditConversationTitle} {ondeleteConversation} />
 				{/each}
 			{/if}


### PR DESCRIPTION
## What

Two sidebar fixes:

- `NavMenu`'s conversation list `{#each}` was unkeyed while new conversations are prepended with `unshift`. Positional reconciliation can attach row-local state (open dropdown menu, inline rename, delete confirmation) to the wrong conversation when the list shifts. Keyed by `String(conv.id)` (ids can be `ObjectId | string`, and object identity is not stable across list rebuilds).
- The mobile drawer renders a second full `NavMenu` that was always mounted (hidden via CSS transform), so every page load SSRs and hydrates the conversation list twice. The drawer content now mounts on first open (or swipe) and stays mounted afterward, preserving the slide animation and inner scroll position.

## Verification

- Drawer checked at runtime: 0 children before first open, content mounts on open, swipe and reopen behavior unchanged
- svelte-check and full test suite green

---
Part of a performance series measured from a live profile of hf.co/chat. Each PR is file-disjoint and merges independently, in any order: #2409 (compression), #2410 (models payload), #2411 (markdown pipeline), #2412 (conversation switching), #2413 (stream update batching), #2414 (send handler DB), #2415 (sidebar hydration).
