### PR TITLE
Darken artifact panel header buttons in light mode

### DIFF
--- a/src/lib/components/chat/ArtifactPanel.svelte
+++ b/src/lib/components/chat/ArtifactPanel.svelte
@@ -462,7 +462,9 @@
 			</button>
 		</div>
 
-		<div class="flex flex-none items-center gap-0.5 text-gray-400">
+		<!-- gray-500 in light mode: gray-400 on white reads as disabled, while in dark
+		     mode it sits at the right contrast against the panel already -->
+		<div class="flex flex-none items-center gap-0.5 text-gray-500 dark:text-gray-400">
 			{#if version}
 				<!-- Deploy leads the cluster: it's the promoted action and the only
 				     labeled control here, so keeping it next to the tab switcher leaves

--- a/src/lib/components/chat/ArtifactPanel.svelte
+++ b/src/lib/components/chat/ArtifactPanel.svelte
@@ -462,8 +462,6 @@
 			</button>
 		</div>
 
-		<!-- gray-500 in light mode: gray-400 on white reads as disabled, while in dark
-		     mode it sits at the right contrast against the panel already -->
 		<div class="flex flex-none items-center gap-0.5 text-gray-500 dark:text-gray-400">
 			{#if version}
 				<!-- Deploy leads the cluster: it's the promoted action and the only


### PR DESCRIPTION
The button cluster in the artifact panel header (Deploy, copy, download, fullscreen, close) inherited `text-gray-400` from its container. Against the white header in light mode that's washed out enough to read as disabled.

Bumped the container to `text-gray-500` for light mode and pinned dark mode to `dark:text-gray-400` so it stays exactly as it was.

Hover states already resolve to `text-gray-600` in light mode, so there's still a visible step up on hover from the new resting color.

One-line change in `src/lib/components/chat/ArtifactPanel.svelte`, all five buttons inherit from that one container.