### PR TITLE
docs: add DaoXE OpenAI-compatible gateway example

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ OPENAI_API_KEY=hf_************************
 | llama.cpp server (`llama.cpp --server --api`) | `http://127.0.0.1:8080/v1`         | `OPENAI_API_KEY=sk-local-demo` (any string works; llama.cpp ignores it) |
 | Ollama (with OpenAI-compatible bridge)        | `http://127.0.0.1:11434/v1`        | `OPENAI_API_KEY=ollama`                                                 |
 | OpenRouter                                    | `https://openrouter.ai/api/v1`     | `OPENAI_API_KEY=sk-or-v1-...`                                           |
+| DaoXE (multi-model multi-protocol gateway)    | `https://daoxe.com/v1`             | `OPENAI_API_KEY=<key from https://daoxe.com/dashboard>`                 |
 | Poe                                           | `https://api.poe.com/v1`           | `OPENAI_API_KEY=pk_...`                                                 |
 
 Check the root [`.env` template](./.env) for the full list of optional variables you can override.


### PR DESCRIPTION
## Summary

Add **DaoXE** to the Chat UI Quickstart provider table as an OpenAI-compatible `OPENAI_BASE_URL` option.

- Base URL: `https://daoxe.com/v1`
- Auth: dashboard API key via `OPENAI_API_KEY`
- Models: account-scoped (`GET /v1/models`); no static public price list
- Multi-model multi-protocol gateway; Chat UI path uses Chat Completions
- Not available in mainland China

I maintain DaoXE. Examples: https://github.com/seven7763/DaoXE-AI

## Why

Chat UI is popular with international builders (including Vietnam / Korea / SEA). A one-line table entry makes DaoXE discoverable next to OpenRouter / Ollama without new provider code.

## Test plan
- [ ] README table renders correctly
- [ ] Values match live endpoint (`https://daoxe.com/v1` + dashboard key)
