### PR TITLE
surface background generations in the sidebar

### DIFF
--- a/src/lib/components/GenerationLiveWatcher.svelte
+++ b/src/lib/components/GenerationLiveWatcher.svelte
@@ -3,6 +3,7 @@
 	import { base } from "$app/paths";
 	import { page } from "$app/state";
 	import { onMount } from "svelte";
+	import { get } from "svelte/store";
 	import { loading } from "$lib/stores/loading";
 	import { useConversationsStore } from "$lib/stores/conversations.svelte";
 	import { useActiveGenerationsStore } from "$lib/stores/activeGenerations.svelte";
@@ -23,10 +24,16 @@
 		status: GenerationStatus;
 	}
 
+	// While a run this tab started is still registering, keep looking this often; its DB
+	// record can lag $loading, which won't re-fire to reopen us.
+	const REOPEN_WHILE_LOADING_MS = 2_000;
+
 	let source: EventSource | null = null;
+	let reopenTimer: ReturnType<typeof setTimeout> | undefined;
 
 	function open() {
 		if (!browser || source) return;
+		clearTimeout(reopenTimer);
 		const es = new EventSource(`${base}/api/v2/generations/live`);
 		source = es;
 
@@ -58,12 +65,19 @@
 			}
 		});
 
-		// `idle` means nothing is running: close so we neither hold nor auto-reconnect an
-		// idle connection. A plain close (lifetime cap) does reconnect.
-		es.addEventListener("idle", close);
+		es.addEventListener("idle", onIdle);
+	}
+
+	// `idle` means nothing is running: close so we neither hold nor auto-reconnect an idle
+	// connection (a plain lifetime-cap close does reconnect). But if this tab has a run
+	// starting, keep looking until its record appears rather than stranding it untracked.
+	function onIdle() {
+		close();
+		if (get(loading)) reopenTimer = setTimeout(open, REOPEN_WHILE_LOADING_MS);
 	}
 
 	function close() {
+		clearTimeout(reopenTimer);
 		source?.close();
 		source = null;
 	}

--- a/src/lib/components/GenerationLiveWatcher.svelte
+++ b/src/lib/components/GenerationLiveWatcher.svelte
@@ -1,0 +1,81 @@
+<script lang="ts">
+	import { browser } from "$app/environment";
+	import { base } from "$app/paths";
+	import { page } from "$app/state";
+	import { onMount } from "svelte";
+	import { loading } from "$lib/stores/loading";
+	import { useConversationsStore } from "$lib/stores/conversations.svelte";
+	import { useActiveGenerationsStore } from "$lib/stores/activeGenerations.svelte";
+	import { useNotificationsStore } from "$lib/stores/notifications.svelte";
+	import type { GenerationStatus } from "$lib/types/Generation";
+
+	const convsStore = useConversationsStore();
+	const activeGenerations = useActiveGenerationsStore();
+	const notifications = useNotificationsStore();
+
+	interface RunningEntry {
+		conversationId: string;
+		title: string;
+	}
+	interface EndedEntry {
+		conversationId: string;
+		title: string;
+		status: GenerationStatus;
+	}
+
+	let source: EventSource | null = null;
+
+	function open() {
+		if (!browser || source) return;
+		const es = new EventSource(`${base}/api/v2/generations/live`);
+		source = es;
+
+		es.addEventListener("sync", (event) => {
+			let payload: { running: RunningEntry[]; ended: EndedEntry[] };
+			try {
+				payload = JSON.parse((event as MessageEvent).data);
+			} catch {
+				return;
+			}
+
+			activeGenerations.setRunning(payload.running.map((run) => run.conversationId));
+			for (const run of payload.running) {
+				if (run.title) convsStore.update(run.conversationId, { title: run.title });
+			}
+			for (const done of payload.ended) {
+				if (done.title) {
+					convsStore.update(done.conversationId, { title: done.title, updatedAt: new Date() });
+				}
+				// The viewed conversation reports its own completion on the page; only toast
+				// for one finishing in the background.
+				if (done.conversationId !== page.params.id) {
+					notifications.push({
+						conversationId: done.conversationId,
+						title: done.title,
+						status: done.status,
+					});
+				}
+			}
+		});
+
+		// `idle` means nothing is running: close so we neither hold nor auto-reconnect an
+		// idle connection. A plain close (lifetime cap) does reconnect.
+		es.addEventListener("idle", close);
+	}
+
+	function close() {
+		source?.close();
+		source = null;
+	}
+
+	onMount(() => {
+		// Catch runs already in flight (e.g. started elsewhere before this load).
+		open();
+		return close;
+	});
+
+	// Reopen when a generation starts in this tab, so navigating away keeps it tracked.
+	$effect(() => {
+		if ($loading) open();
+	});
+</script>

