### PR TITLE
Fix thinking-block collapse and Safari layout shifts

### DIFF
--- a/src/lib/components/chat/ChatMessage.svelte
+++ b/src/lib/components/chat/ChatMessage.svelte
@@ -410,62 +410,57 @@
 				{#if isLast && loading && blocks.length === 0}
 					<IconLoading classNames="loading inline ml-2 first:ml-0" />
 				{/if}
-				{#if isProcessStreaming}
-					<!-- Streaming the thinking / tool phase: render every block flat and
-					     inline, exactly like today. Nesting kicks in once the answer starts. -->
-					{#each blocks as block, blockIndex (block.type === "tool" ? `tool-${block.uuid}-${blockIndex}` : `block-${blockIndex}`)}
-						{#if block.type === "text"}
-							{#if block.content.trim().length > 0}
-								<div class={proseClasses}>
-									<MarkdownRenderer content={block.content} loading={isLast && loading} />
-								</div>
-							{/if}
-						{:else if block.type === "artifact"}
-							<ArtifactCard op={block.op} messageId={message.id} opIndex={block.opIndex} />
-						{:else}
-							<div data-exclude-from-copy class="not-last:mb-1 has-[+.prose]:mb-2! [.prose+&]:mt-3">
-								{#if block.type === "think"}
-									<OpenReasoningResults
-										content={block.content}
-										loading={isLast && loading && !block.closed}
-									/>
-								{:else}
-									<ToolUpdate tool={block.updates} {loading} />
-								{/if}
+				<!-- One template for the streaming and settled phases: the trailing
+				     process group renders live while thinking/tools stream and settles
+				     in place when the answer starts. A single branch per unit shape
+				     keeps component instances alive across that flip — a lone thinking
+				     block ANIMATES its collapse instead of being remounted ~300px
+				     shorter in one frame (the layout jump this replaces). -->
+				{#each renderUnits as unit, unitIndex (`${unit.kind}-${unitIndex}`)}
+					{#if unit.kind === "text"}
+						{#if isLast && loading && unit.content.length === 0}
+							<IconLoading classNames="loading inline ml-2 first:ml-0" />
+						{:else if unit.content.trim().length > 0}
+							<div class={proseClasses}>
+								<MarkdownRenderer content={unit.content} loading={isLast && loading} />
 							</div>
 						{/if}
-					{/each}
-				{:else}
-					<!-- Answer started or generation finished: nest the process blocks. -->
-					{#each renderUnits as unit, unitIndex (`${unit.kind}-${unitIndex}`)}
-						{#if unit.kind === "text"}
-							{#if isLast && loading && unit.content.length === 0}
-								<IconLoading classNames="loading inline ml-2 first:ml-0" />
-							{:else if unit.content.trim().length > 0}
-								<div class={proseClasses}>
-									<MarkdownRenderer content={unit.content} loading={isLast && loading} />
-								</div>
-							{/if}
-						{:else if unit.kind === "artifact"}
-							<ArtifactCard op={unit.op} messageId={message.id} opIndex={unit.opIndex} />
-						{:else if unit.kind === "group"}
-							<div data-exclude-from-copy class="not-last:mb-1 has-[+.prose]:mb-2! [.prose+&]:mt-3">
-								{#if unit.blocks.length > 1}
-									<!-- Collapse the whole run into a single summary -->
-									<ToolCallsSummary blocks={unit.blocks} toolCount={unit.toolCount} />
-								{:else}
-									<!-- A lone process block stays standalone -->
-									{@const only = unit.blocks[0]}
-									{#if only.type === "think"}
-										<OpenReasoningResults content={only.content} loading={false} />
-									{:else}
-										<ToolUpdate tool={only.updates} loading={false} />
-									{/if}
+					{:else if unit.kind === "artifact"}
+						<ArtifactCard op={unit.op} messageId={message.id} opIndex={unit.opIndex} />
+					{:else if unit.kind === "group"}
+						{@const isLiveGroup = isProcessStreaming && unitIndex === renderUnits.length - 1}
+						<div data-exclude-from-copy class="not-last:mb-1 has-[+.prose]:mb-2! [.prose+&]:mt-3">
+							{#if unit.blocks.length === 1 && unit.blocks[0].type === "think"}
+								<OpenReasoningResults
+									content={unit.blocks[0].content}
+									loading={isLiveGroup && isLast && loading && !unit.blocks[0].closed}
+								/>
+							{:else if isLiveGroup}
+								<!-- Live multi-block run (thinking + tools): flat and inline -->
+								{#each unit.blocks as block, blockIndex (block.type === "tool" ? `tool-${block.uuid}` : `think-${blockIndex}`)}
+									<div class="not-last:mb-1">
+										{#if block.type === "think"}
+											<OpenReasoningResults
+												content={block.content}
+												loading={isLast && loading && !block.closed}
+											/>
+										{:else}
+											<ToolUpdate tool={block.updates} {loading} />
+										{/if}
+									</div>
+								{/each}
+							{:else if unit.blocks.length > 1}
+								<!-- Collapse the whole settled run into a single summary -->
+								<ToolCallsSummary blocks={unit.blocks} toolCount={unit.toolCount} />
+							{:else}
+								{@const only = unit.blocks[0]}
+								{#if only.type === "tool"}
+									<ToolUpdate tool={only.updates} loading={false} />
 								{/if}
-							</div>
-						{/if}
-					{/each}
-				{/if}
+							{/if}
+						</div>
+					{/if}
+				{/each}
 			</div>
 		</div>
 

--- a/src/lib/components/chat/OpenReasoningResults.svelte
+++ b/src/lib/components/chat/OpenReasoningResults.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+	import { slide } from "svelte/transition";
+	import { cubicOut } from "svelte/easing";
+	import { browser } from "$app/environment";
 	import MarkdownRenderer from "./MarkdownRenderer.svelte";
 	import BlockWrapper from "./BlockWrapper.svelte";
 	import CarbonChevronRight from "~icons/carbon/chevron-right";
@@ -9,6 +12,12 @@
 	}
 
 	let { content, loading = false }: Props = $props();
+
+	// Expand/collapse animates as a height slide instead of a single-frame
+	// ~300px layout change: the scroll system tracks geometry per frame, so a
+	// smooth height change means no jump for anything below the block.
+	const collapseDuration =
+		browser && window.matchMedia("(prefers-reduced-motion: reduce)").matches ? 0 : 220;
 	let isOpen = $state(false);
 	let wasLoading = $state(false);
 	let initialized = $state(false);
@@ -63,31 +72,33 @@
 
 	<!-- Expandable content -->
 	{#if isOpen}
-		{#if loading}
-			<!--
-				Streaming view: fixed-height viewport, content bottom-aligned so newly
-				arriving tokens stay visible while older lines scroll off the top behind
-				a gradient fade. Works for any model output format (no parsing).
-			-->
-			<div
-				bind:clientHeight={viewportHeight}
-				class="thinking-viewport mt-2 flex max-h-56 flex-col justify-end overflow-hidden md:max-h-80"
-				class:has-overflow={contentHeight > viewportHeight}
-			>
+		<div transition:slide={{ duration: collapseDuration, easing: cubicOut }}>
+			{#if loading}
+				<!--
+					Streaming view: fixed-height viewport, content bottom-aligned so newly
+					arriving tokens stay visible while older lines scroll off the top behind
+					a gradient fade. Works for any model output format (no parsing).
+				-->
 				<div
-					bind:clientHeight={contentHeight}
-					class="prose prose-sm max-w-none text-sm leading-relaxed text-gray-500 *:first:mt-0 *:last:mb-0 dark:text-gray-400 dark:prose-invert"
+					bind:clientHeight={viewportHeight}
+					class="thinking-viewport mt-2 flex max-h-56 flex-col justify-end overflow-hidden md:max-h-80"
+					class:has-overflow={contentHeight > viewportHeight}
+				>
+					<div
+						bind:clientHeight={contentHeight}
+						class="prose prose-sm max-w-none text-sm leading-relaxed text-gray-500 *:first:mt-0 *:last:mb-0 dark:text-gray-400 dark:prose-invert"
+					>
+						<MarkdownRenderer {content} {loading} />
+					</div>
+				</div>
+			{:else}
+				<div
+					class="prose prose-sm mt-2 max-w-none text-sm leading-relaxed text-gray-500 dark:text-gray-400 dark:prose-invert"
 				>
 					<MarkdownRenderer {content} {loading} />
 				</div>
-			</div>
-		{:else}
-			<div
-				class="prose prose-sm mt-2 max-w-none text-sm leading-relaxed text-gray-500 dark:text-gray-400 dark:prose-invert"
-			>
-				<MarkdownRenderer {content} {loading} />
-			</div>
-		{/if}
+			{/if}
+		</div>
 	{/if}
 </BlockWrapper>
 

--- a/src/lib/components/chat/OpenReasoningResults.svelte
+++ b/src/lib/components/chat/OpenReasoningResults.svelte
@@ -27,8 +27,13 @@
 	let viewportHeight = $state(0);
 	let contentHeight = $state(0);
 
-	// Track loading transitions to auto-expand/collapse
-	$effect(() => {
+	// Track loading transitions to auto-expand/collapse. Runs PRE-render:
+	// when loading flips false, the collapse must be decided before the
+	// template re-renders, so the slide-out starts from the still-capped
+	// streaming viewport — a post-render effect would let the uncapped
+	// settled prose mount first and a long thought would bounce to its full
+	// height for a frame before collapsing.
+	$effect.pre(() => {
 		if (!initialized) {
 			initialized = true;
 			if (loading) {
@@ -73,7 +78,10 @@
 	<!-- Expandable content -->
 	{#if isOpen}
 		<div transition:slide={{ duration: collapseDuration, easing: cubicOut }}>
-			{#if loading}
+			<!-- `|| !isOpen`: while the slide-out is running, any re-render must
+			     keep the capped streaming shape — switching to the uncapped
+			     settled prose mid-outro would grow the collapsing box. -->
+			{#if loading || !isOpen}
 				<!--
 					Streaming view: fixed-height viewport, content bottom-aligned so newly
 					arriving tokens stay visible while older lines scroll off the top behind

--- a/src/lib/components/chat/OpenReasoningResults.svelte.test.ts
+++ b/src/lib/components/chat/OpenReasoningResults.svelte.test.ts
@@ -32,6 +32,38 @@ describe("OpenReasoningResults", () => {
 		expect(page.getByText("Paragraph 1:", { exact: false })).toBeInTheDocument();
 	});
 
+	it("collapses in the capped streaming shape at answer-start (no expand bounce)", async () => {
+		const { container, rerender } = render(OpenReasoningResults, {
+			content: LONG_REASONING,
+			loading: true,
+		});
+		await new Promise((r) => setTimeout(r, 100));
+		const initial = container.getBoundingClientRect().height;
+		expect(container.querySelector(".thinking-viewport")).not.toBeNull();
+
+		// Answer starts: loading flips false and the auto-collapse slides out.
+		// The OUTGOING content must keep the capped .thinking-viewport shape for
+		// the whole slide — if the uncapped settled prose mounts first (isOpen
+		// still true for one render), a long thought bounces to its full height
+		// before collapsing. The settled prose is any .prose OUTSIDE the capped
+		// viewport; the box must also never grow past its streaming height.
+		await rerender({ loading: false });
+		let sawSettledProse = false;
+		let maxHeight = 0;
+		for (let i = 0; i < 30; i++) {
+			await new Promise((r) => requestAnimationFrame(r));
+			maxHeight = Math.max(maxHeight, container.getBoundingClientRect().height);
+			sawSettledProse ||= [...container.querySelectorAll(".prose")].some(
+				(p) => !p.closest(".thinking-viewport")
+			);
+		}
+		expect(sawSettledProse).toBe(false);
+		expect(maxHeight).toBeLessThanOrEqual(initial + 8);
+		// The slide finished: streaming viewport unmounted, header-row height.
+		expect(container.querySelector(".thinking-viewport")).toBeNull();
+		expect(container.getBoundingClientRect().height).toBeLessThan(initial / 2);
+	});
+
 	it("renders the full text view when not loading", async () => {
 		const { baseElement } = render(OpenReasoningResults, {
 			content: LONG_REASONING,

--- a/src/lib/utils/scroll/__tests__/chatScroll.svelte.test.ts
+++ b/src/lib/utils/scroll/__tests__/chatScroll.svelte.test.ts
@@ -6,6 +6,7 @@ import {
 	dragScrollbarTo,
 	frame,
 	frames,
+	nextTask,
 	startClsProbe,
 	waitFor,
 	wheel,
@@ -356,6 +357,91 @@ describe("floating buttons", () => {
 			label: "previous user message reaches the anchor offset",
 		});
 		expect(chat.chat.state.pinned).toBe(false);
+	});
+});
+
+describe("thinking-block collapse (layout-shift regressions)", () => {
+	it("a large in-turn collapse keeps everything below it viewport-stable (no spacer re-inflation)", async () => {
+		const chat = createChat({ turns: 3, viewportHeight: 600 });
+		chat.chat.armSend();
+		const { assistant: thinking } = chat.mountPair();
+		await waitFor(() => chat.fixture.distance() <= ARRIVED, { label: "send anchored" });
+
+		// Thinking streams: the block grows well past the fill slack, so the
+		// spacer floors and real following takes over.
+		for (let i = 0; i < 16; i++) {
+			thinking.style.height = `${parseFloat(thinking.style.height) + 20}px`;
+			await frame();
+		}
+		const answer = chat.fixture.addBlock(24, { id: "answer" });
+		await waitFor(() => chat.fixture.distance() <= ARRIVED, { label: "settled while pinned" });
+
+		const before = topOf(answer, chat);
+		// Answer starts: the reasoning block collapses ~300px in one frame. The
+		// spacer must NOT re-inflate (monotonic within the turn) — the shrink
+		// clamps instead, which keeps the content below the collapse stable.
+		thinking.style.height = "28px";
+		await frames(3);
+		const after = topOf(answer, chat);
+		expect(Math.abs(after - before)).toBeLessThanOrEqual(2);
+		expect(chat.chat.state.pinned).toBe(true);
+	});
+
+	it("manual anchoring (Safari: no overflow-anchor) keeps a detached reader stable through an above-viewport collapse", async () => {
+		// Simulate Safari: native anchoring can never engage, whatever the
+		// controller sets (inline style loses to !important).
+		const style = document.createElement("style");
+		style.textContent = ".sim-safari { overflow-anchor: none !important; }";
+		document.head.appendChild(style);
+
+		const fixture = createFixture({ viewportHeight: 400, blocks: [] });
+		fixture.container.classList.add("sim-safari");
+		const chat = createChatScroll({ forceManualAnchoring: true });
+		const earlier = fixture.addBlock(400, { id: "earlier" }); // reasoning of an earlier part
+		const reading = fixture.addBlock(300, { user: true, id: "reading" });
+		fixture.addBlock(900, { id: "tail" });
+		const spacerAction = chat.attachSpacer(fixture.spacer);
+		const containerAction = chat.attach(fixture.container, { content: () => fixture.content });
+		chat.sync({
+			conversationKey: "c1",
+			messages: [{ id: "reading", from: "user" }],
+			lastMessageEmpty: false,
+		});
+		active.push({
+			fixture,
+			chat,
+			messages: [],
+			sync: () => {},
+			mountPair: () => ({
+				user: document.createElement("div"),
+				assistant: document.createElement("div"),
+			}),
+			swapAssistant: () => document.createElement("div"),
+			viewportTop: () => fixture.container.getBoundingClientRect().top,
+			destroy() {
+				containerAction.destroy();
+				spacerAction.destroy();
+				fixture.destroy();
+				style.remove();
+			},
+		});
+		await waitFor(() => fixture.distance() <= ARRIVED, { label: "settle" });
+		await nextTask();
+
+		// Scroll up to read the middle block (detached).
+		const containerTop = fixture.container.getBoundingClientRect().top;
+		const target = reading.getBoundingClientRect().top - containerTop + fixture.container.scrollTop;
+		dragScrollbarTo(fixture.container, target);
+		await frames(2);
+		expect(chat.state.pinned).toBe(false);
+		const before = reading.getBoundingClientRect().top - containerTop;
+
+		// The earlier thinking block collapses ABOVE the viewport: without
+		// compensation this shifts the reading position by the full 350px.
+		earlier.style.height = "50px";
+		await frames(3);
+		const after = reading.getBoundingClientRect().top - containerTop;
+		expect(Math.abs(after - before)).toBeLessThanOrEqual(2);
 	});
 });
 

--- a/src/lib/utils/scroll/__tests__/chatScroll.svelte.test.ts
+++ b/src/lib/utils/scroll/__tests__/chatScroll.svelte.test.ts
@@ -443,6 +443,69 @@ describe("thinking-block collapse (layout-shift regressions)", () => {
 		const after = reading.getBoundingClientRect().top - containerTop;
 		expect(Math.abs(after - before)).toBeLessThanOrEqual(2);
 	});
+
+	it("manual anchoring tracks a descendant INSIDE a long message, not just the wrapper", async () => {
+		// Reading the middle of one long assistant message whose own thinking
+		// block collapses above the reading position: the wrapper's top never
+		// moves, so a wrapper-level anchor would read delta 0 and let the text
+		// jump — the anchor must be the descendant at the viewport top.
+		const style = document.createElement("style");
+		style.textContent = ".sim-safari { overflow-anchor: none !important; }";
+		document.head.appendChild(style);
+
+		const fixture = createFixture({ viewportHeight: 400, blocks: [] });
+		fixture.container.classList.add("sim-safari");
+		const chat = createChatScroll({ forceManualAnchoring: true });
+
+		const mkInner = (height: number) => {
+			const el = document.createElement("div");
+			el.style.cssText = `height: ${height}px; flex-shrink: 0; background: #eef;`;
+			return el;
+		};
+		const message = document.createElement("div");
+		message.style.cssText = "display: flex; flex-direction: column; flex-shrink: 0;";
+		message.dataset.messageId = "long-message";
+		const thinking = mkInner(400);
+		const reading = mkInner(300);
+		message.append(thinking, reading, mkInner(900));
+		fixture.content.appendChild(message);
+
+		const spacerAction = chat.attachSpacer(fixture.spacer);
+		const containerAction = chat.attach(fixture.container, { content: () => fixture.content });
+		chat.sync({ conversationKey: "c1", messages: [], lastMessageEmpty: false });
+		active.push({
+			fixture,
+			chat,
+			messages: [],
+			sync: () => {},
+			mountPair: () => ({
+				user: document.createElement("div"),
+				assistant: document.createElement("div"),
+			}),
+			swapAssistant: () => document.createElement("div"),
+			viewportTop: () => fixture.container.getBoundingClientRect().top,
+			destroy() {
+				containerAction.destroy();
+				spacerAction.destroy();
+				fixture.destroy();
+				style.remove();
+			},
+		});
+		await waitFor(() => fixture.distance() <= ARRIVED, { label: "settle" });
+		await nextTask();
+
+		const containerTop = fixture.container.getBoundingClientRect().top;
+		const target = reading.getBoundingClientRect().top - containerTop + fixture.container.scrollTop;
+		dragScrollbarTo(fixture.container, target);
+		await frames(2);
+		expect(chat.state.pinned).toBe(false);
+		const before = reading.getBoundingClientRect().top - containerTop;
+
+		thinking.style.height = "50px"; // collapse INSIDE the same message
+		await frames(3);
+		const after = reading.getBoundingClientRect().top - containerTop;
+		expect(Math.abs(after - before)).toBeLessThanOrEqual(2);
+	});
 });
 
 describe("composer clearance", () => {

--- a/src/lib/utils/scroll/__tests__/chatScroll.svelte.test.ts
+++ b/src/lib/utils/scroll/__tests__/chatScroll.svelte.test.ts
@@ -506,6 +506,78 @@ describe("thinking-block collapse (layout-shift regressions)", () => {
 		const after = reading.getBoundingClientRect().top - containerTop;
 		expect(Math.abs(after - before)).toBeLessThanOrEqual(2);
 	});
+
+	it("manual anchoring survives the anchored node being replaced (markdown re-render)", async () => {
+		const style = document.createElement("style");
+		style.textContent = ".sim-safari { overflow-anchor: none !important; }";
+		document.head.appendChild(style);
+
+		const fixture = createFixture({ viewportHeight: 400, blocks: [] });
+		fixture.container.classList.add("sim-safari");
+		const chat = createChatScroll({ forceManualAnchoring: true });
+
+		const mkInner = (height: number) => {
+			const el = document.createElement("div");
+			el.style.cssText = `height: ${height}px; flex-shrink: 0; background: #efe;`;
+			return el;
+		};
+		const earlier = fixture.addBlock(400, { id: "earlier" });
+		const message = document.createElement("div");
+		message.style.cssText = "display: flex; flex-direction: column; flex-shrink: 0;";
+		message.dataset.messageId = "rendered-message";
+		let reading = mkInner(300);
+		message.append(reading, mkInner(900));
+		fixture.content.appendChild(message);
+
+		const spacerAction = chat.attachSpacer(fixture.spacer);
+		const containerAction = chat.attach(fixture.container, { content: () => fixture.content });
+		chat.sync({ conversationKey: "c1", messages: [], lastMessageEmpty: false });
+		active.push({
+			fixture,
+			chat,
+			messages: [],
+			sync: () => {},
+			mountPair: () => ({
+				user: document.createElement("div"),
+				assistant: document.createElement("div"),
+			}),
+			swapAssistant: () => document.createElement("div"),
+			viewportTop: () => fixture.container.getBoundingClientRect().top,
+			destroy() {
+				containerAction.destroy();
+				spacerAction.destroy();
+				fixture.destroy();
+				style.remove();
+			},
+		});
+		await waitFor(() => fixture.distance() <= ARRIVED, { label: "settle" });
+		await nextTask();
+
+		const containerTop = fixture.container.getBoundingClientRect().top;
+		const target = reading.getBoundingClientRect().top - containerTop + fixture.container.scrollTop;
+		dragScrollbarTo(fixture.container, target);
+		await frames(2);
+		expect(chat.state.pinned).toBe(false);
+		const before = reading.getBoundingClientRect().top - containerTop;
+
+		// A worker markdown swap REPLACES the anchored paragraph in the same
+		// pass as an above-viewport shrink: the dead node must not silence
+		// compensation (fall back to the surviving message wrapper).
+		const replacement = mkInner(300);
+		reading.replaceWith(replacement);
+		reading = replacement;
+		earlier.style.height = "50px";
+		await frames(3);
+		let position = reading.getBoundingClientRect().top - containerTop;
+		expect(Math.abs(position - before)).toBeLessThanOrEqual(2);
+
+		// And the anchor was re-resolved onto live nodes: a LATER above-viewport
+		// change is compensated too (a stale chain would let this one jump).
+		earlier.style.height = "10px";
+		await frames(3);
+		position = reading.getBoundingClientRect().top - containerTop;
+		expect(Math.abs(position - before)).toBeLessThanOrEqual(2);
+	});
 });
 
 describe("composer clearance", () => {

--- a/src/lib/utils/scroll/chatScroll.svelte.ts
+++ b/src/lib/utils/scroll/chatScroll.svelte.ts
@@ -108,6 +108,23 @@ export class ChatScroll {
 	private knownIds: ReadonlySet<string> = new Set();
 	private initialized = false;
 
+	/**
+	 * Safari has no native scroll anchoring (`overflow-anchor` unsupported), so
+	 * content changes above the viewport — a thinking block collapsing, a late
+	 * image, a markdown swap — shove a detached reader's text by the full
+	 * height delta. Where native anchoring is unavailable, track the message
+	 * element at the viewport top while detached and manually restore its
+	 * position after content resizes: the same job Chrome's anchoring does.
+	 */
+	private manualAnchoring: boolean;
+	private readAnchor: { el: Element; offset: number } | null = null;
+
+	constructor(options: { forceManualAnchoring?: boolean } = {}) {
+		this.manualAnchoring =
+			options.forceManualAnchoring ??
+			(typeof CSS !== "undefined" && !CSS.supports("overflow-anchor", "auto"));
+	}
+
 	// --- wiring -------------------------------------------------------------------
 
 	/** `use:` action for the scroll container. */
@@ -126,10 +143,14 @@ export class ChatScroll {
 			onStateChange: (s) => this.applyState(s),
 			onContentResize: (containerResized) => {
 				if (containerResized) this.measureGutter();
+				this.compensateReadAnchor();
 				this.updateSpacer();
 			},
 		});
 		this.measureGutter();
+		if (this.manualAnchoring) {
+			node.addEventListener("scroll", this.trackReadAnchor, { passive: true });
+		}
 		// Land at the bottom before first paint; being pinned makes the
 		// ResizeObserver absorb the async markdown/image height changes that
 		// used to leave the view off-bottom on load.
@@ -145,12 +166,64 @@ export class ChatScroll {
 		return {
 			destroy: () => {
 				visualViewport?.removeEventListener("resize", onViewportResize);
+				node.removeEventListener("scroll", this.trackReadAnchor);
 				this.controller?.destroy();
 				this.controller = null;
 				this.container = null;
 			},
 		};
 	};
+
+	/** Record the message element at the viewport top (binary search over the
+	 * content children: they are in document order). Only while detached —
+	 * pinned following owns the bottom edge instead. */
+	private trackReadAnchor = () => {
+		if (!this.manualAnchoring) return;
+		if (this.state.pinned || !this.container) {
+			this.readAnchor = null;
+			return;
+		}
+		const content = this.contentEl?.();
+		const children = content?.children;
+		if (!children || children.length === 0) {
+			this.readAnchor = null;
+			return;
+		}
+		const containerTop = this.container.getBoundingClientRect().top;
+		let lo = 0;
+		let hi = children.length - 1;
+		let found = children.length - 1;
+		while (lo <= hi) {
+			const mid = (lo + hi) >> 1;
+			if (children[mid].getBoundingClientRect().bottom > containerTop + 1) {
+				found = mid;
+				hi = mid - 1;
+			} else {
+				lo = mid + 1;
+			}
+		}
+		const el = children[found];
+		this.readAnchor = { el, offset: el.getBoundingClientRect().top - containerTop };
+	};
+
+	/** After a content resize while detached, restore the tracked element's
+	 * viewport position — Safari's stand-in for native scroll anchoring. The
+	 * adjustment goes through the controller, so attribution stays sound (it
+	 * matches the anchoring signature the scroll handler already recognizes). */
+	private compensateReadAnchor() {
+		if (!this.manualAnchoring || this.state.pinned || !this.container) return;
+		const anchor = this.readAnchor;
+		if (!anchor?.el.isConnected) return;
+		const containerTop = this.container.getBoundingClientRect().top;
+		const delta = anchor.el.getBoundingClientRect().top - containerTop - anchor.offset;
+		if (Math.abs(delta) < 1) return;
+		this.controller?.adjustBy(delta);
+		// The write may have been clamped; re-measure the offset we now hold.
+		this.readAnchor = {
+			el: anchor.el,
+			offset: anchor.el.getBoundingClientRect().top - containerTop,
+		};
+	}
 
 	/** `use:` action for the send-anchor spacer element. */
 	attachSpacer = (node: HTMLElement) => {
@@ -360,13 +433,14 @@ export class ChatScroll {
 	private activateSpacer() {
 		this.spacerActive = true;
 		this.anchorEl = null; // re-resolve for the new turn
-		this.updateSpacer();
+		// A new turn may inflate the spacer fresh; within the turn it only shrinks.
+		this.updateSpacer(true);
 	}
 
 	/** Size the spacer so the anchored user message sits near the viewport top;
 	 * runs on every content resize while a turn's anchor is active, shrinking
 	 * 1:1 with reply growth to keep scrollHeight constant (zero motion). */
-	private updateSpacer() {
+	private updateSpacer(allowGrow = false) {
 		if (!this.spacerActive || !this.container || !this.spacerEl) return;
 
 		// Resolve the anchored user message once per turn — this runs every
@@ -383,7 +457,7 @@ export class ChatScroll {
 		const anchorToSpacer =
 			this.spacerEl.getBoundingClientRect().top - anchor.getBoundingClientRect().top;
 
-		const height = computeSpacerHeight({
+		const computed = computeSpacerHeight({
 			viewportHeight: this.container.clientHeight,
 			anchorToSpacer,
 			minSpacer: this.minSpacer(),
@@ -391,6 +465,15 @@ export class ChatScroll {
 		});
 
 		const current = parseFloat(this.spacerEl.style.height) || MIN_SPACER_FALLBACK_PX;
+		// Monotonic within a turn: the spacer only shrinks as the reply grows.
+		// Re-inflating on content SHRINK (a thinking block collapsing at
+		// answer-start) would re-anchor the sent message and visibly scroll the
+		// view mid-read; letting the shrink clamp instead keeps everything
+		// below the collapse viewport-stable (the controller's clamp rule owns
+		// that case). Fresh turns (allowGrow) inflate freely, and the floor
+		// still wins so a growing composer can never occlude the reply.
+		const ceiling = allowGrow ? Infinity : current;
+		const height = Math.max(Math.min(computed, ceiling), this.minSpacer());
 		if (Math.abs(current - height) >= 1) {
 			this.spacerEl.style.height = `${height}px`;
 		}
@@ -433,6 +516,6 @@ export class ChatScroll {
 	}
 }
 
-export function createChatScroll(): ChatScroll {
-	return new ChatScroll();
+export function createChatScroll(options?: { forceManualAnchoring?: boolean }): ChatScroll {
+	return new ChatScroll(options);
 }

--- a/src/lib/utils/scroll/chatScroll.svelte.ts
+++ b/src/lib/utils/scroll/chatScroll.svelte.ts
@@ -117,7 +117,10 @@ export class ChatScroll {
 	 * position after content resizes: the same job Chrome's anchoring does.
 	 */
 	private manualAnchoring: boolean;
-	private readAnchor: { el: Element; offset: number } | null = null;
+	/** Viewport-top anchor as a deepest-first ancestor chain: markdown worker
+	 * swaps and streaming re-renders REPLACE deep nodes, so compensation falls
+	 * back to the nearest still-connected ancestor instead of going silent. */
+	private readAnchor: { el: Element; offset: number }[] | null = null;
 
 	constructor(options: { forceManualAnchoring?: boolean } = {}) {
 		this.manualAnchoring =
@@ -216,7 +219,14 @@ export class ChatScroll {
 			if (!inner) break;
 			el = inner;
 		}
-		this.readAnchor = { el, offset: el.getBoundingClientRect().top - containerTop };
+		// Store the whole ancestor chain (deepest first, up to the content
+		// root): if a re-render replaces the deep node, its ancestors still
+		// carry enough position to compensate cross-message shifts.
+		const chain: { el: Element; offset: number }[] = [];
+		for (let node: Element | null = el; node && node !== content; node = node.parentElement) {
+			chain.push({ el: node, offset: node.getBoundingClientRect().top - containerTop });
+		}
+		this.readAnchor = chain;
 	};
 
 	private firstChildBelow(parent: Element, containerTop: number): Element | null {
@@ -234,17 +244,23 @@ export class ChatScroll {
 	 * matches the anchoring signature the scroll handler already recognizes). */
 	private compensateReadAnchor() {
 		if (!this.manualAnchoring || this.state.pinned || !this.container) return;
-		const anchor = this.readAnchor;
-		if (!anchor?.el.isConnected) return;
-		const containerTop = this.container.getBoundingClientRect().top;
-		const delta = anchor.el.getBoundingClientRect().top - containerTop - anchor.offset;
-		if (Math.abs(delta) < 1) return;
-		this.controller?.adjustBy(delta);
-		// The write may have been clamped; re-measure the offset we now hold.
-		this.readAnchor = {
-			el: anchor.el,
-			offset: anchor.el.getBoundingClientRect().top - containerTop,
-		};
+		const chain = this.readAnchor;
+		if (!chain?.length) return;
+		// The deep anchor may have been replaced by this very resize (markdown
+		// worker swap, streaming re-render) — fall back to the nearest ancestor
+		// that survived, which still compensates every shift originating above
+		// it. Intra-ancestor changes from the replacing pass itself are
+		// unrecoverable (the old node's geometry died with it).
+		const entry = chain.find((e) => e.el.isConnected);
+		if (entry) {
+			const containerTop = this.container.getBoundingClientRect().top;
+			const delta = entry.el.getBoundingClientRect().top - containerTop - entry.offset;
+			if (Math.abs(delta) >= 1) this.controller?.adjustBy(delta);
+		}
+		// Always re-resolve a fresh deep anchor for the NEXT pass (the write may
+		// have been clamped, and a replaced node must not leave a stale chain —
+		// that would silence compensation until the next user scroll).
+		this.trackReadAnchor();
 	}
 
 	/** `use:` action for the send-anchor spacer element. */

--- a/src/lib/utils/scroll/chatScroll.svelte.ts
+++ b/src/lib/utils/scroll/chatScroll.svelte.ts
@@ -174,9 +174,10 @@ export class ChatScroll {
 		};
 	};
 
-	/** Record the message element at the viewport top (binary search over the
-	 * content children: they are in document order). Only while detached —
-	 * pinned following owns the bottom edge instead. */
+	/** Record the element at the viewport top (binary search over the content
+	 * children — they are in document order — then a descent into the
+	 * straddling message). Only while detached — pinned following owns the
+	 * bottom edge instead. */
 	private trackReadAnchor = () => {
 		if (!this.manualAnchoring) return;
 		if (this.state.pinned || !this.container) {
@@ -202,9 +203,30 @@ export class ChatScroll {
 				lo = mid + 1;
 			}
 		}
-		const el = children[found];
+		// Descend into the straddling message: anchoring the outer wrapper
+		// misses changes INSIDE it — a thinking block collapsing above the
+		// reading position within the same long message leaves the wrapper's
+		// top unchanged while the visible paragraph moves. Native anchoring
+		// anchors deep descendants; do the same. Linear scans here (unlike the
+		// top level) because in-message children are few and can be positioned
+		// out of flow, which breaks the binary search's ordering assumption.
+		let el: Element = children[found];
+		for (let depth = 0; depth < 8; depth++) {
+			const inner = this.firstChildBelow(el, containerTop);
+			if (!inner) break;
+			el = inner;
+		}
 		this.readAnchor = { el, offset: el.getBoundingClientRect().top - containerTop };
 	};
+
+	private firstChildBelow(parent: Element, containerTop: number): Element | null {
+		const kids = parent.children;
+		for (let i = 0; i < kids.length; i++) {
+			const rect = kids[i].getBoundingClientRect();
+			if (rect.height > 0 && rect.bottom > containerTop + 1) return kids[i];
+		}
+		return null;
+	}
 
 	/** After a content resize while detached, restore the tracked element's
 	 * viewport position — Safari's stand-in for native scroll anchoring. The

--- a/src/lib/utils/scroll/stickToBottom.ts
+++ b/src/lib/utils/scroll/stickToBottom.ts
@@ -329,6 +329,18 @@ export class StickToBottomController {
 		this.recomputeState();
 	}
 
+	/**
+	 * Attribution-safe relative adjustment that changes neither pin state nor
+	 * animation — for host-level scroll-anchoring compensation on engines
+	 * without native `overflow-anchor` (Safari), where above-viewport content
+	 * changes would otherwise shove a detached reader's text.
+	 */
+	adjustBy(delta: number) {
+		if (this.destroyed || this.anim) return;
+		this.write(this.clampedTop() + delta);
+		this.recomputeState();
+	}
+
 	/** Re-read geometry and re-follow if pinned; safe to call any time. */
 	recompute() {
 		this.onResize();


### PR DESCRIPTION
Follow-up to #2423, fixing the reported shifting around thinking blocks (Safari especially). Each mechanism was reproduced with harness probes before fixing:

## What was shifting

- **Answer-start re-anchor (all browsers, measured 267px):** when thinking output outgrew the send-anchor's fill slack, its ~300px collapse re-inflated the bottom spacer and re-anchored the sent message — scrolling the view mid-read right as the answer began.
- **Safari detached-reader jump (measured 350px, 0px on Chrome):** Safari has no native scroll anchoring (`overflow-anchor` unsupported), so any above-viewport shrink — a collapsing thinking block, a late image — shoved a detached reader's text by the full height delta. Chrome's native anchoring compensates silently, which is why this read as Safari-specific.
- **Single-frame collapse morph:** the reasoning block collapsed ~300px in one frame, and for the common lone-thinking case it couldn't even be animated — the answer-start branch flip in ChatMessage destroyed the expanded component instance and mounted a fresh collapsed one.

## Fixes

- **Spacer is monotonic within a turn:** it only shrinks as the reply grows, so a thinking collapse rides the controller's clamp path, keeping everything below the block viewport-stable. Fresh turns (send/regenerate) still inflate, and the composer-clearance floor still wins.
- **Manual scroll anchoring where the engine has none:** feature-detected via `CSS.supports("overflow-anchor", "auto")`. While detached, the chat glue tracks the message element at the viewport top (binary search per scroll event) and restores its position after content resizes through a new attribution-safe `adjustBy` on the controller. Chrome keeps native anchoring; Safari gets the equivalent.
- **Animated, remount-free collapse:** ChatMessage now renders one `renderUnits` template across the streaming and settled phases, so the lone thinking block's component instance survives the answer-start flip, and its expand/collapse is a 220ms height slide (instant under `prefers-reduced-motion`). Side effect: earlier multi-block tool runs stay summarized while a later step streams instead of re-expanding flat.

## Testing

Two new browser-mode regression tests pin the fixed behaviors (in-turn collapse keeps content below stable; simulated-Safari detached reader stays put through an above-viewport collapse), alongside the existing 50-test scroll suite — all green with the full repo suite, svelte-check, and lint. WebKit itself cannot launch in the CI container (missing system libraries), so Safari is simulated by forcing `overflow-anchor` off in Chromium — the only engine difference relevant to this bug class. A manual pass on real Safari/iOS after deploy is recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148VmxBDazfhczvfE122XVW

---
_Generated by [Claude Code](https://claude.ai/code/session_0148VmxBDazfhczvfE122XVW)_