### PR TITLE
Give the page an explicit light-mode background

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -26,7 +26,7 @@
 		</script>
 		%sveltekit.head%
 	</head>
-	<body data-sveltekit-preload-data="hover" class="h-dvh dark:bg-gray-900">
+	<body data-sveltekit-preload-data="hover" class="h-dvh bg-white dark:bg-gray-900">
 		<div id="app" class="contents h-full">%sveltekit.body%</div>
 
 		<!-- Google Tag Manager -->


### PR DESCRIPTION
## What

One line: `bg-white` on `<body>` next to the existing `dark:bg-gray-900`.

## Why

In light mode the page root was fully transparent: body only declares a dark-mode background, and every light-mode surface composites over whatever sits behind the page. In a standalone browser that's the default white canvas, so nothing looks wrong. In an embedded webview the transparent root composites over the embedder's UI instead, and with a forced-dark canvas the same happens: the sidebar's gradient-to-transparent and the transparent chat column smear into black.

Repro that surfaced it: viewing the app in light mode inside an embedded browser pane. Screenshot comparison in the thread that reported it: sidebar and chat cards fading into black; with this change light mode renders on white as designed. Verified against dark mode too, which is unchanged (body still resolves to the theme's near-black).

Not tied to any recent PR: bisected back through the last two weeks of commits and the transparency has been there all along; it only shows in embedding scenarios.