### PR TITLE
prevent reattachment corruptions

### DIFF
--- a/src/lib/server/generation/writer.spec.ts
+++ b/src/lib/server/generation/writer.spec.ts
@@ -1,5 +1,8 @@
-import { describe, it, expect } from "vitest";
-import { mergedStreamToken } from "./writer";
+import { afterEach, beforeAll, describe, it, expect } from "vitest";
+import { ObjectId } from "mongodb";
+import { randomUUID } from "node:crypto";
+import { collections, ready } from "$lib/server/database";
+import { createGenerationWriter, mergedStreamToken } from "./writer";
 import {
 	MessageUpdateType,
 	MessageReasoningUpdateType,
@@ -55,5 +58,76 @@ describe("mergedStreamToken", () => {
 	it("returns null when there is no tail to merge into", () => {
 		expect(mergedStreamToken(undefined, text("x"))).toBeNull();
 		expect(mergedStreamToken(undefined, reasoning("x"))).toBeNull();
+	});
+});
+
+describe.sequential("generation writer cursor", () => {
+	beforeAll(async () => {
+		await ready;
+	});
+
+	afterEach(async () => {
+		await Promise.all([
+			collections.conversations.deleteMany({}),
+			collections.generations.deleteMany({}),
+			collections.generationEvents.deleteMany({}),
+		]);
+	});
+
+	it("seals the event covered by a synchronously captured cursor", async () => {
+		const conversationId = new ObjectId();
+		const messageId = randomUUID();
+		const generationId = randomUUID();
+		const now = new Date();
+		let content = "";
+
+		await collections.conversations.insertOne({
+			_id: conversationId,
+			messages: [
+				{
+					id: messageId,
+					from: "assistant",
+					content,
+					updates: [],
+					createdAt: now,
+					updatedAt: now,
+				},
+			],
+			createdAt: now,
+			updatedAt: now,
+		} as never);
+
+		const writer = await createGenerationWriter({
+			generationId,
+			conversationId,
+			messageId,
+			snapshot: () => ({ content }),
+		});
+
+		content += "alpha ";
+		writer.push(text("alpha "));
+
+		// This is how the POST handler snapshots on client detach: capture the
+		// cursor and content synchronously, then persist them together.
+		const materializedSeq = writer.currentSeq();
+		const materializedContent = content;
+
+		// A later token must not merge into the pending event already covered by
+		// materializedSeq, which would make replay disagree with the captured content.
+		content += "beta ";
+		writer.push(text("beta "));
+		await writer.finish({ status: "completed" });
+
+		const events = await collections.generationEvents
+			.find({ generationId, seq: { $lte: materializedSeq } })
+			.sort({ seq: 1 })
+			.toArray();
+		const replayed = events
+			.filter((event) => event.event.type === MessageUpdateType.Stream)
+			.map((event) => (event.event.type === MessageUpdateType.Stream ? event.event.token : ""))
+			.join("");
+
+		expect(materializedSeq).toBeGreaterThan(0);
+		expect(replayed).toBe(materializedContent);
 	});
 });

--- a/src/lib/server/generation/writer.ts
+++ b/src/lib/server/generation/writer.ts
@@ -68,6 +68,8 @@ export interface GenerationWriter {
 	 * A caller writing the message out by some other route must read this
 	 * synchronously alongside the content it is about to persist, or the two
 	 * disagree and a reader replays text it already has — see `materialize`.
+	 * Capturing the cursor seals its pending tail so later tokens cannot extend
+	 * an event the persisted snapshot claims to cover.
 	 */
 	currentSeq(): number;
 	finish(outcome: { status: GenerationStatus; error?: string }): Promise<void>;
@@ -212,7 +214,14 @@ export async function createGenerationWriter(
 	materializeTimer.unref?.();
 
 	return {
-		currentSeq: () => seq,
+		currentSeq: () => {
+			const at = seq;
+			// `flush` synchronously moves pending events out of the coalescing buffer
+			// before it queues the database write. A subsequent token therefore gets
+			// a new sequence rather than changing an event covered by `at`.
+			void flush();
+			return at;
+		},
 
 		push(event: MessageUpdate) {
 			if (finished) return;

--- a/src/lib/utils/consumeMessageUpdates.spec.ts
+++ b/src/lib/utils/consumeMessageUpdates.spec.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Message } from "$lib/types/Message";
+import {
+	MessageUpdateType,
+	type MessageStreamUpdate,
+	type MessageUpdate,
+} from "$lib/types/MessageUpdate";
+import { consumeMessageUpdates, type ConsumeContext } from "./consumeMessageUpdates";
+
+async function* fromArray(values: MessageUpdate[]): AsyncGenerator<MessageUpdate> {
+	for (const value of values) yield value;
+}
+
+function context(): ConsumeContext {
+	return {
+		streamingMode: "raw",
+		maxUpdateTime: Number.POSITIVE_INFINITY,
+		isAborted: () => false,
+		onAbort: vi.fn(),
+		onStreamStart: vi.fn(),
+		onTitle: vi.fn(),
+		onError: vi.fn(),
+	};
+}
+
+function renderedText(message: Message): string {
+	let cursor = 0;
+	let rendered = "";
+	for (const update of message.updates ?? []) {
+		if (update.type !== MessageUpdateType.Stream) continue;
+		const token = update.token.length > 0 ? update.token : null;
+		const len = token?.length ?? update.len ?? 0;
+		rendered += token ?? message.content.slice(cursor, cursor + len);
+		cursor += len;
+	}
+	return rendered + message.content.slice(cursor);
+}
+
+describe("consumeMessageUpdates", () => {
+	it("preserves a compressed stream marker when reattach appends live text", async () => {
+		const prefix = "north of Greenland";
+		const boundary = "'s";
+		const continuation = " fractured coast";
+		const message: Message = {
+			id: "00000000-0000-4000-8000-000000000000",
+			from: "assistant",
+			content: prefix + boundary,
+			updates: [
+				{ type: MessageUpdateType.Stream, token: "", len: prefix.length },
+				{ type: MessageUpdateType.Stream, token: "", len: boundary.length },
+			],
+		};
+
+		await consumeMessageUpdates(
+			fromArray([{ type: MessageUpdateType.Stream, token: continuation }]),
+			message,
+			context()
+		);
+
+		expect(message.content).toBe(prefix + boundary + continuation);
+		expect(message.updates?.at(-1)).toEqual({
+			type: MessageUpdateType.Stream,
+			token: "",
+			len: boundary.length + continuation.length,
+		});
+		expect(renderedText(message)).toBe(message.content);
+	});
+
+	it("continues merging ordinary live stream tokens", async () => {
+		const message: Message = {
+			id: "00000000-0000-4000-8000-000000000000",
+			from: "assistant",
+			content: "hello ",
+			updates: [{ type: MessageUpdateType.Stream, token: "hello " }],
+		};
+
+		await consumeMessageUpdates(
+			fromArray([{ type: MessageUpdateType.Stream, token: "world" }]),
+			message,
+			context()
+		);
+
+		expect(message.updates?.at(-1)).toEqual({
+			type: MessageUpdateType.Stream,
+			token: "hello world",
+		} satisfies MessageStreamUpdate);
+		expect(renderedText(message)).toBe("hello world");
+	});
+});

--- a/src/lib/utils/consumeMessageUpdates.ts
+++ b/src/lib/utils/consumeMessageUpdates.ts
@@ -89,11 +89,21 @@ export async function consumeMessageUpdates(
 			if (update.type === MessageUpdateType.Stream) {
 				const lastUpdate = updatesBuffer.at(-1);
 				if (lastUpdate?.type === MessageUpdateType.Stream) {
-					// Fresh objects/arrays so the UI reacts to merged tokens.
-					const merged = {
-						...lastUpdate,
-						token: (lastUpdate.token ?? "") + (update.token ?? ""),
-					};
+					// Persisted streams use empty-token length markers whose spans are
+					// read from message.content. Keep that representation when live text
+					// resumes, or replacing the marker with a token makes the renderer
+					// drop the marker's original span at the reattach boundary.
+					const merged =
+						lastUpdate.token === "" && lastUpdate.len !== undefined
+							? {
+									...lastUpdate,
+									len: lastUpdate.len + update.token.length,
+								}
+							: {
+									...lastUpdate,
+									token: lastUpdate.token + update.token,
+								};
+					// Fresh objects/arrays so the UI reacts to merged tokens or lengths.
 					updatesBuffer = [...updatesBuffer.slice(0, -1), merged];
 				} else {
 					updatesBuffer = [...updatesBuffer, update];

--- a/src/lib/utils/messageUpdates.spec.ts
+++ b/src/lib/utils/messageUpdates.spec.ts
@@ -306,6 +306,42 @@ describe("smoothStreamUpdates", () => {
 		expect(streamText(updates)).toBe(blob);
 	});
 
+	it("preserves long text across reattach-style backlogs and bursts", async () => {
+		const text =
+			Array.from(
+				{ length: 2_500 },
+				(_, i) =>
+					`passage-${i} over the murderous reefs stretching westward Some keepers brought dogs `
+			).join("") + "the end";
+		const sizes = [4_096, 1, 127, 8_192, 7, 509, 2_048, 3, 997];
+		const events: TimedEvent[] = [];
+		let offset = 0;
+		let sizeIndex = 0;
+		let burstChars = 0;
+		let at = 0;
+
+		while (offset < text.length) {
+			const size = sizes[sizeIndex++ % sizes.length];
+			const token = text.slice(offset, offset + size);
+			events.push({
+				at,
+				update: { type: MessageUpdateType.Stream, token },
+			});
+			offset += token.length;
+			burstChars += token.length;
+			if (burstChars >= 8_000) {
+				at += 250;
+				burstChars = 0;
+			}
+		}
+
+		const clock = createVirtualClock();
+		const emitted = await collectTimed(events, clock);
+
+		expect(text.length).toBeGreaterThan(20_000);
+		expect(emitted.map((event) => event.token).join("")).toBe(text);
+	});
+
 	it("closes the source iterator when the consumer stops early", async () => {
 		let closed = false;
 		async function* source(): AsyncGenerator<MessageUpdate> {

--- a/src/routes/conversation/[id]/stream/+server.ts
+++ b/src/routes/conversation/[id]/stream/+server.ts
@@ -77,12 +77,20 @@ export const GET: RequestHandler = async ({ params, locals, url, request }) => {
 						.sort({ seq: 1 })
 						.limit(REPLAY_BATCH)
 						.toArray();
+					let sawGap = false;
 					for (const e of batch) {
+						// An unordered multi-document insert is not atomically visible.
+						// Do not advance past a sequence that may appear on the next poll,
+						// or it can never be emitted to this connection.
+						if (e.seq !== cursor + 1) {
+							sawGap = true;
+							break;
+						}
 						sendUpdate(e.seq, e.event);
 						cursor = e.seq;
 						emitted++;
 					}
-					if (batch.length < REPLAY_BATCH) break;
+					if (sawGap || batch.length < REPLAY_BATCH) break;
 				}
 				return emitted;
 			};

--- a/tests/generation-reattach.spec.ts
+++ b/tests/generation-reattach.spec.ts
@@ -309,6 +309,77 @@ test("rejects a conversation the caller does not own", async ({ db, session }) =
 	expect(status).toBe(404);
 });
 
+test("preserves text at a compressed-marker reattach boundary", async ({ db, session, page }) => {
+	test.setTimeout(30_000);
+	const now = new Date();
+	const systemId = randomUUID();
+	const userId = randomUUID();
+	const assistantId = randomUUID();
+	const generationId = randomUUID();
+	const conversationId = new ObjectId();
+	const prefix = "north of Greenland";
+	const boundary = "'s";
+	const continuation = " fractured coast ";
+
+	await db.collection("conversations").insertOne({
+		_id: conversationId,
+		sessionId: session.sessionId,
+		model: "test-org/test-model",
+		title: "compressed marker boundary",
+		rootMessageId: systemId,
+		messages: [
+			{ id: systemId, from: "system", content: "", ancestors: [], children: [userId] },
+			{
+				id: userId,
+				from: "user",
+				content: "continue",
+				ancestors: [systemId],
+				children: [assistantId],
+			},
+			{
+				id: assistantId,
+				from: "assistant",
+				content: prefix + boundary,
+				generationId,
+				materializedSeq: 2,
+				updates: [
+					{ type: "stream", token: "", len: prefix.length },
+					{ type: "stream", token: "", len: boundary.length },
+				],
+				ancestors: [systemId, userId],
+				children: [],
+			},
+		],
+		createdAt: now,
+		updatedAt: now,
+	} as never);
+	await db.collection("generations").insertOne({
+		_id: new ObjectId(),
+		generationId,
+		conversationId,
+		messageId: assistantId,
+		sessionId: session.sessionId,
+		status: "running",
+		seq: 3,
+		lastHeartbeatAt: now,
+		startedAt: now,
+		createdAt: now,
+		updatedAt: now,
+	} as never);
+	await db.collection("generationEvents").insertOne({
+		_id: new ObjectId(),
+		generationId,
+		seq: 3,
+		event: { type: "stream", token: continuation },
+		createdAt: now,
+	} as never);
+
+	await page.goto(`/conversation/${conversationId.toString()}`);
+	await expect(page.locator('[data-message-role="assistant"]').last()).toContainText(
+		prefix + boundary + continuation.trimEnd()
+	);
+});
+
 test("tails a live generation to completion (writer → endpoint)", async ({
 	api,
 	session,

--- a/tests/generation-reattach.spec.ts
+++ b/tests/generation-reattach.spec.ts
@@ -199,6 +199,69 @@ test("resumes from fromSeq, replaying only later events", async ({ db, session }
 	expect(updates(frames).map((f) => f.id)).toEqual(["3", "4", "5"]);
 });
 
+test("waits for a temporarily invisible sequence before advancing the cursor", async ({
+	db,
+	session,
+}) => {
+	test.setTimeout(30_000);
+	const { convId, generationId } = await seedRun(db, session.sessionId, {
+		tokenCount: 0,
+		status: "running",
+	});
+	const now = new Date();
+
+	// Model an unordered insert becoming visible non-atomically: seq 3 can be
+	// observed while seq 2 is still absent.
+	await db.collection("generationEvents").insertMany([
+		{
+			_id: new ObjectId(),
+			generationId,
+			seq: 1,
+			event: { type: "stream", token: "one " },
+			createdAt: now,
+		},
+		{
+			_id: new ObjectId(),
+			generationId,
+			seq: 3,
+			event: { type: "stream", token: "three " },
+			createdAt: now,
+		},
+	] as never[]);
+	await db.collection("generations").updateOne({ generationId }, { $set: { seq: 3 } });
+
+	const collecting = collectFrames({
+		convId,
+		secret: session.secret,
+		query: `generationId=${generationId}&fromSeq=0`,
+		until: (f) => f.event === "end",
+	});
+
+	// Let the initial drain observe 1 and 3, then make the missing event visible.
+	await new Promise((resolve) => setTimeout(resolve, 100));
+	await db.collection("generationEvents").insertOne({
+		_id: new ObjectId(),
+		generationId,
+		seq: 2,
+		event: { type: "stream", token: "two " },
+		createdAt: new Date(),
+	} as never);
+	await db
+		.collection("generations")
+		.updateOne(
+			{ generationId },
+			{ $set: { status: "completed", endedAt: new Date(), updatedAt: new Date() } }
+		);
+
+	const { frames } = await collecting;
+	expect(updates(frames).map((f) => f.id)).toEqual(["1", "2", "3"]);
+	expect(
+		updates(frames)
+			.map((f) => JSON.parse(f.data ?? "{}").token)
+			.join("")
+	).toBe("one two three ");
+});
+
 test("an interrupted run ends with status interrupted", async ({ db, session }) => {
 	test.setTimeout(30_000);
 	const { convId, generationId } = await seedRun(db, session.sessionId, {


### PR DESCRIPTION
Tests + fix for: https://github.com/huggingface/chat-ui/pull/2447#issuecomment-5068655342

Reattached generation streams could skip temporarily invisible events or resume past an event that later grew, causing dropped or duplicated text. The stream now advances only through contiguous events, and captured writer cursors seal pending events so persisted snapshots and replay logs remain consistent.