### PR TITLE
Harden the streaming code-block guard and narrow provider serialization

### DIFF
--- a/src/lib/components/CodeBlock.svelte
+++ b/src/lib/components/CodeBlock.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import CopyToClipBoardBtn from "./CopyToClipBoardBtn.svelte";
 	import DOMPurify from "isomorphic-dompurify";
+	import { isTrustedHighlighterHtml } from "$lib/utils/markedLight";
 	import HtmlPreviewModal from "./HtmlPreviewModal.svelte";
 	import PlayFilledAlt from "~icons/carbon/play-filled-alt";
 	import EosIconsLoading from "~icons/eos-icons/loading";
@@ -21,12 +22,11 @@
 	// every flush, and re-sanitizing the whole growing block each time is the
 	// main-thread hot path of code streaming. Skip DOMPurify during that
 	// window only while the html verifiably matches the highlighter's output
-	// alphabet (raw `<` may open nothing but a span tag): any other markup —
-	// which our highlighter cannot produce — falls back to a full sanitize.
-	// Every completed block still gets sanitized as defense in depth.
-	const NON_HIGHLIGHTER_TAG = /<(?!\/?span[\s>])/i;
+	// alphabet (bare spans or spans with a lone class attribute); anything
+	// else falls back to a full sanitize. Every completed block still gets
+	// sanitized as defense in depth.
 	let sanitizedCode = $derived(
-		loading && !NON_HIGHLIGHTER_TAG.test(code) ? code : DOMPurify.sanitize(code)
+		loading && isTrustedHighlighterHtml(code) ? code : DOMPurify.sanitize(code)
 	);
 
 	function hasStrictHtml5Doctype(input: string): boolean {

--- a/src/lib/server/api/types.ts
+++ b/src/lib/server/api/types.ts
@@ -26,7 +26,9 @@ export type GETModelsResponse = Array<{
 }>;
 
 export type GETModelResponse = GETModelsResponse[number] & {
-	providers?: Array<{ provider: string } & Record<string, unknown>>;
+	// Deliberately just the provider name: the rest of the upstream router's
+	// provider object is server-internal and never crosses the API boundary.
+	providers?: Array<{ provider: string }>;
 	parameters: BackendModel["parameters"];
 };
 

--- a/src/lib/server/api/utils/serializeModel.ts
+++ b/src/lib/server/api/utils/serializeModel.ts
@@ -36,9 +36,17 @@ export function serializeModelSummary(model: ProcessedModel): GETModelsResponse[
 // heavyweight fields (providers is ~60KB across all models) that only the
 // per-model settings page needs, fetched on demand.
 export function serializeModelDetail(model: ProcessedModel): GETModelResponse {
+	// `providers` is an upstream-router passthrough; the only field any client
+	// reads is the provider name. Map it down explicitly so arbitrary upstream
+	// fields (whatever a self-hosted router attaches) never cross the API
+	// boundary.
+	const providers = (model.providers as unknown as Array<{ provider?: unknown }> | undefined)
+		?.filter((entry): entry is { provider: string } => typeof entry?.provider === "string")
+		.map((entry) => ({ provider: entry.provider }));
+
 	return {
 		...serializeModelSummary(model),
-		providers: model.providers as unknown as Array<{ provider: string } & Record<string, unknown>>,
+		providers,
 		parameters: model.parameters,
 	};
 }

--- a/src/lib/utils/markedLight.spec.ts
+++ b/src/lib/utils/markedLight.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { isTrustedHighlighterHtml } from "./markedLight";
+
+describe("isTrustedHighlighterHtml", () => {
+	it("accepts plain escaped text with no tags", () => {
+		expect(isTrustedHighlighterHtml("const x = 1;")).toBe(true);
+		expect(isTrustedHighlighterHtml("if (a &lt; b &amp;&amp; c) {}")).toBe(true);
+	});
+
+	it("accepts hljs-style spans with a lone class attribute", () => {
+		expect(
+			isTrustedHighlighterHtml('<span class="hljs-keyword">const</span> x = <span>1</span>;')
+		).toBe(true);
+		expect(
+			isTrustedHighlighterHtml(
+				'<span class="hljs-title function_">fn</span>(<span class="hljs-params"></span>)'
+			)
+		).toBe(true);
+	});
+
+	it("accepts nested spans", () => {
+		expect(
+			isTrustedHighlighterHtml(
+				'<span class="hljs-string">"a<span class="hljs-subst">b</span>"</span>'
+			)
+		).toBe(true);
+	});
+
+	it("rejects spans carrying any attribute other than a double-quoted class", () => {
+		expect(isTrustedHighlighterHtml('<span onclick="x()">a</span>')).toBe(false);
+		expect(isTrustedHighlighterHtml('<span class="x" onclick="y()">a</span>')).toBe(false);
+		expect(isTrustedHighlighterHtml("<span class='x'>a</span>")).toBe(false);
+		expect(isTrustedHighlighterHtml('<span data-x="1">a</span>')).toBe(false);
+		expect(isTrustedHighlighterHtml('<span class="x"  >a</span>')).toBe(false);
+	});
+
+	it("rejects any non-span markup", () => {
+		expect(isTrustedHighlighterHtml("<script>alert(1)</script>")).toBe(false);
+		expect(isTrustedHighlighterHtml('<img src="x" onerror="y()">')).toBe(false);
+		expect(isTrustedHighlighterHtml("<style>*{}</style>")).toBe(false);
+		expect(isTrustedHighlighterHtml("a < b")).toBe(false);
+	});
+
+	it("rejects malformed closing spans", () => {
+		expect(isTrustedHighlighterHtml("</span >")).toBe(false);
+		expect(isTrustedHighlighterHtml('</span onclick="x">')).toBe(false);
+	});
+});

--- a/src/lib/utils/markedLight.ts
+++ b/src/lib/utils/markedLight.ts
@@ -26,6 +26,24 @@ export type BlockToken = {
 	tokens: Token[];
 };
 
+// Matches any `<` that opens something other than the exact markup our
+// highlighter can emit: `</span>`, `<span>`, or `<span class="...">` (double
+// quotes, single space, no other attributes). Anything else - including a
+// span with any additional or differently quoted attribute - is not
+// highlighter output and must be sanitized.
+const NON_HIGHLIGHTER_TAG = /<(?!\/span>|span(?: class="[^"]*")?>)/i;
+
+/**
+ * True when `html` contains only markup the markdown highlighter itself can
+ * produce (escaped text plus hljs-style span/class wrappers). Used to decide
+ * when a streaming code block may skip DOMPurify: the check enforces the
+ * highlighter's output alphabet directly instead of relying on the implicit
+ * contract that highlightCode() never emits attributes.
+ */
+export function isTrustedHighlighterHtml(html: string): boolean {
+	return !NON_HIGHLIGHTER_TAG.test(html);
+}
+
 export function escapeHTML(content: string) {
 	return content.replace(
 		/[<>&"']/g,


### PR DESCRIPTION
## What

Two small hardening follow-ups from an external security review of the perf series (#2409 to #2415). Neither is an exploitable issue today; both remove implicit contracts that current safety silently depends on.

1. **Streaming code-block guard now enforces the highlighter's output alphabet directly.** The guard introduced in #2411 skipped DOMPurify on open fences when the html contained only span tags, but its regex allowed arbitrary attributes on those spans (`<span onclick=...>` would have passed). That was safe only via the implicit contract that `highlightCode()` never emits attributes. The guard now lives in `markedLight.ts` as `isTrustedHighlighterHtml()` and accepts exactly `</span>`, `<span>`, or `<span class="...">` (double quotes, single space, no other attributes); anything else falls through to a full DOMPurify pass. Covered by unit tests including the attribute-injection cases.

2. **Per-model `providers` serialization narrowed to the one field clients read.** `serializeModelDetail` passed the upstream router's provider objects through verbatim. On HuggingChat that content is public metadata, but for self-hosted deployments with a custom router it would forward arbitrary upstream fields across an unauthenticated API boundary. The endpoint now maps providers down to `{ provider: string }`, which is the only field the settings page uses, and the `GETModelResponse` type is tightened to match.

## Verification

- New `markedLight.spec.ts` covering accepted hljs markup (including nested spans) and rejected payloads (`onclick` spans, single-quoted class, extra attributes, script/img/style tags, malformed closing tags)
- svelte-check, lint, and the utils test suites green (271 tests)

Independent of #2416 (disjoint files); the two merge in either order.
