### PR TITLE
Add Figma-style comment annotations to the screenshot annotator

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -26,7 +26,7 @@
 		</script>
 		%sveltekit.head%
 	</head>
-	<body data-sveltekit-preload-data="hover" class="h-dvh dark:bg-gray-900">
+	<body data-sveltekit-preload-data="hover" class="h-dvh bg-white dark:bg-gray-900">
 		<div id="app" class="contents h-full">%sveltekit.body%</div>
 
 		<!-- Google Tag Manager -->

--- a/src/lib/components/chat/ArtifactPanel.svelte
+++ b/src/lib/components/chat/ArtifactPanel.svelte
@@ -359,7 +359,9 @@
 		canScreenshot && effectiveTab === "preview" && !!srcdoc && previewLoaded
 	);
 	let capturing = $state(false);
-	let pendingScreenshot = $state<{ dataUrl: string; fileName: string } | null>(null);
+	let pendingScreenshot = $state<{ dataUrl: string; fileName: string; subject: string } | null>(
+		null
+	);
 
 	async function screenshotPreview() {
 		// pendingScreenshot guard: a capture resolving while the annotation modal
@@ -368,10 +370,11 @@
 		// the previous document would answer the request under the new name.
 		if (!iframeEl || capturing || pendingScreenshot || !previewLoaded || !artifact) return;
 		capturing = true;
-		// Freeze the name now: a new version can stream in (or the user can
-		// navigate) while the annotation modal is open
+		// Freeze name and subject now: a new version can stream in (or the user
+		// can navigate) while the annotation modal is open
 		const slug = artifact.identifier.replace(/[^a-zA-Z0-9_-]+/g, "-") || "artifact";
 		const fileName = `${slug}-v${displayVersionNumber}-screenshot.png`;
+		const subject = `"${version?.title ?? artifact.identifier}" (v${displayVersionNumber})`;
 		const requestedSrcdoc = srcdoc;
 		try {
 			// Transparent documents composite over the iframe's own backing, so
@@ -386,7 +389,7 @@
 			if (srcdoc !== requestedSrcdoc) {
 				throw new Error("the preview changed during capture");
 			}
-			pendingScreenshot = { dataUrl, fileName };
+			pendingScreenshot = { dataUrl, fileName, subject };
 		} catch (err) {
 			errorStore.set(
 				`Screenshot failed: ${err instanceof Error ? err.message : "unexpected error"}`
@@ -401,8 +404,9 @@
 		if (!shot) return;
 		pendingComposerPayload.set({
 			files: [pngDataUrlToFile(annotatedDataUrl, shot.fileName)],
-			// Numbered to match the badges baked into the image
-			text: formatScreenshotNotes(notes),
+			// Numbered to match the badges baked into the image; the subject header
+			// keeps blocks apart when several annotated screenshots share a draft
+			text: formatScreenshotNotes(notes, shot.subject),
 		});
 		pendingScreenshot = null;
 		// On mobile the panel overlays the chat; close it so the attachment is visible

--- a/src/lib/components/chat/ArtifactPanel.svelte
+++ b/src/lib/components/chat/ArtifactPanel.svelte
@@ -16,7 +16,8 @@
 	import { escapeHTML } from "$lib/utils/markedLight";
 	import { artifactPanel, ARTIFACT_PANEL_DEFAULT_FRACTION } from "$lib/stores/artifactPanel.svelte";
 	import { StickToBottomController } from "$lib/utils/scroll/stickToBottom";
-	import { pendingChatFiles } from "$lib/stores/pendingChatFiles";
+	import { pendingComposerPayload } from "$lib/stores/pendingComposerPayload";
+	import { formatScreenshotNotes } from "$lib/utils/screenshotNotes";
 	import { error as errorStore } from "$lib/stores/errors";
 	import { usePublicConfig } from "$lib/utils/PublicConfig.svelte";
 	import { page } from "$app/state";
@@ -395,10 +396,14 @@
 		}
 	}
 
-	function attachScreenshot(annotatedDataUrl: string) {
+	function attachScreenshot(annotatedDataUrl: string, notes: string[]) {
 		const shot = pendingScreenshot;
 		if (!shot) return;
-		pendingChatFiles.set([pngDataUrlToFile(annotatedDataUrl, shot.fileName)]);
+		pendingComposerPayload.set({
+			files: [pngDataUrlToFile(annotatedDataUrl, shot.fileName)],
+			// Numbered to match the badges baked into the image
+			text: formatScreenshotNotes(notes),
+		});
 		pendingScreenshot = null;
 		// On mobile the panel overlays the chat; close it so the attachment is visible
 		if (!isDesktop) artifactPanel.close();

--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -48,7 +48,7 @@
 	import FeatureAnnouncementToast from "../FeatureAnnouncementToast.svelte";
 	import { getActiveAnnouncement } from "$lib/utils/featureAnnouncements";
 	import { usePublicConfig } from "$lib/utils/PublicConfig.svelte";
-	import { pendingChatFiles } from "$lib/stores/pendingChatFiles";
+	import { pendingComposerPayload } from "$lib/stores/pendingComposerPayload";
 	import { mimeMatchesAllowlist } from "$lib/utils/mimeMatch";
 	import LucideHammer from "~icons/lucide/hammer";
 	import LucideSparkles from "~icons/lucide/sparkles";
@@ -470,16 +470,23 @@
 		activeRouterExamplePrompt = match ? match.prompt : null;
 	});
 
-	// Files queued from outside the composer (e.g. artifact screenshots),
-	// consumed and cleared on arrival, same accept rules as paste
+	// Composer content queued from outside (e.g. an annotated artifact
+	// screenshot plus its notes), consumed and cleared on arrival: files use
+	// the same accept rules as paste, text appends to the editable draft
 	$effect(() => {
-		const pending = $pendingChatFiles;
-		if (!pending?.length || shared) return;
-		const accepted = pending.filter((file) => mimeMatchesAllowlist(file.type, activeMimeTypes));
+		const pending = $pendingComposerPayload;
+		if (!pending || shared) return;
+		const accepted = (pending.files ?? []).filter((file) =>
+			mimeMatchesAllowlist(file.type, activeMimeTypes)
+		);
 		if (accepted.length) {
 			files = [...untrack(() => files), ...accepted];
 		}
-		pendingChatFiles.set(undefined);
+		if (pending.text) {
+			const currentDraft = untrack(() => draft);
+			draft = currentDraft.trim() ? `${currentDraft}\n\n${pending.text}` : pending.text;
+		}
+		pendingComposerPayload.set(undefined);
 	});
 
 	function triggerPrompt(prompt: string) {

--- a/src/lib/components/chat/ScreenshotAnnotationModal.svelte
+++ b/src/lib/components/chat/ScreenshotAnnotationModal.svelte
@@ -69,6 +69,13 @@
 	let draftRegion = $state<{ ox: number; oy: number; px: number; py: number } | null>(null);
 	/** Bumped to re-trigger the focus effect when editingIndex itself doesn't change */
 	let focusNonce = $state(0);
+	/**
+	 * True while a note's IME composition is active. Modal calls `onclose`
+	 * without the event, so Escape can't be inspected for `isComposing` there;
+	 * tracked here instead (same approach as ChatInput) so an Escape meant to
+	 * cancel a composition doesn't dismiss the editor and drop the candidate.
+	 */
+	let composingNote = $state(false);
 	let nextCommentId = 0;
 
 	let canvasEl: HTMLCanvasElement | undefined = $state();
@@ -393,6 +400,8 @@
 
 	/** Close the note editor; a comment left with an empty note is discarded */
 	function commitEditing() {
+		// The composing textarea is going away, so compositionend may never fire
+		composingNote = false;
 		if (editingIndex === null) return;
 		const index = editingIndex;
 		editingIndex = null;
@@ -456,6 +465,8 @@
 	// whole session right after the first one dismissed the editor.
 	let closeRequestLatched = false;
 	function requestClose() {
+		// Escape that is cancelling an IME composition belongs to the IME
+		if (composingNote) return;
 		if (closeRequestLatched) return;
 		closeRequestLatched = true;
 		queueMicrotask(() => (closeRequestLatched = false));
@@ -723,6 +734,8 @@
 							placeholder="What about this area?"
 							bind:value={comments[editingIndex].note}
 							onkeydown={onNoteKeydown}
+							oncompositionstart={() => (composingNote = true)}
+							oncompositionend={() => (composingNote = false)}
 							onblur={(e) => onNoteBlur(e, ownIndex)}
 							use:autogrow
 						></textarea>
@@ -757,6 +770,8 @@
 							placeholder="What about this area?"
 							bind:value={comment.note}
 							onkeydown={onNoteKeydown}
+							oncompositionstart={() => (composingNote = true)}
+							oncompositionend={() => (composingNote = false)}
 							onblur={() => onRowBlur(i)}
 							use:autofocus={editingIndex === i ? editingIndex : null}
 							use:autogrow

--- a/src/lib/components/chat/ScreenshotAnnotationModal.svelte
+++ b/src/lib/components/chat/ScreenshotAnnotationModal.svelte
@@ -506,7 +506,15 @@
 	function autogrow(node: HTMLTextAreaElement) {
 		function resize() {
 			node.style.height = "auto";
-			node.style.height = `${node.scrollHeight}px`;
+			const contentHeight = node.scrollHeight;
+			const maxHeight = parseFloat(getComputedStyle(node).maxHeight);
+			// The themed scrollbar is a classic 8px gutter rather than an overlay,
+			// so a permanent overflow-y:auto would show a track even for a
+			// single-line note (scrollHeight rounds above the box by a pixel).
+			// Only allow scrolling once the note is actually clamped at max height.
+			node.style.overflowY =
+				Number.isFinite(maxHeight) && contentHeight > maxHeight ? "auto" : "hidden";
+			node.style.height = `${contentHeight}px`;
 		}
 		resize();
 		node.addEventListener("input", resize);
@@ -590,8 +598,10 @@
 	const toolBtnActive = "bg-white text-gray-800 shadow-xs dark:bg-gray-600 dark:text-gray-100";
 	const toolBtnInactive =
 		"text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200";
+	// overflow-y-hidden by default; autogrow flips it to auto only when the note
+	// is clamped at max-height, so no scrollbar gutter shows for short notes
 	const noteInput =
-		"scrollbar-custom max-h-32 min-w-0 flex-1 resize-none overflow-y-auto rounded-md border border-gray-200 bg-white px-2 py-1 text-sm leading-snug text-gray-800 outline-hidden placeholder:text-gray-400 focus:border-blue-400 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-200 dark:focus:border-blue-500";
+		"scrollbar-custom max-h-32 min-w-0 flex-1 resize-none overflow-y-hidden rounded-md border border-gray-200 bg-white px-2 py-1 text-sm leading-snug text-gray-800 outline-hidden placeholder:text-gray-400 focus:border-blue-400 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-200 dark:focus:border-blue-500";
 </script>
 
 <svelte:window onkeydown={onKeydown} onresize={() => (resizeNonce += 1)} />

--- a/src/lib/components/chat/ScreenshotAnnotationModal.svelte
+++ b/src/lib/components/chat/ScreenshotAnnotationModal.svelte
@@ -117,7 +117,9 @@
 	let strokeWidth = $derived(
 		image ? Math.max(3, Math.round(Math.max(image.naturalWidth, image.naturalHeight) / 350)) : 3
 	);
-	let badgeRadius = $derived(Math.max(9, strokeWidth * 2.4));
+	let badgeRadius = $derived(Math.max(11, strokeWidth * 2.8));
+	/** White halo ring width around badges (shared with the edge clamp) */
+	let badgeHalo = $derived(Math.max(2, strokeWidth * 0.6));
 
 	function drawAnnotation(ctx: CanvasRenderingContext2D, annotation: Annotation) {
 		const pts = annotation.points;
@@ -186,12 +188,19 @@
 		comment: { x: number; y: number; w: number; h: number },
 		label: string | null
 	) {
-		const outlineWidth = Math.max(2, strokeWidth * 0.8);
+		const outlineWidth = Math.max(2.5, strokeWidth);
 		if (comment.w > 0 || comment.h > 0) {
+			// Two-pass dash: a wider white casing under the blue keeps the
+			// outline readable on any artifact, including blue and purple ones
+			// (both dashes share the pattern and phase, so the white frames
+			// each blue segment)
+			ctx.lineCap = "butt";
+			ctx.setLineDash([strokeWidth * 2.2, strokeWidth * 1.6]);
+			ctx.strokeStyle = "rgba(255, 255, 255, 0.95)";
+			ctx.lineWidth = outlineWidth + Math.max(2, strokeWidth * 0.7);
+			ctx.strokeRect(comment.x, comment.y, comment.w, comment.h);
 			ctx.strokeStyle = COMMENT_COLOR;
 			ctx.lineWidth = outlineWidth;
-			ctx.lineCap = "butt";
-			ctx.setLineDash([strokeWidth * 2, strokeWidth * 1.5]);
 			ctx.strokeRect(comment.x, comment.y, comment.w, comment.h);
 			ctx.setLineDash([]);
 		}
@@ -205,7 +214,7 @@
 		ctx.arc(center.x, center.y, badgeRadius, 0, Math.PI * 2);
 		ctx.fillStyle = COMMENT_COLOR;
 		ctx.fill();
-		ctx.lineWidth = Math.max(1.5, strokeWidth * 0.5);
+		ctx.lineWidth = badgeHalo;
 		ctx.strokeStyle = "#ffffff";
 		ctx.beginPath();
 		ctx.arc(center.x, center.y, badgeRadius, 0, Math.PI * 2);
@@ -225,7 +234,7 @@
 	function badgeCenter(comment: { x: number; y: number }): Point {
 		const canvas = canvasEl;
 		if (!canvas) return { x: comment.x, y: comment.y };
-		const margin = badgeRadius + Math.max(1.5, strokeWidth * 0.5) / 2;
+		const margin = badgeRadius + badgeHalo / 2;
 		return {
 			x: Math.min(Math.max(comment.x, margin), Math.max(canvas.width - margin, margin)),
 			y: Math.min(Math.max(comment.y, margin), Math.max(canvas.height - margin, margin)),

--- a/src/lib/components/chat/ScreenshotAnnotationModal.svelte
+++ b/src/lib/components/chat/ScreenshotAnnotationModal.svelte
@@ -197,21 +197,39 @@
 		}
 		if (label === null) return;
 		// Badge sits on the pin point / the region's top-left corner, with a
-		// white halo so the number stays readable on any background
+		// white halo so the number stays readable on any background. Its center
+		// is pulled inside the canvas so an edge pin doesn't export a clipped,
+		// unreadable number.
+		const center = badgeCenter(comment);
 		ctx.beginPath();
-		ctx.arc(comment.x, comment.y, badgeRadius, 0, Math.PI * 2);
+		ctx.arc(center.x, center.y, badgeRadius, 0, Math.PI * 2);
 		ctx.fillStyle = COMMENT_COLOR;
 		ctx.fill();
 		ctx.lineWidth = Math.max(1.5, strokeWidth * 0.5);
 		ctx.strokeStyle = "#ffffff";
 		ctx.beginPath();
-		ctx.arc(comment.x, comment.y, badgeRadius, 0, Math.PI * 2);
+		ctx.arc(center.x, center.y, badgeRadius, 0, Math.PI * 2);
 		ctx.stroke();
 		ctx.fillStyle = "#ffffff";
 		ctx.font = `600 ${Math.round(badgeRadius * 1.1)}px system-ui, sans-serif`;
 		ctx.textAlign = "center";
 		ctx.textBaseline = "middle";
-		ctx.fillText(label, comment.x, comment.y + badgeRadius * 0.06);
+		ctx.fillText(label, center.x, center.y + badgeRadius * 0.06);
+	}
+
+	/**
+	 * Where a comment's badge is drawn: the anchor point, clamped inward so the
+	 * circle (and halo) stays fully inside the canvas at the edges. Hit-testing
+	 * and popover anchoring use the same point so they match the pixels.
+	 */
+	function badgeCenter(comment: { x: number; y: number }): Point {
+		const canvas = canvasEl;
+		if (!canvas) return { x: comment.x, y: comment.y };
+		const margin = badgeRadius + Math.max(1.5, strokeWidth * 0.5) / 2;
+		return {
+			x: Math.min(Math.max(comment.x, margin), Math.max(canvas.width - margin, margin)),
+			y: Math.min(Math.max(comment.y, margin), Math.max(canvas.height - margin, margin)),
+		};
 	}
 
 	function normalizedDraft(region: { ox: number; oy: number; px: number; py: number }) {
@@ -271,7 +289,8 @@
 			displayScale > 0 ? 14 / displayScale : badgeRadius * 1.4
 		);
 		for (let i = comments.length - 1; i >= 0; i--) {
-			if (Math.hypot(point.x - comments[i].x, point.y - comments[i].y) <= hitRadius) return i;
+			const center = badgeCenter(comments[i]);
+			if (Math.hypot(point.x - center.x, point.y - center.y) <= hitRadius) return i;
 		}
 		return null;
 	}
@@ -489,9 +508,13 @@
 		};
 	}
 
-	/** Enter commits the note, Shift+Enter inserts a newline */
+	/**
+	 * Enter commits the note, Shift+Enter inserts a newline. Enter that is
+	 * accepting an IME composition candidate (CJK input) must pass through,
+	 * or the candidate would be committed as a premature note commit.
+	 */
 	function onNoteKeydown(e: KeyboardEvent) {
-		if (e.key === "Enter" && !e.shiftKey) {
+		if (e.key === "Enter" && !e.shiftKey && !e.isComposing) {
 			e.preventDefault();
 			(e.target as HTMLTextAreaElement).blur();
 		}
@@ -536,8 +559,10 @@
 		if (canvasRect.width === 0 || canvas.width === 0) return;
 		const scaleX = canvasRect.width / canvas.width;
 		const scaleY = canvasRect.height / canvas.height;
-		const badgeX = canvasRect.left - wrapRect.left + comment.x * scaleX;
-		const badgeY = canvasRect.top - wrapRect.top + comment.y * scaleY;
+		// Anchor on the drawn badge (clamped inward at edges), not the raw point
+		const center = badgeCenter(comment);
+		const badgeX = canvasRect.left - wrapRect.left + center.x * scaleX;
+		const badgeY = canvasRect.top - wrapRect.top + center.y * scaleY;
 		const width = 280;
 		const left = Math.min(
 			Math.max(8, badgeX + badgeRadius * scaleX + 8),
@@ -687,8 +712,8 @@
 						type="button"
 						class="btn flex-none rounded-md p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-700 dark:hover:text-gray-300"
 						title="Delete note"
-						onpointerdown={(e) => {
-							e.preventDefault();
+						onpointerdown={(e) => e.preventDefault()}
+						onclick={() => {
 							if (editingIndex !== null) deleteComment(editingIndex);
 						}}
 					>
@@ -721,10 +746,8 @@
 							type="button"
 							class="btn flex-none rounded-md p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-800 dark:hover:text-gray-300"
 							title="Delete note"
-							onpointerdown={(e) => {
-								e.preventDefault();
-								deleteComment(i);
-							}}
+							onpointerdown={(e) => e.preventDefault()}
+							onclick={() => deleteComment(i)}
 						>
 							<LucideX />
 						</button>

--- a/src/lib/components/chat/ScreenshotAnnotationModal.svelte
+++ b/src/lib/components/chat/ScreenshotAnnotationModal.svelte
@@ -278,6 +278,11 @@
 
 	function onPointerDown(e: PointerEvent) {
 		if (!image || e.button !== 0) return;
+		// The canvas never needs focus: without this, a real mouse press moves
+		// focus to the dialog AFTER this handler, and the resulting textarea
+		// blur would immediately close or even delete the editor this handler
+		// just opened (synthetic-event tests don't reproduce that default).
+		e.preventDefault();
 		const point = toImagePoint(e);
 		if (!point) return;
 		// A badge is clickable with any tool selected: clicking a number is an
@@ -375,7 +380,11 @@
 		else if (editingIndex !== null && editingIndex > index) editingIndex -= 1;
 	}
 
-	function onNoteBlur(e: FocusEvent) {
+	function onNoteBlur(e: FocusEvent, index: number) {
+		// A blur from a textarea that is no longer the active editor (its
+		// popover target switched within the same interaction) must not commit
+		// against the new editor's index
+		if (editingIndex !== index) return;
 		// Focus moving within the popover (to its delete button) isn't a dismissal
 		if (popoverEl && e.relatedTarget instanceof Node && popoverEl.contains(e.relatedTarget)) return;
 		commitEditing();
@@ -412,8 +421,16 @@
 
 	// Escape reaches us through Modal's onclose: with a note editor open it
 	// dismisses just the editor (mirroring how the panel's nested modals handle
-	// Escape); otherwise it closes the whole modal
+	// Escape); otherwise it closes the whole modal. Modal dispatches the same
+	// Escape twice when focus is inside the dialog (window capture listener
+	// plus the dialog's own keydown), so duplicate calls within one event are
+	// latched — otherwise the second call would fall through and close the
+	// whole session right after the first one dismissed the editor.
+	let closeRequestLatched = false;
 	function requestClose() {
+		if (closeRequestLatched) return;
+		closeRequestLatched = true;
+		queueMicrotask(() => (closeRequestLatched = false));
 		if (editingIndex !== null) {
 			commitEditing();
 			return;
@@ -527,7 +544,10 @@
 			wrapRect.width - width - 8
 		);
 		// Bottom clamp leaves room for the textarea to grow a few lines
-		const top = Math.min(Math.max(8, badgeY + badgeRadius * scaleY + 8), wrapRect.height - 120);
+		// Reserve the popover's full potential height (textarea max-h-32 = 128px
+		// plus padding and borders): the wrapper is overflow-hidden, so a short
+		// reserve would clip long multiline notes near the bottom edge
+		const top = Math.min(Math.max(8, badgeY + badgeRadius * scaleY + 8), wrapRect.height - 150);
 		popoverStyle = `left:${left}px; top:${top}px; width:${width}px;`;
 	});
 
@@ -638,6 +658,10 @@
 			{/if}
 
 			{#if !isNarrow && editingIndex !== null && comments[editingIndex]}
+				<!-- ownIndex freezes which comment this editor instance belongs to:
+				     the blur handler must not act when the editing target has
+				     already moved on (stale blur committing against the new index) -->
+				{@const ownIndex = editingIndex}
 				<div
 					bind:this={popoverEl}
 					class="absolute z-10 flex items-start gap-1.5 rounded-lg border border-gray-200 bg-white p-1.5 shadow-lg dark:border-gray-600 dark:bg-gray-800"
@@ -655,7 +679,7 @@
 							placeholder="What about this area?"
 							bind:value={comments[editingIndex].note}
 							onkeydown={onNoteKeydown}
-							onblur={onNoteBlur}
+							onblur={(e) => onNoteBlur(e, ownIndex)}
 							use:autogrow
 						></textarea>
 					{/key}

--- a/src/lib/components/chat/ScreenshotAnnotationModal.svelte
+++ b/src/lib/components/chat/ScreenshotAnnotationModal.svelte
@@ -1,50 +1,91 @@
 <script lang="ts">
 	import Modal from "../Modal.svelte";
 
+	import LucideMessageSquareText from "~icons/lucide/message-square-text";
 	import LucideMoveUpRight from "~icons/lucide/move-up-right";
 	import LucidePencil from "~icons/lucide/pencil";
 	import LucideSquare from "~icons/lucide/square";
 	import LucideUndo2 from "~icons/lucide/undo-2";
 	import LucideTrash2 from "~icons/lucide/trash-2";
+	import LucideX from "~icons/lucide/x";
 	import EosIconsLoading from "~icons/eos-icons/loading";
 
-	type Tool = "arrow" | "pen" | "rect";
+	type Tool = "comment" | "arrow" | "pen" | "rect";
 	interface Point {
 		x: number;
 		y: number;
 	}
 	/** One drawn shape, in image-space coordinates (canvas pixels, not CSS pixels) */
 	interface Annotation {
-		tool: Tool;
+		tool: "arrow" | "pen" | "rect";
 		color: string;
 		points: Point[];
+	}
+	/**
+	 * A numbered note anchored to a point (pin: w = h = 0) or a dragged region.
+	 * The badge and dashed outline are baked into the exported image; the note
+	 * text travels as plain text next to it (see formatScreenshotNotes), so no
+	 * user text is ever rasterized.
+	 */
+	interface CommentAnnotation {
+		id: number;
+		x: number;
+		y: number;
+		w: number;
+		h: number;
+		note: string;
 	}
 
 	interface Props {
 		/** PNG data URL of the captured screenshot */
 		dataUrl: string;
-		/** Called with the final (annotated) PNG data URL */
-		onconfirm: (dataUrl: string) => void;
+		/** Called with the final (annotated) PNG data URL and the numbered note texts */
+		onconfirm: (dataUrl: string, notes: string[]) => void;
 		onclose: () => void;
 	}
 
 	let { dataUrl, onconfirm, onclose }: Props = $props();
 
 	const COLORS = ["#ef4444", "#f59e0b", "#3b82f6", "#22c55e"];
+	// Comments keep one fixed identity (blue badge, dashed region) so they read
+	// as "referenced note" rather than a drawing; the palette only affects the
+	// drawing tools
+	const COMMENT_COLOR = "#3b82f6";
 	const TOOLS: { id: Tool; label: string; icon: typeof LucidePencil }[] = [
+		{ id: "comment", label: "Comment", icon: LucideMessageSquareText },
 		{ id: "arrow", label: "Arrow", icon: LucideMoveUpRight },
 		{ id: "pen", label: "Pen", icon: LucidePencil },
 		{ id: "rect", label: "Rectangle", icon: LucideSquare },
 	];
 
-	let tool = $state<Tool>("arrow");
+	let tool = $state<Tool>("comment");
 	let color = $state(COLORS[0]);
 	let annotations = $state<Annotation[]>([]);
 	let current = $state<Annotation | null>(null);
+	let comments = $state<CommentAnnotation[]>([]);
+	/** Index into comments whose note is being edited (desktop popover target) */
+	let editingIndex = $state<number | null>(null);
+	/** Live drag preview for the comment tool, kept as origin + pointer */
+	let draftRegion = $state<{ ox: number; oy: number; px: number; py: number } | null>(null);
+	let nextCommentId = 0;
 
 	let canvasEl: HTMLCanvasElement | undefined = $state();
+	let containerEl: HTMLDivElement | undefined = $state();
+	let popoverEl: HTMLDivElement | undefined = $state();
 	let image = $state<HTMLImageElement | null>(null);
 	let loadFailed = $state(false);
+	let resizeNonce = $state(0);
+
+	// Below sm the note editor is an in-flow list instead of an anchored
+	// popover: a floating input mid-canvas loses against the on-screen keyboard
+	let isNarrow = $state(false);
+	$effect(() => {
+		const mq = window.matchMedia("(max-width: 639px)");
+		isNarrow = mq.matches;
+		const onChange = () => (isNarrow = mq.matches);
+		mq.addEventListener("change", onChange);
+		return () => mq.removeEventListener("change", onChange);
+	});
 
 	$effect(() => {
 		const img = new Image();
@@ -62,6 +103,9 @@
 			cancelled = true;
 			annotations = [];
 			current = null;
+			comments = [];
+			editingIndex = null;
+			draftRegion = null;
 			loadFailed = false;
 		};
 	});
@@ -71,6 +115,7 @@
 	let strokeWidth = $derived(
 		image ? Math.max(3, Math.round(Math.max(image.naturalWidth, image.naturalHeight) / 350)) : 3
 	);
+	let badgeRadius = $derived(Math.max(9, strokeWidth * 2.4));
 
 	function drawAnnotation(ctx: CanvasRenderingContext2D, annotation: Annotation) {
 		const pts = annotation.points;
@@ -134,20 +179,66 @@
 		ctx.fill();
 	}
 
-	// Full redraw on every change: the canvas holds the composited image at
-	// natural resolution, so confirm() is just toDataURL on it
-	$effect(() => {
+	function drawCommentMarker(
+		ctx: CanvasRenderingContext2D,
+		comment: { x: number; y: number; w: number; h: number },
+		label: string | null
+	) {
+		const outlineWidth = Math.max(2, strokeWidth * 0.8);
+		if (comment.w > 0 || comment.h > 0) {
+			ctx.strokeStyle = COMMENT_COLOR;
+			ctx.lineWidth = outlineWidth;
+			ctx.lineCap = "butt";
+			ctx.setLineDash([strokeWidth * 2, strokeWidth * 1.5]);
+			ctx.strokeRect(comment.x, comment.y, comment.w, comment.h);
+			ctx.setLineDash([]);
+		}
+		if (label === null) return;
+		// Badge sits on the pin point / the region's top-left corner, with a
+		// white halo so the number stays readable on any background
+		ctx.beginPath();
+		ctx.arc(comment.x, comment.y, badgeRadius, 0, Math.PI * 2);
+		ctx.fillStyle = COMMENT_COLOR;
+		ctx.fill();
+		ctx.lineWidth = Math.max(1.5, strokeWidth * 0.5);
+		ctx.strokeStyle = "#ffffff";
+		ctx.beginPath();
+		ctx.arc(comment.x, comment.y, badgeRadius, 0, Math.PI * 2);
+		ctx.stroke();
+		ctx.fillStyle = "#ffffff";
+		ctx.font = `600 ${Math.round(badgeRadius * 1.1)}px system-ui, sans-serif`;
+		ctx.textAlign = "center";
+		ctx.textBaseline = "middle";
+		ctx.fillText(label, comment.x, comment.y + badgeRadius * 0.06);
+	}
+
+	function normalizedDraft(region: { ox: number; oy: number; px: number; py: number }) {
+		return {
+			x: Math.min(region.ox, region.px),
+			y: Math.min(region.oy, region.py),
+			w: Math.abs(region.px - region.ox),
+			h: Math.abs(region.py - region.oy),
+		};
+	}
+
+	// Full redraw: the canvas holds the composited image at natural resolution,
+	// so exporting is just toDataURL on it. Called from the tracking effect (its
+	// state reads register the dependencies) and synchronously before export.
+	function redraw() {
 		const canvas = canvasEl;
 		const img = image;
 		if (!canvas || !img) return;
-		void annotations;
-		void current;
 		const ctx = canvas.getContext("2d");
 		if (!ctx) return;
 		ctx.clearRect(0, 0, canvas.width, canvas.height);
 		ctx.drawImage(img, 0, 0);
 		for (const annotation of annotations) drawAnnotation(ctx, annotation);
 		if (current) drawAnnotation(ctx, current);
+		comments.forEach((comment, i) => drawCommentMarker(ctx, comment, String(i + 1)));
+		if (draftRegion) drawCommentMarker(ctx, normalizedDraft(draftRegion), null);
+	}
+	$effect(() => {
+		redraw();
 	});
 
 	function toImagePoint(e: PointerEvent): Point | null {
@@ -164,18 +255,44 @@
 		};
 	}
 
+	/** Topmost comment whose badge contains the point, for click-to-reopen */
+	function commentIndexAt(point: Point): number | null {
+		const hitRadius = badgeRadius * 1.4;
+		for (let i = comments.length - 1; i >= 0; i--) {
+			if (Math.hypot(point.x - comments[i].x, point.y - comments[i].y) <= hitRadius) return i;
+		}
+		return null;
+	}
+
 	function onPointerDown(e: PointerEvent) {
 		if (!image || e.button !== 0) return;
 		const point = toImagePoint(e);
 		if (!point) return;
+		if (tool === "comment") {
+			// Runs before the open editor's blur: settle it first so indices are
+			// stable for the hit test below
+			commitEditing();
+			const hit = commentIndexAt(point);
+			if (hit !== null) {
+				editingIndex = hit;
+				return;
+			}
+			(e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+			draftRegion = { ox: point.x, oy: point.y, px: point.x, py: point.y };
+			return;
+		}
 		(e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
 		current = { tool, color, points: [point] };
 	}
 
 	function onPointerMove(e: PointerEvent) {
-		if (!current) return;
 		const point = toImagePoint(e);
 		if (!point) return;
+		if (draftRegion) {
+			draftRegion = { ...draftRegion, px: point.x, py: point.y };
+			return;
+		}
+		if (!current) return;
 		current =
 			current.tool === "pen"
 				? { ...current, points: [...current.points, point] }
@@ -183,6 +300,20 @@
 	}
 
 	function onPointerUp() {
+		if (draftRegion) {
+			const rect = normalizedDraft(draftRegion);
+			const moved = Math.hypot(rect.w, rect.h) >= strokeWidth;
+			// Click = pin (zero-size), drag = region; either way the editor opens
+			comments = [
+				...comments,
+				moved
+					? { id: nextCommentId++, ...rect, note: "" }
+					: { id: nextCommentId++, x: draftRegion.ox, y: draftRegion.oy, w: 0, h: 0, note: "" },
+			];
+			editingIndex = comments.length - 1;
+			draftRegion = null;
+			return;
+		}
 		if (!current) return;
 		const pts = current.points;
 		const moved =
@@ -198,6 +329,37 @@
 
 	function onPointerCancel() {
 		current = null;
+		draftRegion = null;
+	}
+
+	/** Close the note editor; a comment left with an empty note is discarded */
+	function commitEditing() {
+		if (editingIndex === null) return;
+		const index = editingIndex;
+		editingIndex = null;
+		const comment = comments[index];
+		if (comment && !comment.note.trim()) {
+			comments = comments.filter((_, i) => i !== index);
+		}
+	}
+
+	function deleteComment(index: number) {
+		comments = comments.filter((_, i) => i !== index);
+		if (editingIndex === index) editingIndex = null;
+		else if (editingIndex !== null && editingIndex > index) editingIndex -= 1;
+	}
+
+	function onNoteBlur(e: FocusEvent) {
+		// Focus moving within the popover (to its delete button) isn't a dismissal
+		if (popoverEl && e.relatedTarget instanceof Node && popoverEl.contains(e.relatedTarget)) return;
+		commitEditing();
+	}
+
+	/** Blur handler for mobile list rows: empty rows evaporate on leave */
+	function onRowBlur(index: number) {
+		if (editingIndex === index) editingIndex = null;
+		const comment = comments[index];
+		if (comment && !comment.note.trim()) deleteComment(index);
 	}
 
 	function undo() {
@@ -207,34 +369,94 @@
 	function clearAll() {
 		annotations = [];
 		current = null;
+		comments = [];
+		editingIndex = null;
+		draftRegion = null;
 	}
 
 	function onKeydown(e: KeyboardEvent) {
+		// Typing in a note input keeps native text editing shortcuts
+		const target = e.target as HTMLElement | null;
+		if (target && (target.tagName === "INPUT" || target.tagName === "TEXTAREA")) return;
 		if ((e.metaKey || e.ctrlKey) && !e.shiftKey && e.key.toLowerCase() === "z") {
 			e.preventDefault();
 			undo();
 		}
 	}
 
+	// Escape reaches us through Modal's onclose: with a note editor open it
+	// dismisses just the editor (mirroring how the panel's nested modals handle
+	// Escape); otherwise it closes the whole modal
+	function requestClose() {
+		if (editingIndex !== null) {
+			commitEditing();
+			return;
+		}
+		onclose();
+	}
+
 	function confirm() {
 		if (!canvasEl || !image) return;
-		onconfirm(canvasEl.toDataURL("image/png"));
+		commitEditing();
+		// Sweep any stragglers so no unnumbered/empty badge gets baked, then
+		// repaint synchronously: the effect redraw only lands next flush
+		comments = comments.filter((comment) => comment.note.trim());
+		redraw();
+		onconfirm(
+			canvasEl.toDataURL("image/png"),
+			comments.map((comment) => comment.note.trim())
+		);
 	}
+
+	function autofocus(node: HTMLElement, enabled: boolean = true) {
+		if (enabled) node.focus();
+	}
+
+	// ----- desktop popover positioning (image space -> container CSS space) -----
+	let popoverStyle = $state("");
+	$effect(() => {
+		void resizeNonce;
+		if (editingIndex === null || isNarrow) return;
+		const comment = comments[editingIndex];
+		const canvas = canvasEl;
+		const wrap = containerEl;
+		if (!comment || !canvas || !wrap) return;
+		const canvasRect = canvas.getBoundingClientRect();
+		const wrapRect = wrap.getBoundingClientRect();
+		if (canvasRect.width === 0 || canvas.width === 0) return;
+		const scaleX = canvasRect.width / canvas.width;
+		const scaleY = canvasRect.height / canvas.height;
+		const badgeX = canvasRect.left - wrapRect.left + comment.x * scaleX;
+		const badgeY = canvasRect.top - wrapRect.top + comment.y * scaleY;
+		const width = 264;
+		const left = Math.min(
+			Math.max(8, badgeX + badgeRadius * scaleX + 8),
+			wrapRect.width - width - 8
+		);
+		const top = Math.min(Math.max(8, badgeY + badgeRadius * scaleY + 8), wrapRect.height - 56);
+		popoverStyle = `left:${left}px; top:${top}px; width:${width}px;`;
+	});
 
 	const toolBtnBase =
 		"btn rounded-md px-2 py-1.5 text-xs transition-colors disabled:cursor-not-allowed disabled:opacity-40";
 	const toolBtnActive = "bg-white text-gray-800 shadow-xs dark:bg-gray-600 dark:text-gray-100";
 	const toolBtnInactive =
 		"text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200";
+	const noteInput =
+		"min-w-0 flex-1 rounded-md border border-gray-200 bg-white px-2 py-1 text-sm text-gray-800 outline-hidden placeholder:text-gray-400 focus:border-blue-400 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-200 dark:focus:border-blue-500";
 </script>
 
-<svelte:window onkeydown={onKeydown} />
+<svelte:window onkeydown={onKeydown} onresize={() => (resizeNonce += 1)} />
 
 <!-- Width override needs the important marker: Modal's own max-w-[90dvw] targets
      the same property and stylesheet order between two utilities isn't guaranteed.
      min() keeps the desktop cap at 64rem while mobile stretches nearly edge to
      edge so the screenshot gets the room. -->
-<Modal width="max-w-[min(64rem,calc(100dvw-0.75rem))]!" closeOnBackdrop={false} {onclose}>
+<Modal
+	width="max-w-[min(64rem,calc(100dvw-0.75rem))]!"
+	closeOnBackdrop={false}
+	onclose={requestClose}
+>
 	<div class="flex flex-col gap-2.5 p-2.5 sm:gap-3 sm:p-4">
 		<div class="flex flex-wrap items-center gap-x-1.5 gap-y-2 sm:gap-2">
 			<h2 class="mr-auto text-sm font-semibold text-gray-800 dark:text-gray-200">
@@ -255,7 +477,13 @@
 				{/each}
 			</div>
 
-			<div class="flex items-center gap-1.5 px-1">
+			<!-- The palette only applies to the drawing tools; comments keep their
+			     fixed identity, so the swatches mute while the comment tool is active -->
+			<div
+				class="flex items-center gap-1.5 px-1 {tool === 'comment'
+					? 'pointer-events-none opacity-40'
+					: ''}"
+			>
 				{#each COLORS as colorOption (colorOption)}
 					<button
 						type="button"
@@ -274,7 +502,7 @@
 				<button
 					type="button"
 					class="btn rounded-md p-1.5 text-xs hover:bg-gray-100 hover:text-gray-600 disabled:cursor-not-allowed disabled:opacity-40 dark:hover:bg-gray-800 dark:hover:text-gray-300"
-					title="Undo (Ctrl+Z)"
+					title="Undo drawing (Ctrl+Z)"
 					disabled={annotations.length === 0}
 					onclick={undo}
 				>
@@ -284,7 +512,7 @@
 					type="button"
 					class="btn rounded-md p-1.5 text-xs hover:bg-gray-100 hover:text-gray-600 disabled:cursor-not-allowed disabled:opacity-40 dark:hover:bg-gray-800 dark:hover:text-gray-300"
 					title="Clear all annotations"
-					disabled={annotations.length === 0}
+					disabled={annotations.length === 0 && comments.length === 0}
 					onclick={clearAll}
 				>
 					<LucideTrash2 />
@@ -295,7 +523,8 @@
 		<!-- On mobile the image bleeds to the modal edges (negative margin swallows
 		     the container padding) so every horizontal pixel goes to the screenshot -->
 		<div
-			class="flex min-h-40 items-center justify-center overflow-hidden rounded-lg border border-gray-200 bg-gray-50 max-sm:-mx-2.5 max-sm:rounded-none max-sm:border-x-0 dark:border-gray-700 dark:bg-gray-950"
+			bind:this={containerEl}
+			class="relative flex min-h-40 items-center justify-center overflow-hidden rounded-lg border border-gray-200 bg-gray-50 max-sm:-mx-2.5 max-sm:rounded-none max-sm:border-x-0 dark:border-gray-700 dark:bg-gray-950"
 		>
 			{#if loadFailed}
 				<p class="p-8 text-sm text-gray-500">Could not load the screenshot.</p>
@@ -306,14 +535,82 @@
 					bind:this={canvasEl}
 					width={image.naturalWidth}
 					height={image.naturalHeight}
-					class="max-h-[75dvh] max-w-full cursor-crosshair touch-none select-none max-sm:max-h-[76dvh]"
+					class="max-h-[75dvh] max-w-full cursor-crosshair touch-none select-none max-sm:max-h-[70dvh]"
 					onpointerdown={onPointerDown}
 					onpointermove={onPointerMove}
 					onpointerup={onPointerUp}
 					onpointercancel={onPointerCancel}
 				></canvas>
 			{/if}
+
+			{#if !isNarrow && editingIndex !== null && comments[editingIndex]}
+				<div
+					bind:this={popoverEl}
+					class="absolute z-10 flex items-center gap-1.5 rounded-lg border border-gray-200 bg-white p-1.5 shadow-lg dark:border-gray-600 dark:bg-gray-800"
+					style={popoverStyle}
+				>
+					<span
+						class="flex size-5 flex-none items-center justify-center rounded-full bg-blue-500 text-xs font-semibold text-white"
+					>
+						{editingIndex + 1}
+					</span>
+					<input
+						type="text"
+						class={noteInput}
+						placeholder="What about this area?"
+						bind:value={comments[editingIndex].note}
+						onkeydown={(e) => e.key === "Enter" && commitEditing()}
+						onblur={onNoteBlur}
+						use:autofocus
+					/>
+					<button
+						type="button"
+						class="btn flex-none rounded-md p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-700 dark:hover:text-gray-300"
+						title="Delete note"
+						onpointerdown={(e) => {
+							e.preventDefault();
+							if (editingIndex !== null) deleteComment(editingIndex);
+						}}
+					>
+						<LucideX />
+					</button>
+				</div>
+			{/if}
 		</div>
+
+		{#if isNarrow && comments.length > 0}
+			<ul class="flex flex-col gap-1.5">
+				{#each comments as comment, i (comment.id)}
+					<li class="flex items-center gap-2">
+						<span
+							class="flex size-5 flex-none items-center justify-center rounded-full bg-blue-500 text-xs font-semibold text-white"
+						>
+							{i + 1}
+						</span>
+						<input
+							type="text"
+							class={noteInput}
+							placeholder="What about this area?"
+							bind:value={comment.note}
+							onkeydown={(e) => e.key === "Enter" && (e.target as HTMLInputElement).blur()}
+							onblur={() => onRowBlur(i)}
+							use:autofocus={editingIndex === i}
+						/>
+						<button
+							type="button"
+							class="btn flex-none rounded-md p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-800 dark:hover:text-gray-300"
+							title="Delete note"
+							onpointerdown={(e) => {
+								e.preventDefault();
+								deleteComment(i);
+							}}
+						>
+							<LucideX />
+						</button>
+					</li>
+				{/each}
+			</ul>
+		{/if}
 
 		<div class="flex items-center justify-end gap-2">
 			<button

--- a/src/lib/components/chat/ScreenshotAnnotationModal.svelte
+++ b/src/lib/components/chat/ScreenshotAnnotationModal.svelte
@@ -114,6 +114,7 @@
 			current = null;
 			comments = [];
 			editingIndex = null;
+			composingNote = false;
 			draftRegion = null;
 			loadFailed = false;
 		};
@@ -413,8 +414,12 @@
 
 	function deleteComment(index: number) {
 		comments = comments.filter((_, i) => i !== index);
-		if (editingIndex === index) editingIndex = null;
-		else if (editingIndex !== null && editingIndex > index) editingIndex -= 1;
+		if (editingIndex === index) {
+			// Deleting via the X suppresses the textarea's blur (to keep focus
+			// controlled), so compositionend may never fire for a composing note
+			composingNote = false;
+			editingIndex = null;
+		} else if (editingIndex !== null && editingIndex > index) editingIndex -= 1;
 	}
 
 	function onNoteBlur(e: FocusEvent, index: number) {
@@ -429,7 +434,10 @@
 
 	/** Blur handler for mobile list rows: empty rows evaporate on leave */
 	function onRowBlur(index: number) {
-		if (editingIndex === index) editingIndex = null;
+		if (editingIndex === index) {
+			composingNote = false;
+			editingIndex = null;
+		}
 		const comment = comments[index];
 		if (comment && !comment.note.trim()) deleteComment(index);
 	}
@@ -443,6 +451,7 @@
 		current = null;
 		comments = [];
 		editingIndex = null;
+		composingNote = false;
 		draftRegion = null;
 	}
 

--- a/src/lib/components/chat/ScreenshotAnnotationModal.svelte
+++ b/src/lib/components/chat/ScreenshotAnnotationModal.svelte
@@ -67,6 +67,8 @@
 	let editingIndex = $state<number | null>(null);
 	/** Live drag preview for the comment tool, kept as origin + pointer */
 	let draftRegion = $state<{ ox: number; oy: number; px: number; py: number } | null>(null);
+	/** Bumped to re-trigger the focus effect when editingIndex itself doesn't change */
+	let focusNonce = $state(0);
 	let nextCommentId = 0;
 
 	let canvasEl: HTMLCanvasElement | undefined = $state();
@@ -255,9 +257,19 @@
 		};
 	}
 
-	/** Topmost comment whose badge contains the point, for click-to-reopen */
+	/**
+	 * Topmost comment whose badge contains the point, for click-to-reopen.
+	 * The hit target has a floor in screen pixels: on a heavily downscaled
+	 * capture the badge's image-space radius can shrink to a couple of CSS
+	 * pixels, which would make badges effectively unclickable.
+	 */
 	function commentIndexAt(point: Point): number | null {
-		const hitRadius = badgeRadius * 1.4;
+		const canvas = canvasEl;
+		const displayScale = canvas ? canvas.getBoundingClientRect().width / canvas.width : 1;
+		const hitRadius = Math.max(
+			badgeRadius * 1.4,
+			displayScale > 0 ? 14 / displayScale : badgeRadius * 1.4
+		);
 		for (let i = comments.length - 1; i >= 0; i--) {
 			if (Math.hypot(point.x - comments[i].x, point.y - comments[i].y) <= hitRadius) return i;
 		}
@@ -268,15 +280,23 @@
 		if (!image || e.button !== 0) return;
 		const point = toImagePoint(e);
 		if (!point) return;
+		// A badge is clickable with any tool selected: clicking a number is an
+		// unambiguous "show me this note". Clicking the badge of the note that's
+		// already open keeps it open and pulls focus back to it (editingIndex
+		// doesn't change on this path, so the focus effect needs the nudge).
+		if (editingIndex !== null && commentIndexAt(point) === editingIndex) {
+			focusNonce += 1;
+			return;
+		}
+		// Settle any open editor first so indices are stable for the hit test
+		// (an abandoned empty comment gets dropped here)
+		commitEditing();
+		const hit = commentIndexAt(point);
+		if (hit !== null) {
+			editingIndex = hit;
+			return;
+		}
 		if (tool === "comment") {
-			// Runs before the open editor's blur: settle it first so indices are
-			// stable for the hit test below
-			commitEditing();
-			const hit = commentIndexAt(point);
-			if (hit !== null) {
-				editingIndex = hit;
-				return;
-			}
 			(e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
 			draftRegion = { ox: point.x, oy: point.y, px: point.x, py: point.y };
 			return;
@@ -292,11 +312,17 @@
 			draftRegion = { ...draftRegion, px: point.x, py: point.y };
 			return;
 		}
-		if (!current) return;
-		current =
-			current.tool === "pen"
-				? { ...current, points: [...current.points, point] }
-				: { ...current, points: [current.points[0], point] };
+		if (current) {
+			current =
+				current.tool === "pen"
+					? { ...current, points: [...current.points, point] }
+					: { ...current, points: [current.points[0], point] };
+			return;
+		}
+		// Idle hover: badges advertise their clickability
+		if (canvasEl) {
+			canvasEl.style.cursor = commentIndexAt(point) !== null ? "pointer" : "";
+		}
 	}
 
 	function onPointerUp() {
@@ -408,9 +434,76 @@
 		);
 	}
 
-	function autofocus(node: HTMLElement, enabled: boolean = true) {
-		if (enabled) node.focus();
+	// Focus when the token is set, and again whenever it changes: the popover
+	// element survives switching between comments (the {#if} block never
+	// unmounts), so a mount-only focus would miss badge-to-badge jumps
+	function autofocus(node: HTMLElement, token: unknown = true) {
+		function apply(value: unknown) {
+			if (value === false || value === null || value === undefined) return;
+			// Deferred a task: focusing a just-mounted element synchronously
+			// during the render flush doesn't reliably stick. setTimeout rather
+			// than requestAnimationFrame — rAF can be throttled to never when the
+			// page isn't actively compositing.
+			setTimeout(() => {
+				if (node.isConnected) {
+					node.focus();
+					node.scrollIntoView({ block: "nearest" });
+				}
+			}, 0);
+		}
+		apply(token);
+		return {
+			update: apply,
+		};
 	}
+
+	/** Keep a note textarea as tall as its content (capped by CSS max-height) */
+	function autogrow(node: HTMLTextAreaElement) {
+		function resize() {
+			node.style.height = "auto";
+			node.style.height = `${node.scrollHeight}px`;
+		}
+		resize();
+		node.addEventListener("input", resize);
+		return {
+			destroy() {
+				node.removeEventListener("input", resize);
+			},
+		};
+	}
+
+	/** Enter commits the note, Shift+Enter inserts a newline */
+	function onNoteKeydown(e: KeyboardEvent) {
+		if (e.key === "Enter" && !e.shiftKey) {
+			e.preventDefault();
+			(e.target as HTMLTextAreaElement).blur();
+		}
+	}
+
+	// Popover focus is driven by state, not element mount: mount-time focus
+	// proved unreliable for the reopen path. The popover element is read lazily
+	// inside the deferred attempts (untracked on purpose) with a short bounded
+	// retry, so the effect doesn't depend on bind:this flush ordering.
+	$effect(() => {
+		if (isNarrow || editingIndex === null) return;
+		void comments[editingIndex]?.id;
+		void focusNonce;
+		let cancelled = false;
+		let tries = 0;
+		const attempt = () => {
+			if (cancelled) return;
+			const target = popoverEl?.querySelector("textarea");
+			if (target) {
+				target.focus();
+				return;
+			}
+			if (++tries < 10) setTimeout(attempt, 16);
+		};
+		setTimeout(attempt, 0);
+		return () => {
+			cancelled = true;
+		};
+	});
 
 	// ----- desktop popover positioning (image space -> container CSS space) -----
 	let popoverStyle = $state("");
@@ -428,12 +521,13 @@
 		const scaleY = canvasRect.height / canvas.height;
 		const badgeX = canvasRect.left - wrapRect.left + comment.x * scaleX;
 		const badgeY = canvasRect.top - wrapRect.top + comment.y * scaleY;
-		const width = 264;
+		const width = 280;
 		const left = Math.min(
 			Math.max(8, badgeX + badgeRadius * scaleX + 8),
 			wrapRect.width - width - 8
 		);
-		const top = Math.min(Math.max(8, badgeY + badgeRadius * scaleY + 8), wrapRect.height - 56);
+		// Bottom clamp leaves room for the textarea to grow a few lines
+		const top = Math.min(Math.max(8, badgeY + badgeRadius * scaleY + 8), wrapRect.height - 120);
 		popoverStyle = `left:${left}px; top:${top}px; width:${width}px;`;
 	});
 
@@ -443,7 +537,7 @@
 	const toolBtnInactive =
 		"text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200";
 	const noteInput =
-		"min-w-0 flex-1 rounded-md border border-gray-200 bg-white px-2 py-1 text-sm text-gray-800 outline-hidden placeholder:text-gray-400 focus:border-blue-400 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-200 dark:focus:border-blue-500";
+		"scrollbar-custom max-h-32 min-w-0 flex-1 resize-none overflow-y-auto rounded-md border border-gray-200 bg-white px-2 py-1 text-sm leading-snug text-gray-800 outline-hidden placeholder:text-gray-400 focus:border-blue-400 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-200 dark:focus:border-blue-500";
 </script>
 
 <svelte:window onkeydown={onKeydown} onresize={() => (resizeNonce += 1)} />
@@ -546,23 +640,25 @@
 			{#if !isNarrow && editingIndex !== null && comments[editingIndex]}
 				<div
 					bind:this={popoverEl}
-					class="absolute z-10 flex items-center gap-1.5 rounded-lg border border-gray-200 bg-white p-1.5 shadow-lg dark:border-gray-600 dark:bg-gray-800"
+					class="absolute z-10 flex items-start gap-1.5 rounded-lg border border-gray-200 bg-white p-1.5 shadow-lg dark:border-gray-600 dark:bg-gray-800"
 					style={popoverStyle}
 				>
 					<span
-						class="flex size-5 flex-none items-center justify-center rounded-full bg-blue-500 text-xs font-semibold text-white"
+						class="mt-0.5 flex size-5 flex-none items-center justify-center rounded-full bg-blue-500 text-xs font-semibold text-white"
 					>
 						{editingIndex + 1}
 					</span>
-					<input
-						type="text"
-						class={noteInput}
-						placeholder="What about this area?"
-						bind:value={comments[editingIndex].note}
-						onkeydown={(e) => e.key === "Enter" && commitEditing()}
-						onblur={onNoteBlur}
-						use:autofocus
-					/>
+					{#key comments[editingIndex].id}
+						<textarea
+							rows="1"
+							class={noteInput}
+							placeholder="What about this area?"
+							bind:value={comments[editingIndex].note}
+							onkeydown={onNoteKeydown}
+							onblur={onNoteBlur}
+							use:autogrow
+						></textarea>
+					{/key}
 					<button
 						type="button"
 						class="btn flex-none rounded-md p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-700 dark:hover:text-gray-300"
@@ -581,21 +677,22 @@
 		{#if isNarrow && comments.length > 0}
 			<ul class="flex flex-col gap-1.5">
 				{#each comments as comment, i (comment.id)}
-					<li class="flex items-center gap-2">
+					<li class="flex items-start gap-2">
 						<span
-							class="flex size-5 flex-none items-center justify-center rounded-full bg-blue-500 text-xs font-semibold text-white"
+							class="mt-1 flex size-5 flex-none items-center justify-center rounded-full bg-blue-500 text-xs font-semibold text-white"
 						>
 							{i + 1}
 						</span>
-						<input
-							type="text"
+						<textarea
+							rows="1"
 							class={noteInput}
 							placeholder="What about this area?"
 							bind:value={comment.note}
-							onkeydown={(e) => e.key === "Enter" && (e.target as HTMLInputElement).blur()}
+							onkeydown={onNoteKeydown}
 							onblur={() => onRowBlur(i)}
-							use:autofocus={editingIndex === i}
-						/>
+							use:autofocus={editingIndex === i ? editingIndex : null}
+							use:autogrow
+						></textarea>
 						<button
 							type="button"
 							class="btn flex-none rounded-md p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-800 dark:hover:text-gray-300"

--- a/src/lib/stores/pendingChatFiles.ts
+++ b/src/lib/stores/pendingChatFiles.ts
@@ -1,8 +1,0 @@
-import { writable } from "svelte/store";
-
-/**
- * Files queued for the chat composer from outside ChatWindow (e.g. an artifact
- * preview screenshot). ChatWindow appends them to its attachment list and
- * clears the store on arrival.
- */
-export const pendingChatFiles = writable<File[] | undefined>(undefined);

--- a/src/lib/stores/pendingComposerPayload.ts
+++ b/src/lib/stores/pendingComposerPayload.ts
@@ -1,0 +1,16 @@
+import { writable } from "svelte/store";
+
+export interface ComposerPayload {
+	/** Attachments to append to the composer's file list */
+	files?: File[];
+	/** Text appended to the current draft, still editable before sending */
+	text?: string;
+}
+
+/**
+ * Content queued for the chat composer from outside ChatWindow (e.g. an
+ * annotated artifact screenshot plus its numbered notes). ChatWindow consumes
+ * and clears this on arrival: files join the attachment list, text is
+ * appended to the draft.
+ */
+export const pendingComposerPayload = writable<ComposerPayload | undefined>(undefined);

--- a/src/lib/utils/screenshotNotes.spec.ts
+++ b/src/lib/utils/screenshotNotes.spec.ts
@@ -18,4 +18,16 @@ describe("formatScreenshotNotes", () => {
 			"Screenshot notes:\n1. first\n2. second"
 		);
 	});
+
+	it("indents continuation lines of multiline notes", () => {
+		expect(formatScreenshotNotes(["first line\nsecond line", "plain"])).toBe(
+			"Screenshot notes:\n1. first line\n   second line\n2. plain"
+		);
+	});
+
+	it("names the screenshot in the header so stacked blocks stay apart", () => {
+		expect(formatScreenshotNotes(["overlaps"], '"Pomodoro Timer" (v2)')).toBe(
+			'Notes on the "Pomodoro Timer" (v2) screenshot:\n1. overlaps'
+		);
+	});
 });

--- a/src/lib/utils/screenshotNotes.spec.ts
+++ b/src/lib/utils/screenshotNotes.spec.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { formatScreenshotNotes } from "./screenshotNotes";
 
+const HEADER = "Screenshot with numbered marks:";
+
 describe("formatScreenshotNotes", () => {
-	it("numbers notes in order", () => {
+	it("numbers notes in order under the marker-correspondence header", () => {
 		expect(formatScreenshotNotes(["button overlaps", "too cramped"])).toBe(
-			"Screenshot notes:\n1. button overlaps\n2. too cramped"
+			`${HEADER}\n1. button overlaps\n2. too cramped`
 		);
 	});
 
@@ -15,19 +17,19 @@ describe("formatScreenshotNotes", () => {
 
 	it("trims and skips empty entries while keeping numbering dense", () => {
 		expect(formatScreenshotNotes(["  first  ", "", "second"])).toBe(
-			"Screenshot notes:\n1. first\n2. second"
+			`${HEADER}\n1. first\n2. second`
 		);
 	});
 
 	it("indents continuation lines of multiline notes", () => {
 		expect(formatScreenshotNotes(["first line\nsecond line", "plain"])).toBe(
-			"Screenshot notes:\n1. first line\n   second line\n2. plain"
+			`${HEADER}\n1. first line\n   second line\n2. plain`
 		);
 	});
 
 	it("names the screenshot in the header so stacked blocks stay apart", () => {
 		expect(formatScreenshotNotes(["overlaps"], '"Pomodoro Timer" (v2)')).toBe(
-			'Notes on the "Pomodoro Timer" (v2) screenshot:\n1. overlaps'
+			'"Pomodoro Timer" (v2) screenshot with numbered marks:\n1. overlaps'
 		);
 	});
 });

--- a/src/lib/utils/screenshotNotes.spec.ts
+++ b/src/lib/utils/screenshotNotes.spec.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { formatScreenshotNotes } from "./screenshotNotes";
+
+describe("formatScreenshotNotes", () => {
+	it("numbers notes in order", () => {
+		expect(formatScreenshotNotes(["button overlaps", "too cramped"])).toBe(
+			"Screenshot notes:\n1. button overlaps\n2. too cramped"
+		);
+	});
+
+	it("returns undefined when there are no usable notes", () => {
+		expect(formatScreenshotNotes([])).toBeUndefined();
+		expect(formatScreenshotNotes(["", "   "])).toBeUndefined();
+	});
+
+	it("trims and skips empty entries while keeping numbering dense", () => {
+		expect(formatScreenshotNotes(["  first  ", "", "second"])).toBe(
+			"Screenshot notes:\n1. first\n2. second"
+		);
+	});
+});

--- a/src/lib/utils/screenshotNotes.ts
+++ b/src/lib/utils/screenshotNotes.ts
@@ -1,0 +1,10 @@
+/**
+ * Format the numbered notes of an annotated screenshot into the text block
+ * appended to the composer draft. Numbers match the badges baked into the
+ * exported PNG, so the model can correlate each note with its marked area.
+ */
+export function formatScreenshotNotes(notes: readonly string[]): string | undefined {
+	const cleaned = notes.map((note) => note.trim()).filter(Boolean);
+	if (cleaned.length === 0) return undefined;
+	return ["Screenshot notes:", ...cleaned.map((note, i) => `${i + 1}. ${note}`)].join("\n");
+}

--- a/src/lib/utils/screenshotNotes.ts
+++ b/src/lib/utils/screenshotNotes.ts
@@ -13,8 +13,11 @@ export function formatScreenshotNotes(
 ): string | undefined {
 	const cleaned = notes.map((note) => note.trim()).filter(Boolean);
 	if (cleaned.length === 0) return undefined;
+	// "numbered marks" states the number-to-image correspondence in two words:
+	// without it models tend to infer the referent from conversation context
+	// instead of locating the marker on the image
 	return [
-		subject ? `Notes on the ${subject} screenshot:` : "Screenshot notes:",
+		subject ? `${subject} screenshot with numbered marks:` : "Screenshot with numbered marks:",
 		// Continuation lines of a multiline note are indented so the numbering
 		// stays scannable
 		...cleaned.map((note, i) => `${i + 1}. ${note.replace(/\s*\n\s*/g, "\n   ")}`),

--- a/src/lib/utils/screenshotNotes.ts
+++ b/src/lib/utils/screenshotNotes.ts
@@ -2,9 +2,21 @@
  * Format the numbered notes of an annotated screenshot into the text block
  * appended to the composer draft. Numbers match the badges baked into the
  * exported PNG, so the model can correlate each note with its marked area.
+ *
+ * `subject` names the screenshot in the header (e.g. `"Pomodoro Timer" (v2)`):
+ * a draft can carry blocks from several annotated screenshots, whose badge
+ * numbering each restarts at 1, so the headers are what keeps them apart.
  */
-export function formatScreenshotNotes(notes: readonly string[]): string | undefined {
+export function formatScreenshotNotes(
+	notes: readonly string[],
+	subject?: string
+): string | undefined {
 	const cleaned = notes.map((note) => note.trim()).filter(Boolean);
 	if (cleaned.length === 0) return undefined;
-	return ["Screenshot notes:", ...cleaned.map((note, i) => `${i + 1}. ${note}`)].join("\n");
+	return [
+		subject ? `Notes on the ${subject} screenshot:` : "Screenshot notes:",
+		// Continuation lines of a multiline note are indented so the numbering
+		// stays scannable
+		...cleaned.map((note, i) => `${i + 1}. ${note.replace(/\s*\n\s*/g, "\n   ")}`),
+	].join("\n");
 }


### PR DESCRIPTION
## What

Adds a **comment tool** to the artifact screenshot annotator, in the spirit of Figma comments: click drops a numbered pin, drag marks a region, and the note is typed into a **regular input**, never rasterized onto the canvas. It leads the toolbar and is the default tool.

On "Add to chat" the exported PNG carries only minimal baked markers per comment (blue numbered badge with a white halo, dashed outline for regions), while the note texts are appended to the composer draft as a matching numbered list:

```
Screenshot notes:
1. the title should be bigger
2. this whole area feels empty
```

The numbers in the image correlate with the numbers in the text, so a multimodal model reads the notes losslessly instead of deciphering rendered pixels, and the user can still edit everything before sending. Zero comments means zero appended text, so the existing flow is unchanged.

## Design decisions

- **Desktop**: notes edit in a popover anchored at the marker. Click a badge to reopen it, Enter or click-away commits, Escape dismisses just the popover (second Escape closes the modal), an X deletes the comment. Empty notes are discarded, matching Figma's draft behavior.
- **Mobile** (below sm): the editor is an in-flow numbered list under the canvas instead of a floating popover, so the on-screen keyboard interacts with a normal input the way browsers already handle well.
- **Comments have one fixed identity** (blue, dashed) and the color palette keeps applying only to arrow/pen/rect; the swatches mute while the comment tool is active. Dashed outlines also let the model distinguish "referenced region" from hand-drawn solid rectangles.
- **Undo stays strokes-only.** There is no redo stack, so typed text is deliberately kept out of Ctrl+Z reach; comments are deleted explicitly. Ctrl+Z inside a note input keeps native text undo. Clear-all wipes both.
- The `pendingChatFiles` store becomes `pendingComposerPayload` (`files` plus optional `text` appended to the draft).

## Tests

Unit tests for the notes formatter; existing capture round-trip browser suites pass (96 client, 487 server/SSR). Verified live in the app: pin and region flows, popover reopen/delete, Escape scoping, empty-note discard, mobile list, and the final composer state (attachment plus prefilled numbered notes).

Closes #2460 (supersedes the canvas text tool: notes as structured text turned out strictly better than rasterizing text into the image).