### PR TITLE
Fix SSRF blocklist missing the 10.0.0.0/8 private range

### DIFF
--- a/src/lib/server/urlSafety.ts
+++ b/src/lib/server/urlSafety.ts
@@ -5,6 +5,7 @@ import { Agent, fetch as undiciFetch } from "undici";
 
 const UNSAFE_IPV4_SUBNETS = [
 	"0.0.0.0/8",
+	"10.0.0.0/8",
 	"100.64.0.0/10",
 	"127.0.0.0/8",
 	"169.254.0.0/16",


### PR DESCRIPTION
## Problem

`UNSAFE_IPV4_SUBNETS` in `src/lib/server/urlSafety.ts` is the sole data behind `isUnsafeIp()`, which backs the entire server-side SSRF boundary:

- `isValidUrl()` — validates IP-literal hostnames.
- `assertSafeIp()` → the `ssrfSafeAgent` custom DNS `lookup` — validates the **resolved** IP at connect time (the anti-DNS-rebinding guard).

The list includes loopback (`127/8`), link-local (`169.254/16`), CGNAT (`100.64/10`), and **two of the three** RFC1918 private blocks (`172.16/12`, `192.168/16`) — but omits the largest one, `10.0.0.0/8`:

```ts
const UNSAFE_IPV4_SUBNETS = [
	"0.0.0.0/8",
	"100.64.0.0/10",
	"127.0.0.0/8",
	"169.254.0.0/16",
	"172.16.0.0/12",
	"192.168.0.0/16",
].map((s) => new Address4(s));
```

Because `isValidUrl` requires `https:`, a literal `https://10.0.0.1/...` passes; and independently, any hostname that **resolves** to `10.x.x.x` passes the DNS guard. Either way the server can be induced to reach internal `10.0.0.0/8` hosts (cloud metadata/VPC services, internal APIs, admin panels) — SSRF via the public file-fetch proxy (`api/fetch-url`) and MCP URL handling (`runMcpFlow`, `clientPool`, `mcp/tools`, `mcp/health`).

## Evidence (sibling proves intent)

The client-side private-IP validator (`src/lib/utils/mcpValidation.ts`) lists `10\.` first:

```ts
const ipv4Regex = /^(10\.|172\.(1[6-9]|2[0-9]|3[01])\.|192\.168\.|127\.|0\.0\.0\.0|169\.254\.)/;
```

Both validators are meant to cover the same private space; the real security boundary (`urlSafety.ts`) is the one that dropped `10/8`.

## Fix

Add `10.0.0.0/8` to the blocklist (also covers IPv4-mapped IPv6 `::ffff:10.x.x.x`, since the same list is reused there). No behavior change for legitimate public URLs.

## Reproduction

Faithful CIDR reimplementation of `isUnsafeIp`'s IPv4 path:

| address | current → unsafe? | fixed → unsafe? |
|---|---|---|
| `10.0.0.1` | `false` ❌ | `true` ✅ |
| `10.255.255.254` | `false` ❌ | `true` ✅ |
| `172.16.0.1` | `true` | `true` |
| `192.168.1.1` | `true` | `true` |
| `8.8.8.8` (public) | `false` | `false` |
