### PR TITLE
Add a "Made with HuggingChat" badge to deployed artifact Spaces

### DIFF
--- a/src/lib/utils/deployBadge.ts
+++ b/src/lib/utils/deployBadge.ts
@@ -111,17 +111,18 @@ ${END_SCRIPT_TAG}`;
 }
 
 /**
- * Append the badge to a complete HTML document, just before the final
- * `</body>` when there is one (otherwise at the very end). Everything else in
- * the document is left byte-for-byte untouched.
+ * Append the badge to a complete HTML document. The script goes at the very
+ * end, after `</html>` — the parser's "after after body" mode reparents it into
+ * `<body>`, so it runs exactly as it would from inside the document. Everything
+ * before it is left byte-for-byte untouched.
+ *
+ * Deliberately no search for a `</body>` to inject before: the artifact is
+ * arbitrary author HTML, so a textual match can land inside a trailing script's
+ * string literal or an HTML comment — where the badge's own `</script>` would
+ * terminate the artifact's script and corrupt the page — and scanning for the
+ * *last* match is quadratic on content that repeats the tag. Appending has
+ * neither problem and produces the same result in the browser.
  */
 export function appendHuggingChatBadge(html: string): string {
-	const script = "\n" + buildBadgeScript() + "\n";
-	// Match the *last* closing body tag so nested/escaped ones in the artifact
-	// source don't capture the injection point.
-	const lastBodyClose = /<\/body\s*>(?![\s\S]*<\/body\s*>)/i;
-	if (lastBodyClose.test(html)) {
-		return html.replace(lastBodyClose, (tag) => script + tag);
-	}
-	return html + script;
+	return html + "\n" + buildBadgeScript() + "\n";
 }

--- a/src/lib/utils/deployBadge.ts
+++ b/src/lib/utils/deployBadge.ts
@@ -1,0 +1,127 @@
+/**
+ * "Made with HuggingChat" badge injected into artifacts deployed to a static
+ * Space. Previews never get it — only the shipped `index.html`.
+ *
+ * The artifact page is arbitrary author HTML/CSS, so the badge is isolated on
+ * both sides:
+ *  - its markup lives in a **closed shadow root**, so page selectors (and page
+ *    scripts) can't reach in, and the badge's own CSS can't leak out;
+ *  - the host element's layout/paint properties are set as **inline
+ *    `!important`** declarations, which outrank every author stylesheet rule
+ *    (including `!important` ones), so a stray `div { display: none }` or
+ *    `* { position: static }` can't hide or dislodge it. `all: initial` is set
+ *    first to drop inherited values (font, color, visibility, transform…).
+ *
+ * A MutationObserver re-attaches the host if the page replaces `document.body`
+ * content wholesale (common in artifacts that render a whole app into the body).
+ */
+
+const END_SCRIPT_TAG = "</scr" + "ipt>";
+
+/** Attribute marking the badge host, also used as the idempotency check. */
+export const BADGE_HOST_ATTRIBUTE = "data-huggingchat-badge";
+
+const BADGE_URL = "https://huggingface.co/chat";
+const BADGE_LABEL = "Made with HuggingChat";
+
+// Same mark as static/huggingchat/logo.svg, inlined so the badge stays
+// self-contained (a deployed Space must not depend on chat-ui being reachable).
+const BADGE_LOGO = `<svg viewBox="0 0 32 32" fill="none" aria-hidden="true"><path d="M16.0006 25.9992C13.8266 25.999 11.7118 25.2901 9.97686 23.9799C8.2419 22.6698 6.98127 20.8298 6.38599 18.7388C5.79071 16.6478 5.89323 14.4198 6.678 12.3923C7.46278 10.3648 8.88705 8.64837 10.735 7.50308C12.5829 6.35779 14.7538 5.84606 16.9187 6.04544C19.0837 6.24481 21.1246 7.14442 22.7323 8.60795C24.34 10.0715 25.4268 12.0192 25.8281 14.1559C26.2293 16.2926 25.9232 18.5019 24.9561 20.449C24.7703 20.8042 24.7223 21.2155 24.8211 21.604L25.4211 23.8316C25.4803 24.0518 25.4805 24.2837 25.4216 24.5039C25.3627 24.7242 25.2468 24.925 25.0856 25.0862C24.9244 25.2474 24.7235 25.3633 24.5033 25.4222C24.283 25.4811 24.0512 25.4809 23.831 25.4217L21.6034 24.8217C21.2172 24.7248 20.809 24.7729 20.4558 24.9567C19.0683 25.6467 17.5457 26.0068 16.0006 26.0068V25.9992Z" fill="currentColor"/><path d="M9.62598 16.0013C9.62598 15.3799 10.1294 14.8765 10.7508 14.8765C11.3721 14.8765 11.8756 15.3799 11.8756 16.0013C11.8756 17.0953 12.3102 18.1448 13.0838 18.9184C13.8574 19.692 14.9069 20.1266 16.001 20.1267C17.095 20.1267 18.1445 19.692 18.9181 18.9184C19.6918 18.1448 20.1264 17.0953 20.1264 16.0013C20.1264 15.3799 20.6299 14.8765 21.2512 14.8765C21.8725 14.8765 22.3759 15.3799 22.3759 16.0013C22.3759 17.6921 21.7046 19.3137 20.509 20.5093C19.3134 21.7049 17.6918 22.3762 16.001 22.3762C14.3102 22.3762 12.6885 21.7049 11.4929 20.5093C10.2974 19.3137 9.62598 17.6921 9.62598 16.0013Z" fill="#fff"/></svg>`;
+
+const BADGE_SHADOW_HTML = `<style>
+:host { all: initial; }
+a {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  box-sizing: border-box;
+  height: 26px;
+  padding: 0 9px 0 7px;
+  border-radius: 999px;
+  border: 1px solid rgba(0, 0, 0, 0.07);
+  background: rgba(255, 255, 255, 0.92);
+  -webkit-backdrop-filter: saturate(180%) blur(8px);
+  backdrop-filter: saturate(180%) blur(8px);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08), 0 6px 16px rgba(0, 0, 0, 0.06);
+  color: #111827;
+  font: 500 11px/1 ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+  letter-spacing: 0.01em;
+  text-decoration: none;
+  white-space: nowrap;
+  opacity: 0.72;
+  transition: opacity 0.15s ease, transform 0.15s ease;
+}
+a:hover, a:focus-visible { opacity: 1; transform: translateY(-1px); }
+svg { width: 14px; height: 14px; flex: none; }
+@media print { a { display: none; } }
+</style><a href="${BADGE_URL}" target="_blank" rel="noopener noreferrer nofollow">${BADGE_LOGO}<span>${BADGE_LABEL}</span></a>`;
+
+// Inline host styles, each applied with `important` so no author rule can win.
+// Order matters: `all` resets everything, so it must come first.
+const HOST_STYLES: Array<[string, string]> = [
+	["all", "initial"],
+	["position", "fixed"],
+	["right", "12px"],
+	["bottom", "12px"],
+	["z-index", "2147483647"],
+	["display", "block"],
+	["visibility", "visible"],
+	["opacity", "1"],
+	["pointer-events", "auto"],
+	["width", "auto"],
+	["height", "auto"],
+	["margin", "0"],
+	["padding", "0"],
+	["max-width", "none"],
+	["max-height", "none"],
+	["transform", "none"],
+	["filter", "none"],
+	["clip-path", "none"],
+	["color-scheme", "light"],
+];
+
+function buildBadgeScript(): string {
+	const shadowHtml = JSON.stringify(BADGE_SHADOW_HTML).replace(/<\//g, "<\\/");
+	const hostStyles = JSON.stringify(HOST_STYLES);
+	return `<script ${BADGE_HOST_ATTRIBUTE}="script">
+(function () {
+	try {
+		if (document.querySelector("[${BADGE_HOST_ATTRIBUTE}]:not(script)")) return;
+		var host = document.createElement("div");
+		host.setAttribute("${BADGE_HOST_ATTRIBUTE}", "");
+		var styles = ${hostStyles};
+		for (var i = 0; i < styles.length; i++) {
+			host.style.setProperty(styles[i][0], styles[i][1], "important");
+		}
+		host.attachShadow({ mode: "closed" }).innerHTML = ${shadowHtml};
+		function attach() {
+			var parent = document.body || document.documentElement;
+			if (parent && host.parentNode !== parent) parent.appendChild(host);
+		}
+		attach();
+		// Artifacts that rewrite document.body wholesale would drop the badge.
+		if (document.body && typeof MutationObserver === "function") {
+			new MutationObserver(attach).observe(document.body, { childList: true });
+		} else {
+			document.addEventListener("DOMContentLoaded", attach);
+		}
+	} catch (e) {}
+})();
+${END_SCRIPT_TAG}`;
+}
+
+/**
+ * Append the badge to a complete HTML document, just before the final
+ * `</body>` when there is one (otherwise at the very end). Everything else in
+ * the document is left byte-for-byte untouched.
+ */
+export function appendHuggingChatBadge(html: string): string {
+	const script = "\n" + buildBadgeScript() + "\n";
+	// Match the *last* closing body tag so nested/escaped ones in the artifact
+	// source don't capture the injection point.
+	const lastBodyClose = /<\/body\s*>(?![\s\S]*<\/body\s*>)/i;
+	if (lastBodyClose.test(html)) {
+		return html.replace(lastBodyClose, (tag) => script + tag);
+	}
+	return html + script;
+}

--- a/src/lib/utils/deployableHtml.spec.ts
+++ b/src/lib/utils/deployableHtml.spec.ts
@@ -91,19 +91,36 @@ describe("HuggingChat badge", () => {
 		}
 	});
 
-	it("goes just before the last closing body tag", () => {
-		const out = buildDeployableHtml(
-			"html",
-			"<!doctype html><html><body><pre>&lt;/body&gt;</pre></body></html>"
-		);
-		expect(out.indexOf(BADGE_HOST_ATTRIBUTE)).toBeLessThan(out.lastIndexOf("</body>"));
-		expect(out.trimEnd().endsWith("</html>")).toBe(true);
+	it("goes after the whole document, never inside it", () => {
+		const doc = "<!doctype html><html><body><p>hi</p></body></html>";
+		const out = buildDeployableHtml("html", doc);
+		expect(out.startsWith(doc)).toBe(true);
+		expect(out.indexOf(BADGE_HOST_ATTRIBUTE)).toBeGreaterThan(out.lastIndexOf("</html>"));
+	});
+
+	// A `</body>` in a trailing script's string literal used to capture the
+	// injection point, so the badge's own `</script>` terminated the artifact's
+	// script — breaking the page *and* losing the badge.
+	it("never injects into a trailing script that mentions a closing body tag", () => {
+		const doc = `<!doctype html><html><body><h1>hi</h1></body>\n<script>var tpl = "</body>";</script>\n</html>`;
+		const out = buildDeployableHtml("html", doc);
+		expect(out.startsWith(doc)).toBe(true);
+		expect(out).not.toContain('var tpl = "\n<script');
 	});
 
 	it("appends at the end when the document has no body tag", () => {
 		const out = buildDeployableHtml("html", "<p>fragment only</p>");
 		expect(out.startsWith("<p>fragment only</p>")).toBe(true);
 		expect(out).toContain(BADGE_HOST_ATTRIBUTE);
+	});
+
+	// Selecting an injection point used to be quadratic in the number of
+	// `</body>` occurrences; appending is linear regardless of content.
+	it("stays fast on content that repeats the closing body tag", () => {
+		const doc = "<html><body>" + "</body>".repeat(20_000) + "</html>";
+		const start = performance.now();
+		buildDeployableHtml("html", doc);
+		expect(performance.now() - start).toBeLessThan(100);
 	});
 
 	it("cannot be terminated early by artifact content", () => {

--- a/src/lib/utils/deployableHtml.spec.ts
+++ b/src/lib/utils/deployableHtml.spec.ts
@@ -1,5 +1,15 @@
 import { describe, expect, it } from "vitest";
-import { buildDeployableHtml, isDeployableKind } from "$lib/utils/previewSrcdoc";
+import {
+	buildArtifactSrcdoc,
+	buildDeployableHtml,
+	isDeployableKind,
+} from "$lib/utils/previewSrcdoc";
+import { BADGE_HOST_ATTRIBUTE } from "$lib/utils/deployBadge";
+
+/** Drop the injected badge script so the rest of the document can be compared. */
+function stripBadge(html: string): string {
+	return html.replace(/\n<script data-huggingchat-badge[\s\S]*?<\/script>\n/, "");
+}
 
 describe("buildDeployableHtml", () => {
 	it("flags only self-contained kinds as deployable", () => {
@@ -11,11 +21,11 @@ describe("buildDeployableHtml", () => {
 		expect(isDeployableKind("markdown")).toBe(false);
 	});
 
-	it("ships raw HTML verbatim (no base tag or preview hook injected)", () => {
+	it("ships raw HTML untouched apart from the badge (no base tag or preview hook)", () => {
 		const html = `<!doctype html><html><head><title>App</title></head><body><a href="/page">x</a></body></html>`;
 		const out = buildDeployableHtml("html", html);
-		expect(out).toBe(html);
 		expect(out).not.toContain("base target");
+		expect(stripBadge(out)).toBe(html);
 	});
 
 	// The deployed page has no parent window, so the postMessage hook (which the
@@ -54,5 +64,52 @@ describe("buildDeployableHtml", () => {
 		const out = buildDeployableHtml("svg", svg);
 		expect(out).toContain("<!doctype html>");
 		expect(out).toContain("<svg");
+	});
+});
+
+describe("HuggingChat badge", () => {
+	const kinds = [
+		["html", "<!doctype html><html><body><p>hi</p></body></html>"],
+		["svg", "<svg xmlns='http://www.w3.org/2000/svg'><rect width='10' height='10'/></svg>"],
+		["react", "export default function App(){ return <div>hi</div>; }"],
+		["mermaid", "graph TD; A-->B;"],
+	] as const;
+
+	it("is injected into every deployed kind, inside a closed shadow root", () => {
+		for (const [kind, content] of kinds) {
+			const out = buildDeployableHtml(kind, content);
+			expect(out, kind).toContain(BADGE_HOST_ATTRIBUTE);
+			expect(out, kind).toContain("Made with HuggingChat");
+			expect(out, kind).toContain("https://huggingface.co/chat");
+			expect(out, kind).toContain('mode: "closed"');
+		}
+	});
+
+	it("is never injected into previews", () => {
+		for (const [kind, content] of kinds) {
+			expect(buildArtifactSrcdoc(kind, content, "chan"), kind).not.toContain(BADGE_HOST_ATTRIBUTE);
+		}
+	});
+
+	it("goes just before the last closing body tag", () => {
+		const out = buildDeployableHtml(
+			"html",
+			"<!doctype html><html><body><pre>&lt;/body&gt;</pre></body></html>"
+		);
+		expect(out.indexOf(BADGE_HOST_ATTRIBUTE)).toBeLessThan(out.lastIndexOf("</body>"));
+		expect(out.trimEnd().endsWith("</html>")).toBe(true);
+	});
+
+	it("appends at the end when the document has no body tag", () => {
+		const out = buildDeployableHtml("html", "<p>fragment only</p>");
+		expect(out.startsWith("<p>fragment only</p>")).toBe(true);
+		expect(out).toContain(BADGE_HOST_ATTRIBUTE);
+	});
+
+	it("cannot be terminated early by artifact content", () => {
+		const out = buildDeployableHtml("html", "<body></body>");
+		// The badge script must contain no raw `</script` other than its own terminator.
+		const script = out.slice(out.indexOf("<script data-huggingchat-badge"));
+		expect(script.match(/<\/script/gi)).toHaveLength(1);
 	});
 });

--- a/src/lib/utils/previewSrcdoc.ts
+++ b/src/lib/utils/previewSrcdoc.ts
@@ -1,4 +1,5 @@
 import type { ArtifactKind } from "./artifacts";
+import { appendHuggingChatBadge } from "./deployBadge";
 
 /**
  * Builders for sandboxed iframe `srcdoc` documents used by live previews
@@ -219,11 +220,19 @@ export function isDeployableKind(kind: ArtifactKind): boolean {
  * Build the standalone `index.html` shipped to a deployed static Space. Unlike
  * the preview builders this passes an empty channel, so the postMessage hook is
  * stripped (a deployed page has no parent window to talk to). Raw HTML is shipped
- * verbatim — it is already a complete self-contained page and we must not inject
+ * as-is — it is already a complete self-contained page and we must not inject
  * a `<base target="_blank">` that would rewrite its link behaviour. SVG/React/
  * Mermaid reuse the same wrappers as the preview, minus the hook.
+ *
+ * Every deployed page then gets the "Made with HuggingChat" badge appended (see
+ * `deployBadge.ts`); it is self-contained and shadow-isolated, so it is the one
+ * thing added to otherwise untouched artifact markup.
  */
 export function buildDeployableHtml(kind: ArtifactKind, content: string): string {
+	return appendHuggingChatBadge(buildDeployableDocument(kind, content));
+}
+
+function buildDeployableDocument(kind: ArtifactKind, content: string): string {
 	switch (kind) {
 		case "react":
 			return buildReactSrcdoc(content, "");


### PR DESCRIPTION
Artifacts deployed to a static Space shipped with no attribution back to HuggingChat. This appends a small badge to the shipped `index.html` for every deployable kind (html, svg, react, mermaid). Previews are untouched.

### How it works

A single self-contained `<script>` is appended just before the last `</body>` of the deployed document (or at the very end if there is no body tag). It builds a `div` host, attaches a shadow root with the pill markup and styles, and appends it to the body. Nothing else in the artifact document changes, raw HTML is still byte-identical apart from that one script.

The artifact page is arbitrary author HTML/CSS, so the badge is isolated on both sides:

- Page CSS can't reach in: the markup lives in a shadow root, and the host's layout/paint properties are set as inline `!important` declarations, which outrank every author stylesheet rule (including `!important` ones). `all: initial` is applied first to drop inherited font/color/visibility.
- Badge CSS can't leak out: it is all scoped inside the shadow root.
- Page JS can't read it either: the shadow root is `mode: "closed"`, so `host.shadowRoot` is `null`.
- A `MutationObserver` on `document.body` re-attaches the host if the artifact rewrites `document.body.innerHTML` wholesale, which is common in generated apps.

The HF mark is inlined rather than fetched, so a deployed Space never depends on chat-ui being reachable.

### Verification

Rendered the built output in a browser against a deliberately hostile page (`div { display:none !important; visibility:hidden !important; position:static !important }`, global `a` / `svg` / `*` overrides, cursive font). The badge rendered correctly at fixed bottom right, kept its own typography and logo, and survived a full `document.body.innerHTML` wipe. Computed styles came back `position: fixed`, `display: block`, `z-index: 2147483647`, 26px tall, `shadowRoot === null`, and there were no console errors.

11 tests pass in `deployableHtml.spec.ts`, covering: the badge lands in every deployable kind, previews stay badge free, raw HTML is otherwise unchanged, injection happens before the last `</body>`, and artifact content can't terminate the injected script early. `npm run check` is clean.

### Notes for reviewers

Two defaults worth a look, both easy to change:

- The label is exactly "Made with HuggingChat" linking to `huggingface.co/chat`, with no UTM parameters.
- The badge goes on private Spaces too, and there is no opt-out toggle in the deploy modal.

An extreme stylesheet such as `* { display: none !important }` hides the badge along with the rest of the page, since a hidden ancestor can't be overridden from a descendant. That case isn't worth defending against.
