### PR TITLE
Refine ChatIntroduction logo and text sizing

### DIFF
--- a/src/lib/components/chat/ChatIntroduction.svelte
+++ b/src/lib/components/chat/ChatIntroduction.svelte
@@ -21,9 +21,9 @@
 
 <div class="my-auto grid items-center justify-center gap-8 text-center">
 	<div
-		class="flex -translate-y-16 items-center rounded-xl text-3xl font-semibold select-none md:-translate-y-12 md:text-5xl"
+		class="flex -translate-y-16 items-center rounded-xl text-[1.6rem] font-semibold select-none md:-translate-y-12 md:text-[2.55rem]"
 	>
-		<Logo classNames="size-12 md:size-20 dark:invert mr-0.5" />
+		<Logo classNames="size-[2.55rem] md:size-[4.25rem] dark:invert mr-0.5" />
 		{publicConfig.PUBLIC_APP_NAME}
 	</div>
 	<!-- <div class="lg:col-span-1">


### PR DESCRIPTION
## Summary
Updated the ChatIntroduction component to use more precise sizing values for the logo and app name text, replacing Tailwind's predefined size classes with custom rem-based values for better visual consistency.

## Changes
- Updated app name text sizing from `text-3xl` / `md:text-5xl` to `text-[1.6rem]` / `md:text-[2.55rem]` for more granular control
- Updated Logo component sizing from `size-12` / `md:size-20` to `size-[2.55rem]` / `md:size-[4.25rem]` to better match the text proportions

## Details
These changes use Tailwind's arbitrary value syntax to specify exact rem measurements instead of relying on predefined size scales. This provides finer control over the visual hierarchy and ensures the logo and text scale proportionally across breakpoints.

https://claude.ai/code/session_01EgZeaLF4PeW2L78vamYwFA