### PR TITLE
create test request helper

### DIFF
--- a/src/lib/server/__tests__/conversation-stop-generating.spec.ts
+++ b/src/lib/server/__tests__/conversation-stop-generating.spec.ts
@@ -1,7 +1,7 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { ObjectId } from "mongodb";
 
-import { collections } from "$lib/server/database";
+import { collections, ready } from "$lib/server/database";
 import { AbortRegistry } from "$lib/server/abortRegistry";
 import {
 	cleanupTestData,
@@ -10,6 +10,11 @@ import {
 	createTestUser,
 } from "$lib/server/api/__tests__/testHelpers";
 import { POST } from "../../../routes/conversation/[id]/stop-generating/+server";
+
+// `collections` is undefined until the database IIFE resolves.
+beforeAll(async () => {
+	await ready;
+});
 
 describe.sequential("POST /conversation/[id]/stop-generating", () => {
 	afterEach(async () => {

--- a/src/lib/server/__tests__/testRequest.ts
+++ b/src/lib/server/__tests__/testRequest.ts
@@ -1,0 +1,216 @@
+/**
+ * Invokes a route handler through the real `handle` hook, so auth, CSRF, CORS and cookie
+ * refresh run as they do in production. Only path-to-handler routing is stubbed. A thrown
+ * `error()` or `redirect()` comes back as a `Response`, so assert `res.status` rather than
+ * catching.
+ *
+ * Authenticate either with a session cookie from `createTestUser()`, or by passing `locals`.
+ * `locals` is applied after the hook has authenticated, so it changes what the handler sees
+ * but not what the middleware saw — assertions about identity-keyed middleware rules need
+ * the cookie.
+ */
+import {
+	isHttpError,
+	isRedirect,
+	type Cookies,
+	type RequestEvent,
+	type RequestHandler,
+} from "@sveltejs/kit";
+// Not `hooks.server.ts`'s `handle`, which would pull `hooks/init.ts` — the migration runner,
+// MCP registry and font loader — into every spec. Same code path under Vitest.
+import { handleRequest } from "$lib/server/hooks/handle";
+import { ready } from "$lib/server/database";
+
+/** The `Origin` a native-form POST must send to satisfy the CSRF check in `handle`. */
+export const TEST_ORIGIN = "http://localhost:5173";
+
+export interface TestRequestOptions {
+	/** Origin-relative, query string included: `"/api/v2/conversations?p=1"`. */
+	path: string;
+	/** Defaults to `GET`. */
+	method?: string;
+	body?: BodyInit;
+	headers?: HeadersInit;
+	params?: Record<string, string>;
+	locals?: Partial<App.Locals>;
+}
+
+type CookieSetOptions = Parameters<Cookies["set"]>[2];
+
+function serializeCookie(name: string, value: string, opts: CookieSetOptions): string {
+	const parts = [`${name}=${encodeURIComponent(value)}`];
+
+	if (opts.maxAge !== undefined) parts.push(`Max-Age=${Math.floor(opts.maxAge)}`);
+	if (opts.domain) parts.push(`Domain=${opts.domain}`);
+	if (opts.path) parts.push(`Path=${opts.path}`);
+	if (opts.expires) parts.push(`Expires=${new Date(opts.expires).toUTCString()}`);
+	if (opts.httpOnly) parts.push("HttpOnly");
+	if (opts.secure) parts.push("Secure");
+	if (opts.sameSite) {
+		const sameSite = opts.sameSite === true ? "strict" : opts.sameSite;
+		parts.push(`SameSite=${sameSite.charAt(0).toUpperCase()}${sameSite.slice(1)}`);
+	}
+
+	return parts.join("; ");
+}
+
+function parseCookieHeader(header: string | null): Map<string, string> {
+	const jar = new Map<string, string>();
+	if (!header) return jar;
+
+	for (const pair of header.split(";")) {
+		const eq = pair.indexOf("=");
+		if (eq < 0) continue;
+		const name = pair.slice(0, eq).trim();
+		if (!name) continue;
+		jar.set(name, decodeURIComponent(pair.slice(eq + 1).trim()));
+	}
+
+	return jar;
+}
+
+/** Stand-in for SvelteKit's cookie jar, which is internal and not importable. */
+function createCookies(request: Request): {
+	cookies: Cookies;
+	setCookieHeaders: () => string[];
+} {
+	const jar = parseCookieHeader(request.headers.get("cookie"));
+	const written: string[] = [];
+
+	return {
+		cookies: {
+			get: (name) => jar.get(name),
+			getAll: () => [...jar].map(([name, value]) => ({ name, value })),
+			set: (name, value, opts) => {
+				jar.set(name, value);
+				written.push(serializeCookie(name, value, opts));
+			},
+			delete: (name, opts) => {
+				jar.delete(name);
+				written.push(serializeCookie(name, "", { ...opts, maxAge: 0 }));
+			},
+			serialize: (name, value, opts) => serializeCookie(name, value, opts),
+		},
+		setCookieHeaders: () => written,
+	};
+}
+
+/**
+ * Tracing is off in tests, but SvelteKit types these as OpenTelemetry `Span`s — a
+ * self-returning proxy satisfies any chained call a handler makes.
+ */
+const NOOP_SPAN: unknown = new Proxy(
+	{},
+	{
+		get:
+			() =>
+			(...args: unknown[]) => {
+				void args;
+				return NOOP_SPAN;
+			},
+	}
+);
+
+const NOOP_TRACING = {
+	enabled: false,
+	root: NOOP_SPAN,
+	current: NOOP_SPAN,
+} as RequestEvent["tracing"];
+
+/** Anything that is not a SvelteKit `error()` or `redirect()` is a genuine fault. */
+function toResponse(thrown: unknown): Response {
+	if (isRedirect(thrown)) {
+		return new Response(undefined, {
+			status: thrown.status,
+			headers: { location: thrown.location },
+		});
+	}
+
+	if (isHttpError(thrown)) {
+		return new Response(JSON.stringify(thrown.body), {
+			status: thrown.status,
+			headers: { "content-type": "application/json" },
+		});
+	}
+
+	throw thrown;
+}
+
+export async function testRequest(
+	handler: RequestHandler,
+	opts: TestRequestOptions
+): Promise<Response> {
+	// `collections` is undefined until the database IIFE resolves, and `handle` writes to
+	// `collections.sessions` on POST.
+	await ready;
+
+	const url = new URL(opts.path, TEST_ORIGIN);
+	const method = (opts.method ?? "GET").toUpperCase();
+	const hasBody = opts.body !== undefined && method !== "GET" && method !== "HEAD";
+
+	const request = new Request(url, {
+		method,
+		headers: opts.headers,
+		...(hasBody ? { body: opts.body } : {}),
+	});
+
+	const { cookies, setCookieHeaders } = createCookies(request);
+	const deferredHeaders = new Map<string, string>();
+
+	const event: RequestEvent = {
+		cookies,
+		fetch: globalThis.fetch,
+		getClientAddress: () => "127.0.0.1",
+		locals: {} as App.Locals,
+		params: (opts.params ?? {}) as RequestEvent["params"],
+		platform: undefined,
+		request,
+		route: { id: null },
+		setHeaders: (headers) => {
+			for (const [rawKey, value] of Object.entries(headers)) {
+				const key = rawKey.toLowerCase();
+				if (key === "set-cookie") {
+					throw new Error("Use `cookies.set(...)` rather than `setHeaders` for set-cookie");
+				}
+				if (deferredHeaders.has(key)) {
+					throw new Error(`"${key}" header is already set`);
+				}
+				deferredHeaders.set(key, value);
+			}
+		},
+		url,
+		isDataRequest: false,
+		isSubRequest: false,
+		isRemoteRequest: false,
+		tracing: NOOP_TRACING,
+	};
+
+	const response = await handleRequest({
+		event,
+		resolve: async (resolvedEvent) => {
+			// Deliberately after the hook has authenticated — see the module docs.
+			if (opts.locals) {
+				Object.assign(resolvedEvent.locals, opts.locals);
+			}
+
+			let res: Response;
+			try {
+				res = await handler(resolvedEvent);
+			} catch (thrown) {
+				res = toResponse(thrown);
+			}
+
+			for (const [key, value] of deferredHeaders) {
+				res.headers.set(key, value);
+			}
+
+			return res;
+		},
+	});
+
+	for (const header of setCookieHeaders()) {
+		response.headers.append("set-cookie", header);
+	}
+
+	return response;
+}

--- a/src/lib/server/api/__tests__/conversations-id.spec.ts
+++ b/src/lib/server/api/__tests__/conversations-id.spec.ts
@@ -1,7 +1,7 @@
-import { describe, expect, it, afterEach } from "vitest";
+import { describe, expect, it, afterEach, beforeAll } from "vitest";
 import { ObjectId } from "mongodb";
 import superjson from "superjson";
-import { collections } from "$lib/server/database";
+import { collections, ready } from "$lib/server/database";
 import {
 	createTestLocals,
 	createTestUser,
@@ -18,6 +18,11 @@ async function parseResponse<T = unknown>(res: Response): Promise<T> {
 function mockUrl(): URL {
 	return new URL("http://localhost:5173/api/v2/conversations/some-id");
 }
+
+// `collections` is undefined until the database IIFE resolves.
+beforeAll(async () => {
+	await ready;
+});
 
 describe.sequential("GET /api/v2/conversations/[id]", () => {
 	afterEach(async () => {

--- a/src/lib/server/api/__tests__/conversations-message.spec.ts
+++ b/src/lib/server/api/__tests__/conversations-message.spec.ts
@@ -1,8 +1,8 @@
-import { describe, expect, it, afterEach } from "vitest";
+import { describe, expect, it, afterEach, beforeAll } from "vitest";
 import { ObjectId } from "mongodb";
 import { v4 } from "uuid";
 import superjson from "superjson";
-import { collections } from "$lib/server/database";
+import { collections, ready } from "$lib/server/database";
 import type { Message } from "$lib/types/Message";
 import {
 	createTestLocals,
@@ -85,6 +85,11 @@ function buildMessageTree(): {
 		unrelatedId,
 	};
 }
+
+// `collections` is undefined until the database IIFE resolves.
+beforeAll(async () => {
+	await ready;
+});
 
 describe.sequential("DELETE /api/v2/conversations/[id]/message/[messageId]", () => {
 	afterEach(async () => {

--- a/src/lib/server/api/__tests__/conversations.spec.ts
+++ b/src/lib/server/api/__tests__/conversations.spec.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it, afterEach } from "vitest";
+import { describe, expect, it, afterEach, beforeAll } from "vitest";
 import superjson from "superjson";
-import { collections } from "$lib/server/database";
+import { collections, ready } from "$lib/server/database";
 import { CONV_NUM_PER_PAGE } from "$lib/constants/pagination";
 import {
 	createTestLocals,
@@ -8,6 +8,7 @@ import {
 	createTestConversation,
 	cleanupTestData,
 } from "./testHelpers";
+import { testRequest } from "$lib/server/__tests__/testRequest";
 
 import { GET, DELETE } from "../../../../routes/api/v2/conversations/+server";
 
@@ -15,15 +16,14 @@ async function parseResponse<T = unknown>(res: Response): Promise<T> {
 	return superjson.parse(await res.text()) as T;
 }
 
-function mockUrl(params?: Record<string, string>): URL {
-	const url = new URL("http://localhost:5173/api/v2/conversations");
-	if (params) {
-		for (const [key, value] of Object.entries(params)) {
-			url.searchParams.set(key, value);
-		}
-	}
-	return url;
+function conversationsPath(params?: Record<string, string>): string {
+	const query = params ? `?${new URLSearchParams(params)}` : "";
+	return `/api/v2/conversations${query}`;
 }
+
+beforeAll(async () => {
+	await ready;
+}, 30000);
 
 describe.sequential("GET /api/v2/conversations", () => {
 	afterEach(async () => {
@@ -34,10 +34,7 @@ describe.sequential("GET /api/v2/conversations", () => {
 		const { locals } = await createTestUser();
 		const conv = await createTestConversation(locals, { title: "My Chat" });
 
-		const res = await GET({
-			locals,
-			url: mockUrl(),
-		} as never);
+		const res = await testRequest(GET, { path: conversationsPath(), locals });
 
 		expect(res.status).toBe(200);
 		const data = await parseResponse<{
@@ -53,10 +50,7 @@ describe.sequential("GET /api/v2/conversations", () => {
 	it("returns empty array for user with no conversations", async () => {
 		const { locals } = await createTestUser();
 
-		const res = await GET({
-			locals,
-			url: mockUrl(),
-		} as never);
+		const res = await testRequest(GET, { path: conversationsPath(), locals });
 
 		expect(res.status).toBe(200);
 		const data = await parseResponse<{ conversations: unknown[]; hasMore: boolean }>(res);
@@ -75,10 +69,7 @@ describe.sequential("GET /api/v2/conversations", () => {
 			});
 		}
 
-		const resPage0 = await GET({
-			locals,
-			url: mockUrl({ p: "0" }),
-		} as never);
+		const resPage0 = await testRequest(GET, { path: conversationsPath({ p: "0" }), locals });
 
 		const dataPage0 = await parseResponse<{
 			conversations: Array<{ title: string }>;
@@ -87,10 +78,7 @@ describe.sequential("GET /api/v2/conversations", () => {
 		expect(dataPage0.conversations).toHaveLength(CONV_NUM_PER_PAGE);
 		expect(dataPage0.hasMore).toBe(true);
 
-		const resPage1 = await GET({
-			locals,
-			url: mockUrl({ p: "1" }),
-		} as never);
+		const resPage1 = await testRequest(GET, { path: conversationsPath({ p: "1" }), locals });
 
 		const dataPage1 = await parseResponse<{
 			conversations: Array<{ title: string }>;
@@ -110,10 +98,7 @@ describe.sequential("GET /api/v2/conversations", () => {
 			});
 		}
 
-		const res = await GET({
-			locals,
-			url: mockUrl(),
-		} as never);
+		const res = await testRequest(GET, { path: conversationsPath(), locals });
 
 		const data = await parseResponse<{ conversations: unknown[]; hasMore: boolean }>(res);
 		expect(data.conversations).toHaveLength(CONV_NUM_PER_PAGE);
@@ -136,10 +121,7 @@ describe.sequential("GET /api/v2/conversations", () => {
 			updatedAt: new Date("2024-03-01"),
 		});
 
-		const res = await GET({
-			locals,
-			url: mockUrl(),
-		} as never);
+		const res = await testRequest(GET, { path: conversationsPath(), locals });
 
 		const data = await parseResponse<{ conversations: Array<{ title: string }> }>(res);
 		expect(data.conversations[0].title).toBe("Newest");
@@ -147,18 +129,12 @@ describe.sequential("GET /api/v2/conversations", () => {
 		expect(data.conversations[2].title).toBe("Oldest");
 	});
 
-	it("throws 401 for unauthenticated request", async () => {
+	it("returns 401 for unauthenticated request", async () => {
 		const locals = createTestLocals({ sessionId: undefined, user: undefined });
 
-		try {
-			await GET({
-				locals,
-				url: mockUrl(),
-			} as never);
-			expect.fail("Should have thrown");
-		} catch (e: unknown) {
-			expect((e as { status: number }).status).toBe(401);
-		}
+		const res = await testRequest(GET, { path: conversationsPath(), locals });
+
+		expect(res.status).toBe(401);
 	});
 
 	it("does not return other users' conversations", async () => {
@@ -168,14 +144,24 @@ describe.sequential("GET /api/v2/conversations", () => {
 		await createTestConversation(localsA, { title: "User A Chat" });
 		await createTestConversation(localsB, { title: "User B Chat" });
 
-		const res = await GET({
-			locals: localsA,
-			url: mockUrl(),
-		} as never);
+		const res = await testRequest(GET, { path: conversationsPath(), locals: localsA });
 
 		const data = await parseResponse<{ conversations: Array<{ title: string }> }>(res);
 		expect(data.conversations).toHaveLength(1);
 		expect(data.conversations[0].title).toBe("User A Chat");
+	});
+
+	it("scopes results to the session resolved from a real cookie", async () => {
+		const { locals, cookie } = await createTestUser();
+		await createTestConversation(locals, { title: "Cookie Chat" });
+		const { locals: other } = await createTestUser();
+		await createTestConversation(other, { title: "Someone Else" });
+
+		const res = await testRequest(GET, { path: conversationsPath(), headers: { cookie } });
+
+		const data = await parseResponse<{ conversations: Array<{ title: string }> }>(res);
+		expect(data.conversations).toHaveLength(1);
+		expect(data.conversations[0].title).toBe("Cookie Chat");
 	});
 });
 
@@ -191,7 +177,11 @@ describe.sequential("DELETE /api/v2/conversations", () => {
 		await createTestConversation(locals, { title: "Chat 2" });
 		await createTestConversation(locals, { title: "Chat 3" });
 
-		const res = await DELETE({ locals } as never);
+		const res = await testRequest(DELETE, {
+			path: conversationsPath(),
+			method: "DELETE",
+			locals,
+		});
 		expect(res.status).toBe(200);
 
 		const data = await parseResponse<number>(res);
@@ -201,15 +191,16 @@ describe.sequential("DELETE /api/v2/conversations", () => {
 		expect(remaining).toBe(0);
 	});
 
-	it("throws 401 for unauthenticated request", async () => {
+	it("returns 401 for unauthenticated request", async () => {
 		const locals = createTestLocals({ sessionId: undefined, user: undefined });
 
-		try {
-			await DELETE({ locals } as never);
-			expect.fail("Should have thrown");
-		} catch (e: unknown) {
-			expect((e as { status: number }).status).toBe(401);
-		}
+		const res = await testRequest(DELETE, {
+			path: conversationsPath(),
+			method: "DELETE",
+			locals,
+		});
+
+		expect(res.status).toBe(401);
 	});
 
 	it("does not remove other users' conversations", async () => {
@@ -219,7 +210,11 @@ describe.sequential("DELETE /api/v2/conversations", () => {
 		await createTestConversation(localsA, { title: "User A Chat" });
 		await createTestConversation(localsB, { title: "User B Chat" });
 
-		const res = await DELETE({ locals: localsA } as never);
+		const res = await testRequest(DELETE, {
+			path: conversationsPath(),
+			method: "DELETE",
+			locals: localsA,
+		});
 		const data = await parseResponse<number>(res);
 		expect(data).toBe(1);
 

--- a/src/lib/server/api/__tests__/misc.spec.ts
+++ b/src/lib/server/api/__tests__/misc.spec.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import superjson from "superjson";
+import { collections, ready } from "$lib/server/database";
 import { createTestLocals, createTestUser, cleanupTestData } from "./testHelpers";
+import { testRequest } from "$lib/server/__tests__/testRequest";
 import { GET as featureFlagsGET } from "../../../../routes/api/v2/feature-flags/+server";
 import { GET as publicConfigGET } from "../../../../routes/api/v2/public-config/+server";
 import type { FeatureFlags } from "$lib/server/api/types";
@@ -9,23 +11,16 @@ async function parseResponse<T = unknown>(res: Response): Promise<T> {
 	return superjson.parse(await res.text()) as T;
 }
 
-function mockRequestEvent(locals: App.Locals) {
-	return {
-		locals,
-		url: new URL("http://localhost"),
-		request: new Request("http://localhost"),
-	} as Parameters<typeof featureFlagsGET>[0];
-}
-
 describe("GET /api/v2/feature-flags", () => {
 	beforeEach(async () => {
+		await ready;
 		await cleanupTestData();
 	}, 20000);
 
 	it("returns correct shape with expected fields", async () => {
 		const locals = createTestLocals();
 
-		const res = await featureFlagsGET(mockRequestEvent(locals));
+		const res = await testRequest(featureFlagsGET, { path: "/api/v2/feature-flags", locals });
 		const data = await parseResponse<FeatureFlags>(res);
 
 		expect(data).toHaveProperty("enableAssistants");
@@ -41,7 +36,7 @@ describe("GET /api/v2/feature-flags", () => {
 	it("reflects isAdmin from locals for non-admin user", async () => {
 		const locals = createTestLocals({ isAdmin: false });
 
-		const res = await featureFlagsGET(mockRequestEvent(locals));
+		const res = await testRequest(featureFlagsGET, { path: "/api/v2/feature-flags", locals });
 		const data = await parseResponse<FeatureFlags>(res);
 
 		expect(data.isAdmin).toBe(false);
@@ -51,16 +46,45 @@ describe("GET /api/v2/feature-flags", () => {
 		const { locals } = await createTestUser();
 		locals.isAdmin = true;
 
-		const res = await featureFlagsGET(mockRequestEvent(locals));
+		const res = await testRequest(featureFlagsGET, { path: "/api/v2/feature-flags", locals });
 		const data = await parseResponse<FeatureFlags>(res);
 
 		expect(data.isAdmin).toBe(true);
 	});
+
+	it("derives isAdmin from the persisted user under real cookie auth", async () => {
+		const { user, cookie } = await createTestUser();
+		await collections.users.updateOne({ _id: user._id }, { $set: { isAdmin: true } });
+
+		const res = await testRequest(featureFlagsGET, {
+			path: "/api/v2/feature-flags",
+			headers: { cookie },
+		});
+		const data = await parseResponse<FeatureFlags>(res);
+
+		expect(data.isAdmin).toBe(true);
+	});
+
+	it("serves CORS headers on /api/** when the request carries no Origin", async () => {
+		const res = await testRequest(featureFlagsGET, {
+			path: "/api/v2/feature-flags",
+			locals: createTestLocals(),
+		});
+
+		expect(res.headers.get("access-control-allow-origin")).toBe("*");
+		expect(res.headers.get("access-control-allow-methods")).toBe(
+			"GET, POST, PUT, PATCH, DELETE, OPTIONS"
+		);
+		expect(res.headers.get("access-control-allow-headers")).toBe("Content-Type, Authorization");
+	});
 });
+
+const publicConfigRequest = () =>
+	testRequest(publicConfigGET, { path: "/api/v2/public-config", locals: createTestLocals() });
 
 describe("GET /api/v2/public-config", () => {
 	it("exposes only PUBLIC_-prefixed keys", async () => {
-		const res = await publicConfigGET(mockRequestEvent(createTestLocals()));
+		const res = await publicConfigRequest();
 		const data = await parseResponse<Record<string, unknown>>(res);
 
 		const keys = Object.keys(data);
@@ -71,7 +95,7 @@ describe("GET /api/v2/public-config", () => {
 	});
 
 	it("never leaks server-only secrets", async () => {
-		const res = await publicConfigGET(mockRequestEvent(createTestLocals()));
+		const res = await publicConfigRequest();
 		const data = await parseResponse<Record<string, unknown>>(res);
 
 		for (const secret of [
@@ -94,7 +118,7 @@ describe("GET /api/v2/public-config", () => {
 	});
 
 	it("serves known public config with a private cache header", async () => {
-		const res = await publicConfigGET(mockRequestEvent(createTestLocals()));
+		const res = await publicConfigRequest();
 		const data = await parseResponse<Record<string, unknown>>(res);
 
 		expect(data).toHaveProperty("PUBLIC_APP_NAME");

--- a/src/lib/server/api/__tests__/testHelpers.ts
+++ b/src/lib/server/api/__tests__/testHelpers.ts
@@ -1,5 +1,7 @@
 import { ObjectId } from "mongodb";
-import { collections } from "$lib/server/database";
+import { collections, ready } from "$lib/server/database";
+import { config } from "$lib/server/config";
+import { sha256 } from "$lib/utils/sha256";
 import type { User } from "$lib/types/User";
 import type { Session } from "$lib/types/Session";
 import type { Conversation } from "$lib/types/Conversation";
@@ -14,13 +16,25 @@ export function createTestLocals(overrides?: Partial<App.Locals>): App.Locals {
 	};
 }
 
-export async function createTestUser(): Promise<{
+export interface TestUser {
 	user: User;
 	session: Session;
 	locals: App.Locals;
-}> {
+	/**
+	 * The raw session secret. `authenticateRequest()` reads this from the cookie and looks
+	 * the session up by its sha256, so it is *not* `session.sessionId`.
+	 */
+	secretSessionId: string;
+	/** Ready-made `Cookie` header value, for driving real authentication. */
+	cookie: string;
+}
+
+export async function createTestUser(): Promise<TestUser> {
+	await ready;
+
 	const userId = new ObjectId();
-	const sessionId = `test-session-${userId.toString()}`;
+	const secretSessionId = crypto.randomUUID();
+	const sessionId = await sha256(secretSessionId);
 
 	const user: User = {
 		_id: userId,
@@ -53,6 +67,8 @@ export async function createTestUser(): Promise<{
 			isAdmin: false,
 			token: undefined,
 		},
+		secretSessionId,
+		cookie: `${config.COOKIE_NAME}=${secretSessionId}`,
 	};
 }
 
@@ -60,6 +76,8 @@ export async function createTestConversation(
 	locals: App.Locals,
 	overrides?: Partial<Conversation>
 ): Promise<Conversation> {
+	await ready;
+
 	const conv: Conversation = {
 		_id: new ObjectId(),
 		title: "Test Conversation",
@@ -75,12 +93,34 @@ export async function createTestConversation(
 	return conv;
 }
 
+/** Wipes every collection the app writes to. Anything added to `getCollections()` belongs here. */
 export async function cleanupTestData() {
-	await collections.conversations.deleteMany({});
-	await collections.abortedGenerations.deleteMany({});
-	await collections.users.deleteMany({});
-	await collections.sessions.deleteMany({});
-	await collections.settings.deleteMany({});
-	await collections.sharedConversations.deleteMany({});
-	await collections.reports.deleteMany({});
+	await ready;
+
+	await Promise.all([
+		collections.conversations.deleteMany({}),
+		collections.conversationStats.deleteMany({}),
+		collections.abortedGenerations.deleteMany({}),
+		collections.users.deleteMany({}),
+		collections.sessions.deleteMany({}),
+		collections.settings.deleteMany({}),
+		collections.sharedConversations.deleteMany({}),
+		collections.reports.deleteMany({}),
+		collections.assistants.deleteMany({}),
+		collections.messageEvents.deleteMany({}),
+		collections.semaphores.deleteMany({}),
+		collections.migrationResults.deleteMany({}),
+		collections.tokenCaches.deleteMany({}),
+		collections.tools.deleteMany({}),
+		cleanupGridFS(),
+	]);
+}
+
+/**
+ * Deletes files rather than calling `bucket.drop()`, which would take the bucket's indexes
+ * with it and rejects outright when the namespace was never created.
+ */
+async function cleanupGridFS() {
+	const files = await collections.bucket.find({}).toArray();
+	await Promise.all(files.map((file) => collections.bucket.delete(file._id)));
 }

--- a/src/lib/server/api/__tests__/user-reports.spec.ts
+++ b/src/lib/server/api/__tests__/user-reports.spec.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
 import { ObjectId } from "mongodb";
 import superjson from "superjson";
-import { collections } from "$lib/server/database";
+import { collections, ready } from "$lib/server/database";
 import { createTestLocals, createTestUser, cleanupTestData } from "./testHelpers";
 import { GET } from "../../../../routes/api/v2/user/reports/+server";
 import type { Report } from "$lib/types/Report";
@@ -17,6 +17,11 @@ function mockRequestEvent(locals: App.Locals) {
 		request: new Request("http://localhost"),
 	} as Parameters<typeof GET>[0];
 }
+
+// `collections` is undefined until the database IIFE resolves.
+beforeAll(async () => {
+	await ready;
+});
 
 describe("GET /api/v2/user/reports", () => {
 	beforeEach(async () => {

--- a/src/lib/server/api/__tests__/user.spec.ts
+++ b/src/lib/server/api/__tests__/user.spec.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, beforeAll } from "vitest";
 import superjson from "superjson";
-import { collections } from "$lib/server/database";
+import { collections, ready } from "$lib/server/database";
 import { createTestLocals, createTestUser, cleanupTestData } from "./testHelpers";
+import { testRequest, TEST_ORIGIN } from "$lib/server/__tests__/testRequest";
 import { GET as userGET } from "../../../../routes/api/v2/user/+server";
 import {
 	GET as settingsGET,
@@ -12,14 +13,17 @@ async function parseResponse<T = unknown>(res: Response): Promise<T> {
 	return superjson.parse(await res.text()) as T;
 }
 
-function mockRequestEvent(locals: App.Locals, overrides?: Record<string, unknown>) {
+function jsonBody(body: unknown) {
 	return {
-		locals,
-		url: new URL("http://localhost"),
-		request: new Request("http://localhost"),
-		...overrides,
-	} as Parameters<typeof userGET>[0];
+		method: "POST",
+		body: JSON.stringify(body),
+		headers: { "Content-Type": "application/json" },
+	} as const;
 }
+
+beforeAll(async () => {
+	await ready;
+}, 30000);
 
 describe("GET /api/v2/user", () => {
 	beforeEach(async () => {
@@ -29,7 +33,7 @@ describe("GET /api/v2/user", () => {
 	it("returns user info for authenticated user", async () => {
 		const { user, locals } = await createTestUser();
 
-		const res = await userGET(mockRequestEvent(locals));
+		const res = await testRequest(userGET, { path: "/api/v2/user", locals });
 		const data = await parseResponse<Record<string, unknown>>(res);
 
 		expect(data).not.toBeNull();
@@ -45,10 +49,28 @@ describe("GET /api/v2/user", () => {
 	it("returns null for unauthenticated user", async () => {
 		const locals = createTestLocals();
 
-		const res = await userGET(mockRequestEvent(locals));
+		const res = await testRequest(userGET, { path: "/api/v2/user", locals });
 		const data = await parseResponse(res);
 
 		expect(data).toBeNull();
+	});
+
+	it("resolves the user from a session cookie, with no locals override", async () => {
+		const { user, cookie } = await createTestUser();
+
+		const res = await testRequest(userGET, { path: "/api/v2/user", headers: { cookie } });
+		const data = await parseResponse<Record<string, unknown>>(res);
+
+		expect(data).toMatchObject({ id: user._id.toString(), username: user.username });
+	});
+
+	it("returns null when the session cookie matches no stored session", async () => {
+		const res = await testRequest(userGET, {
+			path: "/api/v2/user",
+			headers: { cookie: "hf-chat=not-a-real-session" },
+		});
+
+		expect(await parseResponse(res)).toBeNull();
 	});
 });
 
@@ -60,7 +82,7 @@ describe("GET /api/v2/user/settings", () => {
 	it("returns default settings when none exist", async () => {
 		const { locals } = await createTestUser();
 
-		const res = await settingsGET(mockRequestEvent(locals));
+		const res = await testRequest(settingsGET, { path: "/api/v2/user/settings", locals });
 		const data = await parseResponse<Record<string, unknown>>(res);
 
 		expect(data).toMatchObject({
@@ -96,7 +118,7 @@ describe("GET /api/v2/user/settings", () => {
 			updatedAt: new Date(),
 		});
 
-		const res = await settingsGET(mockRequestEvent(locals));
+		const res = await testRequest(settingsGET, { path: "/api/v2/user/settings", locals });
 		const data = await parseResponse<Record<string, unknown>>(res);
 
 		expect(data).toMatchObject({
@@ -130,7 +152,7 @@ describe("GET /api/v2/user/settings", () => {
 			legacySettingsWithFinal as unknown as Parameters<typeof collections.settings.insertOne>[0]
 		);
 
-		const res = await settingsGET(mockRequestEvent(locals));
+		const res = await testRequest(settingsGET, { path: "/api/v2/user/settings", locals });
 		const data = await parseResponse<Record<string, unknown>>(res);
 
 		expect(data).toMatchObject({
@@ -159,15 +181,11 @@ describe("POST /api/v2/user/settings", () => {
 			hidePromptExamples: {},
 		};
 
-		const res = await settingsPOST(
-			mockRequestEvent(locals, {
-				request: new Request("http://localhost", {
-					method: "POST",
-					body: JSON.stringify(body),
-					headers: { "Content-Type": "application/json" },
-				}),
-			})
-		);
+		const res = await testRequest(settingsPOST, {
+			path: "/api/v2/user/settings",
+			locals,
+			...jsonBody(body),
+		});
 
 		expect(res.status).toBe(200);
 
@@ -195,15 +213,11 @@ describe("POST /api/v2/user/settings", () => {
 			hidePromptExamples: {},
 		};
 
-		await settingsPOST(
-			mockRequestEvent(locals, {
-				request: new Request("http://localhost", {
-					method: "POST",
-					body: JSON.stringify(body),
-					headers: { "Content-Type": "application/json" },
-				}),
-			})
-		);
+		await testRequest(settingsPOST, {
+			path: "/api/v2/user/settings",
+			locals,
+			...jsonBody(body),
+		});
 
 		const stored = await collections.settings.findOne({ userId: user._id });
 		expect(stored).not.toBeNull();
@@ -216,15 +230,11 @@ describe("POST /api/v2/user/settings", () => {
 		// POST with minimal body — Zod defaults should fill in the rest
 		const body = {};
 
-		const res = await settingsPOST(
-			mockRequestEvent(locals, {
-				request: new Request("http://localhost", {
-					method: "POST",
-					body: JSON.stringify(body),
-					headers: { "Content-Type": "application/json" },
-				}),
-			})
-		);
+		const res = await testRequest(settingsPOST, {
+			path: "/api/v2/user/settings",
+			locals,
+			...jsonBody(body),
+		});
 
 		expect(res.status).toBe(200);
 
@@ -235,5 +245,101 @@ describe("POST /api/v2/user/settings", () => {
 		expect(stored?.streamingMode).toBe("smooth");
 		expect(stored?.directPaste).toBe(false);
 		expect(stored?.customPrompts).toEqual({});
+	});
+});
+
+describe("handle hook, via POST /api/v2/user/settings", () => {
+	beforeEach(async () => {
+		await cleanupTestData();
+	}, 20000);
+
+	it("exempts application/json POSTs from the CSRF origin check", async () => {
+		const { locals } = await createTestUser();
+
+		const res = await testRequest(settingsPOST, {
+			path: "/api/v2/user/settings",
+			locals,
+			...jsonBody({}),
+		});
+
+		expect(res.status).toBe(200);
+	});
+
+	it.each(["multipart/form-data", "application/x-www-form-urlencoded", "text/plain"])(
+		"rejects a %s POST that carries no Origin",
+		async (contentType) => {
+			const { locals } = await createTestUser();
+
+			const res = await testRequest(settingsPOST, {
+				path: "/api/v2/user/settings",
+				method: "POST",
+				body: "welcomeModalSeen=true",
+				headers: { "Content-Type": contentType },
+				locals,
+			});
+
+			expect(res.status).toBe(403);
+			expect(await res.text()).toBe("Non-JSON form requests need to have an origin");
+		}
+	);
+
+	it("rejects a native-form POST whose Origin is a different host", async () => {
+		const { locals } = await createTestUser();
+
+		const res = await testRequest(settingsPOST, {
+			path: "/api/v2/user/settings",
+			method: "POST",
+			body: "welcomeModalSeen=true",
+			headers: { "Content-Type": "text/plain", origin: "https://evil.example" },
+			locals,
+		});
+
+		expect(res.status).toBe(403);
+		expect(await res.text()).toBe("Invalid referer for POST request");
+	});
+
+	it("accepts a native-form POST whose Origin matches the request host", async () => {
+		const { locals } = await createTestUser();
+
+		const res = await testRequest(settingsPOST, {
+			path: "/api/v2/user/settings",
+			method: "POST",
+			body: JSON.stringify({}),
+			headers: { "Content-Type": "text/plain", origin: TEST_ORIGIN },
+			locals,
+		});
+
+		expect(res.status).toBe(200);
+	});
+
+	it("refreshes the session cookie on POST", async () => {
+		const { cookie, secretSessionId } = await createTestUser();
+
+		const res = await testRequest(settingsPOST, {
+			path: "/api/v2/user/settings",
+			headers: { cookie, "Content-Type": "application/json" },
+			method: "POST",
+			body: JSON.stringify({}),
+		});
+
+		const setCookie = res.headers.get("set-cookie");
+		expect(setCookie).toContain(`hf-chat=${secretSessionId}`);
+		expect(setCookie).toContain("HttpOnly");
+		expect(setCookie).toContain("Path=/");
+	});
+
+	it("extends the stored session's expiry on POST", async () => {
+		const { cookie, session } = await createTestUser();
+		const before = await collections.sessions.findOne({ sessionId: session.sessionId });
+
+		await testRequest(settingsPOST, {
+			path: "/api/v2/user/settings",
+			headers: { cookie, "Content-Type": "application/json" },
+			method: "POST",
+			body: JSON.stringify({}),
+		});
+
+		const after = await collections.sessions.findOne({ sessionId: session.sessionId });
+		expect(after?.expiresAt.getTime()).toBeGreaterThan(before?.expiresAt.getTime() ?? 0);
 	});
 });

--- a/src/lib/server/config.ts
+++ b/src/lib/server/config.ts
@@ -14,9 +14,19 @@ class ConfigManager {
 	private keysFromDB: Partial<Record<ConfigKey, string>> = {};
 	private isInitialized = false;
 
-	private configCollection: Collection<ConfigKeyType> | undefined;
-	private semaphoreCollection: Collection<Semaphore> | undefined;
-	private lastConfigUpdate: Date | undefined;
+	// These need explicit initialisers. tsconfig targets ES2018, so
+	// `useDefineForClassFields` is off and a declaration-only field is erased rather than
+	// defined — the property never exists on the instance. The `config` Proxy below falls
+	// back to `ConfigManager.get()` for any prop not `in` the target, which returns `""`
+	// for unknown keys. So an unassigned field reads as an empty string, `?.` fails to
+	// short-circuit on it, and `this.configCollection?.find({})` throws.
+	//
+	// Reachable whenever `init()` early-returns without assigning them (test mode and
+	// `building`), which makes every `config.checkForUpdates()` — called per-request from
+	// the handle hook — an unhandled rejection.
+	private configCollection: Collection<ConfigKeyType> | undefined = undefined;
+	private semaphoreCollection: Collection<Semaphore> | undefined = undefined;
+	private lastConfigUpdate: Date | undefined = undefined;
 
 	async init() {
 		if (this.isInitialized) return;

--- a/src/lib/server/config.ts
+++ b/src/lib/server/config.ts
@@ -14,16 +14,10 @@ class ConfigManager {
 	private keysFromDB: Partial<Record<ConfigKey, string>> = {};
 	private isInitialized = false;
 
-	// These need explicit initialisers. tsconfig targets ES2018, so
-	// `useDefineForClassFields` is off and a declaration-only field is erased rather than
-	// defined — the property never exists on the instance. The `config` Proxy below falls
-	// back to `ConfigManager.get()` for any prop not `in` the target, which returns `""`
-	// for unknown keys. So an unassigned field reads as an empty string, `?.` fails to
-	// short-circuit on it, and `this.configCollection?.find({})` throws.
-	//
-	// Reachable whenever `init()` early-returns without assigning them (test mode and
-	// `building`), which makes every `config.checkForUpdates()` — called per-request from
-	// the handle hook — an unhandled rejection.
+	// The `= undefined` is load-bearing: under ES2018 `useDefineForClassFields` is off, so a
+	// declaration-only field is erased and never becomes an own property. The Proxy below
+	// then falls through to `get()`, and these would read as `""` rather than undefined,
+	// defeating every `?.` on them.
 	private configCollection: Collection<ConfigKeyType> | undefined = undefined;
 	private semaphoreCollection: Collection<Semaphore> | undefined = undefined;
 	private lastConfigUpdate: Date | undefined = undefined;

--- a/src/lib/utils/tree/addChildren.spec.ts
+++ b/src/lib/utils/tree/addChildren.spec.ts
@@ -1,6 +1,6 @@
-import { collections } from "$lib/server/database";
+import { collections, ready } from "$lib/server/database";
 import { ObjectId } from "mongodb";
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 
 import { insertLegacyConversation, insertSideBranchesConversation } from "./treeHelpers.spec";
 import { addChildren } from "./addChildren";
@@ -12,6 +12,11 @@ const newMessage: Omit<Message, "id"> = {
 };
 
 Object.freeze(newMessage);
+
+// `collections` is undefined until the database IIFE resolves.
+beforeAll(async () => {
+	await ready;
+});
 
 describe("addChildren", async () => {
 	it("should let you append on legacy conversations", async () => {

--- a/src/lib/utils/tree/addSibling.spec.ts
+++ b/src/lib/utils/tree/addSibling.spec.ts
@@ -1,6 +1,6 @@
-import { collections } from "$lib/server/database";
+import { collections, ready } from "$lib/server/database";
 import { ObjectId } from "mongodb";
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 
 import { insertLegacyConversation, insertSideBranchesConversation } from "./treeHelpers.spec";
 import type { Message } from "$lib/types/Message";
@@ -13,6 +13,11 @@ const newMessage = {
 };
 
 Object.freeze(newMessage);
+
+// `collections` is undefined until the database IIFE resolves.
+beforeAll(async () => {
+	await ready;
+});
 
 describe("addSibling", async () => {
 	it("should fail on empty conversations", () => {

--- a/src/lib/utils/tree/buildSubtree.spec.ts
+++ b/src/lib/utils/tree/buildSubtree.spec.ts
@@ -1,6 +1,6 @@
-import { collections } from "$lib/server/database";
+import { collections, ready } from "$lib/server/database";
 import { ObjectId } from "mongodb";
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 
 import {
 	insertLegacyConversation,
@@ -8,6 +8,11 @@ import {
 	insertSideBranchesConversation,
 } from "./treeHelpers.spec";
 import { buildSubtree } from "./buildSubtree";
+
+// `collections` is undefined until the database IIFE resolves.
+beforeAll(async () => {
+	await ready;
+});
 
 describe("buildSubtree", () => {
 	it("a subtree in a legacy conversation should be just a slice", async () => {

--- a/src/lib/utils/tree/convertLegacyConversation.spec.ts
+++ b/src/lib/utils/tree/convertLegacyConversation.spec.ts
@@ -1,9 +1,14 @@
-import { collections } from "$lib/server/database";
+import { collections, ready } from "$lib/server/database";
 import { ObjectId } from "mongodb";
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 
 import { convertLegacyConversation } from "./convertLegacyConversation";
 import { insertLegacyConversation } from "./treeHelpers.spec";
+
+// `collections` is undefined until the database IIFE resolves.
+beforeAll(async () => {
+	await ready;
+});
 
 describe("convertLegacyConversation", () => {
 	it("should convert a legacy conversation", async () => {

--- a/src/routes/login/callback/updateUser.spec.ts
+++ b/src/routes/login/callback/updateUser.spec.ts
@@ -1,6 +1,6 @@
-import { assert, it, describe, afterEach, vi, expect } from "vitest";
+import { assert, it, describe, afterEach, beforeAll, vi, expect } from "vitest";
 import type { Cookies } from "@sveltejs/kit";
-import { collections } from "$lib/server/database";
+import { collections, ready } from "$lib/server/database";
 import { updateUser } from "./updateUser";
 import { ObjectId } from "mongodb";
 import { DEFAULT_SETTINGS } from "$lib/types/Settings";
@@ -33,6 +33,11 @@ const token = {
 const cookiesMock: Cookies = {
 	set: vi.fn(),
 };
+
+// `collections` is undefined until the database IIFE resolves.
+beforeAll(async () => {
+	await ready;
+});
 
 const insertRandomUser = async () => {
 	const res = await collections.users.insertOne({


### PR DESCRIPTION
This PR adds a test request helper for two reasons:

- ensure `handle` middleware is invoked so we are testing a production-like flow
- unlock some tests that weren't possible before, such as CSRF assertions.
- proper typing

The changes are essentially:
- a single helper file, then 
- some mechanical replacements to use the util
- a few extra tests that we couldn't do before