### PR TITLE
Show a Deploy label in the artifact panel header when there's room

### DIFF
--- a/src/lib/components/chat/ArtifactPanel.svelte
+++ b/src/lib/components/chat/ArtifactPanel.svelte
@@ -464,6 +464,26 @@
 
 		<div class="flex flex-none items-center gap-0.5 text-gray-400">
 			{#if version}
+				<!-- Deploy leads the cluster: it's the promoted action and the only
+				     labeled control here, so keeping it next to the tab switcher leaves
+				     the trailing icons as one uniform icon-only group.
+				     The label rides a container query on the header, not the viewport:
+				     the panel is user-resizable, so only its own width says whether
+				     there's room for it beside the title. Below the threshold it
+				     collapses back to the bare rocket. -->
+				{#if canDeploy}
+					<button
+						type="button"
+						class="btn gap-1 rounded-md p-1.5 text-xs hover:bg-gray-100 hover:text-gray-600 @min-[470px]:pr-2 dark:hover:bg-gray-800 dark:hover:text-gray-300"
+						title={currentDeployment ? "Update Space" : "Deploy to Space"}
+						onclick={() => (deployModalOpen = true)}
+					>
+						<CarbonRocket />
+						<span class="hidden font-medium @min-[470px]:inline">
+							{currentDeployment ? "Update" : "Deploy"}
+						</span>
+					</button>
+				{/if}
 				<CopyToClipBoardBtn
 					value={version.content}
 					classNames="btn rounded-md p-1.5 text-sm hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-800 dark:hover:text-gray-300 focus:ring-0"
@@ -477,23 +497,6 @@
 				>
 					<CarbonDownload />
 				</button>
-				{#if canDeploy}
-					<!-- The label rides a container query on the header, not the viewport:
-					     the panel is user-resizable, so only its own width says whether
-					     there's room for it beside the title. Below the threshold it
-					     collapses back to the bare rocket. -->
-					<button
-						type="button"
-						class="btn gap-1 rounded-md p-1.5 text-xs hover:bg-gray-100 hover:text-gray-600 @min-[470px]:pr-2 dark:hover:bg-gray-800 dark:hover:text-gray-300"
-						title={currentDeployment ? "Update Space" : "Deploy to Space"}
-						onclick={() => (deployModalOpen = true)}
-					>
-						<CarbonRocket />
-						<span class="hidden font-medium @min-[470px]:inline">
-							{currentDeployment ? "Update" : "Deploy"}
-						</span>
-					</button>
-				{/if}
 				{#if fullscreenSupported}
 					<button
 						type="button"

--- a/src/lib/components/chat/ArtifactPanel.svelte
+++ b/src/lib/components/chat/ArtifactPanel.svelte
@@ -426,7 +426,7 @@
 {#snippet panelContent()}
 	<!-- header (z-10 so button tooltips aren't painted over by the body) -->
 	<header
-		class="relative z-10 flex h-12 flex-none items-center gap-2 border-b border-gray-100 px-3 dark:border-gray-800"
+		class="@container relative z-10 flex h-12 flex-none items-center gap-2 border-b border-gray-100 px-3 dark:border-gray-800"
 	>
 		<div class="flex min-w-0 flex-1 items-center gap-2">
 			{#if isStreamingVersion}
@@ -478,13 +478,20 @@
 					<CarbonDownload />
 				</button>
 				{#if canDeploy}
+					<!-- The label rides a container query on the header, not the viewport:
+					     the panel is user-resizable, so only its own width says whether
+					     there's room for it beside the title. Below the threshold it
+					     collapses back to the bare rocket. -->
 					<button
 						type="button"
-						class="btn rounded-md p-1.5 text-xs hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-800 dark:hover:text-gray-300"
+						class="btn gap-1 rounded-md p-1.5 text-xs hover:bg-gray-100 hover:text-gray-600 @min-[470px]:pr-2 dark:hover:bg-gray-800 dark:hover:text-gray-300"
 						title={currentDeployment ? "Update Space" : "Deploy to Space"}
 						onclick={() => (deployModalOpen = true)}
 					>
 						<CarbonRocket />
+						<span class="hidden font-medium @min-[470px]:inline">
+							{currentDeployment ? "Update" : "Deploy"}
+						</span>
 					</button>
 				{/if}
 				{#if fullscreenSupported}


### PR DESCRIPTION
The deploy action in the artifact panel was icon-only (just the rocket), which made it easy to miss. It now shows a "Deploy" / "Update" label whenever the panel is wide enough to fit it.

### What changed

The header becomes a `@container` and the label rides a container query on it, not on the viewport. That matters because the panel is user-resizable: only the panel's own width says whether there is room for the label beside the artifact title.

```svelte
<button class="btn gap-1 ... @min-[470px]:pr-2">
  <CarbonRocket />
  <span class="hidden font-medium @min-[470px]:inline">
    {currentDeployment ? "Update" : "Deploy"}
  </span>
</button>
```

### Behavior

- The query measures the header's content box, so with `px-3` the flip lands at roughly 494px of panel width: the label shows at 520px, and is gone at 480px.
- Default panel width (about 708px on a 1440px window) shows the label comfortably, and at 520px the title still keeps around 190px before truncating.
- Below the threshold it collapses back to the bare rocket, so the minimum-width panel (300px) and the mobile full-screen variant are unchanged.
- The text follows existing state: "Deploy" on first deploy, "Update" once the artifact already has a Space.

### Verification

Ran the app locally, generated an HTML artifact, and dragged the resize handle across widths (708 / 520 / 480 / 465 / 400 / 320) with Playwright at 2x to confirm the flip point and that nothing else in the header reflows. Prettier and ESLint pass on the file.