### PR TITLE
Add screenshot annotation to the artifact panel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
 				"@polka/compression": "^1.0.0-next.28",
 				"@resvg/resvg-js": "^2.6.2",
 				"@tailwindcss/vite": "^4.3.0",
+				"@zumer/snapdom": "^2.23.1",
 				"bits-ui": "^2.14.2",
 				"date-fns": "^2.29.3",
 				"file-type": "^21.3.1",
@@ -3804,6 +3805,15 @@
 			"funding": {
 				"url": "https://opencollective.com/vitest"
 			}
+		},
+		"node_modules/@zumer/snapdom": {
+			"version": "2.23.1",
+			"resolved": "https://registry.npmjs.org/@zumer/snapdom/-/snapdom-2.23.1.tgz",
+			"integrity": "sha512-r+6LRFXIpzTxlvGBjTr7mhvVW05TozgyE1QFmvO1hbchdbl4Km5/7DIkeyl2+nEVbz8Sp6/K2g4b86pXhCrFIQ==",
+			"license": "MIT",
+			"workspaces": [
+				"packages/*"
+			]
 		},
 		"node_modules/abort-controller": {
 			"version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
 		"@polka/compression": "^1.0.0-next.28",
 		"@resvg/resvg-js": "^2.6.2",
 		"@tailwindcss/vite": "^4.3.0",
+		"@zumer/snapdom": "^2.23.1",
 		"bits-ui": "^2.14.2",
 		"date-fns": "^2.29.3",
 		"file-type": "^21.3.1",

--- a/src/lib/components/chat/ArtifactPanel.svelte
+++ b/src/lib/components/chat/ArtifactPanel.svelte
@@ -299,6 +299,17 @@
 		errors = [];
 	});
 
