### PR TITLE
Send preview error fix requests directly instead of prefilling the composer

### DIFF
--- a/src/lib/components/CodeBlock.svelte
+++ b/src/lib/components/CodeBlock.svelte
@@ -4,6 +4,7 @@
 	import HtmlPreviewModal from "./HtmlPreviewModal.svelte";
 	import PlayFilledAlt from "~icons/carbon/play-filled-alt";
 	import EosIconsLoading from "~icons/eos-icons/loading";
+	import { getArtifactsContext } from "$lib/utils/artifactsContext";
 
 	interface Props {
 		code?: string;
@@ -12,6 +13,10 @@
 	}
 
 	let { code = "", rawCode = "", loading = false }: Props = $props();
+
+	// Lets the preview modal send its ask-to-fix message straight to the chat.
+	// Undefined outside a chat window (or while it can't accept messages).
+	const artifactsContext = getArtifactsContext();
 
 	let previewOpen = $state(false);
 
@@ -82,6 +87,10 @@
 		></pre>
 
 	{#if previewOpen}
-		<HtmlPreviewModal html={rawCode} onclose={() => (previewOpen = false)} />
+		<HtmlPreviewModal
+			html={rawCode}
+			onclose={() => (previewOpen = false)}
+			onsend={artifactsContext?.requestFix}
+		/>
 	{/if}
 </div>

--- a/src/lib/components/HtmlPreviewModal.svelte
+++ b/src/lib/components/HtmlPreviewModal.svelte
@@ -3,8 +3,11 @@
 	import ExternalLinkModal from "./ExternalLinkModal.svelte";
 	import { onMount, onDestroy } from "svelte";
 	import CarbonClose from "~icons/carbon/close";
-	import { pendingChatInput } from "$lib/stores/pendingChatInput";
-	import { buildArtifactSrcdoc } from "$lib/utils/previewSrcdoc";
+	import {
+		buildArtifactSrcdoc,
+		composeFixRequest,
+		type PreviewError,
+	} from "$lib/utils/previewSrcdoc";
 	import { parseExternalUrl } from "$lib/utils/externalLink";
 	import type { ArtifactKind } from "$lib/utils/artifacts";
 
@@ -13,13 +16,19 @@
 		/** How to render the content; html also covers raw SVG documents */
 		kind?: ArtifactKind;
 		onclose?: () => void;
+		/**
+		 * Sends an ask-to-fix message directly to the chat, returning whether it
+		 * was dispatched. Absent when sending isn't possible, which hides the
+		 * error button.
+		 */
+		onsend?: (text: string) => boolean;
 	}
 
-	let { html, kind = "html", onclose }: Props = $props();
+	let { html, kind = "html", onclose, onsend }: Props = $props();
 
 	let iframeEl: HTMLIFrameElement | undefined = $state();
 	let channel = $state(`preview_${Math.random().toString(36).slice(2)}`);
-	let errors: { message: string; stack?: string }[] = $state([]);
+	let errors: PreviewError[] = $state([]);
 	let externalLinkUrl = $state<URL | null>(null);
 
 	let srcdoc = $derived(buildArtifactSrcdoc(kind, html, channel));
@@ -57,14 +66,6 @@
 		window.removeEventListener("message", onMessage);
 	});
 
-	function composeText(): string {
-		const lines = errors.map((e, i) => `${i + 1}. ${e.message}${e.stack ? `\n${e.stack}` : ""}`);
-		const summary = lines[0] ?? "Unknown error";
-		return errors.length > 1
-			? `it's not working: ${summary} (+${errors.length - 1} more) - can you fix it?`
-			: `it's not working: ${summary} - can you fix it?`;
-	}
-
 	// Esc/backdrop while the external-link confirm is open dismisses just the
 	// confirm; the fullscreen preview itself stays up. (Esc reaches this Modal's
 	// handler first because it registered its window listener before the nested
@@ -99,16 +100,17 @@
 			Close preview
 		</button>
 
