### PR TITLE
Improve settings navigation hover states and dark mode colors

### DIFF
--- a/src/routes/settings/(nav)/+layout.svelte
+++ b/src/routes/settings/(nav)/+layout.svelte
@@ -170,7 +170,7 @@
 				<button
 					type="button"
 					onclick={() => goto(`${base}/settings/${model.id}`)}
-					class="group flex h-9 w-full flex-none items-center gap-1 rounded-lg px-3 text-[13px] text-gray-600 hover:bg-gray-100 md:rounded-xl md:px-3 dark:text-gray-300 dark:hover:bg-gray-800/60 {model.id ===
+					class="group flex h-9 w-full flex-none items-center gap-1 rounded-lg px-3 text-[13px] text-gray-600 hover:bg-gray-100 md:rounded-xl md:px-3 dark:text-gray-300 dark:hover:bg-gray-700/50 {model.id ===
 					page.params.model
 						? 'bg-gray-100! text-gray-800! dark:bg-gray-700! dark:text-gray-200!'
 						: ''}"
@@ -275,7 +275,7 @@
 				class="group sticky bottom-0 mt-1 flex h-9 w-full flex-none items-center gap-1 rounded-lg px-3 text-[13px] text-gray-600 max-md:order-first md:rounded-xl md:px-3 dark:text-gray-300 {page
 					.url.pathname === `${base}/settings/application`
 					? 'bg-gray-100! text-gray-800! dark:bg-gray-700! dark:text-gray-200!'
-					: 'bg-white dark:bg-gray-800'}"
+					: 'bg-white hover:bg-gray-100 dark:bg-gray-800 dark:hover:bg-gray-700'}"
 				aria-label="Configure application settings"
 			>
 				<IconGear class="mr-0.5 text-xxs" />


### PR DESCRIPTION
## Summary
Refined the visual styling of the settings navigation sidebar to improve consistency and accessibility across light and dark modes.

## Changes
- **Model settings button**: Updated dark mode hover background from `dark:hover:bg-gray-800/60` to `dark:hover:bg-gray-700/50` for better contrast and visual feedback
- **Application settings button**: Added missing hover states (`hover:bg-gray-100` for light mode and `dark:hover:bg-gray-700` for dark mode) to match the interactive behavior of other navigation items

## Details
These changes ensure that all navigation buttons in the settings sidebar have consistent hover feedback across both light and dark modes, improving the user experience and visual hierarchy of the interface.

https://claude.ai/code/session_01VnSVoWnp6BH4L1P11ZjhGU