--- a/src/lib/components/NavConversationItem.svelte
+++ b/src/lib/components/NavConversationItem.svelte
@@ -12,6 +12,9 @@
 	import EditConversationModal from "$lib/components/EditConversationModal.svelte";
 	import DeleteConversationModal from "$lib/components/DeleteConversationModal.svelte";
 	import { requireAuthUser } from "$lib/utils/auth";
+	import { useActiveGenerationsStore } from "$lib/stores/activeGenerations.svelte";
+
+	const activeGenerations = useActiveGenerationsStore();
 
 	interface Props {
 		conv: ConvSidebar;
@@ -59,6 +62,13 @@
 	class="group flex h-8 flex-none items-center gap-1.5 rounded-lg pr-1.5 pl-2 text-base text-gray-600 hover:bg-gray-100 max-sm:h-10 sm:text-sm dark:text-gray-300 dark:hover:bg-gray-700
 		{conv.id === page.params.id ? 'bg-gray-100 dark:bg-gray-700' : ''}"
 >
+	{#if activeGenerations.has(conv.id)}
+		<span
+			class="size-1.5 flex-none animate-pulse rounded-full bg-blue-500 dark:bg-blue-400"
+			title="Generating…"
+			aria-label="Generating"
+		></span>
+	{/if}
 	{#if inlineEditing}
 		<input
 			bind:this={inputEl}

--- a/src/lib/components/NotificationToasts.svelte
+++ b/src/lib/components/NotificationToasts.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+	import { base } from "$app/paths";
+	import { fade } from "svelte/transition";
+	import Portal from "./Portal.svelte";
+	import { useNotificationsStore } from "$lib/stores/notifications.svelte";
+	import type { GenerationStatus } from "$lib/types/Generation";
+
+	const notifications = useNotificationsStore();
+
+	function label(status: GenerationStatus): string {
+		if (status === "completed") return "Response ready";
+		if (status === "interrupted") return "Generation stopped";
+		return "Generation failed";
+	}
+
+	function dotClass(status: GenerationStatus): string {
+		if (status === "completed") return "bg-green-500";
+		if (status === "error") return "bg-red-500";
+		return "bg-gray-400";
+	}
+</script>
+
+<Portal>
+	<div
+		class="pointer-events-none fixed right-0 bottom-0 z-50 flex flex-col items-end gap-2 p-4 max-sm:text-sm"
+	>
+		{#each notifications.items as item (item.id)}
+			<a
+				href="{base}/conversation/{item.conversationId}"
+				transition:fade|global={{ duration: 200 }}
+				onclick={() => notifications.dismiss(item.id)}
+				class="pointer-events-auto flex max-w-xs items-center gap-2 rounded-lg bg-white/95 px-3 py-2 text-sm text-gray-800 shadow-lg ring-1 ring-gray-200 hover:bg-white dark:bg-gray-800/95 dark:text-gray-100 dark:ring-gray-700"
+			>
+				<span class="size-2 flex-none rounded-full {dotClass(item.status)}"></span>
+				<span class="min-w-0 truncate">
+					<span class="font-semibold">{label(item.status)}</span>
+					{#if item.title}
+						<span class="text-gray-500 dark:text-gray-400">
+							· <span class="first-letter:uppercase">{item.title}</span>
+						</span>
+					{/if}
+				</span>
+			</a>
+		{/each}
+	</div>
+</Portal>

--- a/src/lib/stores/activeGenerations.svelte.ts
+++ b/src/lib/stores/activeGenerations.svelte.ts
@@ -1,0 +1,41 @@
+/**
+ * Which conversations have a generation running right now, kept separate from the
+ * sidebar store on purpose: that store does a last-write-wins full replace on every
+ * conversation invalidation, which would wipe a generating flag stored on the row.
+ * Holding this state alongside it — not on it — sidesteps that entirely.
+ *
+ * SSR-safe like conversations.svelte.ts: a factory plus context helpers, no
+ * module-level mutable state. Populated only in the browser by the live watcher.
+ */
+
+import { getContext, setContext } from "svelte";
+import { SvelteSet } from "svelte/reactivity";
+import type { ObjectId } from "mongodb";
+
+export const ACTIVE_GENERATIONS_CONTEXT_KEY = "activeGenerationsStore";
+
+class ActiveGenerationsStore {
+	#ids = new SvelteSet<string>();
+
+	has(conversationId: string | ObjectId): boolean {
+		return this.#ids.has(String(conversationId));
+	}
+
+	/** Replace the running set with the latest snapshot from the server. */
+	setRunning(conversationIds: string[]): void {
+		const next = new Set(conversationIds.map(String));
+		if (next.size === this.#ids.size && [...next].every((id) => this.#ids.has(id))) return;
+		this.#ids.clear();
+		for (const id of next) this.#ids.add(id);
+	}
+}
+
+export function createActiveGenerationsStore(): ActiveGenerationsStore {
+	const store = new ActiveGenerationsStore();
+	setContext(ACTIVE_GENERATIONS_CONTEXT_KEY, store);
+	return store;
+}
+
+export function useActiveGenerationsStore(): ActiveGenerationsStore {
+	return getContext<ActiveGenerationsStore>(ACTIVE_GENERATIONS_CONTEXT_KEY);
+}

--- a/src/lib/stores/notifications.svelte.ts
+++ b/src/lib/stores/notifications.svelte.ts
@@ -1,0 +1,52 @@
+/**
+ * Transient completion toasts for background generations. Separate from the error
+ * banner (errors.ts), which is a single-slot red banner with no queue or variants.
+ *
+ * SSR-safe like conversations.svelte.ts: factory plus context helpers, no
+ * module-level mutable state. Pushed only in the browser by the live watcher.
+ */
+
+import { getContext, setContext } from "svelte";
+import type { GenerationStatus } from "$lib/types/Generation";
+
+export const NOTIFICATIONS_CONTEXT_KEY = "notificationsStore";
+
+const AUTO_DISMISS_MS = 8_000;
+
+export interface GenerationNotification {
+	id: number;
+	conversationId: string;
+	title: string;
+	status: GenerationStatus;
+}
+
+class NotificationsStore {
+	#items = $state<GenerationNotification[]>([]);
+	#nextId = 0;
+
+	get items(): GenerationNotification[] {
+		return this.#items;
+	}
+
+	push(notification: Omit<GenerationNotification, "id">): void {
+		const id = this.#nextId++;
+		this.#items = [...this.#items, { ...notification, id }];
+		setTimeout(() => this.dismiss(id), AUTO_DISMISS_MS);
+	}
+
+	dismiss(id: number): void {
+		this.#items = this.#items.filter((item) => item.id !== id);
+	}
+}
+
+export function createNotificationsStore(): NotificationsStore {
+	const store = new NotificationsStore();
+	setContext(NOTIFICATIONS_CONTEXT_KEY, store);
+	return store;
+}
+
+export function useNotificationsStore(): NotificationsStore {
+	return getContext<NotificationsStore>(NOTIFICATIONS_CONTEXT_KEY);
+}
+
+export type { NotificationsStore };

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -13,6 +13,8 @@
 	import { initWithServers } from "$lib/stores/mcpServers";
 
 	import Toast from "$lib/components/Toast.svelte";
+	import NotificationToasts from "$lib/components/NotificationToasts.svelte";
+	import GenerationLiveWatcher from "$lib/components/GenerationLiveWatcher.svelte";
 	import NavMenu from "$lib/components/NavMenu.svelte";
 	import NavigationLoadingBar from "$lib/components/NavigationLoadingBar.svelte";
 	import MobileNav from "$lib/components/MobileNav.svelte";
@@ -24,6 +26,8 @@
 	import { isPro } from "$lib/stores/isPro";
 	import { requireAuthUser } from "$lib/utils/auth";
 	import { createConversationsStore } from "$lib/stores/conversations.svelte";
+	import { createActiveGenerationsStore } from "$lib/stores/activeGenerations.svelte";
+	import { createNotificationsStore } from "$lib/stores/notifications.svelte";
 
 	let { data = $bindable(), children } = $props();
 
@@ -33,6 +37,9 @@
 	const client = useAPIClient();
 
 	const convsStore = createConversationsStore();
+	// Cross-conversation generation liveness: the watcher (mounted below) feeds both.
+	createActiveGenerationsStore();
+	createNotificationsStore();
 	// Synchronous seed for SSR: $effect is stripped by the server-side compiler,
 	// so we must call init() immediately to populate the list on first paint.
 	// The $effect below handles client-side resyncs when data.conversations
@@ -296,6 +303,8 @@
 	{#if currentError}
 		<Toast message={currentError} />
 	{/if}
+	<GenerationLiveWatcher />
+	<NotificationToasts />
 	{@render children?.()}
 
 	{#if publicConfig.PUBLIC_PLAUSIBLE_SCRIPT_URL}

--- a/src/routes/api/v2/generations/live/+server.ts
+++ b/src/routes/api/v2/generations/live/+server.ts
@@ -1,0 +1,134 @@
+import type { RequestHandler } from "./$types";
+import type { ObjectId } from "mongodb";
+import { collections } from "$lib/server/database";
+import { authCondition } from "$lib/server/auth";
+
+/**
+ * Cross-conversation liveness feed. Reports the user's own running generations so
+ * the sidebar can show which conversations are generating and toast when a
+ * background one finishes — without a per-conversation stream for each.
+ *
+ * Scoped by `authCondition` against the denormalised user/session on `generations`
+ * (no join). SSE: `event: sync {running, ended}` each tick; `event: idle` when the
+ * user has no running generations, after which the client closes rather than
+ * reconnecting (a plain lifetime-cap close, by contrast, means reconnect).
+ */
+const TICK_MS = 2_000;
+const MAX_LIFETIME_MS = 5 * 60_000;
+// Release the connection once nothing is running; the client reopens on the next run.
+const IDLE_TICKS_BEFORE_CLOSE = 2;
+
+export const GET: RequestHandler = async ({ locals, request }) => {
+	let auth: ReturnType<typeof authCondition>;
+	try {
+		auth = authCondition(locals);
+	} catch {
+		return new Response("Unauthorized", { status: 401 });
+	}
+
+	const encoder = new TextEncoder();
+
+	const stream = new ReadableStream({
+		async start(controller) {
+			const signal = request.signal;
+			const deadline = Date.now() + MAX_LIFETIME_MS;
+
+			const send = (event: string, data: unknown) =>
+				controller.enqueue(encoder.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`));
+
+			// generationIds seen running on the previous tick, to detect endings.
+			let prevRunning = new Set<string>();
+			let idleTicks = 0;
+
+			const titlesFor = async (ids: ObjectId[]) => {
+				const map = new Map<string, string>();
+				if (ids.length === 0) return map;
+				const convs = await collections.conversations
+					.find({ _id: { $in: ids } }, { projection: { title: 1 } })
+					.toArray();
+				for (const c of convs) map.set(c._id.toString(), c.title ?? "");
+				return map;
+			};
+
+			// One sweep. Returns false when the user has been idle long enough to close.
+			const tick = async (): Promise<boolean> => {
+				const running = await collections.generations
+					.find(
+						{ status: "running", ...auth },
+						{ projection: { generationId: 1, conversationId: 1 } }
+					)
+					.toArray();
+
+				const currentIds = new Set(running.map((g) => g.generationId));
+				const endedIds = [...prevRunning].filter((id) => !currentIds.has(id));
+
+				const runningTitles = await titlesFor(running.map((g) => g.conversationId));
+				const runningPayload = running.map((g) => ({
+					conversationId: g.conversationId.toString(),
+					title: runningTitles.get(g.conversationId.toString()) ?? "",
+				}));
+
+				let endedPayload: Array<{ conversationId: string; status: string; title: string }> = [];
+				if (endedIds.length > 0) {
+					const endedGens = await collections.generations
+						.find(
+							{ generationId: { $in: endedIds } },
+							{ projection: { conversationId: 1, status: 1 } }
+						)
+						.toArray();
+					const endedTitles = await titlesFor(endedGens.map((g) => g.conversationId));
+					endedPayload = endedGens.map((g) => ({
+						conversationId: g.conversationId.toString(),
+						status: g.status,
+						title: endedTitles.get(g.conversationId.toString()) ?? "",
+					}));
+				}
+
+				send("sync", { running: runningPayload, ended: endedPayload });
+				prevRunning = currentIds;
+				idleTicks = currentIds.size === 0 ? idleTicks + 1 : 0;
+				return idleTicks < IDLE_TICKS_BEFORE_CLOSE;
+			};
+
+			const sleep = () =>
+				new Promise<void>((resolve) => {
+					const t = setTimeout(resolve, TICK_MS);
+					signal.addEventListener(
+						"abort",
+						() => {
+							clearTimeout(t);
+							resolve();
+						},
+						{ once: true }
+					);
+				});
+
+			try {
+				let alive = await tick();
+				while (alive && !signal.aborted && Date.now() < deadline) {
+					await sleep();
+					if (signal.aborted) break;
+					alive = await tick();
+				}
+				if (!alive) send("idle", {});
+			} catch {
+				// Transient — fall through to a plain close so the client reconnects.
+			}
+
+			try {
+				controller.close();
+			} catch {
+				// already closed
+			}
+		},
+	});
+
+	return new Response(stream, {
+		headers: {
+			"Content-Type": "text/event-stream",
+			"Cache-Control": "no-cache, no-transform",
+			Connection: "keep-alive",
+			"X-Accel-Buffering": "no",
+		},
+	});
+};

--- a/src/routes/api/v2/generations/live/+server.ts
+++ b/src/routes/api/v2/generations/live/+server.ts
@@ -92,15 +92,17 @@ export const GET: RequestHandler = async ({ locals, request }) => {
 
 			const sleep = () =>
 				new Promise<void>((resolve) => {
-					const t = setTimeout(resolve, TICK_MS);
-					signal.addEventListener(
-						"abort",
-						() => {
-							clearTimeout(t);
-							resolve();
-						},
-						{ once: true }
-					);
+					// Remove the listener when the timer wins, or one accumulates per tick for
+					// the whole connection (only {once} cleans up, and only on abort).
+					const onAbort = () => {
+						clearTimeout(t);
+						resolve();
+					};
+					const t = setTimeout(() => {
+						signal.removeEventListener("abort", onAbort);
+						resolve();
+					}, TICK_MS);
+					signal.addEventListener("abort", onAbort, { once: true });
 				});
 
 			try {

--- a/tests/generation-live.spec.ts
+++ b/tests/generation-live.spec.ts
@@ -1,0 +1,238 @@
+/**
+ * Live generations feed (P4): GET /api/v2/generations/live.
+ *
+ * Reports the caller's own running generations so the sidebar can show which
+ * conversations are generating and toast when a background one finishes. It is scoped
+ * to the caller — another user's runs never appear — and releases the connection with
+ * an `idle` event once nothing is running.
+ */
+import { test, expect, E2E_APP_URL, SESSION_COOKIE_NAME } from "./fixtures.ts";
+import { ObjectId, type Db } from "mongodb";
+import { randomUUID } from "node:crypto";
+
+interface SseFrame {
+	event?: string;
+	data?: string;
+	comment?: boolean;
+}
+
+function parseFrame(raw: string): SseFrame {
+	if (raw.startsWith(":")) return { comment: true };
+	const frame: SseFrame = {};
+	for (const line of raw.split("\n")) {
+		const idx = line.indexOf(":");
+		if (idx === -1) continue;
+		const field = line.slice(0, idx);
+		const value = line.slice(idx + 1).replace(/^ /, "");
+		if (field === "event") frame.event = value;
+		else if (field === "data") frame.data = frame.data ? `${frame.data}\n${value}` : value;
+	}
+	return frame;
+}
+
+interface SyncPayload {
+	running: Array<{ conversationId: string; title: string }>;
+	ended: Array<{ conversationId: string; status: string; title: string }>;
+}
+
+const syncFrames = (frames: SseFrame[]): SyncPayload[] =>
+	frames.filter((f) => f.event === "sync").map((f) => JSON.parse(f.data ?? "{}") as SyncPayload);
+
+/** Open the live feed and collect frames until `until` matches or the timeout fires. */
+async function collectLive(opts: {
+	secret: string;
+	until: (f: SseFrame) => boolean;
+	timeoutMs?: number;
+}): Promise<{ status: number; frames: SseFrame[] }> {
+	const controller = new AbortController();
+	const timer = setTimeout(() => controller.abort(), opts.timeoutMs ?? 20_000);
+	let res: Response;
+	try {
+		res = await fetch(`${E2E_APP_URL}/api/v2/generations/live`, {
+			headers: { cookie: `${SESSION_COOKIE_NAME}=${opts.secret}`, accept: "text/event-stream" },
+			signal: controller.signal,
+		});
+	} catch (err) {
+		clearTimeout(timer);
+		throw err;
+	}
+	if (!res.ok || !res.body) {
+		clearTimeout(timer);
+		return { status: res.status, frames: [] };
+	}
+	const reader = res.body.getReader();
+	const decoder = new TextDecoder();
+	const frames: SseFrame[] = [];
+	let buffer = "";
+	try {
+		for (;;) {
+			const { done, value } = await reader.read();
+			if (done) break;
+			buffer += decoder.decode(value, { stream: true });
+			let sep: number;
+			while ((sep = buffer.indexOf("\n\n")) !== -1) {
+				const frame = parseFrame(buffer.slice(0, sep));
+				buffer = buffer.slice(sep + 2);
+				frames.push(frame);
+				if (opts.until(frame)) {
+					controller.abort();
+					clearTimeout(timer);
+					return { status: 200, frames };
+				}
+			}
+		}
+	} catch {
+		// aborted (timeout) — return what we have
+	}
+	clearTimeout(timer);
+	return { status: 200, frames };
+}
+
+/** Seed a conversation + a generation record with the given status/title. */
+async function seedGeneration(
+	db: Db,
+	sessionId: string,
+	opts: { status: "running" | "completed" | "interrupted" | "error"; title: string }
+): Promise<{ convId: string; generationId: string }> {
+	const now = new Date();
+	const systemId = randomUUID();
+	const userId = randomUUID();
+	const assistantId = randomUUID();
+	const generationId = randomUUID();
+	const conversationId = new ObjectId();
+	const terminal = opts.status !== "running";
+
+	await db.collection("conversations").insertOne({
+		_id: conversationId,
+		sessionId,
+		model: "test-org/test-model",
+		title: opts.title,
+		rootMessageId: systemId,
+		messages: [
+			{ id: systemId, from: "system", content: "", ancestors: [], children: [userId] },
+			{ id: userId, from: "user", content: "go", ancestors: [systemId], children: [assistantId] },
+			{
+				id: assistantId,
+				from: "assistant",
+				content: "partial",
+				generationId,
+				materializedSeq: 1,
+				updates: [],
+				ancestors: [systemId, userId],
+				children: [],
+			},
+		],
+		createdAt: now,
+		updatedAt: now,
+	} as never);
+
+	await db.collection("generations").insertOne({
+		_id: new ObjectId(),
+		generationId,
+		conversationId,
+		messageId: assistantId,
+		sessionId,
+		status: opts.status,
+		seq: 1,
+		lastHeartbeatAt: now,
+		startedAt: now,
+		createdAt: now,
+		updatedAt: now,
+		...(terminal ? { endedAt: now } : {}),
+	} as never);
+
+	return { convId: conversationId.toString(), generationId };
+}
+
+test("reports a running generation, with its title, in the running set", async ({
+	db,
+	session,
+}) => {
+	test.setTimeout(30_000);
+	const { convId } = await seedGeneration(db, session.sessionId, {
+		status: "running",
+		title: "long job",
+	});
+
+	const { frames } = await collectLive({
+		secret: session.secret,
+		until: (f) =>
+			f.event === "sync" && (JSON.parse(f.data ?? "{}") as SyncPayload).running.length > 0,
+	});
+
+	const running = syncFrames(frames).flatMap((s) => s.running);
+	const row = running.find((r) => r.conversationId === convId);
+	expect(row, "the running generation should be reported").toBeTruthy();
+	expect(row?.title).toBe("long job");
+});
+
+test("emits an ended event with the terminal status when a run completes", async ({
+	db,
+	session,
+}) => {
+	test.setTimeout(30_000);
+	const { convId, generationId } = await seedGeneration(db, session.sessionId, {
+		status: "running",
+		title: "finishing soon",
+	});
+
+	// Flip the run to completed after the first tick has observed it running.
+	const flip = (async () => {
+		await new Promise((r) => setTimeout(r, 800));
+		await db
+			.collection("generations")
+			.updateOne(
+				{ generationId },
+				{ $set: { status: "completed", endedAt: new Date(), updatedAt: new Date() } }
+			);
+	})();
+
+	const { frames } = await collectLive({
+		secret: session.secret,
+		until: (f) =>
+			f.event === "sync" && (JSON.parse(f.data ?? "{}") as SyncPayload).ended.length > 0,
+		timeoutMs: 25_000,
+	});
+	await flip;
+
+	const ended = syncFrames(frames).flatMap((s) => s.ended);
+	const row = ended.find((e) => e.conversationId === convId);
+	expect(row, "the completed run should be reported as ended").toBeTruthy();
+	expect(row?.status).toBe("completed");
+	expect(row?.title).toBe("finishing soon");
+});
+
+test("sends idle and closes when the caller has no running generations", async ({ session }) => {
+	test.setTimeout(20_000);
+	// No seeded runs for this fresh session.
+	const { frames } = await collectLive({
+		secret: session.secret,
+		until: (f) => f.event === "idle",
+		timeoutMs: 15_000,
+	});
+	expect(
+		frames.some((f) => f.event === "idle"),
+		"should go idle with nothing running"
+	).toBe(true);
+});
+
+test("does not report another session's running generation", async ({ db, session }) => {
+	test.setTimeout(20_000);
+	const { convId } = await seedGeneration(db, "someone-elses-session", {
+		status: "running",
+		title: "not yours",
+	});
+
+	// This caller has nothing running, so the feed goes idle without ever listing it.
+	const { frames } = await collectLive({
+		secret: session.secret,
+		until: (f) => f.event === "idle",
+		timeoutMs: 15_000,
+	});
+
+	const running = syncFrames(frames).flatMap((s) => s.running);
+	expect(
+		running.some((r) => r.conversationId === convId),
+		"must not leak across sessions"
+	).toBe(false);
+});

--- a/tests/sidebar-liveness.spec.ts
+++ b/tests/sidebar-liveness.spec.ts
@@ -1,0 +1,117 @@
+/**
+ * Sidebar generation liveness (P4).
+ *
+ * A generation running in a conversation you are NOT viewing shows a live indicator on
+ * its sidebar row (fed by /api/v2/generations/live) and raises a completion toast when it
+ * finishes in the background. Drives the real UI, flipping the generation's DB status to
+ * simulate a run completing elsewhere.
+ */
+import { test, expect } from "./fixtures.ts";
+import { ObjectId, type Db } from "mongodb";
+import { randomUUID } from "node:crypto";
+
+async function seedRunning(
+	db: Db,
+	sessionId: string,
+	title: string
+): Promise<{ convId: string; generationId: string }> {
+	const now = new Date();
+	const systemId = randomUUID();
+	const userId = randomUUID();
+	const assistantId = randomUUID();
+	const generationId = randomUUID();
+	const conversationId = new ObjectId();
+
+	await db.collection("conversations").insertOne({
+		_id: conversationId,
+		sessionId,
+		model: "test-org/test-model",
+		title,
+		rootMessageId: systemId,
+		messages: [
+			{ id: systemId, from: "system", content: "", ancestors: [], children: [userId] },
+			{ id: userId, from: "user", content: "go", ancestors: [systemId], children: [assistantId] },
+			{
+				id: assistantId,
+				from: "assistant",
+				content: "partial",
+				generationId,
+				materializedSeq: 1,
+				updates: [],
+				ancestors: [systemId, userId],
+				children: [],
+			},
+		],
+		createdAt: now,
+		updatedAt: now,
+	} as never);
+
+	await db.collection("generations").insertOne({
+		_id: new ObjectId(),
+		generationId,
+		conversationId,
+		messageId: assistantId,
+		sessionId,
+		status: "running",
+		seq: 1,
+		lastHeartbeatAt: now,
+		startedAt: now,
+		createdAt: now,
+		updatedAt: now,
+	} as never);
+
+	return { convId: conversationId.toString(), generationId };
+}
+
+test("a background run shows a sidebar indicator and toasts on completion", async ({
+	page,
+	db,
+	session,
+}) => {
+	test.setTimeout(60_000);
+	const { generationId } = await seedRunning(db, session.sessionId, "background job");
+
+	// Land on home — not viewing the generating conversation.
+	await page.goto("/");
+
+	// Its sidebar row shows the live generating indicator.
+	await expect(page.getByLabel("Generating").first()).toBeVisible({ timeout: 20_000 });
+
+	// Complete the run server-side; the feed reports it ended on the next tick.
+	await db
+		.collection("generations")
+		.updateOne(
+			{ generationId },
+			{ $set: { status: "completed", endedAt: new Date(), updatedAt: new Date() } }
+		);
+
+	// A completion toast appears (we are not viewing that conversation)...
+	await expect(page.getByText("Response ready")).toBeVisible({ timeout: 20_000 });
+	// ...and the indicator clears.
+	await expect(page.getByLabel("Generating")).toHaveCount(0, { timeout: 20_000 });
+});
+
+test("no toast fires for the conversation you are currently viewing", async ({
+	page,
+	db,
+	session,
+}) => {
+	test.setTimeout(60_000);
+	const { convId, generationId } = await seedRunning(db, session.sessionId, "viewed job");
+
+	// View the generating conversation itself.
+	await page.goto(`/conversation/${convId}`);
+	// Let the live feed observe it running at least once.
+	await page.waitForTimeout(3000);
+
+	await db
+		.collection("generations")
+		.updateOne(
+			{ generationId },
+			{ $set: { status: "completed", endedAt: new Date(), updatedAt: new Date() } }
+		);
+
+	// The page owns this conversation's completion, so the background toast is suppressed.
+	await page.waitForTimeout(6000);
+	await expect(page.getByText("Response ready")).toHaveCount(0);
+});


### PR DESCRIPTION
Once a conversation's response is streaming, navigating away used to leave the sidebar silent, no sign the run was still going, no signal when it landed. 

This adds a lightweight server feed (GET /api/v2/generations/live) scoped to the caller's own in-flight runs, which a single app-level watcher consumes to show a live indicator on the generating conversation's sidebar row and raise a clickable completion toast when a background run finishes. so you can kick off a long generation, move on to other chats, and still see at a glance what's working and get pulled back when it's done. 

The feed is scoped per-caller (a run never leaks across users) and releases its connection whenever nothing is running, reopening on the next run, so idle sessions cost nothing.