-		{#if errors.length > 0}
+		{#if errors.length > 0 && onsend}
 			<button
 				class="fixed right-4 bottom-4 z-50 btn flex items-center gap-2 rounded-full border-2 border-red-500/60 bg-red-800/90 px-4 py-1.5 text-sm text-white shadow-lg"
-				title="Send error to chat"
+				title="Send the errors and ask for a fix"
 				onclick={() => {
-					pendingChatInput.set(composeText());
-					onclose?.();
+					// Close only once the message is actually on its way, so the
+					// preview (and the errors backing the request) stays up otherwise
+					if (onsend?.(composeFixRequest(errors))) onclose?.();
 				}}
 			>
-				<span>Error caught ({errors.length})</span>
+				<span>Error caught ({errors.length}) — ask to fix</span>
 			</button>
 		{/if}
 	</div>

--- a/src/lib/components/chat/ArtifactPanel.svelte
+++ b/src/lib/components/chat/ArtifactPanel.svelte
@@ -5,12 +5,16 @@
 	import type { ArtifactRegistry, ArtifactVersion } from "$lib/utils/artifacts";
 	import { artifactFileName, isPreviewableKind } from "$lib/utils/artifacts";
 	import { diffLines, diffStats, renderDiffHtml } from "$lib/utils/artifactDiff";
-	import { buildArtifactSrcdoc, isDeployableKind } from "$lib/utils/previewSrcdoc";
+	import {
+		buildArtifactSrcdoc,
+		composeFixRequest,
+		isDeployableKind,
+		type PreviewError,
+	} from "$lib/utils/previewSrcdoc";
 	import { parseExternalUrl } from "$lib/utils/externalLink";
 	import { escapeHTML } from "$lib/utils/markedLight";
 	import { artifactPanel, ARTIFACT_PANEL_DEFAULT_FRACTION } from "$lib/stores/artifactPanel.svelte";
 	import { StickToBottomController } from "$lib/utils/scroll/stickToBottom";
-	import { pendingChatInput } from "$lib/stores/pendingChatInput";
 	import { usePublicConfig } from "$lib/utils/PublicConfig.svelte";
 	import { page } from "$app/state";
 
@@ -33,9 +37,15 @@
 	interface Props {
 		registry: ArtifactRegistry;
 		loading?: boolean;
+		/**
+		 * Sends an ask-to-fix message directly to the chat, returning whether it
+		 * was dispatched. Absent when the conversation can't accept messages
+		 * (read-only, errored generation), which hides the ask-to-fix controls.
+		 */
+		onsend?: (text: string) => boolean;
 	}
 
-	let { registry, loading = false }: Props = $props();
+	let { registry, loading = false, onsend }: Props = $props();
 
 	let artifact = $derived(
 		artifactPanel.identifier ? registry.artifacts.get(artifactPanel.identifier) : undefined
@@ -267,7 +277,7 @@
 	// ----- live preview -----
 	const previewChannel = `artifact_${Math.random().toString(36).slice(2)}`;
 	let iframeEl: HTMLIFrameElement | undefined = $state();
-	let errors: { message: string; stack?: string }[] = $state([]);
+	let errors: PreviewError[] = $state([]);
 	let externalLinkUrl = $state<URL | null>(null);
 
 	let srcdoc = $derived.by(() => {
@@ -308,14 +318,19 @@
 		errors = [...errors, { message: String(detail.message ?? "Error"), stack: detail.stack }];
 	}
 
+	// Sends the fix request as a chat message right away. On mobile the panel
+	// is a fullscreen overlay that would hide both the sent message and the
+	// streaming reply, so close it on send; the panel auto-reopens when the
+	// fixed version starts streaming in (maybeAutoOpen). On desktop the chat is
+	// visible next to the panel, which stays open to receive the fix.
+	function sendFixRequest(text: string): boolean {
+		const sent = onsend?.(text) ?? false;
+		if (sent && !isDesktop) artifactPanel.close();
+		return sent;
+	}
+
 	function askToFixErrors() {
-		const lines = errors.map((e, i) => `${i + 1}. ${e.message}${e.stack ? `\n${e.stack}` : ""}`);
-		const summary = lines[0] ?? "Unknown error";
-		pendingChatInput.set(
-			errors.length > 1
-				? `it's not working: ${summary} (+${errors.length - 1} more) - can you fix it?`
-				: `it's not working: ${summary} - can you fix it?`
-		);
+		sendFixRequest(composeFixRequest(errors));
 	}
 
 	// ----- actions -----
@@ -643,11 +658,14 @@
 				<span class="router-shimmer whitespace-nowrap">
 					{version?.op === "update" ? "Applying edit" : "Generating"}
 				</span>
-			{:else if errors.length > 0}
+			{:else if errors.length > 0 && onsend}
 				<button
 					type="button"
-					class="btn flex items-center gap-1.5 rounded-full border border-red-300/60 bg-red-50 px-2.5 py-0.5 text-red-600 hover:bg-red-100 dark:border-red-500/40 dark:bg-red-500/10 dark:text-red-400 dark:hover:bg-red-500/20"
-					title="Send the error to the chat input"
+					class="btn flex items-center gap-1.5 rounded-full border border-red-300/60 bg-red-50 px-2.5 py-0.5 text-red-600 hover:bg-red-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-red-500/40 dark:bg-red-500/10 dark:text-red-400 dark:hover:bg-red-500/20"
+					title={loading
+						? "Wait for the current response to finish"
+						: "Send the errors and ask for a fix"}
+					disabled={loading}
 					onclick={askToFixErrors}
 				>
 					{errors.length} error{errors.length > 1 ? "s" : ""} — ask to fix
@@ -708,10 +726,13 @@
 {/if}
 
 {#if fullscreenOpen && version}
+	<!-- The modal can't render a disabled state for its floating error button,
+	     so streaming gates the handler entirely -->
 	<HtmlPreviewModal
 		html={version.content}
 		kind={version.type}
 		onclose={() => (fullscreenOpen = false)}
+		onsend={onsend && !loading ? sendFixRequest : undefined}
 	/>
 {/if}
 

--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -48,7 +48,6 @@
 	import FeatureAnnouncementToast from "../FeatureAnnouncementToast.svelte";
 	import { getActiveAnnouncement } from "$lib/utils/featureAnnouncements";
 	import { usePublicConfig } from "$lib/utils/PublicConfig.svelte";
-	import { pendingChatInput } from "$lib/stores/pendingChatInput";
 	import LucideHammer from "~icons/lucide/hammer";
 	import LucideSparkles from "~icons/lucide/sparkles";
 
@@ -127,6 +126,12 @@
 			return artifactRegistry;
 		},
 		panel: artifactPanel,
+		// Deep consumers (e.g. the code-block preview modal) can't render a
+		// meaningful disabled state, so streaming also gates availability here;
+		// the panel gets the handler as a prop and disables on `loading` itself.
+		get requestFix() {
+			return canSendFix && !loading ? sendFixRequest : undefined;
+		},
 	});
 
 	// Auto-open the panel when a new artifact version starts streaming in
@@ -240,6 +245,30 @@
 				(u) => u.type === "status" && u.status === "error"
 			) ?? -1) !== -1
 	);
