### PR TITLE
Fix scroll stability during mid-turn content collapse and add Safari manual anchoring

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: verify
+description: Build, launch, and drive chat-ui end-to-end against a mock streaming backend (no real LLM key) to verify UI/streaming changes at the real surface.
+---
+
+# Verifying chat-ui end-to-end
+
+No LLM key is needed: point the app at a local OpenAI-compatible mock.
+
+1. **Mock backend** (node, no deps): serve `GET /v1/models` returning
+   `{"object":"list","data":[{"id":"test/thinker",...}]}` and
+   `POST /v1/chat/completions`; when `stream: true`, write SSE
+   `data: {"choices":[{"delta":{"content":"..."}}]}` chunks every ~60ms —
+   start with `<think>` + ~45 chunks + `</think>` to exercise the reasoning
+   block, then ~90 answer chunks; finish with `finish_reason:"stop"` then
+   `data: [DONE]`. Answer non-stream requests (title generation) with a
+   plain completion JSON.
+
+2. **Launch**: write `.env.local` (gitignored) with
+   `OPENAI_BASE_URL=http://127.0.0.1:<mockport>/v1`, `OPENAI_API_KEY=sk-mock`,
+   `MONGODB_URL=` (empty → in-memory Mongo persisted to ./db), then
+   `npm run dev` (port 5173). Ready in ~10s.
+
+3. **Drive** with the repo's own playwright
+   (`import { chromium } from "<repo>/node_modules/playwright/index.mjs"`;
+   browsers live under `PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers` — if the
+   pinned build number is missing, symlink the nearest build).
+
+Gotchas:
+- A **welcome modal** ("Start chatting") blocks the first visit — click it away.
+- Wait ~600ms after load before typing (model list/settings hydration), and
+  fall back to clicking `button[aria-label="Send message"]` if Enter races.
+- The chat scroller is `[aria-label="Conversation messages"]`; user messages
+  are `[data-message-type="user"]`; the live reasoning box is
+  `.thinking-viewport`; assistant messages are `[data-message-role="assistant"]`.
+- The FIRST exchange of a conversation deliberately does not anchor — do
+  scroll-behavior measurements on the second send.
+- While pinned, streaming text flows UP smoothly (spring follow) — when
+  asserting "no jump", check for sudden DOWNWARD displacement of the answer
+  text (view moving away from the live edge), not any motion.
+
+Browser unit suites (not a substitute for driving the app):
+`VITEST_BROWSER=true npx vitest run --project client src/lib/utils/scroll/`.
+Two pre-existing client-suite failures are environmental (Tailwind cap
+utilities don't load there): the OpenReasoningResults mask test and a
+ToolCallsSummary expansion test.

--- a/src/lib/components/chat/ChatMessage.svelte
+++ b/src/lib/components/chat/ChatMessage.svelte
@@ -410,62 +410,61 @@
 				{#if isLast && loading && blocks.length === 0}
 					<IconLoading classNames="loading inline ml-2 first:ml-0" />
 				{/if}
-				{#if isProcessStreaming}
-					<!-- Streaming the thinking / tool phase: render every block flat and
-					     inline, exactly like today. Nesting kicks in once the answer starts. -->
-					{#each blocks as block, blockIndex (block.type === "tool" ? `tool-${block.uuid}-${blockIndex}` : `block-${blockIndex}`)}
-						{#if block.type === "text"}
-							{#if block.content.trim().length > 0}
-								<div class={proseClasses}>
-									<MarkdownRenderer content={block.content} loading={isLast && loading} />
-								</div>
-							{/if}
-						{:else if block.type === "artifact"}
-							<ArtifactCard op={block.op} messageId={message.id} opIndex={block.opIndex} />
-						{:else}
-							<div data-exclude-from-copy class="not-last:mb-1 has-[+.prose]:mb-2! [.prose+&]:mt-3">
-								{#if block.type === "think"}
-									<OpenReasoningResults
-										content={block.content}
-										loading={isLast && loading && !block.closed}
-									/>
-								{:else}
-									<ToolUpdate tool={block.updates} {loading} />
-								{/if}
+				<!-- One template for the streaming and settled phases: process groups
+				     render flat and live while thinking/tools stream (exactly like
+				     before) and nest into summaries once the answer starts — but the
+				     LONE thinking block renders through the same branch in both
+				     phases, so its component instance survives the answer-start flip
+				     and its collapse is an animated slide instead of a remount that
+				     teleports the layout ~300px in one frame. -->
+				{#each renderUnits as unit, unitIndex (`${unit.kind}-${unitIndex}`)}
+					{#if unit.kind === "text"}
+						{#if isLast && loading && unit.content.length === 0}
+							<IconLoading classNames="loading inline ml-2 first:ml-0" />
+						{:else if unit.content.trim().length > 0}
+							<div class={proseClasses}>
+								<MarkdownRenderer content={unit.content} loading={isLast && loading} />
 							</div>
 						{/if}
-					{/each}
-				{:else}
-					<!-- Answer started or generation finished: nest the process blocks. -->
-					{#each renderUnits as unit, unitIndex (`${unit.kind}-${unitIndex}`)}
-						{#if unit.kind === "text"}
-							{#if isLast && loading && unit.content.length === 0}
-								<IconLoading classNames="loading inline ml-2 first:ml-0" />
-							{:else if unit.content.trim().length > 0}
-								<div class={proseClasses}>
-									<MarkdownRenderer content={unit.content} loading={isLast && loading} />
-								</div>
-							{/if}
-						{:else if unit.kind === "artifact"}
-							<ArtifactCard op={unit.op} messageId={message.id} opIndex={unit.opIndex} />
-						{:else if unit.kind === "group"}
-							<div data-exclude-from-copy class="not-last:mb-1 has-[+.prose]:mb-2! [.prose+&]:mt-3">
-								{#if unit.blocks.length > 1}
-									<!-- Collapse the whole run into a single summary -->
-									<ToolCallsSummary blocks={unit.blocks} toolCount={unit.toolCount} />
-								{:else}
-									<!-- A lone process block stays standalone -->
-									{@const only = unit.blocks[0]}
-									{#if only.type === "think"}
-										<OpenReasoningResults content={only.content} loading={false} />
-									{:else}
-										<ToolUpdate tool={only.updates} loading={false} />
-									{/if}
+					{:else if unit.kind === "artifact"}
+						<ArtifactCard op={unit.op} messageId={message.id} opIndex={unit.opIndex} />
+					{:else if unit.kind === "group"}
+						<div data-exclude-from-copy class="not-last:mb-1 has-[+.prose]:mb-2! [.prose+&]:mt-3">
+							{#if unit.blocks.length === 1 && unit.blocks[0].type === "think"}
+								<!-- Phase-independent: streams live, settles in place. -->
+								<OpenReasoningResults
+									content={unit.blocks[0].content}
+									loading={isProcessStreaming && isLast && loading && !unit.blocks[0].closed}
+								/>
+							{:else if isProcessStreaming}
+								<!-- Streaming the thinking / tool phase: every block flat and
+								     inline, exactly like before nesting kicks in. -->
+								{#each unit.blocks as block, blockIndex (block.type === "tool" ? `tool-${block.uuid}` : `think-${blockIndex}`)}
+									<div class="not-last:mb-1">
+										{#if block.type === "think"}
+											<OpenReasoningResults
+												content={block.content}
+												loading={isLast && loading && !block.closed}
+											/>
+										{:else}
+											<ToolUpdate tool={block.updates} {loading} />
+										{/if}
+									</div>
+								{/each}
+							{:else if unit.blocks.length > 1}
+								<!-- Answer started or generation finished: collapse the whole
+								     run into a single summary -->
+								<ToolCallsSummary blocks={unit.blocks} toolCount={unit.toolCount} />
+							{:else}
+								<!-- A lone tool block stays standalone (think is handled above) -->
+								{@const only = unit.blocks[0]}
+								{#if only.type === "tool"}
+									<ToolUpdate tool={only.updates} loading={false} />
 								{/if}
-							</div>
-						{/if}
-					{/each}
-				{/if}
+							{/if}
+						</div>
+					{/if}
+				{/each}
 			</div>
 		</div>
 

--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -348,6 +348,13 @@
 		chatScroll.setComposerHeight(composerHeight);
 	});
 
+	// While a response streams, the send-anchor spacer is one-way (shrink-only)
+	// so a mid-stream collapse can never re-anchor the view; once settled it may
+	// re-inflate again, which absorbs post-turn collapses with zero motion.
+	$effect(() => {
+		chatScroll.setStreaming(loading);
+	});
+
 	// Shared conversations containing artifacts usually exist to show one off:
 	// open the most recent artifact on load. Desktop only, since on mobile the
 	// panel is a fullscreen overlay that would hide the conversation entirely.

--- a/src/lib/components/chat/OpenReasoningResults.svelte
+++ b/src/lib/components/chat/OpenReasoningResults.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+	import { slide } from "svelte/transition";
+	import { cubicOut } from "svelte/easing";
+	import { browser } from "$app/environment";
 	import MarkdownRenderer from "./MarkdownRenderer.svelte";
 	import BlockWrapper from "./BlockWrapper.svelte";
 	import CarbonChevronRight from "~icons/carbon/chevron-right";
@@ -9,6 +12,12 @@
 	}
 
 	let { content, loading = false }: Props = $props();
+
+	// Expand/collapse animates as a height slide instead of a single-frame
+	// ~300px layout change: the scroll system tracks geometry per frame, so a
+	// smooth height change means no jump for anything below the block.
+	const collapseDuration =
+		browser && window.matchMedia("(prefers-reduced-motion: reduce)").matches ? 0 : 220;
 	let isOpen = $state(false);
 	let wasLoading = $state(false);
 	let initialized = $state(false);
@@ -18,8 +27,13 @@
 	let viewportHeight = $state(0);
 	let contentHeight = $state(0);
 
-	// Track loading transitions to auto-expand/collapse
-	$effect(() => {
+	// Track loading transitions to auto-expand/collapse. Runs PRE-render:
+	// when loading flips false, the collapse must be decided before the
+	// template re-renders, so the slide-out starts from the still-capped
+	// streaming viewport — a post-render effect would let the uncapped
+	// settled prose mount first and a long thought would bounce to its full
+	// height for a frame before collapsing.
+	$effect.pre(() => {
 		if (!initialized) {
 			initialized = true;
 			if (loading) {
@@ -63,31 +77,36 @@
 
 	<!-- Expandable content -->
 	{#if isOpen}
-		{#if loading}
-			<!--
-				Streaming view: fixed-height viewport, content bottom-aligned so newly
-				arriving tokens stay visible while older lines scroll off the top behind
-				a gradient fade. Works for any model output format (no parsing).
-			-->
-			<div
-				bind:clientHeight={viewportHeight}
-				class="thinking-viewport mt-2 flex max-h-56 flex-col justify-end overflow-hidden md:max-h-80"
-				class:has-overflow={contentHeight > viewportHeight}
-			>
+		<div transition:slide={{ duration: collapseDuration, easing: cubicOut }}>
+			<!-- `|| !isOpen`: while the slide-out is running, any re-render must
+			     keep the capped streaming shape — switching to the uncapped
+			     settled prose mid-outro would grow the collapsing box. -->
+			{#if loading || !isOpen}
+				<!--
+					Streaming view: fixed-height viewport, content bottom-aligned so newly
+					arriving tokens stay visible while older lines scroll off the top behind
+					a gradient fade. Works for any model output format (no parsing).
+				-->
 				<div
-					bind:clientHeight={contentHeight}
-					class="prose prose-sm max-w-none text-sm leading-relaxed text-gray-500 *:first:mt-0 *:last:mb-0 dark:text-gray-400 dark:prose-invert"
+					bind:clientHeight={viewportHeight}
+					class="thinking-viewport mt-2 flex max-h-56 flex-col justify-end overflow-hidden md:max-h-80"
+					class:has-overflow={contentHeight > viewportHeight}
+				>
+					<div
+						bind:clientHeight={contentHeight}
+						class="prose prose-sm max-w-none text-sm leading-relaxed text-gray-500 *:first:mt-0 *:last:mb-0 dark:text-gray-400 dark:prose-invert"
+					>
+						<MarkdownRenderer {content} {loading} />
+					</div>
+				</div>
+			{:else}
+				<div
+					class="prose prose-sm mt-2 max-w-none text-sm leading-relaxed text-gray-500 dark:text-gray-400 dark:prose-invert"
 				>
 					<MarkdownRenderer {content} {loading} />
 				</div>
-			</div>
-		{:else}
-			<div
-				class="prose prose-sm mt-2 max-w-none text-sm leading-relaxed text-gray-500 dark:text-gray-400 dark:prose-invert"
-			>
-				<MarkdownRenderer {content} {loading} />
-			</div>
-		{/if}
+			{/if}
+		</div>
 	{/if}
 </BlockWrapper>
 

--- a/src/lib/components/chat/OpenReasoningResults.svelte.test.ts
+++ b/src/lib/components/chat/OpenReasoningResults.svelte.test.ts
@@ -32,6 +32,38 @@ describe("OpenReasoningResults", () => {
 		expect(page.getByText("Paragraph 1:", { exact: false })).toBeInTheDocument();
 	});
 
+	it("collapses in the capped streaming shape at answer-start (no expand bounce)", async () => {
+		const { container, rerender } = render(OpenReasoningResults, {
+			content: LONG_REASONING,
+			loading: true,
+		});
+		await new Promise((r) => setTimeout(r, 100));
+		const initial = container.getBoundingClientRect().height;
+		expect(container.querySelector(".thinking-viewport")).not.toBeNull();
+
+		// Answer starts: loading flips false and the auto-collapse slides out.
+		// The OUTGOING content must keep the capped .thinking-viewport shape for
+		// the whole slide — if the uncapped settled prose mounts first (isOpen
+		// still true for one render), a long thought bounces to its full height
+		// before collapsing. The settled prose is any .prose OUTSIDE the capped
+		// viewport; the box must also never grow past its streaming height.
+		await rerender({ loading: false });
+		let sawSettledProse = false;
+		let maxHeight = 0;
+		for (let i = 0; i < 30; i++) {
+			await new Promise((r) => requestAnimationFrame(r));
+			maxHeight = Math.max(maxHeight, container.getBoundingClientRect().height);
+			sawSettledProse ||= [...container.querySelectorAll(".prose")].some(
+				(p) => !p.closest(".thinking-viewport")
+			);
+		}
+		expect(sawSettledProse).toBe(false);
+		expect(maxHeight).toBeLessThanOrEqual(initial + 8);
+		// The slide finished: streaming viewport unmounted, header-row height.
+		expect(container.querySelector(".thinking-viewport")).toBeNull();
+		expect(container.getBoundingClientRect().height).toBeLessThan(initial / 2);
+	});
+
 	it("renders the full text view when not loading", async () => {
 		const { baseElement } = render(OpenReasoningResults, {
 			content: LONG_REASONING,

--- a/src/lib/utils/scroll/__tests__/chatScroll.svelte.test.ts
+++ b/src/lib/utils/scroll/__tests__/chatScroll.svelte.test.ts
@@ -359,6 +359,79 @@ describe("floating buttons", () => {
 	});
 });
 
+describe("in-turn content shrink (thinking-block collapse)", () => {
+	it("a large mid-stream collapse keeps everything below it viewport-stable (no spacer re-inflation)", async () => {
+		const chat = createChat({ turns: 3, viewportHeight: 600 });
+		chat.chat.setStreaming(true);
+		chat.chat.armSend();
+		const { assistant: thinking } = chat.mountPair();
+		await waitFor(() => chat.fixture.distance() <= ARRIVED, { label: "send anchored" });
+
+		// Thinking streams: the block grows well past the fill slack, so the
+		// spacer floors and real following takes over.
+		for (let i = 0; i < 16; i++) {
+			thinking.style.height = `${parseFloat(thinking.style.height) + 20}px`;
+			await frame();
+		}
+		const answer = chat.fixture.addBlock(24, { id: "answer" });
+		await waitFor(() => chat.fixture.distance() <= ARRIVED, { label: "settled while pinned" });
+
+		const before = topOf(answer, chat);
+		// Answer starts: the reasoning block collapses ~300px in one frame. The
+		// spacer must NOT re-inflate (one-way while streaming) — the shrink
+		// clamps instead, which keeps the content below the collapse stable.
+		thinking.style.height = "28px";
+		await frames(3);
+		const after = topOf(answer, chat);
+		expect(Math.abs(after - before)).toBeLessThanOrEqual(2);
+		expect(chat.chat.state.pinned).toBe(true);
+	});
+
+	it("a post-stream collapse re-inflates the spacer instead: constant scrollHeight, zero motion", async () => {
+		const chat = createChat({ turns: 3, viewportHeight: 600 });
+		chat.chat.setStreaming(true);
+		chat.chat.armSend();
+		const { assistant: thinking } = chat.mountPair();
+		await waitFor(() => chat.fixture.distance() <= ARRIVED, { label: "send anchored" });
+		// Streams within the fill slack (the capped thinking viewport in the
+		// app), so the spacer shrinks 1:1 and never floors.
+		thinking.style.height = "240px";
+		await frames(3);
+
+		// Stream ends; the trailing think block auto-collapses in the same
+		// breath (think-only reply). Re-inflation absorbs the shrink exactly.
+		chat.chat.setStreaming(false);
+		const scrollTopBefore = chat.fixture.scrollTop();
+		const headerBefore = topOf(thinking, chat);
+		thinking.style.height = "28px";
+		await frames(3);
+		expect(chat.fixture.scrollTop()).toBe(scrollTopBefore);
+		expect(topOf(thinking, chat)).toBe(headerBefore);
+	});
+
+	it("a container resize mid-turn re-derives the anchor geometry (mobile keyboard close)", async () => {
+		const chat = createChat({ turns: 3, viewportHeight: 400 });
+		chat.chat.setStreaming(true);
+		chat.chat.armSend();
+		const { user, assistant } = chat.mountPair();
+		await waitFor(() => Math.abs(topOf(user, chat) - ANCHOR_OFFSET) <= 2, { label: "anchored" });
+		// A short reply streams in while the anchor holds.
+		assistant.style.height = "40px";
+		await frames(3);
+		const spacerBefore = parseFloat(chat.fixture.spacer.style.height);
+
+		// The virtual keyboard closes: the container gets ~40% taller. The
+		// spacer must re-inflate for the new viewport even mid-stream (a frozen
+		// spacer would leave the anchored message stranded mid-screen).
+		chat.fixture.container.style.height = "560px";
+		await waitFor(() => Math.abs(topOf(user, chat) - ANCHOR_OFFSET) <= 2, {
+			label: "re-anchored after viewport growth",
+		});
+		expect(parseFloat(chat.fixture.spacer.style.height)).toBeGreaterThan(spacerBefore);
+		expect(chat.chat.state.pinned).toBe(true);
+	});
+});
+
 describe("composer clearance", () => {
 	it("grows the spacer floor under a tall composer and shrinks it back", async () => {
 		const chat = createChat();

--- a/src/lib/utils/scroll/__tests__/chatScroll.svelte.test.ts
+++ b/src/lib/utils/scroll/__tests__/chatScroll.svelte.test.ts
@@ -6,6 +6,7 @@ import {
 	dragScrollbarTo,
 	frame,
 	frames,
+	nextTask,
 	startClsProbe,
 	waitFor,
 	wheel,
@@ -429,6 +430,177 @@ describe("in-turn content shrink (thinking-block collapse)", () => {
 		});
 		expect(parseFloat(chat.fixture.spacer.style.height)).toBeGreaterThan(spacerBefore);
 		expect(chat.chat.state.pinned).toBe(true);
+	});
+});
+
+describe("manual scroll anchoring (Safari: no overflow-anchor)", () => {
+	/** Simulated-Safari chat: native anchoring forced off (inline style loses
+	 * to !important), manual anchoring forced on. WebKit itself cannot launch
+	 * in this container; the missing native anchoring is the only engine
+	 * difference relevant to this bug class. */
+	function createManualChat(build: (fixture: Fixture) => void): ChatFixture {
+		const style = document.createElement("style");
+		style.textContent = ".sim-safari { overflow-anchor: none !important; }";
+		document.head.appendChild(style);
+
+		const fixture = createFixture({ viewportHeight: 400, blocks: [] });
+		fixture.container.classList.add("sim-safari");
+		const chat = createChatScroll({ forceManualAnchoring: true });
+		build(fixture);
+		const spacerAction = chat.attachSpacer(fixture.spacer);
+		const containerAction = chat.attach(fixture.container, { content: () => fixture.content });
+		chat.sync({ conversationKey: "c1", messages: [], lastMessageEmpty: false });
+		const api: ChatFixture = {
+			fixture,
+			chat,
+			messages: [],
+			sync: () => {},
+			mountPair: () => ({
+				user: document.createElement("div"),
+				assistant: document.createElement("div"),
+			}),
+			swapAssistant: () => document.createElement("div"),
+			viewportTop: () => fixture.container.getBoundingClientRect().top,
+			destroy() {
+				containerAction.destroy();
+				spacerAction.destroy();
+				fixture.destroy();
+				style.remove();
+			},
+		};
+		active.push(api);
+		return api;
+	}
+
+	/** Scroll up until `el` sits at the viewport top, and let the scroll event
+	 * process so the read anchor is captured from a settled position. */
+	async function readAt(chat: ChatFixture, el: Element) {
+		const target = el.getBoundingClientRect().top - chat.viewportTop() + chat.fixture.scrollTop();
+		dragScrollbarTo(chat.fixture.container, target);
+		await frames(2);
+		await nextTask();
+		expect(chat.chat.state.pinned).toBe(false);
+	}
+
+	it("keeps a detached reader stable through an above-viewport collapse", async () => {
+		let earlier!: HTMLDivElement;
+		let reading!: HTMLDivElement;
+		const chat = createManualChat((fixture) => {
+			earlier = fixture.addBlock(400, { id: "earlier" }); // reasoning of an earlier turn
+			reading = fixture.addBlock(300, { user: true, id: "reading" });
+			fixture.addBlock(900, { id: "tail" });
+		});
+		await waitFor(() => chat.fixture.distance() <= ARRIVED, { label: "settle" });
+		await nextTask();
+
+		await readAt(chat, reading);
+		const before = topOf(reading, chat);
+
+		// The earlier thinking block collapses ABOVE the viewport: without
+		// compensation this shifts the reading position by the full 350px.
+		earlier.style.height = "50px";
+		await frames(3);
+		expect(Math.abs(topOf(reading, chat) - before)).toBeLessThanOrEqual(2);
+	});
+
+	it("tracks a descendant INSIDE a long message, not just the wrapper", async () => {
+		// Reading the middle of one long assistant message whose own thinking
+		// block collapses above the reading position: the wrapper's top never
+		// moves, so a wrapper-level anchor would read delta 0 and let the text
+		// jump — the anchor must be the descendant at the viewport top.
+		const mkInner = (height: number) => {
+			const el = document.createElement("div");
+			el.style.cssText = `height: ${height}px; flex-shrink: 0; background: #eef;`;
+			return el;
+		};
+		let thinking!: HTMLDivElement;
+		let reading!: HTMLDivElement;
+		const chat = createManualChat((fixture) => {
+			const message = document.createElement("div");
+			message.style.cssText = "display: flex; flex-direction: column; flex-shrink: 0;";
+			message.dataset.messageId = "long-message";
+			thinking = mkInner(400);
+			reading = mkInner(300);
+			message.append(thinking, reading, mkInner(900));
+			fixture.content.appendChild(message);
+		});
+		await waitFor(() => chat.fixture.distance() <= ARRIVED, { label: "settle" });
+		await nextTask();
+
+		await readAt(chat, reading);
+		const before = topOf(reading, chat);
+
+		thinking.style.height = "50px"; // collapse INSIDE the same message
+		await frames(3);
+		expect(Math.abs(topOf(reading, chat) - before)).toBeLessThanOrEqual(2);
+	});
+
+	it("survives the anchored node being replaced (markdown re-render)", async () => {
+		const mkInner = (height: number) => {
+			const el = document.createElement("div");
+			el.style.cssText = `height: ${height}px; flex-shrink: 0; background: #efe;`;
+			return el;
+		};
+		let earlier!: HTMLDivElement;
+		let reading!: HTMLDivElement;
+		const chat = createManualChat((fixture) => {
+			earlier = fixture.addBlock(400, { id: "earlier" });
+			const message = document.createElement("div");
+			message.style.cssText = "display: flex; flex-direction: column; flex-shrink: 0;";
+			message.dataset.messageId = "rendered-message";
+			reading = mkInner(300);
+			message.append(reading, mkInner(900));
+			fixture.content.appendChild(message);
+		});
+		await waitFor(() => chat.fixture.distance() <= ARRIVED, { label: "settle" });
+		await nextTask();
+
+		await readAt(chat, reading);
+		const containerTop = chat.viewportTop();
+		const before = reading.getBoundingClientRect().top - containerTop;
+
+		// A worker markdown swap REPLACES the anchored paragraph in the same
+		// pass as an above-viewport shrink: the dead node must not silence
+		// compensation (fall back to the surviving message wrapper).
+		const replacement = mkInner(300);
+		reading.replaceWith(replacement);
+		reading = replacement;
+		earlier.style.height = "50px";
+		await frames(3);
+		let position = reading.getBoundingClientRect().top - containerTop;
+		expect(Math.abs(position - before)).toBeLessThanOrEqual(2);
+
+		// And the anchor was re-resolved onto live nodes: a LATER above-viewport
+		// change is compensated too (a stale chain would let this one jump).
+		earlier.style.height = "10px";
+		await frames(3);
+		position = reading.getBoundingClientRect().top - containerTop;
+		expect(Math.abs(position - before)).toBeLessThanOrEqual(2);
+	});
+
+	it("never cancels a user scroll pending in the same pass as a shrink", async () => {
+		let earlier!: HTMLDivElement;
+		let reading!: HTMLDivElement;
+		const chat = createManualChat((fixture) => {
+			earlier = fixture.addBlock(400, { id: "earlier" });
+			reading = fixture.addBlock(300, { user: true, id: "reading" });
+			fixture.addBlock(900, { id: "tail" });
+		});
+		await waitFor(() => chat.fixture.distance() <= ARRIVED, { label: "settle" });
+		await nextTask();
+		await readAt(chat, reading);
+
+		// A user scroll AND an above-viewport shrink land in the same task —
+		// the resize pass can run BEFORE the scroll event is processed, so the
+		// captured anchor is stale (it includes the unprocessed movement).
+		// Compensating from it would yank the view away from where the user
+		// just scrolled; the pass must be skipped instead.
+		const userTarget = chat.fixture.scrollTop() - 120;
+		dragScrollbarTo(chat.fixture.container, userTarget);
+		earlier.style.height = "250px";
+		await frames(3);
+		expect(Math.abs(chat.fixture.scrollTop() - userTarget)).toBeLessThanOrEqual(2);
+		expect(chat.chat.state.pinned).toBe(false);
 	});
 });
 

--- a/src/lib/utils/scroll/chatScroll.svelte.ts
+++ b/src/lib/utils/scroll/chatScroll.svelte.ts
@@ -115,6 +115,29 @@ export class ChatScroll {
 	private knownIds: ReadonlySet<string> = new Set();
 	private initialized = false;
 
+	/**
+	 * Safari has no native scroll anchoring (`overflow-anchor` unsupported), so
+	 * content changes above the viewport — a thinking block collapsing, a late
+	 * image, a markdown swap — shove a detached reader's text by the full
+	 * height delta. Where native anchoring is unavailable, track the element at
+	 * the viewport top while detached and manually restore its position after
+	 * content resizes: the same job Chrome's anchoring does.
+	 */
+	private manualAnchoring: boolean;
+	/** Viewport-top anchor as a deepest-first ancestor chain (markdown worker
+	 * swaps and streaming re-renders REPLACE deep nodes, so compensation falls
+	 * back to the nearest still-connected ancestor instead of going silent),
+	 * plus the scrollTop it was captured at: a mismatch at compensation time
+	 * means a user scroll is pending in the same pass, and compensating from
+	 * the stale capture would cancel their movement. */
+	private readAnchor: { chain: { el: Element; offset: number }[]; top: number } | null = null;
+
+	constructor(options: { forceManualAnchoring?: boolean } = {}) {
+		this.manualAnchoring =
+			options.forceManualAnchoring ??
+			(typeof CSS !== "undefined" && !CSS.supports("overflow-anchor", "auto"));
+	}
+
 	// --- wiring -------------------------------------------------------------------
 
 	/** `use:` action for the scroll container. */
@@ -133,6 +156,7 @@ export class ChatScroll {
 			onStateChange: (s) => this.applyState(s),
 			onContentResize: (containerResized) => {
 				if (containerResized) this.measureGutter();
+				this.compensateReadAnchor();
 				// Container resizes (keyboard close, window resize, panel toggle)
 				// re-derive the anchor geometry in full; pure content resizes are
 				// one-way within a turn (see updateSpacer).
@@ -140,6 +164,9 @@ export class ChatScroll {
 			},
 		});
 		this.measureGutter();
+		if (this.manualAnchoring) {
+			node.addEventListener("scroll", this.trackReadAnchor, { passive: true });
+		}
 		// Land at the bottom before first paint; being pinned makes the
 		// ResizeObserver absorb the async markdown/image height changes that
 		// used to leave the view off-bottom on load.
@@ -155,12 +182,109 @@ export class ChatScroll {
 		return {
 			destroy: () => {
 				visualViewport?.removeEventListener("resize", onViewportResize);
+				node.removeEventListener("scroll", this.trackReadAnchor);
 				this.controller?.destroy();
 				this.controller = null;
 				this.container = null;
 			},
 		};
 	};
+
+	/** Record the element at the viewport top (binary search over the content
+	 * children — they are in document order — then a descent into the
+	 * straddling message). Only while detached — pinned following owns the
+	 * bottom edge instead. */
+	private trackReadAnchor = () => {
+		if (!this.manualAnchoring) return;
+		if (this.state.pinned || !this.container) {
+			this.readAnchor = null;
+			return;
+		}
+		const content = this.contentEl?.();
+		const children = content?.children;
+		if (!content || !children || children.length === 0) {
+			this.readAnchor = null;
+			return;
+		}
+		const containerTop = this.container.getBoundingClientRect().top;
+		let lo = 0;
+		let hi = children.length - 1;
+		let found = children.length - 1;
+		while (lo <= hi) {
+			const mid = (lo + hi) >> 1;
+			if (children[mid].getBoundingClientRect().bottom > containerTop + 1) {
+				found = mid;
+				hi = mid - 1;
+			} else {
+				lo = mid + 1;
+			}
+		}
+		// Descend into the straddling message: anchoring the outer wrapper
+		// misses changes INSIDE it — a thinking block collapsing above the
+		// reading position within the same long message leaves the wrapper's
+		// top unchanged while the visible paragraph moves. Native anchoring
+		// anchors deep descendants; do the same. Linear scans here (unlike the
+		// top level) because in-message children are few and can be positioned
+		// out of flow, which breaks the binary search's ordering assumption.
+		let el: Element = children[found];
+		for (let depth = 0; depth < 8; depth++) {
+			const inner = this.firstChildBelow(el, containerTop);
+			if (!inner) break;
+			el = inner;
+		}
+		// Store the whole ancestor chain (deepest first, up to the content
+		// root): if a re-render replaces the deep node, its ancestors still
+		// carry enough position to compensate cross-message shifts.
+		const chain: { el: Element; offset: number }[] = [];
+		for (let node: Element | null = el; node && node !== content; node = node.parentElement) {
+			chain.push({ el: node, offset: node.getBoundingClientRect().top - containerTop });
+		}
+		this.readAnchor = { chain, top: this.container.scrollTop };
+	};
+
+	private firstChildBelow(parent: Element, containerTop: number): Element | null {
+		const kids = parent.children;
+		for (let i = 0; i < kids.length; i++) {
+			const rect = kids[i].getBoundingClientRect();
+			if (rect.height > 0 && rect.bottom > containerTop + 1) return kids[i];
+		}
+		return null;
+	}
+
+	/** After a content resize while detached, restore the tracked element's
+	 * viewport position — Safari's stand-in for native scroll anchoring. The
+	 * adjustment goes through the controller, so attribution stays sound (its
+	 * write is consumed like any of ours). */
+	private compensateReadAnchor() {
+		if (!this.manualAnchoring || this.state.pinned || !this.container) return;
+		const anchor = this.readAnchor;
+		if (!anchor?.chain.length) return;
+		// A scrollTop that moved since capture means a user scroll (or clamp)
+		// is pending in this very pass — resize delivery is not ordered after
+		// scroll events. The captured offsets then include that unprocessed
+		// movement, and "compensating" would cancel the user's scroll. Skip
+		// this pass (one uncompensated frame is invisible; fighting the user's
+		// finger is not) and re-capture below.
+		const stale = Math.abs(this.container.scrollTop - anchor.top) > 1;
+		if (!stale) {
+			// The deep anchor may have been replaced by this very resize
+			// (markdown worker swap, streaming re-render) — fall back to the
+			// nearest ancestor that survived, which still compensates every
+			// shift originating above it. Intra-ancestor changes from the
+			// replacing pass itself are unrecoverable (the old node's geometry
+			// died with it).
+			const entry = anchor.chain.find((e) => e.el.isConnected);
+			if (entry) {
+				const containerTop = this.container.getBoundingClientRect().top;
+				const delta = entry.el.getBoundingClientRect().top - containerTop - entry.offset;
+				if (Math.abs(delta) >= 1) this.controller?.adjustBy(delta);
+			}
+		}
+		// Always re-resolve a fresh anchor for the NEXT pass (the write may
+		// have been clamped, and a replaced node must not leave a stale chain —
+		// that would silence compensation until the next user scroll).
+		this.trackReadAnchor();
+	}
 
 	/** `use:` action for the send-anchor spacer element. */
 	attachSpacer = (node: HTMLElement) => {
@@ -466,6 +590,6 @@ export class ChatScroll {
 	}
 }
 
-export function createChatScroll(): ChatScroll {
-	return new ChatScroll();
+export function createChatScroll(options?: { forceManualAnchoring?: boolean }): ChatScroll {
+	return new ChatScroll(options);
 }

--- a/src/lib/utils/scroll/chatScroll.svelte.ts
+++ b/src/lib/utils/scroll/chatScroll.svelte.ts
@@ -89,6 +89,13 @@ export class ChatScroll {
 	private intent: Intent | null = null;
 	/** True while a send anchor is active for the current turn. */
 	private spacerActive = false;
+	/** True while a response is streaming (mirrors ChatWindow's loading prop) —
+	 * the window in which the spacer is one-way (shrink-only), because a reader
+	 * follows the live edge BELOW any collapsing block and re-anchoring would
+	 * yank the text they're reading. Outside it, re-inflation is what keeps a
+	 * post-turn collapse (manual toggle, end-of-stream auto-collapse) perfectly
+	 * still: constant scrollHeight means nothing moves at all. */
+	private streaming = false;
 	/** The anchored user message element, resolved once per turn — updateSpacer
 	 * runs on every streaming frame and must not rescan the whole subtree. */
 	private anchorEl: Element | null = null;
@@ -126,7 +133,10 @@ export class ChatScroll {
 			onStateChange: (s) => this.applyState(s),
 			onContentResize: (containerResized) => {
 				if (containerResized) this.measureGutter();
-				this.updateSpacer();
+				// Container resizes (keyboard close, window resize, panel toggle)
+				// re-derive the anchor geometry in full; pure content resizes are
+				// one-way within a turn (see updateSpacer).
+				this.updateSpacer(containerResized);
 			},
 		});
 		this.measureGutter();
@@ -167,6 +177,14 @@ export class ChatScroll {
 	 * conversation gaining its first messages) — re-check the observer then. */
 	notifyContentChanged() {
 		this.controller?.recompute();
+	}
+
+	/** Mirror of ChatWindow's loading prop. Only a flag flip: no recompute here,
+	 * so the transition itself can never cause motion (an end-of-stream
+	 * recompute could re-inflate a floored spacer and glide the view — the
+	 * #2381 class of bug). The next real resize simply sees the new regime. */
+	setStreaming(streaming: boolean) {
+		this.streaming = streaming;
 	}
 
 	setComposerHeight(height: number | undefined) {
@@ -360,13 +378,14 @@ export class ChatScroll {
 	private activateSpacer() {
 		this.spacerActive = true;
 		this.anchorEl = null; // re-resolve for the new turn
-		this.updateSpacer();
+		// A fresh turn inflates the spacer freely; within the turn it only shrinks.
+		this.updateSpacer(true);
 	}
 
 	/** Size the spacer so the anchored user message sits near the viewport top;
 	 * runs on every content resize while a turn's anchor is active, shrinking
 	 * 1:1 with reply growth to keep scrollHeight constant (zero motion). */
-	private updateSpacer() {
+	private updateSpacer(allowGrow = false) {
 		if (!this.spacerActive || !this.container || !this.spacerEl) return;
 
 		// Resolve the anchored user message once per turn — this runs every
@@ -383,7 +402,7 @@ export class ChatScroll {
 		const anchorToSpacer =
 			this.spacerEl.getBoundingClientRect().top - anchor.getBoundingClientRect().top;
 
-		const height = computeSpacerHeight({
+		const computed = computeSpacerHeight({
 			viewportHeight: this.container.clientHeight,
 			anchorToSpacer,
 			minSpacer: this.minSpacer(),
@@ -391,6 +410,20 @@ export class ChatScroll {
 		});
 
 		const current = parseFloat(this.spacerEl.style.height) || MIN_SPACER_FALLBACK_PX;
+		// One-way handoff while the stream is live: on pure content changes the
+		// spacer only shrinks as the reply grows. Re-inflating on a content
+		// SHRINK (a thinking block collapsing at answer-start) would re-anchor
+		// the sent message and yank the text a reader is following at the live
+		// edge — the shrink rides the controller's clamp rule instead, keeping
+		// everything below the collapse viewport-stable. Growth is still allowed
+		// at turn start, on container resizes (keyboard close, window resize,
+		// panel toggle — the viewport changed, so freezing the stale height
+		// would misplace the anchor), and once the stream has settled (there a
+		// re-inflation is what absorbs a manual or end-of-stream collapse with
+		// zero motion: constant scrollHeight). The composer-clearance floor
+		// always wins so a growing composer can never occlude the reply.
+		const ceiling = allowGrow || !this.streaming ? Infinity : current;
+		const height = Math.max(Math.min(computed, ceiling), this.minSpacer());
 		if (Math.abs(current - height) >= 1) {
 			this.spacerEl.style.height = `${height}px`;
 		}

--- a/src/lib/utils/scroll/stickToBottom.ts
+++ b/src/lib/utils/scroll/stickToBottom.ts
@@ -392,10 +392,21 @@ export class StickToBottomController {
 		this.rafId = requestAnimationFrame(this.tick);
 	};
 
-	/** Pinned + content grew: glide (spring) or snap (instant/reduced-motion/hidden). */
-	private follow() {
+	/**
+	 * Pinned + content grew: glide (spring) or snap (instant/reduced-motion/
+	 * hidden). `snap` forces the instant path for passes where the browser has
+	 * ALREADY clamp-jumped scrollTop (content shrank / container grew while at
+	 * the bottom): restoring the bottom in the same frame is invisible
+	 * (pre-paint) and merges with the clamp into one scroll event that matches
+	 * our write. A spring here would first paint the clamped position — a
+	 * visible bounce — and when a host callback re-inflates scrollHeight in the
+	 * same pass (the chat spacer), the clamp's scroll event loses its
+	 * `max < lastMax` signature and would be misread as user input, unpinning
+	 * mid-glide.
+	 */
+	private follow(snap = false) {
 		if (!this.state.pinned) return;
-		if (this.opts.followMode === "instant" || this.shouldSkipAnimation()) {
+		if (this.opts.followMode === "instant" || snap || this.shouldSkipAnimation()) {
 			this.stopAnimation();
 			this.write(this.maxScrollTop());
 			return;
@@ -473,9 +484,20 @@ export class StickToBottomController {
 		// The gutter (and other container-box-dependent measurements) can only
 		// change when the container itself resized, not on every content frame.
 		const containerResized = !entries || entries.some((e) => e.target === this.container);
+		// Clamp signature, sampled BEFORE the host callback mutates layout (a
+		// spacer re-inflation can immediately restore maxScrollTop and hide it):
+		// scrollTop sits exactly at max after moving UP without a write of ours.
+		// Only this signature may force an instant re-pin — a mere resize must
+		// not, because a user scroll can be pending in the same pass (delivery
+		// order is not guaranteed) and an eager write would overwrite the
+		// user's position and then swallow their coalesced scroll event as ours.
+		const preTop = this.container.scrollTop;
+		const clampJumped =
+			Math.abs(preTop - this.maxScrollTop()) <= WRITE_MATCH_EPS &&
+			preTop < this.lastTop - WRITE_MATCH_EPS;
 		this.syncContentObserver();
 		this.opts.onContentResize?.(containerResized);
-		this.follow();
+		this.follow(clampJumped);
 		// Deliberately do NOT refresh the attribution baselines (lastTop &co)
 		// here: a scroll event can still be in flight for a position change
 		// that happened before this resize (ResizeObserver delivery can precede

--- a/src/lib/utils/scroll/stickToBottom.ts
+++ b/src/lib/utils/scroll/stickToBottom.ts
@@ -329,6 +329,18 @@ export class StickToBottomController {
 		this.recomputeState();
 	}
 
+	/**
+	 * Attribution-safe relative adjustment that changes neither pin state nor
+	 * animation — for host-level scroll-anchoring compensation on engines
+	 * without native `overflow-anchor` (Safari), where above-viewport content
+	 * changes would otherwise shove a detached reader's text.
+	 */
+	adjustBy(delta: number) {
+		if (this.destroyed || this.anim) return;
+		this.write(this.clampedTop() + delta);
+		this.recomputeState();
+	}
+
 	/** Re-read geometry and re-follow if pinned; safe to call any time. */
 	recompute() {
 		this.onResize();


### PR DESCRIPTION
## Summary

This PR fixes scroll instability when content collapses mid-stream (e.g., thinking blocks) and adds manual scroll anchoring for Safari, which lacks native `overflow-anchor` support. The changes ensure that readers following live content aren't yanked away by above-viewport layout shifts, and that post-stream collapses remain perfectly still.

## Key Changes

### Scroll Anchoring System
- **One-way spacer during streaming**: While a response streams, the send-anchor spacer only shrinks (never re-inflates) as reply content grows. This prevents mid-stream collapses from re-anchoring the view and yanking readers away from the live edge.
- **Re-inflation after streaming**: Once streaming ends, the spacer can re-inflate to absorb post-turn collapses (manual toggles, auto-collapse) with zero motion via constant `scrollHeight`.
- **Container resize handling**: Viewport changes (keyboard close, window resize) re-derive anchor geometry mid-turn to keep the anchored message properly positioned.

### Manual Scroll Anchoring (Safari)
- Detects lack of native `overflow-anchor` support and enables manual anchoring as fallback
- Tracks the deepest element at the viewport top while detached (binary search + descent into messages)
- Stores ancestor chain to survive markdown re-renders and streaming updates
- Compensates for above-viewport content changes by restoring the tracked element's position
- Detects pending user scrolls (scrollTop mismatch) to avoid canceling user input

### Thinking Block Collapse Animation
- Unified template for streaming and settled phases so the thinking block component instance survives the answer-start transition
- Adds smooth `slide` transition (220ms) to collapse instead of instant layout jump
- Prevents "expand bounce" by keeping the capped streaming viewport shape during slide-out
- Uses `$effect.pre` to decide collapse before render, ensuring animation starts from correct height

### Controller Enhancement
- New `adjustBy(delta)` method for attribution-safe relative scroll adjustments (used by manual anchoring compensation)
- Detects clamp-jumped scrollTop to force instant re-pin (avoids visible bounce when spacer re-inflates)

## Implementation Details

- `ChatScroll` now tracks `streaming` state (mirrored from `ChatWindow.loading`)
- `updateSpacer()` accepts `allowGrow` flag; during streaming, computed height is clamped to current height (one-way)
- Manual anchoring stores `readAnchor` with element chain + captured scrollTop to detect stale captures
- `OpenReasoningResults` uses `$effect.pre` for loading transitions and conditional viewport rendering during slide-out
- New test suite covers mid-turn collapse stability, post-stream re-inflation, container resizes, and Safari manual anchoring edge cases

## Testing

Added comprehensive test coverage:
- In-turn content shrink (thinking-block collapse) with viewport stability verification
- Post-stream collapse with spacer re-inflation and zero motion
- Container resize mid-turn (mobile keyboard close scenario)
- Manual anchoring: above-viewport collapse, descendant tracking, node replacement, user scroll detection

https://claude.ai/code/session_013T9Ld83jc8eegpSf39wgyD