+	// True once the iframe finished loading the current srcdoc. srcdoc
+	// navigation is asynchronous, so right after a version switch the old
+	// document still occupies the frame (and still answers on the shared
+	// channel); capture stays disabled until the load event confirms the
+	// displayed document is the one srcdoc describes.
+	let previewLoaded = $state(false);
+	$effect(() => {
+		void srcdoc;
+		previewLoaded = false;
+	});
+
 	type PreviewMessage = {
 		type: string;
 		channel: string;
@@ -343,14 +354,18 @@
 	// ----- screenshot to chat -----
 	// Only the live iframe preview can be captured: a non-null srcdoc already
 	// implies a complete, previewable, non-markdown version on the preview tab.
-	let screenshotSupported = $derived(canScreenshot && effectiveTab === "preview" && !!srcdoc);
+	let screenshotSupported = $derived(
+		canScreenshot && effectiveTab === "preview" && !!srcdoc && previewLoaded
+	);
 	let capturing = $state(false);
 	let pendingScreenshot = $state<{ dataUrl: string; fileName: string } | null>(null);
 
 	async function screenshotPreview() {
 		// pendingScreenshot guard: a capture resolving while the annotation modal
-		// is already open would silently swap the image under the user
-		if (!iframeEl || capturing || pendingScreenshot || !artifact) return;
+		// is already open would silently swap the image under the user.
+		// previewLoaded guard: before the iframe committed the current srcdoc,
+		// the previous document would answer the request under the new name.
+		if (!iframeEl || capturing || pendingScreenshot || !previewLoaded || !artifact) return;
 		capturing = true;
 		// Freeze the name now: a new version can stream in (or the user can
 		// navigate) while the annotation modal is open
@@ -617,6 +632,7 @@
 					class="h-full w-full bg-white dark:bg-gray-900 {resizing ? 'pointer-events-none' : ''}"
 					sandbox="allow-scripts allow-forms"
 					referrerpolicy="no-referrer"
+					onload={() => (previewLoaded = true)}
 					{srcdoc}
 				></iframe>
 			{/if}

--- a/src/lib/components/chat/ArtifactPanel.svelte
+++ b/src/lib/components/chat/ArtifactPanel.svelte
@@ -341,12 +341,20 @@
 		// navigate) while the annotation modal is open
 		const slug = artifact.identifier.replace(/[^a-zA-Z0-9_-]+/g, "-") || "artifact";
 		const fileName = `${slug}-v${displayVersionNumber}-screenshot.png`;
+		const requestedSrcdoc = srcdoc;
 		try {
 			// Transparent documents composite over the iframe's own backing, so
 			// passing its computed background keeps the shot true to what the
 			// user sees in light and dark mode
 			const backing = getComputedStyle(iframeEl).backgroundColor;
 			const dataUrl = await captureArtifactScreenshot(iframeEl, previewChannel, backing);
+			// The channel survives srcdoc swaps, so a version switch (streaming
+			// edit, version nav) mid-capture would answer from the replacement
+			// document; a shot of a different document must not be attached
+			// under the frozen file name
+			if (srcdoc !== requestedSrcdoc) {
+				throw new Error("the preview changed during capture");
+			}
 			pendingScreenshot = { dataUrl, fileName };
 		} catch (err) {
 			errorStore.set(

--- a/src/lib/components/chat/ArtifactPanel.svelte
+++ b/src/lib/components/chat/ArtifactPanel.svelte
@@ -6,11 +6,14 @@
 	import { artifactFileName, isPreviewableKind } from "$lib/utils/artifacts";
 	import { diffLines, diffStats, renderDiffHtml } from "$lib/utils/artifactDiff";
 	import { buildArtifactSrcdoc, isDeployableKind } from "$lib/utils/previewSrcdoc";
+	import { captureArtifactScreenshot, pngDataUrlToFile } from "$lib/utils/artifactCapture";
 	import { parseExternalUrl } from "$lib/utils/externalLink";
 	import { escapeHTML } from "$lib/utils/markedLight";
 	import { artifactPanel, ARTIFACT_PANEL_DEFAULT_FRACTION } from "$lib/stores/artifactPanel.svelte";
 	import { StickToBottomController } from "$lib/utils/scroll/stickToBottom";
 	import { pendingChatInput } from "$lib/stores/pendingChatInput";
+	import { pendingChatFiles } from "$lib/stores/pendingChatFiles";
+	import { error as errorStore } from "$lib/stores/errors";
 	import { usePublicConfig } from "$lib/utils/PublicConfig.svelte";
 	import { page } from "$app/state";
 
@@ -19,10 +22,12 @@
 	import ExternalLinkModal from "../ExternalLinkModal.svelte";
 	import HtmlPreviewModal from "../HtmlPreviewModal.svelte";
 	import DeployToSpaceModal from "./DeployToSpaceModal.svelte";
+	import ScreenshotAnnotationModal from "./ScreenshotAnnotationModal.svelte";
 
 	import CarbonCloseLarge from "~icons/carbon/close-large";
 	import CarbonChevronLeft from "~icons/carbon/chevron-left";
 	import CarbonChevronRight from "~icons/carbon/chevron-right";
+	import CarbonCamera from "~icons/carbon/camera";
 	import CarbonDownload from "~icons/carbon/download";
 	import CarbonRocket from "~icons/carbon/rocket";
 	import CarbonMaximize from "~icons/carbon/maximize";
@@ -33,9 +38,11 @@
 	interface Props {
 		registry: ArtifactRegistry;
 		loading?: boolean;
+		/** Whether the current model accepts image attachments (enables screenshot-to-chat) */
+		canScreenshot?: boolean;
 	}
 
-	let { registry, loading = false }: Props = $props();
+	let { registry, loading = false, canScreenshot = false }: Props = $props();
 
 	let artifact = $derived(
 		artifactPanel.identifier ? registry.artifacts.get(artifactPanel.identifier) : undefined
@@ -316,6 +323,47 @@
 				? `it's not working: ${summary} (+${errors.length - 1} more) - can you fix it?`
 				: `it's not working: ${summary} - can you fix it?`
 		);
+	}
+
+	// ----- screenshot to chat -----
+	// Only the live iframe preview can be captured: a non-null srcdoc already
+	// implies a complete, previewable, non-markdown version on the preview tab.
+	let screenshotSupported = $derived(canScreenshot && effectiveTab === "preview" && !!srcdoc);
+	let capturing = $state(false);
+	let pendingScreenshot = $state<{ dataUrl: string; fileName: string } | null>(null);
+
+	async function screenshotPreview() {
+		// pendingScreenshot guard: a capture resolving while the annotation modal
+		// is already open would silently swap the image under the user
+		if (!iframeEl || capturing || pendingScreenshot || !artifact) return;
+		capturing = true;
+		// Freeze the name now: a new version can stream in (or the user can
+		// navigate) while the annotation modal is open
+		const slug = artifact.identifier.replace(/[^a-zA-Z0-9_-]+/g, "-") || "artifact";
+		const fileName = `${slug}-v${displayVersionNumber}-screenshot.png`;
+		try {
+			// Transparent documents composite over the iframe's own backing, so
+			// passing its computed background keeps the shot true to what the
+			// user sees in light and dark mode
+			const backing = getComputedStyle(iframeEl).backgroundColor;
+			const dataUrl = await captureArtifactScreenshot(iframeEl, previewChannel, backing);
+			pendingScreenshot = { dataUrl, fileName };
+		} catch (err) {
+			errorStore.set(
+				`Screenshot failed: ${err instanceof Error ? err.message : "unexpected error"}`
+			);
+		} finally {
+			capturing = false;
+		}
+	}
+
+	function attachScreenshot(annotatedDataUrl: string) {
+		const shot = pendingScreenshot;
+		if (!shot) return;
+		pendingChatFiles.set([pngDataUrlToFile(annotatedDataUrl, shot.fileName)]);
+		pendingScreenshot = null;
+		// On mobile the panel overlays the chat; close it so the attachment is visible
+		if (!isDesktop) artifactPanel.close();
 	}
 
 	// ----- actions -----
@@ -667,6 +715,25 @@
 					<span class="ml-0.5 text-red-600 dark:text-red-500">−{stats.removed}</span>
 				</button>
 			{/if}
+			{#if !isStreamingVersion && screenshotSupported}
+				<!-- Rightmost footer action, labeled with a plain word: the header
+				     camera icon alone wasn't discoverable enough for the
+				     screenshot-and-annotate feedback loop -->
+				<button
+					type="button"
+					class="btn flex-none gap-1.5 rounded-md border border-gray-200/80 bg-white/90 px-2 py-0.5 font-medium text-gray-600 hover:bg-gray-100 hover:text-gray-700 disabled:cursor-not-allowed disabled:opacity-60 dark:border-gray-700/80 dark:bg-gray-900/90 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+					title="Screenshot the preview, annotate it, and attach it to the chat"
+					disabled={capturing}
+					onclick={screenshotPreview}
+				>
+					{#if capturing}
+						<EosIconsLoading class="text-xs" />
+					{:else}
+						<CarbonCamera class="text-xs" />
+					{/if}
+					Annotate
+				</button>
+			{/if}
 		</div>
 	</footer>
 {/snippet}
@@ -717,6 +784,14 @@
 
 {#if externalLinkUrl}
 	<ExternalLinkModal url={externalLinkUrl} onclose={() => (externalLinkUrl = null)} />
+{/if}
+
+{#if pendingScreenshot}
+	<ScreenshotAnnotationModal
+		dataUrl={pendingScreenshot.dataUrl}
+		onconfirm={attachScreenshot}
+		onclose={() => (pendingScreenshot = null)}
+	/>
 {/if}
 
 {#if deployModalOpen && version && artifact && conversationId}

--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -49,6 +49,8 @@
 	import { getActiveAnnouncement } from "$lib/utils/featureAnnouncements";
 	import { usePublicConfig } from "$lib/utils/PublicConfig.svelte";
 	import { pendingChatInput } from "$lib/stores/pendingChatInput";
+	import { pendingChatFiles } from "$lib/stores/pendingChatFiles";
+	import { mimeMatchesAllowlist } from "$lib/utils/mimeMatch";
 	import LucideHammer from "~icons/lucide/hammer";
 	import LucideSparkles from "~icons/lucide/sparkles";
 
@@ -197,15 +199,9 @@
 			e.preventDefault();
 
 			// filter based on activeMimeTypes, including wildcards
-			const filteredFiles = pastedFiles.filter((file) => {
-				return activeMimeTypes.some((mimeType: string) => {
-					const [type, subtype] = mimeType.split("/");
-					const [fileType, fileSubtype] = file.type.split("/");
-					return (
-						(type === "*" || fileType === type) && (subtype === "*" || fileSubtype === subtype)
-					);
-				});
-			});
+			const filteredFiles = pastedFiles.filter((file) =>
+				mimeMatchesAllowlist(file.type, activeMimeTypes)
+			);
 
 			files = [...files, ...filteredFiles];
 		}
@@ -450,6 +446,18 @@
 			draft = $pendingChatInput;
 			pendingChatInput.set(undefined);
 		}
+	});
+
+	// Files queued from outside the composer (e.g. artifact screenshots); same
+	// consume-and-clear contract as pendingChatInput, same accept rules as paste
+	$effect(() => {
+		const pending = $pendingChatFiles;
+		if (!pending?.length || shared) return;
+		const accepted = pending.filter((file) => mimeMatchesAllowlist(file.type, activeMimeTypes));
+		if (accepted.length) {
+			files = [...untrack(() => files), ...accepted];
+		}
+		pendingChatFiles.set(undefined);
 	});
 
 	function triggerPrompt(prompt: string) {
@@ -986,7 +994,11 @@
 		</div>
 	</div>
 
-	<ArtifactPanel registry={artifactRegistry} {loading} />
+	<ArtifactPanel
+		registry={artifactRegistry}
+		{loading}
+		canScreenshot={!shared && !isReadOnly && mimeMatchesAllowlist("image/png", activeMimeTypes)}
+	/>
 </div>
 
 <style>

--- a/src/lib/components/chat/FileDropzone.svelte
+++ b/src/lib/components/chat/FileDropzone.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { requireAuthUser } from "$lib/utils/auth";
+	import { mimeMatchesAllowlist } from "$lib/utils/mimeMatch";
 	import CarbonImage from "~icons/carbon/image";
 
 	interface Props {
@@ -31,16 +32,7 @@
 					if (file) {
 						// check if the file matches the mimeTypes
 						// else abort
-						if (
-							!mimeTypes.some((mimeType: string) => {
-								const [type, subtype] = mimeType.split("/");
-								const [fileType, fileSubtype] = file.type.split("/");
-								return (
-									(type === "*" || type === fileType) &&
-									(subtype === "*" || subtype === fileSubtype)
-								);
-							})
-						) {
+						if (!mimeMatchesAllowlist(file.type, mimeTypes)) {
 							setErrorMsg(
 								`Some file type not supported. Only allowed: ${mimeTypes.join(
 									", "

--- a/src/lib/components/chat/ScreenshotAnnotationModal.svelte
+++ b/src/lib/components/chat/ScreenshotAnnotationModal.svelte
@@ -1,0 +1,336 @@
+<script lang="ts">
+	import Modal from "../Modal.svelte";
+
+	import LucideMoveUpRight from "~icons/lucide/move-up-right";
+	import LucidePencil from "~icons/lucide/pencil";
+	import LucideSquare from "~icons/lucide/square";
+	import LucideUndo2 from "~icons/lucide/undo-2";
+	import LucideTrash2 from "~icons/lucide/trash-2";
+	import EosIconsLoading from "~icons/eos-icons/loading";
+
+	type Tool = "arrow" | "pen" | "rect";
+	interface Point {
+		x: number;
+		y: number;
+	}
+	/** One drawn shape, in image-space coordinates (canvas pixels, not CSS pixels) */
+	interface Annotation {
+		tool: Tool;
+		color: string;
+		points: Point[];
+	}
+
+	interface Props {
+		/** PNG data URL of the captured screenshot */
+		dataUrl: string;
+		/** Called with the final (annotated) PNG data URL */
+		onconfirm: (dataUrl: string) => void;
+		onclose: () => void;
+	}
+
+	let { dataUrl, onconfirm, onclose }: Props = $props();
+
+	const COLORS = ["#ef4444", "#f59e0b", "#3b82f6", "#22c55e"];
+	const TOOLS: { id: Tool; label: string; icon: typeof LucidePencil }[] = [
+		{ id: "arrow", label: "Arrow", icon: LucideMoveUpRight },
+		{ id: "pen", label: "Pen", icon: LucidePencil },
+		{ id: "rect", label: "Rectangle", icon: LucideSquare },
+	];
+
+	let tool = $state<Tool>("arrow");
+	let color = $state(COLORS[0]);
+	let annotations = $state<Annotation[]>([]);
+	let current = $state<Annotation | null>(null);
+
+	let canvasEl: HTMLCanvasElement | undefined = $state();
+	let image = $state<HTMLImageElement | null>(null);
+	let loadFailed = $state(false);
+
+	$effect(() => {
+		const img = new Image();
+		let cancelled = false;
+		img.onload = () => {
+			if (!cancelled) image = img;
+		};
+		img.onerror = () => {
+			if (!cancelled) loadFailed = true;
+		};
+		img.src = dataUrl;
+		return () => {
+			// A new dataUrl replaces the whole session: drawings made on the old
+			// image must not carry over to the new one
+			cancelled = true;
+			annotations = [];
+			current = null;
+			loadFailed = false;
+		};
+	});
+
+	// Stroke width scales with the capture so annotations stay legible whether
+	// the shot is a 400px widget or a 4096px page
+	let strokeWidth = $derived(
+		image ? Math.max(3, Math.round(Math.max(image.naturalWidth, image.naturalHeight) / 350)) : 3
+	);
+
+	function drawAnnotation(ctx: CanvasRenderingContext2D, annotation: Annotation) {
+		const pts = annotation.points;
+		if (pts.length === 0) return;
+		ctx.strokeStyle = annotation.color;
+		ctx.fillStyle = annotation.color;
+		ctx.lineWidth = strokeWidth;
+		ctx.lineCap = "round";
+		ctx.lineJoin = "round";
+
+		if (annotation.tool === "pen") {
+			if (pts.length === 1) {
+				ctx.beginPath();
+				ctx.arc(pts[0].x, pts[0].y, strokeWidth / 2, 0, Math.PI * 2);
+				ctx.fill();
+				return;
+			}
+			// Midpoint smoothing so fast strokes don't look like polylines
+			ctx.beginPath();
+			ctx.moveTo(pts[0].x, pts[0].y);
+			for (let i = 1; i < pts.length - 1; i++) {
+				const midX = (pts[i].x + pts[i + 1].x) / 2;
+				const midY = (pts[i].y + pts[i + 1].y) / 2;
+				ctx.quadraticCurveTo(pts[i].x, pts[i].y, midX, midY);
+			}
+			ctx.lineTo(pts[pts.length - 1].x, pts[pts.length - 1].y);
+			ctx.stroke();
+			return;
+		}
+
+		const start = pts[0];
+		const end = pts[pts.length - 1];
+		if (annotation.tool === "rect") {
+			ctx.strokeRect(
+				Math.min(start.x, end.x),
+				Math.min(start.y, end.y),
+				Math.abs(end.x - start.x),
+				Math.abs(end.y - start.y)
+			);
+			return;
+		}
+
+		// Arrow: shaft stops short of the tip so it doesn't poke through the head
+		const angle = Math.atan2(end.y - start.y, end.x - start.x);
+		const head = strokeWidth * 3.5;
+		ctx.beginPath();
+		ctx.moveTo(start.x, start.y);
+		ctx.lineTo(end.x - Math.cos(angle) * head * 0.6, end.y - Math.sin(angle) * head * 0.6);
+		ctx.stroke();
+		ctx.beginPath();
+		ctx.moveTo(end.x, end.y);
+		ctx.lineTo(
+			end.x - head * Math.cos(angle - Math.PI / 6),
+			end.y - head * Math.sin(angle - Math.PI / 6)
+		);
+		ctx.lineTo(
+			end.x - head * Math.cos(angle + Math.PI / 6),
+			end.y - head * Math.sin(angle + Math.PI / 6)
+		);
+		ctx.closePath();
+		ctx.fill();
+	}
+
+	// Full redraw on every change: the canvas holds the composited image at
+	// natural resolution, so confirm() is just toDataURL on it
+	$effect(() => {
+		const canvas = canvasEl;
+		const img = image;
+		if (!canvas || !img) return;
+		void annotations;
+		void current;
+		const ctx = canvas.getContext("2d");
+		if (!ctx) return;
+		ctx.clearRect(0, 0, canvas.width, canvas.height);
+		ctx.drawImage(img, 0, 0);
+		for (const annotation of annotations) drawAnnotation(ctx, annotation);
+		if (current) drawAnnotation(ctx, current);
+	});
+
+	function toImagePoint(e: PointerEvent): Point | null {
+		const canvas = canvasEl;
+		if (!canvas) return null;
+		const rect = canvas.getBoundingClientRect();
+		if (rect.width === 0 || rect.height === 0) return null;
+		return {
+			x: Math.min(Math.max(((e.clientX - rect.left) / rect.width) * canvas.width, 0), canvas.width),
+			y: Math.min(
+				Math.max(((e.clientY - rect.top) / rect.height) * canvas.height, 0),
+				canvas.height
+			),
+		};
+	}
+
+	function onPointerDown(e: PointerEvent) {
+		if (!image || e.button !== 0) return;
+		const point = toImagePoint(e);
+		if (!point) return;
+		(e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+		current = { tool, color, points: [point] };
+	}
+
+	function onPointerMove(e: PointerEvent) {
+		if (!current) return;
+		const point = toImagePoint(e);
+		if (!point) return;
+		current =
+			current.tool === "pen"
+				? { ...current, points: [...current.points, point] }
+				: { ...current, points: [current.points[0], point] };
+	}
+
+	function onPointerUp() {
+		if (!current) return;
+		const pts = current.points;
+		const moved =
+			pts.length > 1 &&
+			Math.hypot(pts[pts.length - 1].x - pts[0].x, pts[pts.length - 1].y - pts[0].y) >= strokeWidth;
+		// A pen tap leaves a visible dot; a zero-size arrow or rectangle would
+		// just be clutter, so clicks without a drag are discarded for those
+		if (current.tool === "pen" || moved) {
+			annotations = [...annotations, current];
+		}
+		current = null;
+	}
+
+	function onPointerCancel() {
+		current = null;
+	}
+
+	function undo() {
+		annotations = annotations.slice(0, -1);
+	}
+
+	function clearAll() {
+		annotations = [];
+		current = null;
+	}
+
+	function onKeydown(e: KeyboardEvent) {
+		if ((e.metaKey || e.ctrlKey) && !e.shiftKey && e.key.toLowerCase() === "z") {
+			e.preventDefault();
+			undo();
+		}
+	}
+
+	function confirm() {
+		if (!canvasEl || !image) return;
+		onconfirm(canvasEl.toDataURL("image/png"));
+	}
+
+	const toolBtnBase =
+		"btn rounded-md px-2 py-1.5 text-xs transition-colors disabled:cursor-not-allowed disabled:opacity-40";
+	const toolBtnActive = "bg-white text-gray-800 shadow-xs dark:bg-gray-600 dark:text-gray-100";
+	const toolBtnInactive =
+		"text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200";
+</script>
+
+<svelte:window onkeydown={onKeydown} />
+
+<!-- Width override needs the important marker: Modal's own max-w-[90dvw] targets
+     the same property and stylesheet order between two utilities isn't guaranteed.
+     min() keeps the desktop cap at 64rem while mobile stretches nearly edge to
+     edge so the screenshot gets the room. -->
+<Modal width="max-w-[min(64rem,calc(100dvw-0.75rem))]!" closeOnBackdrop={false} {onclose}>
+	<div class="flex flex-col gap-2.5 p-2.5 sm:gap-3 sm:p-4">
+		<div class="flex flex-wrap items-center gap-x-1.5 gap-y-2 sm:gap-2">
+			<h2 class="mr-auto text-sm font-semibold text-gray-800 dark:text-gray-200">
+				Annotate screenshot
+			</h2>
+
+			<div class="flex items-center rounded-lg bg-gray-100 p-0.5 dark:bg-gray-800">
+				{#each TOOLS as toolOption (toolOption.id)}
+					<button
+						type="button"
+						class="{toolBtnBase} {tool === toolOption.id ? toolBtnActive : toolBtnInactive}"
+						title={toolOption.label}
+						aria-pressed={tool === toolOption.id}
+						onclick={() => (tool = toolOption.id)}
+					>
+						<toolOption.icon />
+					</button>
+				{/each}
+			</div>
+
+			<div class="flex items-center gap-1.5 px-1">
+				{#each COLORS as colorOption (colorOption)}
+					<button
+						type="button"
+						class="size-4.5 rounded-full transition-transform hover:scale-110 {color === colorOption
+							? 'ring-2 ring-gray-500 ring-offset-2 dark:ring-gray-300 dark:ring-offset-gray-800'
+							: ''}"
+						style="background-color: {colorOption}"
+						title="Draw in this color"
+						aria-pressed={color === colorOption}
+						onclick={() => (color = colorOption)}
+					></button>
+				{/each}
+			</div>
+
+			<div class="flex items-center gap-0.5 text-gray-500 dark:text-gray-400">
+				<button
+					type="button"
+					class="btn rounded-md p-1.5 text-xs hover:bg-gray-100 hover:text-gray-600 disabled:cursor-not-allowed disabled:opacity-40 dark:hover:bg-gray-800 dark:hover:text-gray-300"
+					title="Undo (Ctrl+Z)"
+					disabled={annotations.length === 0}
+					onclick={undo}
+				>
+					<LucideUndo2 />
+				</button>
+				<button
+					type="button"
+					class="btn rounded-md p-1.5 text-xs hover:bg-gray-100 hover:text-gray-600 disabled:cursor-not-allowed disabled:opacity-40 dark:hover:bg-gray-800 dark:hover:text-gray-300"
+					title="Clear all annotations"
+					disabled={annotations.length === 0}
+					onclick={clearAll}
+				>
+					<LucideTrash2 />
+				</button>
+			</div>
+		</div>
+
+		<!-- On mobile the image bleeds to the modal edges (negative margin swallows
+		     the container padding) so every horizontal pixel goes to the screenshot -->
+		<div
+			class="flex min-h-40 items-center justify-center overflow-hidden rounded-lg border border-gray-200 bg-gray-50 max-sm:-mx-2.5 max-sm:rounded-none max-sm:border-x-0 dark:border-gray-700 dark:bg-gray-950"
+		>
+			{#if loadFailed}
+				<p class="p-8 text-sm text-gray-500">Could not load the screenshot.</p>
+			{:else if !image}
+				<EosIconsLoading class="text-2xl text-gray-400" />
+			{:else}
+				<canvas
+					bind:this={canvasEl}
+					width={image.naturalWidth}
+					height={image.naturalHeight}
+					class="max-h-[75dvh] max-w-full cursor-crosshair touch-none select-none max-sm:max-h-[76dvh]"
+					onpointerdown={onPointerDown}
+					onpointermove={onPointerMove}
+					onpointerup={onPointerUp}
+					onpointercancel={onPointerCancel}
+				></canvas>
+			{/if}
+		</div>
+
+		<div class="flex items-center justify-end gap-2">
+			<button
+				type="button"
+				class="btn rounded-xl px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700"
+				onclick={() => onclose()}
+			>
+				Cancel
+			</button>
+			<button
+				type="button"
+				class="inline-flex items-center gap-1.5 rounded-xl border border-gray-900 bg-gray-900 px-3 py-1.5 text-sm font-semibold text-white hover:bg-black focus:ring-2 focus:ring-gray-400 focus:ring-offset-2 focus:outline-hidden disabled:opacity-60 dark:border-gray-100 dark:bg-gray-100 dark:text-gray-900 dark:hover:bg-white dark:focus:ring-offset-gray-800"
+				disabled={!image}
+				onclick={confirm}
+			>
+				Add to chat
+			</button>
+		</div>
+	</div>
+</Modal>

--- a/src/lib/stores/pendingChatFiles.ts
+++ b/src/lib/stores/pendingChatFiles.ts
@@ -1,0 +1,8 @@
+import { writable } from "svelte/store";
+
+/**
+ * Files queued for the chat composer from outside ChatWindow (e.g. an artifact
+ * preview screenshot). ChatWindow appends them to its attachment list and
+ * clears the store, mirroring how pendingChatInput prefills the text draft.
+ */
+export const pendingChatFiles = writable<File[] | undefined>(undefined);

--- a/src/lib/utils/artifactCapture.ts
+++ b/src/lib/utils/artifactCapture.ts
@@ -1,0 +1,147 @@
+/**
+ * Screenshot capture for artifact preview iframes.
+ *
+ * The preview iframe is sandboxed with an opaque origin, so the parent can
+ * never reach into its DOM. Capture therefore runs inside the iframe: the
+ * hook script injected by previewSrcdoc.ts listens for a capture request
+ * carrying the SnapDOM library source, injects it, renders the document to
+ * a canvas and posts back a PNG data URL. The library is bundled at build
+ * time (lazy chunk, loaded on first use) instead of fetched from a CDN
+ * inside the iframe, so capture works offline and the version stays pinned.
+ *
+ * Everything that comes back crosses a trust boundary — the iframe runs
+ * model-generated code — so results are validated here: the response must
+ * match the pending request id, be a bounded-size PNG data URL, and carry
+ * the PNG magic bytes.
+ */
+
+const CAPTURE_TIMEOUT_MS = 15_000;
+/** ~9MB decoded; the server rejects attachments over 10MB */
+const MAX_DATA_URL_LENGTH = 12_000_000;
+const PNG_DATA_URL_PREFIX = "data:image/png;base64,";
+
+let snapdomSourcePromise: Promise<string> | undefined;
+
+function loadCaptureLibrarySource(): Promise<string> {
+	// Direct file import: the package's `exports` map doesn't expose ./dist/*,
+	// and we need the text of the browser build (it assigns window.snapdom) to
+	// inject into the sandboxed iframe. `?url` emits the file as a hashed
+	// static asset fetched on first use — unlike `?raw`, which would inline it
+	// as an escaped string in a JS chunk at roughly twice the bytes.
+	snapdomSourcePromise ??= import("../../../node_modules/@zumer/snapdom/dist/snapdom.js?url")
+		.then((mod) => fetch(mod.default))
+		.then((res) => {
+			if (!res.ok) throw new Error("could not load the capture library");
+			return res.text();
+		})
+		.catch((err) => {
+			// Don't memoize a transient failure (offline blip): let a later
+			// capture attempt retry the download
+			snapdomSourcePromise = undefined;
+			throw err;
+		});
+	return snapdomSourcePromise;
+}
+
+/** True for a plausible PNG data URL: exact mime prefix plus PNG magic bytes. */
+function isPngDataUrl(value: string): boolean {
+	if (!value.startsWith(PNG_DATA_URL_PREFIX)) return false;
+	try {
+		// 12 base64 chars decode to the first 9 bytes; the PNG signature is 8
+		const head = atob(value.slice(PNG_DATA_URL_PREFIX.length, PNG_DATA_URL_PREFIX.length + 12));
+		return head.startsWith("\x89PNG\r\n\x1a\n");
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Ask the preview iframe to render itself to a PNG. Resolves with a validated
+ * PNG data URL, rejects on error, oversize result, or timeout.
+ *
+ * @param backgroundColor fill for documents with a transparent background, so
+ * the shot matches the panel backing the user actually sees (light vs dark).
+ */
+export function captureArtifactScreenshot(
+	iframe: HTMLIFrameElement,
+	channel: string,
+	backgroundColor: string,
+	{ timeoutMs = CAPTURE_TIMEOUT_MS }: { timeoutMs?: number } = {}
+): Promise<string> {
+	if (!iframe.contentWindow) return Promise.reject(new Error("preview is not ready"));
+
+	return new Promise<string>((resolve, reject) => {
+		const id = `capture_${Math.random().toString(36).slice(2)}`;
+
+		const timer = setTimeout(() => {
+			cleanup();
+			reject(new Error("timed out waiting for the preview"));
+		}, timeoutMs);
+		function cleanup() {
+			clearTimeout(timer);
+			window.removeEventListener("message", onMessage);
+		}
+
+		function onMessage(ev: MessageEvent) {
+			// Same source/channel gating as the panel's own preview listener
+			if (ev.source !== iframe.contentWindow) return;
+			const raw = ev.data as unknown;
+			if (!raw || typeof raw !== "object") return;
+			const data = raw as {
+				type?: unknown;
+				channel?: unknown;
+				detail?: { id?: unknown; dataUrl?: unknown; error?: unknown };
+			};
+			if (data.channel !== channel || data.type !== "chatui.preview.captureResult") return;
+			if (data.detail?.id !== id) return;
+			cleanup();
+
+			const dataUrl = data.detail.dataUrl;
+			if (typeof dataUrl !== "string") {
+				const error = data.detail.error;
+				reject(new Error(typeof error === "string" && error ? error : "capture failed"));
+				return;
+			}
+			if (dataUrl.length > MAX_DATA_URL_LENGTH) {
+				reject(new Error("screenshot is too large to attach"));
+				return;
+			}
+			if (!isPngDataUrl(dataUrl)) {
+				reject(new Error("capture returned an invalid image"));
+				return;
+			}
+			resolve(dataUrl);
+		}
+
+		window.addEventListener("message", onMessage);
+		loadCaptureLibrarySource().then(
+			(source) => {
+				// Re-read contentWindow: the iframe may have reloaded (srcdoc swap)
+				// while the library chunk was loading
+				iframe.contentWindow?.postMessage(
+					{
+						type: "chatui.preview.captureRequest",
+						channel,
+						detail: { id, source, backgroundColor },
+					},
+					"*"
+				);
+			},
+			(err) => {
+				cleanup();
+				reject(err instanceof Error ? err : new Error("could not load the capture library"));
+			}
+		);
+	});
+}
+
+/** Decode a PNG data URL (already validated by the capture path) into a File. */
+export function pngDataUrlToFile(dataUrl: string, fileName: string): File {
+	const base64 = dataUrl.slice(dataUrl.indexOf(",") + 1);
+	const binary = atob(base64);
+	const bytes = new Uint8Array(binary.length);
+	for (let i = 0; i < binary.length; i++) {
+		bytes[i] = binary.charCodeAt(i);
+	}
+	return new File([bytes], fileName, { type: "image/png" });
+}

--- a/src/lib/utils/artifactCapture.ts
+++ b/src/lib/utils/artifactCapture.ts
@@ -72,12 +72,14 @@ export function captureArtifactScreenshot(
 
 	return new Promise<string>((resolve, reject) => {
 		const id = `capture_${Math.random().toString(36).slice(2)}`;
+		let settled = false;
 
 		const timer = setTimeout(() => {
 			cleanup();
 			reject(new Error("timed out waiting for the preview"));
 		}, timeoutMs);
 		function cleanup() {
+			settled = true;
 			clearTimeout(timer);
 			window.removeEventListener("message", onMessage);
 		}
@@ -116,6 +118,11 @@ export function captureArtifactScreenshot(
 		window.addEventListener("message", onMessage);
 		loadCaptureLibrarySource().then(
 			(source) => {
+				// The source fetch can outlive the timeout (first use on a slow
+				// connection): a request posted after rejection would trigger an
+				// expensive render whose response nobody listens for, and stacked
+				// retries would fire several at once
+				if (settled) return;
 				// Re-read contentWindow: the iframe may have reloaded (srcdoc swap)
 				// while the library chunk was loading
 				iframe.contentWindow?.postMessage(
@@ -128,6 +135,7 @@ export function captureArtifactScreenshot(
 				);
 			},
 			(err) => {
+				if (settled) return;
 				cleanup();
 				reject(err instanceof Error ? err : new Error("could not load the capture library"));
 			}

--- a/src/lib/utils/mimeMatch.spec.ts
+++ b/src/lib/utils/mimeMatch.spec.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { mimeMatchesAllowlist } from "./mimeMatch";
+
+describe("mimeMatchesAllowlist", () => {
+	it("matches exact types", () => {
+		expect(mimeMatchesAllowlist("image/png", ["image/png"])).toBe(true);
+		expect(mimeMatchesAllowlist("image/png", ["image/jpeg", "image/png"])).toBe(true);
+	});
+
+	it("matches wildcard subtypes", () => {
+		expect(mimeMatchesAllowlist("text/plain", ["text/*"])).toBe(true);
+		expect(mimeMatchesAllowlist("text/markdown", ["text/*"])).toBe(true);
+		expect(mimeMatchesAllowlist("image/png", ["text/*"])).toBe(false);
+	});
+
+	it("matches a full wildcard", () => {
+		expect(mimeMatchesAllowlist("application/pdf", ["*/*"])).toBe(true);
+	});
+
+	it("rejects types not in the allowlist", () => {
+		expect(mimeMatchesAllowlist("image/png", ["text/*", "application/json"])).toBe(false);
+		expect(mimeMatchesAllowlist("image/svg+xml", ["image/png", "image/jpeg"])).toBe(false);
+	});
+
+	it("rejects everything on an empty allowlist", () => {
+		expect(mimeMatchesAllowlist("image/png", [])).toBe(false);
+	});
+});

--- a/src/lib/utils/mimeMatch.ts
+++ b/src/lib/utils/mimeMatch.ts
@@ -1,0 +1,16 @@
+/**
+ * Match a concrete MIME type against an allowlist that may contain wildcards
+ * ("image/*" for any subtype, or a wildcard type). Shared by every entry point
+ * that accepts user files (paste, drop, programmatic attachments) so they all
+ * agree on what is allowed.
+ */
+export function mimeMatchesAllowlist(mime: string, allowlist: readonly string[]): boolean {
+	const [type, subtype] = mime.split("/");
+	return allowlist.some((allowed) => {
+		const [allowedType, allowedSubtype] = allowed.split("/");
+		return (
+			(allowedType === "*" || allowedType === type) &&
+			(allowedSubtype === "*" || allowedSubtype === subtype)
+		);
+	});
+}

--- a/src/lib/utils/previewSrcdoc.svelte.test.ts
+++ b/src/lib/utils/previewSrcdoc.svelte.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { buildHtmlSrcdoc } from "$lib/utils/previewSrcdoc";
+import { captureArtifactScreenshot } from "$lib/utils/artifactCapture";
 
 type PreviewMessage = {
 	type: string;
@@ -103,5 +104,130 @@ describe("preview hook script", () => {
 		const received = await message;
 		expect(received.type).toBe("chatui.preview.error");
 		expect(received.detail?.message).toContain("boom");
+	});
+});
+
+/** Decode a PNG data URL and read one pixel */
+async function decodePixel(dataUrl: string, x: number, y: number): Promise<Uint8ClampedArray> {
+	const img = new Image();
+	img.src = dataUrl;
+	await img.decode();
+	const canvas = document.createElement("canvas");
+	canvas.width = img.naturalWidth;
+	canvas.height = img.naturalHeight;
+	const ctx = canvas.getContext("2d");
+	if (!ctx) throw new Error("no 2d canvas context");
+	ctx.drawImage(img, 0, 0);
+	return ctx.getImageData(x, y, 1, 1).data;
+}
+
+describe("preview screenshot capture", () => {
+	// Full round trip through the real machinery: the request (carrying the
+	// capture library) crosses into the sandboxed iframe, the document renders
+	// itself, and the parent validates the PNG that comes back.
+	it(
+		"captures the preview document to a PNG whose pixels match the content",
+		{ timeout: 20_000 },
+		async () => {
+			const channel = "test_capture";
+			const iframe = renderPreview(
+				`<div style="width:120px;height:120px;background:#ff0000"></div>`,
+				channel
+			);
+			await new Promise<void>((resolve) =>
+				iframe.addEventListener("load", () => resolve(), { once: true })
+			);
+
+			const dataUrl = await captureArtifactScreenshot(iframe, channel, "#ffffff");
+			expect(dataUrl.startsWith("data:image/png;base64,")).toBe(true);
+
+			// The red square sits at the body margin origin (8,8); probe inside it,
+			// and outside it where the white background fill should show
+			const inside = await decodePixel(dataUrl, 30, 30);
+			expect(inside[3]).toBe(255);
+			expect(inside[0]).toBeGreaterThan(200);
+			expect(inside[1]).toBeLessThan(60);
+			expect(inside[2]).toBeLessThan(60);
+
+			const outside = await decodePixel(dataUrl, 200, 30);
+			expect(outside[0]).toBeGreaterThan(200);
+			expect(outside[1]).toBeGreaterThan(200);
+			expect(outside[2]).toBeGreaterThan(200);
+		}
+	);
+
+	// Regression: SnapDOM renders the <html> element as background-only for
+	// full-viewport layouts (flex-centered body with min-height:100vh), which
+	// is the shape most generated apps take — the hook must capture the body.
+	it(
+		"captures full-viewport flex layouts, not just the background",
+		{ timeout: 20_000 },
+		async () => {
+			const channel = "test_capture_flex";
+			const iframe = renderPreview(
+				`<style>
+				* { margin: 0; }
+				body {
+					display: flex; align-items: center; justify-content: center;
+					min-height: 100vh;
+					background: linear-gradient(135deg, #1a0b2e 0%, #2d1b4e 100%);
+				}
+			</style>
+			<div style="width:40px;height:40px;background:#c084fc"></div>`,
+				channel
+			);
+			await new Promise<void>((resolve) =>
+				iframe.addEventListener("load", () => resolve(), { once: true })
+			);
+			const dataUrl = await captureArtifactScreenshot(iframe, channel, "#0a0a0a");
+			const corner = await decodePixel(dataUrl, 10, 10);
+			// Gradient start #1a0b2e — not the #0a0a0a backing fill, not transparent
+			expect(corner[3]).toBe(255);
+			expect(corner[2]).toBeGreaterThan(30);
+			expect(corner[2]).toBeLessThan(90);
+		}
+	);
+
+	// Regression: a decorative layer wider than the viewport (200% wave strips,
+	// off-screen parallax elements) must not widen the shot — the capture keeps
+	// the visible width instead of the horizontal scroll extent, so the image
+	// doesn't come back with a dead band of background fill on the right.
+	it("clips horizontal overflow to the visible width", { timeout: 20_000 }, async () => {
+		const channel = "test_capture_overflow";
+		const iframe = renderPreview(
+			`<style>
+				* { margin: 0; }
+				body { min-height: 100vh; background: #1a0b2e; }
+			</style>
+			<div style="width:200%;height:40px;background:#c084fc"></div>`,
+			channel
+		);
+		await new Promise<void>((resolve) =>
+			iframe.addEventListener("load", () => resolve(), { once: true })
+		);
+		const dataUrl = await captureArtifactScreenshot(iframe, channel, "#0a0a0a");
+		const img = new Image();
+		img.src = dataUrl;
+		await img.decode();
+		// Default test iframe is 300 CSS px wide; the 200% child must not double it
+		expect(img.naturalWidth).toBeLessThanOrEqual(300);
+		// The purple page background still reaches the right edge of the shot
+		const rightEdge = await decodePixel(dataUrl, img.naturalWidth - 5, img.naturalHeight - 5);
+		expect(rightEdge[2]).toBeGreaterThan(30);
+	});
+
+	it("rejects when the preview never answers", async () => {
+		const iframe = document.createElement("iframe");
+		iframe.sandbox.add("allow-scripts");
+		// A document without the hook script: the request goes nowhere
+		iframe.srcdoc = "<!doctype html><html><body></body></html>";
+		document.body.appendChild(iframe);
+		iframes.push(iframe);
+		await new Promise<void>((resolve) =>
+			iframe.addEventListener("load", () => resolve(), { once: true })
+		);
+		await expect(
+			captureArtifactScreenshot(iframe, "test_capture_missing", "#ffffff", { timeoutMs: 500 })
+		).rejects.toThrow(/timed out/);
 	});
 });

--- a/src/lib/utils/previewSrcdoc.svelte.test.ts
+++ b/src/lib/utils/previewSrcdoc.svelte.test.ts
@@ -216,6 +216,27 @@ describe("preview screenshot capture", () => {
 		expect(rightEdge[2]).toBeGreaterThan(30);
 	});
 
+	// Regression: pages that paint their background on <html> (body left
+	// transparent) must keep that background in the shot, not receive the
+	// panel backing passed by the parent.
+	it("keeps a background painted on the html element", { timeout: 20_000 }, async () => {
+		const channel = "test_capture_root_bg";
+		const iframe = renderPreview(
+			`<style>html { background: #008080; }</style>
+			<div style="width:40px;height:40px"></div>`,
+			channel
+		);
+		await new Promise<void>((resolve) =>
+			iframe.addEventListener("load", () => resolve(), { once: true })
+		);
+		const dataUrl = await captureArtifactScreenshot(iframe, channel, "#0a0a0a");
+		const corner = await decodePixel(dataUrl, 10, 10);
+		// Teal from the html rule, not the #0a0a0a backing
+		expect(corner[0]).toBeLessThan(40);
+		expect(corner[1]).toBeGreaterThan(90);
+		expect(corner[2]).toBeGreaterThan(90);
+	});
+
 	it("rejects when the preview never answers", async () => {
 		const iframe = document.createElement("iframe");
 		iframe.sandbox.add("allow-scripts");

--- a/src/lib/utils/previewSrcdoc.ts
+++ b/src/lib/utils/previewSrcdoc.ts
@@ -138,10 +138,18 @@ function buildPreviewHookScript(channel: string): string {
       var visibleWidth = root.clientWidth > 0 ? Math.min(scrollWidth, root.clientWidth) : scrollWidth;
       // Cap the long edge so a tall page can't produce a giant payload
       var scale = Math.min(1, 4096 / Math.max(visibleWidth, height));
+      // Body capture drops anything painted on <html>, so a page that styles
+      // its background there (body transparent) would get the panel backing
+      // instead of its own color: prefer the root's computed background when
+      // it has one. Gradients/images on <html> stay out of reach (a fill
+      // color is all the capture API takes), but those normally live on body.
+      var rootBackground = '';
+      try { rootBackground = getComputedStyle(document.documentElement).backgroundColor || ''; } catch (err) {}
+      if (rootBackground === 'transparent' || rootBackground === 'rgba(0, 0, 0, 0)') rootBackground = '';
       window.snapdom.toCanvas(root, {
         dpr: 1,
         scale: scale,
-        backgroundColor: typeof detail.backgroundColor === 'string' && detail.backgroundColor ? detail.backgroundColor : '#ffffff',
+        backgroundColor: rootBackground || (typeof detail.backgroundColor === 'string' && detail.backgroundColor ? detail.backgroundColor : '#ffffff'),
         embedFonts: true,
         fast: true
       }).then(function(canvas){

--- a/src/lib/utils/previewSrcdoc.ts
+++ b/src/lib/utils/previewSrcdoc.ts
@@ -16,6 +16,11 @@ import type { ArtifactKind } from "./artifacts";
  * over an attacker-chosen path. Navigating from inside the sandbox would
  * be broken anyway — the opened tab would inherit the sandbox's opaque
  * origin.
+ *
+ * The hook also answers screenshot requests from the parent (see
+ * artifactCapture.ts): the sandbox has an opaque origin the parent cannot
+ * reach into, so the parent sends the capture library's source over
+ * postMessage and the document renders itself to a PNG data URL in-process.
  */
 
 const END_SCRIPT_TAG = "</scr" + "ipt>";
@@ -25,7 +30,138 @@ function buildPreviewHookScript(channel: string): string {
 	// parent window to postMessage to, so the hook is omitted entirely and the
 	// shipped document is just the artifact itself.
 	if (!channel) return "";
-	return `\n<script>\n(function(){\n  function send(type, detail){\n    try{ parent.postMessage({ type: type, channel: '${channel}', detail: detail }, '*'); }catch(e){}\n  }\n  function nearestAnchor(node){\n    while (node && node !== document) {\n      if (node.tagName && node.tagName.toLowerCase() === 'a') return node;\n      node = node.parentNode;\n    }\n    return null;\n  }\n  function anchorHref(anchor){\n    var href = anchor.href;\n    if (typeof href === 'string') return href;\n    if (href && typeof href.baseVal === 'string') {\n      try { return new URL(href.baseVal, document.baseURI).href; } catch (err) { return ''; }\n    }\n    return '';\n  }\n  function scrollToFragment(raw){\n    var id = raw.slice(1);\n    try { id = decodeURIComponent(id); } catch (err) {}\n    var target = id ? document.getElementById(id) : null;\n    if (target && target.scrollIntoView) target.scrollIntoView();\n  }\n  function intercept(ev){\n    var anchor = nearestAnchor(ev.target);\n    if (!anchor) return;\n    ev.preventDefault();\n    ev.stopPropagation();\n    var raw = anchor.getAttribute('href') || anchor.getAttribute('xlink:href') || '';\n    if (raw.charAt(0) === '#') {\n      scrollToFragment(raw);\n      return;\n    }\n    if (!/^\\s*https?:/i.test(raw)) return;\n    var href = anchorHref(anchor);\n    if (/^https?:/i.test(href)) {\n      send('chatui.preview.openLink', { href: href });\n    }\n  }\n  window.addEventListener('click', intercept, true);\n  window.addEventListener('auxclick', intercept, true);\n  window.addEventListener('keydown', function(ev){\n    if (ev.key === 'Enter' || ev.key === ' ') {\n      intercept(ev);\n    }\n  }, true);\n  window.addEventListener('error', function(ev){\n    var msg = ev && ev.message ? ev.message : 'Script error';\n    var stack = ev && ev.error && ev.error.stack ? ev.error.stack : undefined;\n    send('chatui.preview.error', { message: msg, stack: stack });\n  });\n  window.addEventListener('unhandledrejection', function(ev){\n    var r = ev && ev.reason;\n    var msg = (typeof r === 'string') ? r : (r && r.message) ? r.message : 'Unhandled promise rejection';\n    var stack = r && r.stack ? r.stack : undefined;\n    send('chatui.preview.error', { message: msg, stack: stack });\n  });\n})();\n${END_SCRIPT_TAG}`;
+	return `\n<script>
+(function(){
+  function send(type, detail){
+    try{ parent.postMessage({ type: type, channel: '${channel}', detail: detail }, '*'); }catch(e){}
+  }
+  function nearestAnchor(node){
+    while (node && node !== document) {
+      if (node.tagName && node.tagName.toLowerCase() === 'a') return node;
+      node = node.parentNode;
+    }
+    return null;
+  }
+  function anchorHref(anchor){
+    var href = anchor.href;
+    if (typeof href === 'string') return href;
+    if (href && typeof href.baseVal === 'string') {
+      try { return new URL(href.baseVal, document.baseURI).href; } catch (err) { return ''; }
+    }
+    return '';
+  }
+  function scrollToFragment(raw){
+    var id = raw.slice(1);
+    try { id = decodeURIComponent(id); } catch (err) {}
+    var target = id ? document.getElementById(id) : null;
+    if (target && target.scrollIntoView) target.scrollIntoView();
+  }
+  function intercept(ev){
+    var anchor = nearestAnchor(ev.target);
+    if (!anchor) return;
+    ev.preventDefault();
+    ev.stopPropagation();
+    var raw = anchor.getAttribute('href') || anchor.getAttribute('xlink:href') || '';
+    if (raw.charAt(0) === '#') {
+      scrollToFragment(raw);
+      return;
+    }
+    if (!/^\\s*https?:/i.test(raw)) return;
+    var href = anchorHref(anchor);
+    if (/^https?:/i.test(href)) {
+      send('chatui.preview.openLink', { href: href });
+    }
+  }
+  window.addEventListener('click', intercept, true);
+  window.addEventListener('auxclick', intercept, true);
+  window.addEventListener('keydown', function(ev){
+    if (ev.key === 'Enter' || ev.key === ' ') {
+      intercept(ev);
+    }
+  }, true);
+  window.addEventListener('error', function(ev){
+    var msg = ev && ev.message ? ev.message : 'Script error';
+    var stack = ev && ev.error && ev.error.stack ? ev.error.stack : undefined;
+    send('chatui.preview.error', { message: msg, stack: stack });
+  });
+  window.addEventListener('unhandledrejection', function(ev){
+    var r = ev && ev.reason;
+    var msg = (typeof r === 'string') ? r : (r && r.message) ? r.message : 'Unhandled promise rejection';
+    var stack = r && r.stack ? r.stack : undefined;
+    send('chatui.preview.error', { message: msg, stack: stack });
+  });
+  // Screenshots read WebGL canvases via toDataURL, which returns a blank
+  // image once the frame's drawing buffer has been discarded. Default
+  // preserveDrawingBuffer on (unless the artifact set it explicitly) so
+  // three.js scenes and canvas games capture what's on screen. This hook
+  // only exists in previews, so deployed pages keep stock behavior.
+  var getContext = HTMLCanvasElement.prototype.getContext;
+  HTMLCanvasElement.prototype.getContext = function(type, attrs){
+    if ((type === 'webgl' || type === 'webgl2' || type === 'experimental-webgl') &&
+        (!attrs || attrs.preserveDrawingBuffer === undefined)) {
+      attrs = Object.assign({}, attrs, { preserveDrawingBuffer: true });
+    }
+    return getContext.call(this, type, attrs);
+  };
+  window.addEventListener('message', function(ev){
+    // Only the embedding app may request a capture. The artifact's own code
+    // could still forge a request at itself, but that grants nothing it
+    // can't already do, and the parent validates every result it receives.
+    if (ev.source !== window.parent) return;
+    var data = ev.data;
+    if (!data || data.channel !== '${channel}' || data.type !== 'chatui.preview.captureRequest') return;
+    var detail = data.detail || {};
+    var id = typeof detail.id === 'string' ? detail.id : '';
+    function fail(err){
+      send('chatui.preview.captureResult', { id: id, error: String(err && err.message ? err.message : err) });
+    }
+    try {
+      if (!window.snapdom) {
+        if (typeof detail.source !== 'string' || !detail.source) { fail('capture library missing'); return; }
+        var s = document.createElement('script');
+        s.textContent = detail.source;
+        (document.head || document.documentElement).appendChild(s);
+        s.remove();
+        if (!window.snapdom) { fail('capture library failed to initialize'); return; }
+      }
+      // Capture the body, not documentElement: SnapDOM renders the <html>
+      // element as empty/background-only for common full-viewport layouts
+      // (e.g. flex-centered body with min-height:100vh), while body capture
+      // is reliable. Transparent areas get the backgroundColor fill below.
+      var root = document.body || document.documentElement;
+      var scrollWidth = Math.max(root.scrollWidth, root.clientWidth, 1);
+      var height = Math.max(root.scrollHeight, root.clientHeight, 1);
+      // Decorative layers wider than the viewport (200% wave strips, parallax
+      // slides) widen SnapDOM's output into a dead band of background fill;
+      // clip the shot to the visible width. Height is NOT clipped: capturing
+      // tall documents full page is intentional.
+      var visibleWidth = root.clientWidth > 0 ? Math.min(scrollWidth, root.clientWidth) : scrollWidth;
+      // Cap the long edge so a tall page can't produce a giant payload
+      var scale = Math.min(1, 4096 / Math.max(visibleWidth, height));
+      window.snapdom.toCanvas(root, {
+        dpr: 1,
+        scale: scale,
+        backgroundColor: typeof detail.backgroundColor === 'string' && detail.backgroundColor ? detail.backgroundColor : '#ffffff',
+        embedFonts: true,
+        fast: true
+      }).then(function(canvas){
+        var targetWidth = Math.round(visibleWidth * scale);
+        if (canvas.width > targetWidth + 1) {
+          var clipped = document.createElement('canvas');
+          clipped.width = targetWidth;
+          clipped.height = canvas.height;
+          var clipCtx = clipped.getContext('2d');
+          if (clipCtx) {
+            clipCtx.drawImage(canvas, 0, 0);
+            canvas = clipped;
+          }
+        }
+        send('chatui.preview.captureResult', { id: id, dataUrl: canvas.toDataURL('image/png') });
+      }).catch(fail);
+    } catch (err) { fail(err); }
+  });
+})();
+${END_SCRIPT_TAG}`;
 }
 
 /** JSON-encode a string for embedding inside an inline <script>, escaping `</` so the HTML parser can't terminate the script early. */


### PR DESCRIPTION
## What

Adds an **Annotate** button to the artifact panel footer: it screenshots the live artifact preview exactly as rendered, opens a modal with simple annotation tools (arrow, pen, rectangle, four colors, undo/clear, Ctrl+Z), and "Add to chat" attaches the annotated PNG to the composer. Combined with a multimodal model, this closes the loop of pointing at a rendered problem ("this button overlaps") instead of describing it in words.

## How it works

The preview iframe is sandboxed with an opaque origin, so the parent can never read its DOM. Capture therefore runs inside the iframe: the existing preview hook script answers a postMessage capture request carrying the [SnapDOM](https://github.com/zumerlab/snapdom) library source, renders the document to a canvas, and posts back a PNG data URL.

Reliability decisions, each one hit during testing:

- **Bundled, not CDN.** SnapDOM ships as a version-pinned static asset emitted by Vite (`?url` import), fetched lazily on first use: about 50KB gzip once, zero bytes on initial page load, nothing in the entry bundle.
- **Body capture, not documentElement.** SnapDOM renders the `<html>` element as background-only for the most common artifact shape (flex-centered body with `min-height:100vh`). Body capture is pixel-correct.
- **Horizontal overflow is clipped** to the visible width, so decorative layers wider than the viewport (200% wave strips) do not produce a dead band of background fill. Height is kept: tall documents capture full page on purpose.
- **WebGL contexts default to `preserveDrawingBuffer`** in previews (only when the artifact did not set it explicitly), so three.js scenes and canvas games do not capture black.
- **Trust boundary respected.** The iframe runs model-generated code, so the parent validates every result: request id match, source window match, exact PNG mime prefix, PNG magic bytes, bounded size (under the server's 10MB attachment limit). Nothing from the iframe is ever evaluated in the app.
- Transparent documents are composited over the panel's computed backing color, so shots match what the user sees in light and dark mode. Output is capped at 4096px on the long edge.

## Wiring

- `pendingChatFiles` store mirrors the existing `pendingChatInput` pattern; ChatWindow appends the file to the composer with the same accept rules as paste.
- The button only renders when the current model accepts image attachments, and never on shared/read-only views. Deployed Spaces are unaffected (the hook is preview-only).
- The duplicated inline mime matchers in ChatWindow and FileDropzone are replaced by a shared `mimeMatchesAllowlist` helper.
- The annotation modal stretches nearly edge to edge on mobile so the screenshot gets the space.

## Tests

- Browser tests run the full round trip through a real sandboxed iframe with pixel assertions on the returned PNG, including regressions for the full-viewport flex layout and the horizontal overflow clip.
- Unit tests for the mime matcher.
- Verified end to end against the router: attaching a screenshot switches Omni to its multimodal route and the model edited the artifact based on the image.

Follow-up: text tool tracked in #2460.