### PR TITLE
fix(mcp): tolerate null optional client metadata from DCR

### DIFF
--- a/src/lib/server/mcp/oauth/validation.spec.ts
+++ b/src/lib/server/mcp/oauth/validation.spec.ts
@@ -57,6 +57,17 @@ describe("OAuth metadata validation", () => {
 		);
 	});
 
+	it("drops null optional client metadata some servers return", () => {
+		const client = parseClientInformation({
+			client_id: "client",
+			redirect_uris: ["https://chat.example.com/api/mcp/oauth/callback"],
+			logo_uri: null,
+			tos_uri: null,
+		});
+		expect(client.logo_uri).toBeUndefined();
+		expect(client.tos_uri).toBeUndefined();
+	});
+
 	it("requires authorization servers to advertise PKCE S256", () => {
 		expect(() =>
 			assertPkceS256Supported({

--- a/src/lib/server/mcp/oauth/validation.ts
+++ b/src/lib/server/mcp/oauth/validation.ts
@@ -53,8 +53,19 @@ export function parseAuthorizationServerMetadata(input: unknown): AuthorizationS
 	return metadata;
 }
 
+// Some servers send null for optional client fields (logo_uri, tos_uri); the SDK schema rejects
+// null, so drop null-valued keys rather than failing the whole registration.
+function dropNullValues(input: unknown): unknown {
+	if (input === null || typeof input !== "object" || Array.isArray(input)) {
+		return input;
+	}
+	return Object.fromEntries(
+		Object.entries(input as Record<string, unknown>).filter(([, value]) => value !== null)
+	);
+}
+
 export function parseClientInformation(input: unknown): OAuthClientInformationFull {
-	const client = OAuthClientInformationFullSchema.parse(input);
+	const client = OAuthClientInformationFullSchema.parse(dropNullValues(input));
 	if (!client.client_id.trim()) {
 		throw new Error("OAuth client_id must not be empty");
 	}


### PR DESCRIPTION
Some authorization servers return null for optional client fields such as logo_uri/tos_uri in their dynamic client registration response. The SDK schema accepts a URL, "", or undefined but not null, so parseClientInformation threw and DCR silently fell back to manual client entry (and surfaced the raw Zod error on paths that don't catch it). Drop null-valued keys before parsing so lenient registrations succeed.