### PR TITLE
Add scrollbar-on-hover utility for mouse devices

### DIFF
--- a/src/lib/components/NavMenu.svelte
+++ b/src/lib/components/NavMenu.svelte
@@ -150,7 +150,7 @@
 </div>
 
 <div
-	class="scrollbar-custom flex touch-pan-y flex-col gap-1 overflow-y-auto rounded-r-xl border border-l-0 border-gray-100 from-gray-50 px-3 pt-2 pb-3 text-[.9rem] max-sm:bg-linear-to-t md:bg-linear-to-l dark:border-transparent dark:from-gray-800/30"
+	class="scrollbar-custom flex touch-pan-y scrollbar-on-hover flex-col gap-1 overflow-y-auto rounded-r-xl border border-l-0 border-gray-100 from-gray-50 px-3 pt-2 pb-3 text-[.9rem] max-sm:bg-linear-to-t md:bg-linear-to-l dark:border-transparent dark:from-gray-800/30"
 >
 	<div class="flex flex-col gap-px">
 		{#each Object.entries(groupedConversations) as [group, convs]}

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -121,6 +121,24 @@ body {
 	}
 }
 
+/* Keeps the scrollbar gutter but hides thumb & track until the element is hovered.
+   Only applies on devices with a mouse-like pointer; touch devices keep the default
+   always-visible behavior since they have no hover. Combine with scrollbar-custom. */
+@utility scrollbar-on-hover {
+	@media (hover: hover) and (pointer: fine) {
+		&:not(:hover) {
+			scrollbar-color: transparent transparent;
+		}
+
+		&:not(:hover)::-webkit-scrollbar,
+		&:not(:hover)::-webkit-scrollbar-thumb,
+		.dark &:not(:hover)::-webkit-scrollbar,
+		.dark &:not(:hover)::-webkit-scrollbar-thumb {
+			background-color: transparent;
+		}
+	}
+}
+
 @utility no-scrollbar {
 	@apply [scrollbar-width:none] [-ms-overflow-style:none] [&::-ms-scrollbar]:hidden [&::-webkit-scrollbar]:hidden;
 }


### PR DESCRIPTION
## Summary
Adds a new `scrollbar-on-hover` CSS utility that hides scrollbar thumbs and tracks on non-hovered elements while preserving the scrollbar gutter. This utility only applies on devices with mouse-like pointers, allowing touch devices to retain the default always-visible scrollbar behavior.

## Changes
- **src/styles/main.css**: Added `scrollbar-on-hover` utility that:
  - Uses `@media (hover: hover) and (pointer: fine)` to target mouse devices only
  - Hides scrollbar via `scrollbar-color: transparent transparent` for standard scrollbars
  - Hides webkit scrollbar backgrounds when not hovered
  - Includes dark mode support
  - Designed to be combined with the existing `scrollbar-custom` utility

- **src/lib/components/NavMenu.svelte**: Applied `scrollbar-on-hover` class to the navigation menu's scrollable container alongside `scrollbar-custom` for improved UX on desktop while maintaining touch device usability

## Implementation Details
The utility leverages CSS media queries to detect hover capability and pointer precision, ensuring it only affects devices that can hover. This prevents touch devices from losing scrollbar visibility while providing a cleaner interface on desktop when the menu isn't being scrolled.

https://claude.ai/code/session_01GmjepRFguwRcB9Psm6k4Tb