### PR TITLE
Center the composer on a fresh chat

### DIFF
--- a/src/lib/components/chat/ChatIntroduction.svelte
+++ b/src/lib/components/chat/ChatIntroduction.svelte
@@ -19,13 +19,15 @@
 	});
 </script>
 
-<div class="my-auto grid items-center justify-center gap-8 text-center">
-	<div
-		class="flex -translate-y-16 items-center rounded-xl text-[1.6rem] font-semibold select-none md:-translate-y-12 md:text-[2.55rem]"
+<!-- Greeting above the vertically centered composer on a fresh chat. Sized to
+     leave the composer as the visual anchor of the screen. -->
+<div class="flex w-full flex-col items-center justify-end pb-6 text-center select-none md:pb-8">
+	<h1
+		class="flex items-center rounded-xl text-[1.6rem] leading-none font-semibold md:text-[2.55rem]"
 	>
 		<Logo classNames="size-[2.55rem] md:size-[4.25rem] dark:invert mr-0.5" />
 		{publicConfig.PUBLIC_APP_NAME}
-	</div>
+	</h1>
 	<!-- <div class="lg:col-span-1">
 		<div>
 			<div class="mb-3 flex items-center text-2xl font-semibold">

--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -435,15 +435,47 @@
 			: []
 	);
 	let routerUserMessages = $derived(messages.filter((msg) => msg.from === "user"));
