### PR TITLE
Update feature announcement to Inkling model

### DIFF
--- a/chart/env/dev.yaml
+++ b/chart/env/dev.yaml
@@ -60,7 +60,7 @@ envVars:
   PUBLIC_ORIGIN: ""
   PUBLIC_PLAUSIBLE_SCRIPT_URL: "https://plausible.io/js/pa-Io_oigECawqdlgpf5qvHb.js"
   PUBLIC_FEATURE_ANNOUNCEMENTS: >
-    [{"title": "Gemma-4-31B at 700 tokens/s", "description": "Run Gemma-4-31B at 700 tokens/s thanks to Cerebras inference.", "link": "/models/google/gemma-4-31B-it", "cta": "Go to the model", "maxDate": "2026-08-01"}]
+    [{"title": "Inkling is now on HuggingChat", "description": "Thinking Machines' first open-weights model: a 975B-param MoE that reasons over text, images, and audio.", "link": "/models/thinkingmachines/Inkling", "cta": "Try it now", "maxDate": "2026-08-15"}]
 
   TASK_MODEL: "meta-llama/Llama-3.1-8B-Instruct"
   # Tombstone: unread by current code, kept so any old pod still on the pre-#2265

--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -70,7 +70,7 @@ envVars:
   PUBLIC_ORIGIN: "https://huggingface.co"
   PUBLIC_PLAUSIBLE_SCRIPT_URL: "https://plausible.io/js/pa-Io_oigECawqdlgpf5qvHb.js"
   PUBLIC_FEATURE_ANNOUNCEMENTS: >
-    [{"title": "Gemma-4-31B at 700 tokens/s", "description": "Run Gemma-4-31B at 700 tokens/s thanks to Cerebras inference.", "link": "/models/google/gemma-4-31B-it", "cta": "Go to the model", "maxDate": "2026-08-01"}]
+    [{"title": "Inkling is now on HuggingChat", "description": "Thinking Machines' first open-weights model: a 975B-param MoE that reasons over text, images, and audio.", "link": "/models/thinkingmachines/Inkling", "cta": "Try it now", "maxDate": "2026-08-15"}]
 
   TASK_MODEL: "meta-llama/Llama-3.1-8B-Instruct"
   # Tombstone: unread by current code, kept so any old pod still on the pre-#2265


### PR DESCRIPTION
## Summary
Updates the feature announcement banner displayed in HuggingChat to promote Thinking Machines' Inkling model, replacing the previous Gemma-4-31B announcement.

## Changes
- Updated `PUBLIC_FEATURE_ANNOUNCEMENTS` in both dev and prod environment configurations
  - Changed title from "Gemma-4-31B at 700 tokens/s" to "Inkling is now on HuggingChat"
  - Updated description to highlight Inkling as a 975B-param MoE model with multimodal reasoning capabilities
  - Changed model link from `/models/google/gemma-4-31B-it` to `/models/thinkingmachines/Inkling`
  - Updated CTA text from "Go to the model" to "Try it now"
  - Extended expiration date from "2026-08-01" to "2026-08-15"

## Files Modified
- `chart/env/dev.yaml`
- `chart/env/prod.yaml`

https://claude.ai/code/session_013XB5pywNEraEsDi1LdVnvt