### PR TITLE
fix(ChatWindow): make iOS conversations scrollable

### DIFF
--- a/src/lib/actions/snapScrollToBottom.ts
+++ b/src/lib/actions/snapScrollToBottom.ts
@@ -6,6 +6,12 @@ const BOTTOM_THRESHOLD = 50;
 const USER_SCROLL_DEBOUNCE_MS = 150;
 const PROGRAMMATIC_SCROLL_GRACE_MS = 100;
 const TOUCH_DETACH_THRESHOLD_PX = 10;
+// How long after a programmatic scroll a phantom (non-user) scroll on touch
+// devices is still treated as a stale async application and corrected.
+const STALE_SCROLL_WINDOW_MS = 2000;
+// Momentum scroll events keep arriving well after the touch-debounce expires;
+// an up-scroll this soon after touch contact is still the user's flick.
+const TOUCH_MOMENTUM_WINDOW_MS = 2500;
 
 interface ScrollDependency {
 	forceReattach?: number;
@@ -43,6 +49,11 @@ const getScrollBehavior = (value: MaybeScrollDependency): ScrollBehavior => {
 export const snapScrollToBottom = (node: HTMLElement, dependency: MaybeScrollDependency) => {
 	// --- State ----------------------------------------------------------------
 
+	// Scrollbar drags only exist on fine-pointer devices; on touch devices all
+	// genuine user scrolling raises touch events first.
+	const isCoarsePointer =
+		typeof window !== "undefined" && window.matchMedia("(any-pointer: coarse)").matches;
+
 	// Track whether user has intentionally scrolled away from bottom
 	let isDetached = false;
 
@@ -59,9 +70,14 @@ export const snapScrollToBottom = (node: HTMLElement, dependency: MaybeScrollDep
 
 	// Track previous scroll position to detect scrollbar drags
 	let prevScrollTop = node.scrollTop;
+	// Track previous scroll height: a scrollTop drop that coincides with a
+	// scrollHeight change is a layout shift (e.g. the thinking block collapsing),
+	// not a user scroll-up.
+	let prevScrollHeight = node.scrollHeight;
 
 	// Touch handling state
 	let touchStartY = 0;
+	let lastTouchTime = 0;
 
 	// Observers and sentinel
 	let resizeObserver: ResizeObserver | undefined;
@@ -90,6 +106,14 @@ export const snapScrollToBottom = (node: HTMLElement, dependency: MaybeScrollDep
 		if (typeof requestAnimationFrame === "function") {
 			requestAnimationFrame(() => {
 				isProgrammaticScroll = false;
+				// iOS Safari applies rapid successive scrollTo calls asynchronously and
+				// can land them out of order: a clamp computed against a transient short
+				// layout (e.g. the thinking block collapsing mid-stream) may stomp a
+				// later, correct scroll. Verify after paint and correct once.
+				if (!isDetached && !userScrolling && distanceFromBottom() > BOTTOM_THRESHOLD) {
+					lastProgrammaticScrollTime = Date.now();
+					node.scrollTo({ top: node.scrollHeight });
+				}
 			});
 		} else {
 			isProgrammaticScroll = false;
@@ -215,10 +239,12 @@ export const snapScrollToBottom = (node: HTMLElement, dependency: MaybeScrollDep
 
 	// Detect user scroll intent via touch events (mobile)
 	const handleTouchStart = (event: TouchEvent) => {
+		lastTouchTime = Date.now();
 		touchStartY = event.touches[0]?.clientY ?? 0;
 	};
 
 	const handleTouchMove = (event: TouchEvent) => {
+		lastTouchTime = Date.now();
 		const touchY = event.touches[0]?.clientY ?? 0;
 		const deltaY = touchStartY - touchY;
 
@@ -251,10 +277,31 @@ export const snapScrollToBottom = (node: HTMLElement, dependency: MaybeScrollDep
 		// If not from wheel/touch, this is likely a scrollbar drag
 		if (!userScrolling) {
 			const scrollingUp = node.scrollTop < prevScrollTop;
+			// A scrollTop drop that coincides with a scrollHeight change is a layout
+			// shift, not user intent.
+			const heightChanged = node.scrollHeight !== prevScrollHeight;
 
-			// Always allow detach (scrolling up) - don't ignore user intent
-			if (scrollingUp) {
+			// A scrollTop drop here is only a user signal on fine-pointer devices
+			// (scrollbar drag). On touch devices every real user scroll arrives via
+			// the touch handlers; what lands here instead is iOS Safari applying
+			// stale queued scrolls (e.g. a clamp computed while the thinking-block
+			// collapse briefly shortened the layout), sometimes 100ms+ late.
+			if (scrollingUp && !inGracePeriod && !heightChanged && !isCoarsePointer) {
 				isDetached = true;
+			} else if (isCoarsePointer && scrollingUp && now - lastTouchTime < TOUCH_MOMENTUM_WINDOW_MS) {
+				// Momentum tail of a user flick (arrives after the touch debounce
+				// cleared userScrolling): honor it as user intent.
+				isDetached = true;
+			} else if (
+				isCoarsePointer &&
+				!isDetached &&
+				scrollingUp &&
+				!isAtBottom() &&
+				now - lastProgrammaticScrollTime < STALE_SCROLL_WINDOW_MS
+			) {
+				// Phantom scroll (stale async application, no touch anywhere near):
+				// it stranded us off-bottom while following, so correct it.
+				scrollToBottom();
 			}
 
 			// Only re-attach when at bottom if NOT in grace period
@@ -267,6 +314,7 @@ export const snapScrollToBottom = (node: HTMLElement, dependency: MaybeScrollDep
 		}
 
 		prevScrollTop = node.scrollTop;
+		prevScrollHeight = node.scrollHeight;
 	};
 
 	// --- Setup ----------------------------------------------------------------

--- a/src/lib/components/chat/ChatMessage.svelte
+++ b/src/lib/components/chat/ChatMessage.svelte
@@ -344,6 +344,28 @@
 		return !!last && (last.type === "think" || last.type === "tool");
 	});
 
+	// Safari has no scroll anchoring: when the process phase ends, the expanded
+	// streaming think/tool blocks are torn down and replaced by their collapsed
+	// nested summaries in a single flush. Content above the answer shrinks by a
+	// few hundred px and the viewport visibly jumps. Compensate the scroll
+	// container in the same pre-paint flush so what the reader sees stays still.
+	let wasProcessStreaming = false;
+	$effect(() => {
+		const streaming = isProcessStreaming;
+		if (wasProcessStreaming && !streaming && contentEl) {
+			const el = contentEl;
+			const scroller = el.closest(".overflow-y-auto");
+			const before = el.getBoundingClientRect();
+			if (scroller && before.top < scroller.getBoundingClientRect().bottom) {
+				void tick().then(() => {
+					const delta = before.height - el.getBoundingClientRect().height;
+					if (delta > 0) scroller.scrollTop -= delta;
+				});
+			}
+		}
+		wasProcessStreaming = streaming;
+	});
+
 	$effect(() => {
 		if (isCopied) {
 			setTimeout(() => {

--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -659,7 +659,7 @@
 			<!-- @container: descendants (e.g. the per-message router-metadata row) adapt
 			     to the actual column width, which shrinks when the artifact panel is open -->
 			<div
-				class="@container mx-auto flex h-full max-w-3xl flex-col gap-6 px-5 pt-6 sm:gap-8 xl:max-w-4xl xl:pt-10"
+				class="@container mx-auto flex min-h-full max-w-3xl flex-col gap-6 px-5 pt-6 sm:gap-8 xl:max-w-4xl xl:pt-10"
 			>
 				{#if preprompt && preprompt != currentModel.preprompt}
 					<SystemPromptModal preprompt={preprompt ?? ""} />

--- a/src/lib/components/chat/OpenReasoningResults.svelte
+++ b/src/lib/components/chat/OpenReasoningResults.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { slide } from "svelte/transition";
 	import MarkdownRenderer from "./MarkdownRenderer.svelte";
 	import BlockWrapper from "./BlockWrapper.svelte";
 	import CarbonChevronRight from "~icons/carbon/chevron-right";
@@ -10,6 +11,11 @@
 
 	let { content, loading = false }: Props = $props();
 	let isOpen = $state(false);
+	// Distinguishes a user tap from the auto-open during generation: the
+	// uncapped static prose renders only for manual opens. During the automatic
+	// open -> collapse cycle we stay in the capped streaming viewport, so the
+	// moment `loading` flips false never paints a full-height flash frame.
+	let openedManually = $state(false);
 	let wasLoading = $state(false);
 	let initialized = $state(false);
 	// Reactive size bindings (powered by ResizeObserver under the hood) — used
@@ -30,8 +36,10 @@
 		}
 
 		if (loading && !wasLoading) {
+			openedManually = false;
 			isOpen = true;
 		} else if (!loading && wasLoading) {
+			openedManually = false;
 			isOpen = false;
 		}
 		wasLoading = loading;
@@ -43,7 +51,10 @@
 	<button
 		type="button"
 		class="group/header flex w-fit cursor-pointer items-center gap-1 text-left select-none focus:outline-hidden"
-		onclick={() => (isOpen = !isOpen)}
+		onclick={() => {
+			openedManually = !isOpen;
+			isOpen = !isOpen;
+		}}
 		aria-label={isOpen ? "Collapse" : "Expand"}
 	>
 		<span
@@ -61,33 +72,39 @@
 		/>
 	</button>
 
-	<!-- Expandable content -->
+	<!-- Expandable content. The slide keeps open/close gradual: an instant
+	     collapse removes a couple hundred px in one frame, which Safari (no
+	     scroll anchoring) renders as a hard jump right as the answer starts
+	     streaming; animated, the spacer and snapScrollToBottom track it frame
+	     by frame. -->
 	{#if isOpen}
-		{#if loading}
-			<!--
+		<div transition:slide={{ duration: 180 }}>
+			{#if loading || !openedManually}
+				<!--
 				Streaming view: fixed-height viewport, content bottom-aligned so newly
 				arriving tokens stay visible while older lines scroll off the top behind
 				a gradient fade. Works for any model output format (no parsing).
 			-->
-			<div
-				bind:clientHeight={viewportHeight}
-				class="thinking-viewport mt-2 flex max-h-56 flex-col justify-end overflow-hidden md:max-h-80"
-				class:has-overflow={contentHeight > viewportHeight}
-			>
 				<div
-					bind:clientHeight={contentHeight}
-					class="prose prose-sm max-w-none text-sm leading-relaxed text-gray-500 *:first:mt-0 *:last:mb-0 dark:text-gray-400 dark:prose-invert"
+					bind:clientHeight={viewportHeight}
+					class="thinking-viewport mt-2 flex max-h-56 flex-col justify-end overflow-hidden md:max-h-80"
+					class:has-overflow={contentHeight > viewportHeight}
+				>
+					<div
+						bind:clientHeight={contentHeight}
+						class="prose prose-sm max-w-none text-sm leading-relaxed text-gray-500 *:first:mt-0 *:last:mb-0 dark:text-gray-400 dark:prose-invert"
+					>
+						<MarkdownRenderer {content} {loading} />
+					</div>
+				</div>
+			{:else}
+				<div
+					class="prose prose-sm mt-2 max-w-none text-sm leading-relaxed text-gray-500 dark:text-gray-400 dark:prose-invert"
 				>
 					<MarkdownRenderer {content} {loading} />
 				</div>
-			</div>
-		{:else}
-			<div
-				class="prose prose-sm mt-2 max-w-none text-sm leading-relaxed text-gray-500 dark:text-gray-400 dark:prose-invert"
-			>
-				<MarkdownRenderer {content} {loading} />
-			</div>
-		{/if}
+			{/if}
+		</div>
 	{/if}
 </BlockWrapper>
 


### PR DESCRIPTION
Two fixes for conversation scrolling on iOS Safari, both reproduced and verified on the iOS 18.3 Simulator with scroll telemetry injected into a sandbox build.

## 1. Conversations taller than the viewport could not scroll at all

The inner messages wrapper used `h-full`, which clamps it to the scroll container height. WebKit (unlike Blink) does not count that fixed-height flex child's overflow toward the container `scrollHeight`, so `scrollHeight === clientHeight` and the container reports nothing to scroll. New messages and their responses landed off-screen and were unreachable.

Fix: `h-full` to `min-h-full` on the `mx-auto` wrapper (`ChatWindow.svelte`). It still fills the viewport when content is short (intro stays centered) and grows when content is taller.

Measured: before `scrollHeight === clientHeight` (595/595), touch scroll inert; after `scrollHeight` 4296 vs 595 and touch scrolling works.

## 2. Thinking-block collapse killed follow-the-stream

When reasoning ends mid-stream, the thinking block auto-collapses (`OpenReasoningResults`), briefly shortening the layout. iOS Safari applies queued `scrollTo` calls asynchronously and out of order: a clamp computed against that transient short layout can land 100ms+ late. `snapScrollToBottom`'s scroll handler read the resulting scrollTop drop as the user scrolling up, detached, and the streaming answer landed below the fold with no way back (measured stranded 391px below, permanently).

Fix in `snapScrollToBottom.ts`, based on the observation that scroll-event detach is a scrollbar-drag signal which only exists on fine pointers, while on touch devices every real user scroll raises touch events first:

- detach from scroll events only on fine-pointer devices, and not when the scrollTop drop coincides with a scrollHeight change (layout shift, e.g. the collapse)
- on touch devices, honor up-scrolls within 2.5s of touch contact as user intent (momentum tail after the touch debounce)
- correct phantom up-scrolls that arrive within 2s of programmatic scrolling while following
- verify position after paint in `scrollToBottom` and re-issue once if a stale application stomped it

Verified on the simulator: view stays pinned through expand, collapse, streaming, and post-stream phantom scrolls (final distance-from-bottom 0 vs 391 before); a user swipe up mid-stream still detaches and holds with no snap-back, including through its momentum tail.

## 3. Thinking-block collapse jumped the viewport

The auto-collapse when the answer starts removed ~230px in one frame (Safari has no scroll anchoring), and the process-to-nested branch swap in ChatMessage flashed the uncapped static reasoning for one frame (measured up to 1400px) before tearing it down. Frame-by-frame measurement showed a 188px single-frame yank plus the flash.

Fixes: a 180ms slide on the block's open/collapse so the spacer and follower track it frame by frame; the uncapped static prose renders only for manual opens (the automatic cycle stays in the capped streaming viewport, so the loading flip has nothing to flash); and manual scroll anchoring at the branch swap (compensate the container for the content height delta in the same pre-paint flush).

Measured after: no flash, worst single-frame shift is a sub-100px ripple across a few frames, and the view stays pinned to the stream start to finish (final distance-from-bottom 0).