-	let shouldShowRouterFollowUps = $derived(
-		!draft.length &&
-			activeRouterExamplePrompt &&
+
+	// Prompt-example rows (starters above a fresh composer, follow-ups after the
+	// first exchange) are split into "does this row belong on this screen" and
+	// "should its chips be showing right now". The row keeps its box for the
+	// whole first question, and only the chips fade — mounting and unmounting it
+	// instead moved the composer 18px on the first keystroke, and again when the
+	// MCP store hydrated. The chips are always rendered so the reserved height is
+	// the row's real height rather than a hardcoded one; `invisible` also takes
+	// them out of the tab order and the accessibility tree.
+	//
+	// The MCP store only fills in on mount, so before that the server-rendered
+	// markup would have to guess whether tools examples apply. It doesn't have to:
+	// the base-server list travels in the SSR payload and base servers are enabled
+	// unless the user turned them off, so the row is reserved from the first paint
+	// with no guess for a deployment that configures none.
+	let baseMcpServerCount = $derived(
+		((page.data as { mcpBaseServers?: unknown[] }).mcpBaseServers ?? []).length
+	);
+	let toolExamplesApply = $derived(
+		currentModel.isRouter ||
+			(modelSupportsTools && ($mcpServersLoaded ? $allBaseServersEnabled : baseMcpServerCount > 0))
+	);
+	let showExamplesRow = $derived(
+		isFreshChat &&
+			toolExamplesApply &&
+			activeExamples.length > 0 &&
+			!hideRouterExamples &&
+			!lastIsError
+	);
+	let examplesChipsVisible = $derived(
+		showExamplesRow && $mcpServersLoaded && !draft.length && !sources.length && !loading
+	);
+	let showFollowUpsRow = $derived(
+		Boolean(activeRouterExamplePrompt) &&
 			routerFollowUps.length > 0 &&
 			routerUserMessages.length === 1 &&
 			(currentModel.isRouter || (modelSupportsTools && $allBaseServersEnabled)) &&
 			!hideRouterExamples &&
-			!loading
+			!lastIsError
 	);
+	let followUpChipsVisible = $derived(showFollowUpsRow && !draft.length && !loading);
 
 	$effect(() => {
 		if (
@@ -756,9 +788,12 @@
 				max-sm:py-0 sm:px-[calc(1.25rem+var(--scrollbar-gutter,0px))]
 				md:pb-4 dark:from-gray-900 dark:via-gray-900 dark:to-gray-900/0"
 			>
-				{#if !draft.length && !renderedMessageCount && !sources.length && !loading && (currentModel.isRouter || (modelSupportsTools && $allBaseServersEnabled)) && activeExamples.length && !hideRouterExamples && !lastIsError && $mcpServersLoaded}
+				{#if showExamplesRow}
 					<div
-						class="mb-3 no-scrollbar flex w-full justify-start gap-2 overflow-x-auto whitespace-nowrap text-gray-400 select-none dark:text-gray-500"
+						class={[
+							"mb-3 no-scrollbar flex w-full justify-start gap-2 overflow-x-auto whitespace-nowrap text-gray-400 transition-[opacity,visibility] duration-150 select-none dark:text-gray-500",
+							!examplesChipsVisible && "pointer-events-none invisible opacity-0",
+						]}
 					>
 						{#each activeExamples as ex}
 							<button
@@ -773,9 +808,12 @@
 						{/each}
 					</div>
 				{/if}
-				{#if shouldShowRouterFollowUps && !lastIsError}
+				{#if showFollowUpsRow}
 					<div
-						class="mb-3 no-scrollbar flex w-full justify-start gap-2 overflow-x-auto whitespace-nowrap text-gray-400 select-none dark:text-gray-500"
+						class={[
+							"mb-3 no-scrollbar flex w-full justify-start gap-2 overflow-x-auto whitespace-nowrap text-gray-400 transition-[opacity,visibility] duration-150 select-none dark:text-gray-500",
+							!followUpChipsVisible && "pointer-events-none invisible opacity-0",
+						]}
 					>
 						<!-- <span class=" text-gray-500 dark:text-gray-400">Follow ups</span> -->
 						{#each routerFollowUps as followUp}

--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -405,6 +405,25 @@
 	let isFileUploadEnabled = $derived(activeMimeTypes.length > 0);
 	let focused = $state(false);
 
+	// Fresh chat: the composer sits vertically centered with the greeting above
+	// it, and docks to the bottom of the column as soon as the conversation has
+	// content. `pending` covers the gap between a send and the first mounted
+	// message, so the composer never bounces mid-send. `loading` is deliberately
+	// not part of this: on the home/model routes it turns true while the
+	// conversation is being created, and docking there would strand the composer
+	// at the bottom of an empty screen until the navigation lands.
+	// Counted over rendered messages only: a conversation created but never sent
+	// to still carries its `system` preprompt message, which paints nothing — that
+	// screen is as empty as the home route's and gets the same treatment.
+	let renderedMessageCount = $derived(
+		messages.filter((message) => message.from === "user" || message.from === "assistant").length
+	);
+	let isFreshChat = $derived(!renderedMessageCount && !pending);
+	// A virtual keyboard covers the lower half of the screen and no ResizeObserver
+	// fires for it, so a centered composer would end up behind it: dock while the
+	// input is focused on touch devices (what every other chat app does too).
+	let composerCentered = $derived(isFreshChat && !(focused && isVirtualKeyboard()));
+
 	let activeRouterExamplePrompt = $state<string | null>(null);
 	// Use MCP examples when all base servers are enabled, otherwise use router examples
 	let activeExamples = $derived<RouterExample[]>(
@@ -686,14 +705,9 @@
 							readOnly={isReadOnly}
 						/>
 					</div>
-				{:else}
-					<ChatIntroduction
-						{currentModel}
-						onmessage={(content) => {
-							onmessage?.(content);
-						}}
-					/>
 				{/if}
+				<!-- No fresh-chat branch: the greeting is rendered above the
+				     vertically centered composer overlay, not in this column. -->
 			</div>
 
 			<ScrollToPreviousBtn
@@ -711,276 +725,303 @@
 
 		<!-- --scrollbar-gutter (measured by chatScroll) keeps the composer text
 		     aligned with the message column, whose content box is narrowed by
-		     the scroller's scrollbar-gutter on classic-scrollbar platforms. -->
+		     the scroller's scrollbar-gutter on classic-scrollbar platforms.
+
+		     Placement: `bottom-0` docks the composer under the conversation; on a
+		     fresh chat `bottom-1/2` plus a half-its-own-height translate centers
+		     the greeting + composer group in the column instead. Pure CSS, so the
+		     server-rendered markup already lands centered — nothing jumps once JS
+		     takes over. The measured element is the inner wrapper, so the greeting
+		     never inflates the clearance the scroll spacer derives from it.
+
+		     `max-h-full` + `justify-end` is the clamp that keeps the send button
+		     reachable: a group taller than the column (long draft plus
+		     attachments on a short viewport) can no longer center — its box is
+		     capped at the column height, which lands the composer flush with the
+		     bottom exactly as the docked layout does, and the greeting is what
+		     overflows instead. -->
 		<div
-			bind:clientHeight={composerHeight}
-			class="pointer-events-none absolute inset-x-0 bottom-0 z-0 mx-auto flex w-full
-			max-w-3xl flex-col items-center justify-center bg-linear-to-t from-white
-			via-white to-white/0 px-[calc(0.875rem+var(--scrollbar-gutter,0px))] pt-2 *:pointer-events-auto
-			max-sm:py-0 sm:px-[calc(1.25rem+var(--scrollbar-gutter,0px))]
-			md:pb-4 xl:max-w-4xl dark:border-gray-800 dark:from-gray-900 dark:via-gray-900 dark:to-gray-900/0"
+			class={[
+				"pointer-events-none absolute inset-x-0 z-0 mx-auto flex max-h-full w-full max-w-3xl flex-col items-center justify-end xl:max-w-4xl",
+				composerCentered ? "bottom-1/2 translate-y-1/2" : "bottom-0",
+			]}
 		>
-			{#if !draft.length && !messages.length && !sources.length && !loading && (currentModel.isRouter || (modelSupportsTools && $allBaseServersEnabled)) && activeExamples.length && !hideRouterExamples && !lastIsError && $mcpServersLoaded}
-				<div
-					class="mb-3 no-scrollbar flex w-full justify-start gap-2 overflow-x-auto whitespace-nowrap text-gray-400 select-none dark:text-gray-500"
-				>
-					{#each activeExamples as ex}
-						<button
-							class="flex items-center gap-1 rounded-lg bg-gray-100/90 px-2 py-0.5 text-center text-sm backdrop-blur-sm hover:text-gray-500 dark:bg-gray-700/50 dark:hover:text-gray-400"
-							onclick={() => startExample(ex)}
-						>
-							{ex.title}
-							{#if ex.artifact}
-								<LucideSparkles class="size-3 flex-none text-blue-600 dark:text-blue-400" />
-							{/if}
-						</button>
-					{/each}
-				</div>
+			{#if composerCentered}
+				<ChatIntroduction {currentModel} />
 			{/if}
-			{#if shouldShowRouterFollowUps && !lastIsError}
-				<div
-					class="mb-3 no-scrollbar flex w-full justify-start gap-2 overflow-x-auto whitespace-nowrap text-gray-400 select-none dark:text-gray-500"
-				>
-					<!-- <span class=" text-gray-500 dark:text-gray-400">Follow ups</span> -->
-					{#each routerFollowUps as followUp}
-						<button
-							class="flex items-center gap-1 rounded-lg bg-gray-100/90 px-2 py-0.5 text-center text-sm backdrop-blur-sm hover:text-gray-500 dark:bg-gray-700/50 dark:hover:text-gray-400"
-							onclick={() => startFollowUp(followUp)}
-						>
-							<CarbonDirectionRight class="scale-y-[-1] text-xs" />
-							{followUp.title}</button
-						>
-					{/each}
-				</div>
-			{/if}
-			{#if sources?.length && !loading}
-				<div
-					in:fly|local={sources.length === 1 ? { y: -20, easing: cubicInOut } : undefined}
-					class="flex flex-row flex-wrap justify-center gap-2.5 rounded-xl pb-3"
-				>
-					{#each sources as source, index}
-						{#await source then src}
-							<UploadedFile
-								file={src}
-								onclose={() => {
-									files = files.filter((_, i) => i !== index);
-								}}
-							/>
-						{/await}
-					{/each}
-				</div>
-			{/if}
-
-			<div class="w-full">
-				<div class="flex w-full *:mb-3">
-					{#if !loading && lastIsError}
-						<RetryBtn
-							classNames="ml-auto"
-							onClick={() => {
-								if (lastMessage && lastMessage.ancestors) {
-									chatScroll.armRetry();
-									onretry?.({
-										id: lastMessage.id,
-									});
-								}
-							}}
-						/>
-					{/if}
-				</div>
-				<form
-					tabindex="-1"
-					aria-label={isFileUploadEnabled ? "file dropzone" : undefined}
-					onsubmit={(e) => {
-						e.preventDefault();
-						handleSubmit();
-					}}
-					class={{
-						"relative flex w-full max-w-4xl flex-1 items-center rounded-xl border bg-gray-100 dark:border-gray-700 dark:bg-gray-800": true,
-						"opacity-30": isReadOnly,
-						"max-sm:mb-4": focused && isVirtualKeyboard(),
-					}}
-				>
-					{#if isRecording || isTranscribing}
-						<VoiceRecorder
-							{isTranscribing}
-							{isTouchDevice}
-							oncancel={() => {
-								isRecording = false;
-							}}
-							onconfirm={handleRecordingConfirm}
-							onsend={handleRecordingSend}
-							onerror={handleRecordingError}
-						/>
-					{:else if onDrag && isFileUploadEnabled}
-						<FileDropzone bind:files bind:onDrag mimeTypes={activeMimeTypes} />
-					{:else}
-						<div
-							class="flex w-full flex-1 rounded-xl border-none bg-transparent"
-							class:paste-glow={pastedLongContent}
-						>
-							{#if lastIsError}
-								<ChatInput value="Sorry, something went wrong. Please try again." disabled={true} />
-							{:else}
-								<ChatInput
-									placeholder={isReadOnly ? "This conversation is read-only." : "Ask anything"}
-									{loading}
-									bind:value={draft}
-									bind:files
-									mimeTypes={activeMimeTypes}
-									onsubmit={handleSubmit}
-									{onPaste}
-									disabled={isReadOnly || lastIsError}
-									{modelIsMultimodal}
-									{modelSupportsTools}
-									bind:focused
-								/>
-							{/if}
-
-							{#if loading}
-								<StopGeneratingBtn
-									onClick={() => {
-										hapticError();
-										onstop?.();
-									}}
-									showBorder={true}
-									classNames="absolute bottom-2 right-2 size-8 sm:size-7 self-end rounded-full border bg-white text-black shadow-sm transition-none dark:border-transparent dark:bg-gray-600 dark:text-white"
-								/>
-							{:else}
-								{#if transcriptionEnabled}
-									<button
-										type="button"
-										class="absolute right-10 bottom-2 mr-1.5 btn size-8 self-end rounded-full border bg-white/50 text-gray-500 transition-none hover:bg-gray-50 hover:text-gray-700 sm:right-9 sm:size-7 dark:border-transparent dark:bg-gray-600/50 dark:text-gray-300 dark:hover:bg-gray-500 dark:hover:text-white"
-										disabled={isReadOnly}
-										onclick={() => {
-											isRecording = true;
-										}}
-										aria-label="Start voice recording"
-									>
-										<IconMic class="size-4" />
-									</button>
+			<div
+				bind:clientHeight={composerHeight}
+				class="flex w-full flex-col items-center justify-center bg-linear-to-t from-white
+				via-white to-white/0 px-[calc(0.875rem+var(--scrollbar-gutter,0px))] pt-2 *:pointer-events-auto
+				max-sm:py-0 sm:px-[calc(1.25rem+var(--scrollbar-gutter,0px))]
+				md:pb-4 dark:from-gray-900 dark:via-gray-900 dark:to-gray-900/0"
+			>
+				{#if !draft.length && !renderedMessageCount && !sources.length && !loading && (currentModel.isRouter || (modelSupportsTools && $allBaseServersEnabled)) && activeExamples.length && !hideRouterExamples && !lastIsError && $mcpServersLoaded}
+					<div
+						class="mb-3 no-scrollbar flex w-full justify-start gap-2 overflow-x-auto whitespace-nowrap text-gray-400 select-none dark:text-gray-500"
+					>
+						{#each activeExamples as ex}
+							<button
+								class="flex items-center gap-1 rounded-lg bg-gray-100/90 px-2 py-0.5 text-center text-sm backdrop-blur-sm hover:text-gray-500 dark:bg-gray-700/50 dark:hover:text-gray-400"
+								onclick={() => startExample(ex)}
+							>
+								{ex.title}
+								{#if ex.artifact}
+									<LucideSparkles class="size-3 flex-none text-blue-600 dark:text-blue-400" />
 								{/if}
-								<button
-									class="absolute right-2 bottom-2 btn size-8 self-end rounded-full border bg-white text-black shadow transition-none enabled:hover:bg-white enabled:hover:shadow-inner sm:size-7 dark:border-transparent dark:bg-gray-600 dark:text-white dark:hover:enabled:bg-black {!draft ||
-									isReadOnly
-										? ''
-										: 'bg-black! text-white! dark:bg-white! dark:text-black!'}"
-									disabled={!draft || isReadOnly}
-									type="submit"
-									aria-label="Send message"
-									name="submit"
-								>
-									<IconArrowUp />
-								</button>
-							{/if}
-						</div>
-					{/if}
-				</form>
-				<div
-					class={{
-						"mt-1.5 flex h-5 items-center self-stretch px-0.5 text-xs whitespace-nowrap text-gray-400/90 max-md:mb-2 max-sm:gap-2": true,
-						"max-sm:hidden": focused && isVirtualKeyboard(),
-					}}
-				>
-					{#if models.find((m) => m.id === currentModel.id)}
-						{#if loading && streamingToolCallName}
-							<span class="inline-flex items-center gap-1 text-xs whitespace-nowrap">
-								<LucideHammer class="size-3" />
-								Calling tool
-								<span class="loading-dots font-medium">
-									{availableTools.find((t) => t.name === streamingToolCallName)?.displayName ??
-										streamingToolCallName}
-								</span>
-							</span>
-						{:else if !currentModel.isRouter || !loading}
-							<a
-								href="{base}/settings/{currentModel.id}"
-								onclick={(e) => {
-									if (requireAuthUser()) {
-										e.preventDefault();
+							</button>
+						{/each}
+					</div>
+				{/if}
+				{#if shouldShowRouterFollowUps && !lastIsError}
+					<div
+						class="mb-3 no-scrollbar flex w-full justify-start gap-2 overflow-x-auto whitespace-nowrap text-gray-400 select-none dark:text-gray-500"
+					>
+						<!-- <span class=" text-gray-500 dark:text-gray-400">Follow ups</span> -->
+						{#each routerFollowUps as followUp}
+							<button
+								class="flex items-center gap-1 rounded-lg bg-gray-100/90 px-2 py-0.5 text-center text-sm backdrop-blur-sm hover:text-gray-500 dark:bg-gray-700/50 dark:hover:text-gray-400"
+								onclick={() => startFollowUp(followUp)}
+							>
+								<CarbonDirectionRight class="scale-y-[-1] text-xs" />
+								{followUp.title}</button
+							>
+						{/each}
+					</div>
+				{/if}
+				{#if sources?.length && !loading}
+					<div
+						in:fly|local={sources.length === 1 ? { y: -20, easing: cubicInOut } : undefined}
+						class="flex flex-row flex-wrap justify-center gap-2.5 rounded-xl pb-3"
+					>
+						{#each sources as source, index}
+							{#await source then src}
+								<UploadedFile
+									file={src}
+									onclose={() => {
+										files = files.filter((_, i) => i !== index);
+									}}
+								/>
+							{/await}
+						{/each}
+					</div>
+				{/if}
+
+				<div class="w-full">
+					<div class="flex w-full *:mb-3">
+						{#if !loading && lastIsError}
+							<RetryBtn
+								classNames="ml-auto"
+								onClick={() => {
+									if (lastMessage && lastMessage.ancestors) {
+										chatScroll.armRetry();
+										onretry?.({
+											id: lastMessage.id,
+										});
 									}
 								}}
-								class="inline-flex min-w-0 items-center gap-1 hover:underline"
-							>
-								{#if currentModel.isRouter}
-									<IconOmni />
-									<span class="truncate">{currentModel.displayName}</span>
-								{:else}
-									<span class="shrink-0">Model:</span>
-									{#if currentModel.logoUrl}
-										<img
-											src={currentModel.logoUrl}
-											alt=""
-											class="size-3 flex-none rounded-sm border bg-white dark:border-gray-700"
-										/>
-									{/if}
-									<span class="truncate">{currentModel.displayName}</span>
-									{#if hasProviderOverride}
-										{@const hubOrg =
-											PROVIDERS_HUB_ORGS[providerOverride as keyof typeof PROVIDERS_HUB_ORGS]}
-										<span
-											class="inline-flex shrink-0 items-center rounded-sm p-0.5 {providerOverride ===
-											'fastest'
-												? 'bg-green-100 text-green-600 dark:bg-green-800/20 dark:text-green-500'
-												: providerOverride === 'cheapest'
-													? 'bg-blue-100 text-blue-600 dark:bg-blue-800/20 dark:text-blue-500'
-													: ''}"
-											title="Provider: {providerOverride}"
-										>
-											{#if providerOverride === "fastest"}
-												<IconFast classNames="text-sm" />
-											{:else if providerOverride === "cheapest"}
-												<IconCheap classNames="text-sm" />
-											{:else if hubOrg}
-												<img
-													src="https://huggingface.co/api/avatars/{hubOrg}"
-													alt={providerOverride}
-													class="size-3 flex-none rounded-xs"
-												/>
-											{/if}
-										</span>
-									{/if}
-								{/if}
-								<CarbonCaretDown class="-ml-0.5 shrink-0 text-xxs" />
-							</a>
-						{:else if showRouterDetails && streamingRouterMetadata?.route}
-							<div
-								class="mr-2 flex items-center gap-1.5 text-xs text-[.70rem] leading-none whitespace-nowrap text-gray-400 dark:text-gray-400"
-							>
-								<IconOmni classNames="text-xs animate-pulse" />
-
-								<span class="router-badge-text router-shimmer">
-									{streamingRouterMetadata.route}
-								</span>
-
-								<span class="text-gray-500">with</span>
-
-								<span class="router-badge-text">
-									{streamingRouterModelName}
-								</span>
-							</div>
+							/>
+						{/if}
+					</div>
+					<form
+						tabindex="-1"
+						aria-label={isFileUploadEnabled ? "file dropzone" : undefined}
+						onsubmit={(e) => {
+							e.preventDefault();
+							handleSubmit();
+						}}
+						class={{
+							"relative flex w-full max-w-4xl flex-1 items-center rounded-xl border bg-gray-100 dark:border-gray-700 dark:bg-gray-800": true,
+							"opacity-30": isReadOnly,
+							"max-sm:mb-4": focused && isVirtualKeyboard(),
+						}}
+					>
+						{#if isRecording || isTranscribing}
+							<VoiceRecorder
+								{isTranscribing}
+								{isTouchDevice}
+								oncancel={() => {
+									isRecording = false;
+								}}
+								onconfirm={handleRecordingConfirm}
+								onsend={handleRecordingSend}
+								onerror={handleRecordingError}
+							/>
+						{:else if onDrag && isFileUploadEnabled}
+							<FileDropzone bind:files bind:onDrag mimeTypes={activeMimeTypes} />
 						{:else}
 							<div
-								class="loading-dots relative inline-flex items-center text-gray-400 dark:text-gray-400"
-								aria-label="Routing…"
+								class="flex w-full flex-1 rounded-xl border-none bg-transparent"
+								class:paste-glow={pastedLongContent}
 							>
-								<IconOmni classNames="text-xs animate-pulse mr-1" /> Routing
+								{#if lastIsError}
+									<ChatInput
+										value="Sorry, something went wrong. Please try again."
+										disabled={true}
+									/>
+								{:else}
+									<ChatInput
+										placeholder={isReadOnly ? "This conversation is read-only." : "Ask anything"}
+										{loading}
+										bind:value={draft}
+										bind:files
+										mimeTypes={activeMimeTypes}
+										onsubmit={handleSubmit}
+										{onPaste}
+										disabled={isReadOnly || lastIsError}
+										{modelIsMultimodal}
+										{modelSupportsTools}
+										bind:focused
+									/>
+								{/if}
+
+								{#if loading}
+									<StopGeneratingBtn
+										onClick={() => {
+											hapticError();
+											onstop?.();
+										}}
+										showBorder={true}
+										classNames="absolute bottom-2 right-2 size-8 sm:size-7 self-end rounded-full border bg-white text-black shadow-sm transition-none dark:border-transparent dark:bg-gray-600 dark:text-white"
+									/>
+								{:else}
+									{#if transcriptionEnabled}
+										<button
+											type="button"
+											class="absolute right-10 bottom-2 mr-1.5 btn size-8 self-end rounded-full border bg-white/50 text-gray-500 transition-none hover:bg-gray-50 hover:text-gray-700 sm:right-9 sm:size-7 dark:border-transparent dark:bg-gray-600/50 dark:text-gray-300 dark:hover:bg-gray-500 dark:hover:text-white"
+											disabled={isReadOnly}
+											onclick={() => {
+												isRecording = true;
+											}}
+											aria-label="Start voice recording"
+										>
+											<IconMic class="size-4" />
+										</button>
+									{/if}
+									<button
+										class="absolute right-2 bottom-2 btn size-8 self-end rounded-full border bg-white text-black shadow transition-none enabled:hover:bg-white enabled:hover:shadow-inner sm:size-7 dark:border-transparent dark:bg-gray-600 dark:text-white dark:hover:enabled:bg-black {!draft ||
+										isReadOnly
+											? ''
+											: 'bg-black! text-white! dark:bg-white! dark:text-black!'}"
+										disabled={!draft || isReadOnly}
+										type="submit"
+										aria-label="Send message"
+										name="submit"
+									>
+										<IconArrowUp />
+									</button>
+								{/if}
 							</div>
 						{/if}
-					{:else}
-						<span class="inline-flex items-center line-through dark:border-gray-700">
-							{currentModel.id}
-						</span>
-					{/if}
-					{#if !messages.length && !loading}
-						<span class="max-sm:hidden"
-							>{publicConfig.PUBLIC_CAVEAT || "Generated content may be inaccurate or false."}</span
-						>
-					{/if}
-					{#if $settings.reasoningOverrides?.[currentModel.id] ?? currentModel.supportsReasoning}
-						<div class="ml-auto">
-							<ThinkingEffortChip modelId={currentModel.id} />
-						</div>
-					{/if}
+					</form>
+					<div
+						class={{
+							"mt-1.5 flex h-5 items-center self-stretch px-0.5 text-xs whitespace-nowrap text-gray-400/90 max-md:mb-2 max-sm:gap-2": true,
+							"max-sm:hidden": focused && isVirtualKeyboard(),
+						}}
+					>
+						{#if models.find((m) => m.id === currentModel.id)}
+							{#if loading && streamingToolCallName}
+								<span class="inline-flex items-center gap-1 text-xs whitespace-nowrap">
+									<LucideHammer class="size-3" />
+									Calling tool
+									<span class="loading-dots font-medium">
+										{availableTools.find((t) => t.name === streamingToolCallName)?.displayName ??
+											streamingToolCallName}
+									</span>
+								</span>
+							{:else if !currentModel.isRouter || !loading}
+								<a
+									href="{base}/settings/{currentModel.id}"
+									onclick={(e) => {
+										if (requireAuthUser()) {
+											e.preventDefault();
+										}
+									}}
+									class="inline-flex min-w-0 items-center gap-1 hover:underline"
+								>
+									{#if currentModel.isRouter}
+										<IconOmni />
+										<span class="truncate">{currentModel.displayName}</span>
+									{:else}
+										<span class="shrink-0">Model:</span>
+										{#if currentModel.logoUrl}
+											<img
+												src={currentModel.logoUrl}
+												alt=""
+												class="size-3 flex-none rounded-sm border bg-white dark:border-gray-700"
+											/>
+										{/if}
+										<span class="truncate">{currentModel.displayName}</span>
+										{#if hasProviderOverride}
+											{@const hubOrg =
+												PROVIDERS_HUB_ORGS[providerOverride as keyof typeof PROVIDERS_HUB_ORGS]}
+											<span
+												class="inline-flex shrink-0 items-center rounded-sm p-0.5 {providerOverride ===
+												'fastest'
+													? 'bg-green-100 text-green-600 dark:bg-green-800/20 dark:text-green-500'
+													: providerOverride === 'cheapest'
+														? 'bg-blue-100 text-blue-600 dark:bg-blue-800/20 dark:text-blue-500'
+														: ''}"
+												title="Provider: {providerOverride}"
+											>
+												{#if providerOverride === "fastest"}
+													<IconFast classNames="text-sm" />
+												{:else if providerOverride === "cheapest"}
+													<IconCheap classNames="text-sm" />
+												{:else if hubOrg}
+													<img
+														src="https://huggingface.co/api/avatars/{hubOrg}"
+														alt={providerOverride}
+														class="size-3 flex-none rounded-xs"
+													/>
+												{/if}
+											</span>
+										{/if}
+									{/if}
+									<CarbonCaretDown class="-ml-0.5 shrink-0 text-xxs" />
+								</a>
+							{:else if showRouterDetails && streamingRouterMetadata?.route}
+								<div
+									class="mr-2 flex items-center gap-1.5 text-xs text-[.70rem] leading-none whitespace-nowrap text-gray-400 dark:text-gray-400"
+								>
+									<IconOmni classNames="text-xs animate-pulse" />
+
+									<span class="router-badge-text router-shimmer">
+										{streamingRouterMetadata.route}
+									</span>
+
+									<span class="text-gray-500">with</span>
+
+									<span class="router-badge-text">
+										{streamingRouterModelName}
+									</span>
+								</div>
+							{:else}
+								<div
+									class="loading-dots relative inline-flex items-center text-gray-400 dark:text-gray-400"
+									aria-label="Routing…"
+								>
+									<IconOmni classNames="text-xs animate-pulse mr-1" /> Routing
+								</div>
+							{/if}
+						{:else}
+							<span class="inline-flex items-center line-through dark:border-gray-700">
+								{currentModel.id}
+							</span>
+						{/if}
+						{#if !renderedMessageCount && !loading}
+							<span class="max-sm:hidden"
+								>{publicConfig.PUBLIC_CAVEAT ||
+									"Generated content may be inaccurate or false."}</span
+							>
+						{/if}
+						{#if $settings.reasoningOverrides?.[currentModel.id] ?? currentModel.supportsReasoning}
+							<div class="ml-auto">
+								<ThinkingEffortChip modelId={currentModel.id} />
+							</div>
+						{/if}
+					</div>
 				</div>
 			</div>
 		</div>

--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -42,7 +42,6 @@
 	import { routerExamples } from "$lib/constants/routerExamples";
 	import { mcpExamples } from "$lib/constants/mcpExamples";
 	import type { RouterFollowUp, RouterExample } from "$lib/constants/routerExamples";
-	import { allBaseServersEnabled, mcpServersLoaded } from "$lib/stores/mcpServers";
 	import { shareModal } from "$lib/stores/shareModal";
 	import IconShare from "$lib/components/icons/IconShare.svelte";
 	import FeatureAnnouncementToast from "../FeatureAnnouncementToast.svelte";
@@ -425,10 +424,15 @@
 	let composerCentered = $derived(isFreshChat && !(focused && isVirtualKeyboard()));
 
 	let activeRouterExamplePrompt = $state<string | null>(null);
-	// Use MCP examples when all base servers are enabled, otherwise use router examples
-	let activeExamples = $derived<RouterExample[]>(
-		$allBaseServersEnabled ? mcpExamples : routerExamples
+	// Which starter set applies is read from the configured base-server list in
+	// the SSR payload rather than from the MCP store. The store only fills in at
+	// hydration, so keying the set off it swapped every chip's label mid-load —
+	// the deployment's server list is the same fact, and the server has it too.
+	let mcpConfigured = $derived(
+		((page.data as { mcpBaseServers?: unknown[] }).mcpBaseServers ?? []).length > 0
 	);
+	let toolExamplesApply = $derived(modelSupportsTools && mcpConfigured);
+	let activeExamples = $derived<RouterExample[]>(toolExamplesApply ? mcpExamples : routerExamples);
 	let routerFollowUps = $derived<RouterFollowUp[]>(
 		activeRouterExamplePrompt
 			? (activeExamples.find((ex) => ex.prompt === activeRouterExamplePrompt)?.followUps ?? [])
@@ -445,51 +449,41 @@
 	// the row's real height rather than a hardcoded one; `invisible` also takes
 	// them out of the tab order and the accessibility tree.
 	//
-	// Whether the row is reserved is deliberately decided from data the server
-	// also has — the configured base-server list, which travels in the SSR
-	// payload — and never from the MCP store, which only fills in on mount from
-	// localStorage. Reserving on `$allBaseServersEnabled` would put the row back
-	// in the hands of a client-only preference: a returning user who has turned
-	// off any one configured server would get it reserved during SSR and dropped
-	// at hydration, which is the shift this whole split exists to remove. The
-	// cost is that such a user keeps an empty reserved row on a non-router
-	// tools model — invisible whitespace in a centered layout, where a jump on
-	// every page load is not.
-	let baseMcpServerCount = $derived(
-		((page.data as { mcpBaseServers?: unknown[] }).mcpBaseServers ?? []).length
-	);
+	// Nothing here may depend on the MCP store. Every input is either SSR payload
+	// or user settings, both of which the server renders from, so the first
+	// painted frame is already the final one: the chips are in the server HTML
+	// with their final labels, visible before any JavaScript runs. Gating them on
+	// the store instead meant the row painted empty and filled in a few hundred
+	// ms later on a fast connection — and stayed empty for as long as the bundle
+	// took to arrive on a slow one, which read as "the examples are just gone".
+	//
+	// The store's one unique fact is which servers the user has since switched
+	// off, kept in localStorage. Honouring it here would put first paint back in
+	// the hands of a value the server cannot see, so it is deliberately ignored:
+	// a user who turned MCP off still gets tool-flavoured starters, which are
+	// prompts they can send either way.
 	let showExamplesRow = $derived(
 		isFreshChat &&
-			(currentModel.isRouter || (modelSupportsTools && baseMcpServerCount > 0)) &&
+			(currentModel.isRouter || toolExamplesApply) &&
 			activeExamples.length > 0 &&
 			!hideRouterExamples &&
 			!lastIsError
 	);
-	// Whether the chips themselves show is the real, client-side truth, gated on
-	// the store having loaded so the router set never flashes before the MCP one.
 	let examplesChipsVisible = $derived(
-		showExamplesRow &&
-			$mcpServersLoaded &&
-			(currentModel.isRouter || $allBaseServersEnabled) &&
-			!draft.length &&
-			!sources.length &&
-			!loading
+		showExamplesRow && !draft.length && !sources.length && !loading
 	);
 	let showFollowUpsRow = $derived(
 		Boolean(activeRouterExamplePrompt) &&
 			routerFollowUps.length > 0 &&
 			routerUserMessages.length === 1 &&
-			(currentModel.isRouter || (modelSupportsTools && $allBaseServersEnabled)) &&
+			(currentModel.isRouter || toolExamplesApply) &&
 			!hideRouterExamples &&
 			!lastIsError
 	);
 	let followUpChipsVisible = $derived(showFollowUpsRow && !draft.length && !loading);
 
 	$effect(() => {
-		if (
-			!(currentModel.isRouter || (modelSupportsTools && $allBaseServersEnabled)) ||
-			!messages.length
-		) {
+		if (!(currentModel.isRouter || toolExamplesApply) || !messages.length) {
 			activeRouterExamplePrompt = null;
 			return;
 		}
@@ -631,10 +625,19 @@
 <div class="pointer-events-none relative flex min-h-0 min-w-0">
 	<!-- --scrollbar-gutter: measured half-gutter of the scroll container, added
 	     to the composer overlay's padding so its text stays aligned with the
-	     message column on classic-scrollbar platforms. -->
+	     message column on classic-scrollbar platforms.
+
+	     Held at zero on a fresh chat. The gutter can only be measured once the
+	     scroll container exists, so it is 0 in server-rendered markup and jumps
+	     to its real value at hydration — which moved the centered composer 10px
+	     sideways and narrowed it by 20px, in the middle of an otherwise empty
+	     screen where it was the only thing to look at. There are no messages to
+	     align with yet, so the alignment it buys is worth nothing until the
+	     composer docks, and by then the compensation rides along with a
+	     several-hundred-pixel vertical move. -->
 	<div
 		class="pointer-events-auto relative z-[-1] min-h-0 min-w-0 flex-1"
-		style="--scrollbar-gutter: {chatScroll.gutterHalfPx}px"
+		style="--scrollbar-gutter: {composerCentered ? 0 : chatScroll.gutterHalfPx}px"
 	>
 		{#if shareModalOpen}
 			<ShareConversationModal open={shareModalOpen} onclose={() => shareModal.close()} />

--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -445,27 +445,35 @@
 	// the row's real height rather than a hardcoded one; `invisible` also takes
 	// them out of the tab order and the accessibility tree.
 	//
-	// The MCP store only fills in on mount, so before that the server-rendered
-	// markup would have to guess whether tools examples apply. It doesn't have to:
-	// the base-server list travels in the SSR payload and base servers are enabled
-	// unless the user turned them off, so the row is reserved from the first paint
-	// with no guess for a deployment that configures none.
+	// Whether the row is reserved is deliberately decided from data the server
+	// also has — the configured base-server list, which travels in the SSR
+	// payload — and never from the MCP store, which only fills in on mount from
+	// localStorage. Reserving on `$allBaseServersEnabled` would put the row back
+	// in the hands of a client-only preference: a returning user who has turned
+	// off any one configured server would get it reserved during SSR and dropped
+	// at hydration, which is the shift this whole split exists to remove. The
+	// cost is that such a user keeps an empty reserved row on a non-router
+	// tools model — invisible whitespace in a centered layout, where a jump on
+	// every page load is not.
 	let baseMcpServerCount = $derived(
 		((page.data as { mcpBaseServers?: unknown[] }).mcpBaseServers ?? []).length
 	);
-	let toolExamplesApply = $derived(
-		currentModel.isRouter ||
-			(modelSupportsTools && ($mcpServersLoaded ? $allBaseServersEnabled : baseMcpServerCount > 0))
-	);
 	let showExamplesRow = $derived(
 		isFreshChat &&
-			toolExamplesApply &&
+			(currentModel.isRouter || (modelSupportsTools && baseMcpServerCount > 0)) &&
 			activeExamples.length > 0 &&
 			!hideRouterExamples &&
 			!lastIsError
 	);
+	// Whether the chips themselves show is the real, client-side truth, gated on
+	// the store having loaded so the router set never flashes before the MCP one.
 	let examplesChipsVisible = $derived(
-		showExamplesRow && $mcpServersLoaded && !draft.length && !sources.length && !loading
+		showExamplesRow &&
+			$mcpServersLoaded &&
+			(currentModel.isRouter || $allBaseServersEnabled) &&
+			!draft.length &&
+			!sources.length &&
+			!loading
 	);
 	let showFollowUpsRow = $derived(
 		Boolean(activeRouterExamplePrompt) &&


### PR DESCRIPTION
Before the first message the composer no longer sits at the bottom of an
empty column: it centers vertically with the app greeting above it, and
docks to the bottom as soon as the conversation has content — the layout
every other chat app uses for its new-chat screen.

- ChatWindow: the composer overlay switches between `bottom-0` (docked)
  and `bottom-1/2 translate-y-1/2` (centered). Pure CSS, so server-rendered
  markup already lands centered and nothing jumps on hydration.
- `max-h-full` + `justify-end` clamp the centered box to the column height,
  so a group taller than the viewport (long draft plus attachments on a
  short screen) falls back to the docked position instead of pushing the
  send button below the fold.
- The greeting moved out of the scroll column and above the composer;
  clientHeight is now bound to an inner wrapper so the greeting can never
  inflate the clearance the scroll spacer derives from it.
- Touch devices dock while the input is focused: the virtual keyboard
  covers the lower half of the screen and fires no ResizeObserver, so a
  centered composer would end up behind it.
- "Fresh" counts rendered messages only, so a conversation created but
  never sent to — it still carries an invisible `system` preprompt message
  — gets the same screen instead of a blank column, and the example chips
  and caveat line show there too.

Verified in Chromium (desktop 1280x800/520, tablet, iPhone 13 portrait and
landscape, 320x568) against both dev and production builds: centering is
exact in every viewport, docking is unchanged after a send, and the
keyboard-focus/blur, attachment, drag-drop and dropdown paths all behave.
469 unit tests and 32 e2e specs pass.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011s35VQavGEgfwSAR15kuok