### PR TITLE
Add jobs scope to OPENID_SCOPES

### DIFF
--- a/chart/env/dev.yaml
+++ b/chart/env/dev.yaml
@@ -38,7 +38,7 @@ ingressInternal:
 envVars:
   TEST: "test"
   COUPLE_SESSION_WITH_COOKIE_NAME: "token"
-  OPENID_SCOPES: "openid profile inference-api read-mcp read-billing contribute-repos"
+  OPENID_SCOPES: "openid profile inference-api read-mcp read-billing contribute-repos jobs"
   USE_USER_TOKEN: "true"
   MCP_FORWARD_HF_USER_TOKEN: "true"
   AUTOMATIC_LOGIN: "false"

--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -48,7 +48,7 @@ ingressInternal:
 
 envVars:
   COUPLE_SESSION_WITH_COOKIE_NAME: "token"
-  OPENID_SCOPES: "openid profile inference-api read-mcp read-billing contribute-repos"
+  OPENID_SCOPES: "openid profile inference-api read-mcp read-billing contribute-repos jobs"
   USE_USER_TOKEN: "true"
   MCP_FORWARD_HF_USER_TOKEN: "true"
   AUTOMATIC_LOGIN: "false"


### PR DESCRIPTION
## What

Adds the `jobs` OAuth scope to `OPENID_SCOPES` in the prod and dev chart configs.

## Why

Using the official HF MCP server from HuggingChat, `hf_sandbox` create calls fail with `API request failed: 403 Forbidden` (repro: https://huggingface.co/chat/conversation/6a679aa7465c48d4d7783881).

HuggingChat forwards the logged-in user's OIDC access token to `hf.co/mcp?login` (`MCP_FORWARD_HF_USER_TOKEN`), and that token only carries the scopes chat-ui requests at login. Sandboxes ride on the jobs API and there is no separate sandboxes scope on the Hub, so a token without `jobs` gets 403 on sandbox creation (and `hf_jobs` submission would fail the same way).

Checking `jobs` on the OAuth app settings page is not enough: the Hub only uses the app registration's scopes as a fallback when the client sends no `scope` parameter, and chat-ui always sends an explicit list from `OPENID_SCOPES`.

## Notes

- Users pick up the new scope at their next login; existing sessions keep their current token until they re-auth.
- The consent screen will additionally list jobs permission. This does not regress auto-approve, which is already disabled since `contribute-repos` is outside `HF_CHAT_SCOPES` on the Hub side.
- Longer term, the consent-time scope picker and MCP step-up auth work (moon-landing side, chat-ui #2250) should make this kind of broad-grant unnecessary.