+
+	// Preview "ask to fix" buttons (artifact panel footer, fullscreen preview
+	// modals) send their message directly instead of prefilling the composer.
+	// Bypasses the draft on purpose: a half-typed message must survive the click.
+	let canSendFix = $derived(!isReadOnly && !lastIsError);
+	function sendFixRequest(text: string): boolean {
+		if (requireAuthUser() || loading) return false;
+		tap();
+		chatScroll.armSend();
+		// Queued attachments belong to the user's next message, not to this
+		// machine-composed one. The send handler snapshots the bound `files`
+		// synchronously before its first await, so emptying around the call is
+		// enough to keep them out of the request — and it skips clearing them
+		// post-send when it consumed none (see writeMessage), so the restored
+		// queue survives.
+		const queuedFiles = files;
+		files = [];
+		try {
+			onmessage?.(text);
+		} finally {
+			files = queuedFiles;
+		}
+		return true;
+	}
 
 	// Expose currently running tool call name (if any) from the streaming assistant message
 	const availableTools: ToolFront[] = $derived.by(
@@ -443,13 +472,6 @@
 
 		const match = activeExamples.find((ex) => ex.prompt.trim() === firstUserMessage.content.trim());
 		activeRouterExamplePrompt = match ? match.prompt : null;
-	});
-
-	$effect(() => {
-		if ($pendingChatInput) {
-			draft = $pendingChatInput;
-			pendingChatInput.set(undefined);
-		}
 	});
 
 	function triggerPrompt(prompt: string) {
@@ -986,7 +1008,11 @@
 		</div>
 	</div>
 
-	<ArtifactPanel registry={artifactRegistry} {loading} />
+	<ArtifactPanel
+		registry={artifactRegistry}
+		{loading}
+		onsend={canSendFix ? sendFixRequest : undefined}
+	/>
 </div>
 
 <style>

--- a/src/lib/stores/pendingChatInput.ts
+++ b/src/lib/stores/pendingChatInput.ts
@@ -1,3 +1,0 @@
-import { writable } from "svelte/store";
-
-export const pendingChatInput = writable<string | undefined>(undefined);

--- a/src/lib/utils/artifactsContext.ts
+++ b/src/lib/utils/artifactsContext.ts
@@ -10,6 +10,13 @@ import type { artifactPanel } from "$lib/stores/artifactPanel.svelte";
 export interface ArtifactsContext {
 	readonly registry: ArtifactRegistry;
 	panel: typeof artifactPanel;
+	/**
+	 * Sends a preview-error fix request straight to the chat as a user message,
+	 * returning whether it was dispatched. Undefined while the conversation
+	 * can't accept a message (read-only, errored generation, streaming), so
+	 * consumers hide their ask-to-fix control instead of rendering a dead one.
+	 */
+	readonly requestFix?: (text: string) => boolean;
 }
 
 /** Exported for test harnesses that seed this context without mounting ChatWindow. */

--- a/src/lib/utils/composeFixRequest.spec.ts
+++ b/src/lib/utils/composeFixRequest.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { composeFixRequest } from "$lib/utils/previewSrcdoc";
+
+describe("composeFixRequest", () => {
+	it("composes a single error with its stack", () => {
+		expect(
+			composeFixRequest([{ message: "x is not defined", stack: "ReferenceError: x\n  at app:1" }])
+		).toBe("it's not working: x is not defined\nReferenceError: x\n  at app:1 - can you fix it?");
+	});
+
+	it("composes a single error without a stack", () => {
+		expect(composeFixRequest([{ message: "boom" }])).toBe(
+			"it's not working: boom - can you fix it?"
+		);
+	});
+
+	it("summarizes extra errors as a count", () => {
+		expect(composeFixRequest([{ message: "a" }, { message: "b" }, { message: "c" }])).toBe(
+			"it's not working: a (+2 more) - can you fix it?"
+		);
+	});
+});

--- a/src/lib/utils/previewSrcdoc.ts
+++ b/src/lib/utils/previewSrcdoc.ts
@@ -20,6 +20,23 @@ import type { ArtifactKind } from "./artifacts";
 
 const END_SCRIPT_TAG = "</scr" + "ipt>";
 
+/** An uncaught error forwarded from a preview iframe via the postMessage hook. */
+export interface PreviewError {
+	message: string;
+	stack?: string;
+}
+
+/** The chat message sent when the user asks the model to fix captured preview errors. */
+export function composeFixRequest(errors: PreviewError[]): string {
+	const first = errors[0];
+	const summary = first
+		? `${first.message}${first.stack ? `\n${first.stack}` : ""}`
+		: "Unknown error";
+	return errors.length > 1
+		? `it's not working: ${summary} (+${errors.length - 1} more) - can you fix it?`
+		: `it's not working: ${summary} - can you fix it?`;
+}
+
 function buildPreviewHookScript(channel: string): string {
 	// Deployed artifacts (a static Space) pass an empty channel: there is no
 	// parent window to postMessage to, so the hook is omitted entirely and the

--- a/src/routes/conversation/[id]/+page.svelte
+++ b/src/routes/conversation/[id]/+page.svelte
@@ -293,7 +293,11 @@
 			});
 			if (messageUpdatesIterator === undefined) return;
 
