### PR TITLE
fix: make .dockerignore ignore node_modules at any depth

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,7 +4,7 @@ Dockerfile
 .gitignore
 LICENSE
 README.md
-node_modules/
+**/node_modules/
 .svelte-kit/
 .env*
 !.env


### PR DESCRIPTION
Closes #1920

## What this PR does

Fixes a `.dockerignore` pattern that was written assuming `.gitignore`
semantics, which Docker does not follow.

## Root cause

`.dockerignore` line 7 reads:

```
node_modules/
```

In `.gitignore`, a bare directory pattern like `node_modules/` (no leading
or embedded slash) matches that directory name at **any depth** in the
tree. Docker's `.dockerignore` parser does not carry over this behavior:
per the [Docker build context docs](https://docs.docker.com/build/concepts/context/#dockerignore-files),
a pattern without `**/` is anchored and only matches at the root of the
build context. So the current pattern only excludes the top-level
`./node_modules`, not any `node_modules` directory that might exist deeper
in the tree (e.g. under `scripts/`, `chart/`, or any subpackage added in
the future) — the opposite of what the pattern is clearly meant to do.

## Change

Single-line fix in `.dockerignore`:

```
# before
node_modules/

# after
**/node_modules/
```

The `**/` prefix is the documented Docker idiom for "match this pattern at
any depth," which restores the intended gitignore-like behavior the file
was already written to assume.

## Verification

- Read Docker's official `.dockerignore` syntax docs to confirm `**/` is
  required for depth-independent matching (unlike `.gitignore`).
- Confirmed via `grep`/directory listing that the rest of `.dockerignore`
  and the `Dockerfile` build context are unaffected by this change — no
  other rule relies on `node_modules/` staying root-only.
- No nested `node_modules` currently exists in this repo (single
  `package.json`, not a workspace/monorepo), so this change is a no-op for
  the current tree and only guards against future/incidental nested
  `node_modules` directories inflating the build context or getting
  copied into an image layer.

> **Note:** Claude Code was used to assist in drafting this fix. All changes were reviewed by the submitter.
