### PR TITLE
Raise the deploy label threshold in the artifact header to 580px

### DIFF
--- a/src/lib/components/chat/ArtifactPanel.svelte
+++ b/src/lib/components/chat/ArtifactPanel.svelte
@@ -474,12 +474,12 @@
 				{#if canDeploy}
 					<button
 						type="button"
-						class="btn gap-1 rounded-md p-1.5 text-xs hover:bg-gray-100 hover:text-gray-600 @min-[470px]:pr-2 dark:hover:bg-gray-800 dark:hover:text-gray-300"
+						class="btn gap-1 rounded-md p-1.5 text-xs hover:bg-gray-100 hover:text-gray-600 @min-[580px]:pr-2 dark:hover:bg-gray-800 dark:hover:text-gray-300"
 						title={currentDeployment ? "Update Space" : "Deploy to Space"}
 						onclick={() => (deployModalOpen = true)}
 					>
 						<CarbonRocket />
-						<span class="hidden font-medium @min-[470px]:inline">
+						<span class="hidden font-medium @min-[580px]:inline">
 							{currentDeployment ? "Update" : "Deploy"}
 						</span>
 					</button>


### PR DESCRIPTION
Follow-up to #2455. The "Deploy" / "Update" label next to the rocket was gated on a `@min-[470px]` container query; this raises it to `@min-[580px]` so the label only appears once the header is comfortably wide.

### Measured behavior

The query reads the header's content box, and the header has `px-3`, so the flip lands at a panel width of ~604px. Verified by dragging the resize handle:

| Panel width | Label |
| --- | --- |
| 708px (default, 1440px window) | shown |
| 640px | shown |
| 610px | shown |
| 600px | hidden |
| 520px | hidden |

Default panel width is 60% of the chat area, so the label is present by default down to roughly a 1267px window (612px panel at 1280px, 751px at 1512px). Below that the default view starts collapsed, and dragging the panel wider brings the label back.

### Verification

Ran the app locally, generated an HTML artifact, and captured the header at each width above at 2x, plus the default state at 1280 / 1440 / 1512px windows. Prettier passes on the file.