-			files = [];
+			// Clear only attachments this send actually consumed: a direct fix
+			// request (artifact "ask to fix") empties `files` around its call and
+			// restores the user's queued attachments right after, and an
+			// unconditional clear here would wipe that restored queue.
+			if (base64Files.length > 0) files = [];
 
 			await consumeMessageUpdates(messageUpdatesIterator, messageToWriteTo, {
 				streamingMode,


### PR DESCRIPTION
## What

Clicking a preview error button (the "N errors, ask to fix" pill in the artifact panel footer, the error button in the panel's fullscreen preview, and the one in the HTML preview modal on chat code blocks) now sends the fix request as a chat message immediately, instead of appending it to the chat input for the user to send manually.

Mobile gets a specific behavior: the artifact panel is a fullscreen overlay there, so after sending, the panel closes to reveal the sent message and the streaming reply. The existing auto-open logic then re-opens the panel when the fixed artifact version starts streaming, closing the loop. On desktop the chat is visible next to the panel, so the panel stays open and the fix streams into it as a new version.

This matches how comparable tools behave (Lovable's "Try to fix", Bolt's attempt-fix, v0), and follows the visibility-of-system-status principle: a direct send hidden behind a fullscreen overlay would look like the button did nothing.

## How

- `ChatWindow` owns a single `sendFixRequest(text)` that runs the normal send path (auth wall, haptic, scroll anchoring, `onmessage`). It is passed to `ArtifactPanel` as an `onsend` prop and exposed to deep consumers (CodeBlock's preview modal) through the existing artifacts context as `requestFix`.
- Sending bypasses the draft on purpose so a half-typed message survives the click. Queued attachments are stashed around the send and restored, with a matching consumed-only clear in the conversation page, so they are neither silently attached to the machine-composed fix message nor lost.
- The pill is disabled (with a wait tooltip) while a response is streaming, and hidden when the conversation cannot accept messages (read-only, errored last generation). The modals hide their error button in those states too.
- The duplicated error-message composition moved to `composeFixRequest` in `previewSrcdoc.ts` next to the preview channel protocol, with a unit spec. The now-unused `pendingChatInput` store (and its consumer effect) is deleted.

## Notes for review

- Verified end to end in the browser: desktop (message sends, composer stays empty, panel stays open, fix streams in as v2, pill disabled mid-generation), mobile (panel closes on send, chat shows the sent message, auto-reopen on the next version), and the code-block preview modal path. Also verified a staged attachment survives a fix-request send and is not attached to it.
- A Codex review pass (`gpt-5.6-sol`, xhigh) on the diff surfaced the queued-attachment consumption issue; the stash/restore plus consumed-only clear is the fix for it.
- `npm run check`, lint on changed files, and the full test suite (472 tests) pass. The only prettier warnings in the repo are pre-existing, in files this PR does not touch.