### PR TITLE
Add runtime follow mode switching for scroll behavior

### DIFF
--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -348,6 +348,13 @@
 		chatScroll.setComposerHeight(composerHeight);
 	});
 
+	// Follow behavior tracks generation state: glide while a reply streams,
+	// snap while idle — a conversation switch must land at the bottom with no
+	// animated scrolling while its async content (markdown, images) settles.
+	$effect(() => {
+		chatScroll.setStreaming(loading);
+	});
+
 	// Shared conversations containing artifacts usually exist to show one off:
 	// open the most recent artifact on load. Desktop only, since on mobile the
 	// panel is a fullscreen overlay that would hide the conversation entirely.

--- a/src/lib/server/shareThumbnail/shareThumbnail.ssr.test.ts
+++ b/src/lib/server/shareThumbnail/shareThumbnail.ssr.test.ts
@@ -19,6 +19,9 @@ function expectValidPng(png: Uint8Array) {
 }
 
 describe("renderShareThumbnailPng", () => {
+	// The file's first render pays the one-time font/satori/resvg init, which
+	// can exceed the 5s default on a cold CI runner — same allowance as the
+	// adversarial-prompts test below.
 	it("renders a PNG for a normal prompt", async () => {
 		const png = await renderShareThumbnailPng({
 			prompt: renderableThumbnailText("How do I fine-tune a model on my own dataset?", 240),
@@ -26,7 +29,7 @@ describe("renderShareThumbnailPng", () => {
 			appName: "HuggingChat",
 		});
 		expectValidPng(png);
-	});
+	}, 30000);
 
 	it("renders the generic card when the prompt is empty", async () => {
 		const png = await renderShareThumbnailPng({

--- a/src/lib/utils/scroll/__tests__/chatScroll.svelte.test.ts
+++ b/src/lib/utils/scroll/__tests__/chatScroll.svelte.test.ts
@@ -344,7 +344,7 @@ describe("follow behavior", () => {
 		});
 	});
 
-	it("streaming growth glides, and the end-of-stream flip never moves the view", async () => {
+	it("streaming growth glides, and the end-of-stream flip keeps gliding", async () => {
 		const chat = createChat();
 		chat.chat.setStreaming(true);
 		chat.fixture.growLast(700);
@@ -368,7 +368,28 @@ describe("follow behavior", () => {
 		chat.chat.setStreaming(false);
 		const scrollTop = chat.fixture.scrollTop();
 		await frames(3);
+		// The flip alone never moves the view…
 		expect(chat.fixture.scrollTop()).toBe(scrollTop);
+		// …and growth after it still glides: the reply's final chunk can land
+		// in the same task that turns loading off, so flipping to instant here
+		// would snap the end of the stream. Instant only returns on switch.
+		chat.fixture.growLast(600);
+		await frames(2);
+		expect(chat.fixture.distance()).toBeGreaterThan(100);
+		await waitFor(() => chat.fixture.distance() <= ARRIVED, { label: "still glides" });
+	});
+
+	it("a switch after a streamed turn restores the no-glide settle", async () => {
+		const chat = createChat();
+		chat.chat.setStreaming(true);
+		chat.chat.setStreaming(false); // a stream came and went — spring stayed engaged
+		chat.sync(false, "c2");
+		await frame();
+		chat.fixture.growLast(700);
+		await waitFor(() => chat.fixture.distance() <= ARRIVED, {
+			maxFrames: 6,
+			label: "snaps to the bottom",
+		});
 	});
 });
 

--- a/src/lib/utils/scroll/__tests__/chatScroll.svelte.test.ts
+++ b/src/lib/utils/scroll/__tests__/chatScroll.svelte.test.ts
@@ -105,6 +105,7 @@ describe("send anchoring", () => {
 	it("anchors the sent message ~50px below the viewport top", async () => {
 		const chat = createChat();
 		chat.chat.armSend();
+		chat.chat.setStreaming(true); // writeMessage flips loading before the pair mounts
 		const { user } = chat.mountPair();
 		await waitFor(() => Math.abs(topOf(user, chat) - ANCHOR_OFFSET) <= 2, {
 			label: "user message glides to the anchor offset",
@@ -115,6 +116,7 @@ describe("send anchoring", () => {
 	it("fill phase: constant scrollHeight, zero scroll movement, zero layout shift", async () => {
 		const chat = createChat();
 		chat.chat.armSend();
+		chat.chat.setStreaming(true);
 		const { user, assistant } = chat.mountPair();
 		await waitFor(() => Math.abs(topOf(user, chat) - ANCHOR_OFFSET) <= 2, { label: "anchored" });
 		await frames(3); // let everything paint before probing
@@ -137,6 +139,7 @@ describe("send anchoring", () => {
 	it("hands off seamlessly from fill to follow when the reply outgrows the viewport", async () => {
 		const chat = createChat();
 		chat.chat.armSend();
+		chat.chat.setStreaming(true);
 		const { assistant } = chat.mountPair();
 		await waitFor(() => chat.fixture.distance() <= ARRIVED, { label: "anchored" });
 		let maxFrameJump = 0;
@@ -165,9 +168,11 @@ describe("send anchoring", () => {
 	it("spacer stays inflated after the stream ends (no end-of-turn jump)", async () => {
 		const chat = createChat();
 		chat.chat.armSend();
+		chat.chat.setStreaming(true);
 		const { assistant } = chat.mountPair();
 		await waitFor(() => chat.fixture.distance() <= ARRIVED, { label: "anchored" });
 		assistant.style.height = "60px"; // short reply, stream over
+		chat.chat.setStreaming(false);
 		await frames(4);
 		const height = parseFloat(chat.fixture.spacer.style.height);
 		expect(height).toBeGreaterThan(MIN_SPACER_FALLBACK_PX);
@@ -310,6 +315,47 @@ describe("conversation switch", () => {
 		expect(chat.chat.state.pinned).toBe(true);
 		expect(chat.fixture.distance()).toBeLessThanOrEqual(ARRIVED);
 		expect(parseFloat(chat.fixture.spacer.style.height)).toBe(MIN_SPACER_FALLBACK_PX);
+	});
+
+	it("content settling after a switch lands at the bottom with no glide", async () => {
+		const chat = createChat({ turns: 5 });
+		chat.sync(false, "c2");
+		await frame();
+		// The switched-to conversation keeps inflating after the reset (async
+		// markdown, images, code highlighting) — every growth must land at the
+		// bottom immediately instead of playing a visible scroll animation.
+		// Snap = ResizeObserver delivery + one tick (a few frames); a spring
+		// from 700px away cannot get within 2px in 6 ticks in any rAF regime.
+		chat.fixture.growLast(700);
+		await waitFor(() => chat.fixture.distance() <= ARRIVED, {
+			maxFrames: 6,
+			label: "snaps to the bottom",
+		});
+	});
+});
+
+describe("follow behavior", () => {
+	it("idle content growth (late images, initial load) snaps to the bottom", async () => {
+		const chat = createChat();
+		chat.fixture.growLast(700);
+		await waitFor(() => chat.fixture.distance() <= ARRIVED, {
+			maxFrames: 6, // snap arrives in a few frames; a spring cannot
+			label: "snaps to the bottom",
+		});
+	});
+
+	it("streaming growth glides, and the end-of-stream flip never moves the view", async () => {
+		const chat = createChat();
+		chat.chat.setStreaming(true);
+		chat.fixture.growLast(700);
+		await frames(2);
+		// Mid-glide: the spring is still closing the gap.
+		expect(chat.fixture.distance()).toBeGreaterThan(100);
+		await waitFor(() => chat.fixture.distance() <= ARRIVED, { label: "glides to the bottom" });
+		chat.chat.setStreaming(false);
+		const scrollTop = chat.fixture.scrollTop();
+		await frames(3);
+		expect(chat.fixture.scrollTop()).toBe(scrollTop);
 	});
 });
 

--- a/src/lib/utils/scroll/__tests__/chatScroll.svelte.test.ts
+++ b/src/lib/utils/scroll/__tests__/chatScroll.svelte.test.ts
@@ -351,7 +351,20 @@ describe("follow behavior", () => {
 		await frames(2);
 		// Mid-glide: the spring is still closing the gap.
 		expect(chat.fixture.distance()).toBeGreaterThan(100);
-		await waitFor(() => chat.fixture.distance() <= ARRIVED, { label: "glides to the bottom" });
+		// Wait for the spring to fully settle, not just cross the arrival
+		// threshold — it keeps crawling the last couple px after distance()
+		// first dips under ARRIVED, and that residual motion belongs to the
+		// glide, not to the flip below.
+		let last = -1;
+		await waitFor(
+			() => {
+				const top = chat.fixture.scrollTop();
+				const settled = top === last && chat.fixture.distance() <= ARRIVED;
+				last = top;
+				return settled;
+			},
+			{ label: "spring settles at the bottom" }
+		);
 		chat.chat.setStreaming(false);
 		const scrollTop = chat.fixture.scrollTop();
 		await frames(3);

--- a/src/lib/utils/scroll/__tests__/stickToBottom.svelte.test.ts
+++ b/src/lib/utils/scroll/__tests__/stickToBottom.svelte.test.ts
@@ -75,9 +75,34 @@ describe("mount & basic follow", () => {
 
 	it("instant follow mode pins hard on every growth", async () => {
 		const { fixture } = setup({}, { followMode: "instant" });
+		// Snap = ResizeObserver delivery + one tick (a few frames); a spring from
+		// 700px away cannot get within 2px in 6 ticks in any rAF regime.
 		fixture.growLast(700);
-		await frames(2); // ResizeObserver delivery
-		expect(fixture.distance()).toBeLessThanOrEqual(ARRIVED);
+		await waitFor(() => fixture.distance() <= ARRIVED, {
+			maxFrames: 6,
+			label: "snaps to the bottom",
+		});
+	});
+
+	it("setFollowMode swaps behavior at runtime without moving the view", async () => {
+		const { fixture, controller } = setup({}, { followMode: "instant" });
+		// The swap itself is inert — no write, no motion.
+		controller.setFollowMode("spring");
+		const top = fixture.scrollTop();
+		await frames(2);
+		expect(fixture.scrollTop()).toBe(top);
+		// Growth now glides instead of snapping…
+		fixture.growLast(700);
+		await frames(2);
+		expect(fixture.distance()).toBeGreaterThan(100);
+		await waitFor(() => fixture.distance() <= ARRIVED, { label: "spring reaches bottom" });
+		// …and swapping back makes the next growth snap again.
+		controller.setFollowMode("instant");
+		fixture.growLast(700);
+		await waitFor(() => fixture.distance() <= ARRIVED, {
+			maxFrames: 6,
+			label: "snaps to the bottom",
+		});
 	});
 
 	it("re-pins to the live bottom when the container itself resizes", async () => {

--- a/src/lib/utils/scroll/__tests__/stickToBottom.svelte.test.ts
+++ b/src/lib/utils/scroll/__tests__/stickToBottom.svelte.test.ts
@@ -327,6 +327,21 @@ describe("re-attach", () => {
 		await touchDrag(fixture.container, { fromY: 200, toY: 150 });
 		expect(controller.pinned).toBe(true);
 	});
+
+	it("re-attach glides the remaining gap even in instant follow mode", async () => {
+		const { fixture, controller } = setup({}, { followMode: "instant" });
+		wheel(fixture.container, -300);
+		await frame();
+		expect(controller.pinned).toBe(false);
+		// Scroll back down to just inside the near-bottom zone: re-pins and
+		// closes the last stretch with the spring — instant mode is for content
+		// growth, not for the user's own return to the bottom.
+		dragScrollbarTo(fixture.container, fixture.maxScrollTop() - 50);
+		await frames(2);
+		expect(controller.pinned).toBe(true);
+		expect(fixture.distance()).toBeGreaterThan(ARRIVED); // still gliding, no snap
+		await waitFor(() => fixture.distance() <= ARRIVED, { label: "glide closes the gap" });
+	});
 });
 
 describe("commands", () => {

--- a/src/lib/utils/scroll/chatScroll.svelte.ts
+++ b/src/lib/utils/scroll/chatScroll.svelte.ts
@@ -10,6 +10,12 @@
  * Also owns the send-anchor spacer element imperatively (measurement-driven
  * style, not template state), and exposes reactive state for the floating
  * scroll buttons so they carry no listeners of their own.
+ *
+ * Follow behavior is driven by generation state (setStreaming): pinned follows
+ * glide (spring) only while a reply is streaming into this conversation, and
+ * snap (instant) otherwise — so the async content inflation after a
+ * conversation load/switch (markdown, images, syntax highlighting) lands the
+ * view at the bottom with no visible scrolling.
  */
 
 import type { Message } from "$lib/types/Message";
@@ -101,6 +107,8 @@ export class ChatScroll {
 	private suppressSkipPin = false;
 	private composerHeight: number | undefined;
 	private gutterPx = -1;
+	/** True while a reply is streaming into this conversation (see setStreaming). */
+	private streaming = false;
 
 	private lastConversationKey: string | undefined;
 	private lastMessageCount = 0;
@@ -123,6 +131,7 @@ export class ChatScroll {
 		this.controller = new StickToBottomController(node, {
 			content: () => this.contentEl?.() ?? undefined,
 			ignoreTouchZonePx: params?.ignoreTouchZonePx,
+			followMode: this.streaming ? "spring" : "instant",
 			onStateChange: (s) => this.applyState(s),
 			onContentResize: (containerResized) => {
 				if (containerResized) this.measureGutter();
@@ -167,6 +176,18 @@ export class ChatScroll {
 	 * conversation gaining its first messages) — re-check the observer then. */
 	notifyContentChanged() {
 		this.controller?.recompute();
+	}
+
+	/**
+	 * Generation state, mirrored from the page's loading flag. While a reply
+	 * streams, pinned follows glide (spring) so token bursts read as motion;
+	 * while idle they snap instantly, so content settling after a conversation
+	 * load/switch never plays as an animated scroll to the bottom.
+	 */
+	setStreaming(streaming: boolean) {
+		if (streaming === this.streaming) return;
+		this.streaming = streaming;
+		this.controller?.setFollowMode(streaming ? "spring" : "instant");
 	}
 
 	setComposerHeight(height: number | undefined) {

--- a/src/lib/utils/scroll/chatScroll.svelte.ts
+++ b/src/lib/utils/scroll/chatScroll.svelte.ts
@@ -11,11 +11,14 @@
  * style, not template state), and exposes reactive state for the floating
  * scroll buttons so they carry no listeners of their own.
  *
- * Follow behavior is driven by generation state (setStreaming): pinned follows
- * glide (spring) only while a reply is streaming into this conversation, and
- * snap (instant) otherwise — so the async content inflation after a
- * conversation load/switch (markdown, images, syntax highlighting) lands the
- * view at the bottom with no visible scrolling.
+ * Follow behavior: pinned follows snap (instant) from conversation load/switch
+ * until a reply starts streaming, so the async content inflation of a settling
+ * conversation (markdown, images, syntax highlighting) never plays as animated
+ * scrolling; once a reply streams, follows glide (spring). Only the START of a
+ * stream flips the mode — the end of one deliberately leaves spring engaged,
+ * because loading turns false in the same task as the reply's final content
+ * mutation, and flipping there would snap the last chunk's growth instead of
+ * gliding it. Instant returns at the next reset/attach.
  */
 
 import type { Message } from "$lib/types/Message";
@@ -179,15 +182,19 @@ export class ChatScroll {
 	}
 
 	/**
-	 * Generation state, mirrored from the page's loading flag. While a reply
-	 * streams, pinned follows glide (spring) so token bursts read as motion;
-	 * while idle they snap instantly, so content settling after a conversation
-	 * load/switch never plays as an animated scroll to the bottom.
+	 * Generation state, mirrored from the page's loading flag. Only the ON edge
+	 * changes the follow mode: a starting reply engages the spring glide.
+	 * Flipping to instant on the OFF edge would race the final chunk — loading
+	 * turns false in the same task that mutates the reply's last content, so
+	 * the mode would flip before that growth's ResizeObserver delivery and
+	 * snap the end of the stream. Instant mode returns at the next
+	 * conversation switch/load (reset/attach), the only places settling
+	 * needs it.
 	 */
 	setStreaming(streaming: boolean) {
 		if (streaming === this.streaming) return;
 		this.streaming = streaming;
-		this.controller?.setFollowMode(streaming ? "spring" : "instant");
+		if (streaming) this.controller?.setFollowMode("spring");
 	}
 
 	setComposerHeight(height: number | undefined) {
@@ -321,6 +328,11 @@ export class ChatScroll {
 		this.anchorEl = null;
 		this.pendingBranchSwitch = false;
 		if (this.spacerEl) this.spacerEl.style.height = `${this.minSpacer()}px`;
+		// Settling starts over: snap follows until this conversation streams.
+		// (If the switched-to conversation has a generation running, the
+		// loading effect re-engages spring right after — beforeNavigate
+		// guarantees the OFF edge, so the ON edge always fires here.)
+		this.controller?.setFollowMode("instant");
 		this.controller?.jumpToBottom();
 	}
 

--- a/src/lib/utils/scroll/stickToBottom.ts
+++ b/src/lib/utils/scroll/stickToBottom.ts
@@ -44,7 +44,8 @@ export interface StickToBottomOptions {
 	 * callers skip container-box measurements on pure content growth.
 	 */
 	onContentResize?: (containerResized: boolean) => void;
-	/** 'spring' glides toward the bottom; 'instant' hard-pins every growth. */
+	/** 'spring' glides toward the bottom; 'instant' hard-pins every growth.
+	 * Initial value — swappable at runtime via setFollowMode(). */
 	followMode?: "spring" | "instant";
 	nearBottomPx?: number;
 	scrolledUpPx?: number;
@@ -81,6 +82,11 @@ interface Animation {
 	/** Live target — re-read every frame so streaming growth retargets the spring. */
 	target: () => number;
 	lastTime: number;
+	/** Write the full remaining distance on the first tick instead of springing.
+	 * Instant follows still go through a tick (not a synchronous write) so a
+	 * same-frame user scroll — whose scroll event dispatches before rAF
+	 * callbacks — is classified first and its unpin cancels the write. */
+	snap?: boolean;
 }
 
 export class StickToBottomController {
@@ -97,6 +103,9 @@ export class StickToBottomController {
 		scrolledUp: false,
 		distanceFromBottom: 0,
 	};
+
+	/** Current follow behavior; starts from opts.followMode (see setFollowMode). */
+	private followMode: "spring" | "instant";
 
 	/** scrollTop values we wrote and whose scroll events haven't arrived yet. */
 	private pendingWrites: number[] = [];
@@ -123,6 +132,7 @@ export class StickToBottomController {
 			ignoreTouchZonePx: 0,
 			...options,
 		};
+		this.followMode = this.opts.followMode;
 
 		this.lastTop = this.clampedTop();
 		this.lastScrollHeight = container.scrollHeight;
@@ -308,6 +318,14 @@ export class StickToBottomController {
 		this.setPinned(false);
 	}
 
+	/** Swap how pinned follows track content growth: 'spring' glides (streaming
+	 * replies), 'instant' snaps (settling content, where a glide is motion
+	 * without information). Takes effect on the next growth — never moves the
+	 * view by itself, and never interrupts an animation already in flight. */
+	setFollowMode(mode: "spring" | "instant") {
+		this.followMode = mode;
+	}
+
 	/** Animated move that does NOT engage following (e.g. scroll-to-previous). */
 	animateTo(top: number) {
 		this.unpin();
@@ -352,8 +370,8 @@ export class StickToBottomController {
 
 	// --- animation ------------------------------------------------------------------
 
-	private startAnimation(target: () => number) {
-		this.anim = { target, lastTime: performance.now() };
+	private startAnimation(target: () => number, opts?: { snap?: boolean }) {
+		this.anim = { target, lastTime: performance.now(), snap: opts?.snap };
 		if (this.rafId === null) this.rafId = requestAnimationFrame(this.tick);
 	}
 
@@ -376,7 +394,7 @@ export class StickToBottomController {
 		const top = this.clampedTop();
 		const delta = target - top;
 
-		if (Math.abs(delta) <= SPRING_SNAP_PX) {
+		if (this.anim.snap || Math.abs(delta) <= SPRING_SNAP_PX) {
 			this.write(target);
 			this.anim = null;
 			this.recomputeState();
@@ -395,12 +413,27 @@ export class StickToBottomController {
 	/** Pinned + content grew: glide (spring) or snap (instant/reduced-motion/hidden). */
 	private follow() {
 		if (!this.state.pinned) return;
-		if (this.opts.followMode === "instant" || this.shouldSkipAnimation()) {
+		if (this.shouldSkipAnimation()) {
+			// Hidden tabs must not wait on a throttled rAF; reduced-motion keeps
+			// its long-standing synchronous write.
 			this.stopAnimation();
 			this.write(this.maxScrollTop());
 			return;
 		}
-		if (!this.anim) this.startAnimation(() => this.maxScrollTop());
+		// Instant follows snap on the next tick rather than writing synchronously:
+		// this often runs inside a ResizeObserver callback, and a user scroll from
+		// the same frame may not have dispatched its scroll event yet. A
+		// synchronous write would land after the user's movement and be matched
+		// as ours by the coalesced event — silently swallowing the unpin. Scroll
+		// events run before rAF callbacks, so one tick of deferral lets the
+		// user's unpin cancel the write instead.
+		if (this.followMode === "instant") {
+			// A leftover glide (mode just flipped, or an animateToBottom) is
+			// replaced: instant mode owes the bottom on the very next tick.
+			if (!this.anim?.snap) this.startAnimation(() => this.maxScrollTop(), { snap: true });
+		} else if (!this.anim) {
+			this.startAnimation(() => this.maxScrollTop());
+		}
 	}
 
 	// --- event handlers ---------------------------------------------------------------

--- a/src/lib/utils/scroll/stickToBottom.ts
+++ b/src/lib/utils/scroll/stickToBottom.ts
@@ -320,8 +320,9 @@ export class StickToBottomController {
 
 	/** Swap how pinned follows track content growth: 'spring' glides (streaming
 	 * replies), 'instant' snaps (settling content, where a glide is motion
-	 * without information). Takes effect on the next growth — never moves the
-	 * view by itself, and never interrupts an animation already in flight. */
+	 * without information). Growth follows only — a user re-attaching at the
+	 * bottom glides in either mode. Takes effect on the next growth — never
+	 * moves the view by itself, and never interrupts an animation in flight. */
 	setFollowMode(mode: "spring" | "instant") {
 		this.followMode = mode;
 	}
@@ -410,8 +411,13 @@ export class StickToBottomController {
 		this.rafId = requestAnimationFrame(this.tick);
 	};
 
-	/** Pinned + content grew: glide (spring) or snap (instant/reduced-motion/hidden). */
-	private follow() {
+	/**
+	 * Pinned + the view must catch up to the bottom: glide (spring) or snap
+	 * (instant/reduced-motion/hidden). The instant follow mode only applies to
+	 * content growth — a user re-attaching at the bottom glides the remaining
+	 * gap closed regardless of mode, so coming back never feels like a teleport.
+	 */
+	private follow(reason: "growth" | "reattach" = "growth") {
 		if (!this.state.pinned) return;
 		if (this.shouldSkipAnimation()) {
 			// Hidden tabs must not wait on a throttled rAF; reduced-motion keeps
@@ -427,7 +433,7 @@ export class StickToBottomController {
 		// as ours by the coalesced event — silently swallowing the unpin. Scroll
 		// events run before rAF callbacks, so one tick of deferral lets the
 		// user's unpin cancel the write instead.
-		if (this.followMode === "instant") {
+		if (this.followMode === "instant" && reason === "growth") {
 			// A leftover glide (mode just flipped, or an animateToBottom) is
 			// replaced: instant mode owes the bottom on the very next tick.
 			if (!this.anim?.snap) this.startAnimation(() => this.maxScrollTop(), { snap: true });
@@ -490,7 +496,7 @@ export class StickToBottomController {
 					// User came back to the bottom zone: re-engage and glide the
 					// remaining gap closed (spring, so no re-attach snap).
 					this.setPinned(true);
-					this.follow();
+					this.follow("reattach");
 				}
 			}
 		}
@@ -585,7 +591,7 @@ export class StickToBottomController {
 			if (this.distanceFromBottom() > this.opts.nearBottomPx) return;
 			if (this.innerScrollableConsumes(event.target, deltaY)) return;
 			this.setPinned(true);
-			this.follow();
+			this.follow("reattach");
 		}
 	};
 
@@ -627,7 +633,7 @@ export class StickToBottomController {
 			!this.innerScrollableConsumes(this.touch.target, 1)
 		) {
 			this.setPinned(true);
-			this.follow();
+			this.follow("reattach");
 		}
 		this.touch.y = t.clientY;
 	};


### PR DESCRIPTION
## Summary

Adds the ability to swap scroll follow behavior at runtime between "spring" (gliding animation) and "instant" (snapping) modes. This enables the chat scroll controller to adapt its behavior based on generation state—gliding smoothly while a reply streams, and snapping instantly when content settles after conversation switches or loads.

## Key Changes

- **StickToBottomController**: 
  - Added `setFollowMode()` method to swap follow behavior at runtime without moving the view
  - Introduced `snap` flag on animations to force immediate completion on the next tick instead of springing
  - Modified `follow()` logic to defer instant writes by one tick, allowing user scroll events to cancel the write before it lands (prevents silent unpin swallowing)
  - Instant mode now uses snapping animation instead of synchronous writes to avoid race conditions with ResizeObserver callbacks

- **ChatScroll**:
  - Added `setStreaming()` method to mirror generation state and update follow mode accordingly
  - Initializes controller with `followMode: "instant"` by default
  - Exposes streaming state tracking for reply generation

- **ChatWindow.svelte**:
  - Added reactive effect to call `chatScroll.setStreaming(loading)`, keeping follow behavior in sync with the page's loading flag

- **Tests**:
  - Updated existing tests to call `setStreaming()` where needed to properly simulate streaming state
  - Added comprehensive test coverage for `setFollowMode()` runtime swapping
  - Added new test suite "follow behavior" covering idle content growth (snapping) vs streaming growth (gliding)
  - Verified that end-of-stream mode flip never moves the view

## Implementation Details

The key insight is that instant mode now defers its write by one tick rather than writing synchronously. This is necessary because `follow()` often runs inside a ResizeObserver callback, and a user scroll from the same frame may not have dispatched its scroll event yet. By deferring one tick, the user's scroll event (which runs before rAF callbacks) can dispatch and cancel the write via `unpin()`, preventing the silent swallowing of user intent.

The `snap` flag on animations ensures that instant follows complete immediately on the next tick rather than playing out a spring animation, while still going through the animation tick system for proper event ordering.

https://claude.ai/code/session_01TCL54YYW33Z3xu1jKeSjMX