### PR TITLE
List every distinct preview error in fix requests instead of only the first

### DIFF
--- a/src/lib/components/HtmlPreviewModal.svelte
+++ b/src/lib/components/HtmlPreviewModal.svelte
@@ -6,6 +6,7 @@
 	import {
 		buildArtifactSrcdoc,
 		composeFixRequest,
+		MAX_CAPTURED_PREVIEW_ERRORS,
 		type PreviewError,
 	} from "$lib/utils/previewSrcdoc";
 	import { parseExternalUrl } from "$lib/utils/externalLink";
@@ -55,6 +56,7 @@
 			return;
 		}
 		if (data.type !== "chatui.preview.error") return;
+		if (errors.length >= MAX_CAPTURED_PREVIEW_ERRORS) return;
 		const detail = (data.detail ?? {}) as { message?: unknown; stack?: string };
 		errors = [...errors, { message: String(detail.message ?? "Error"), stack: detail.stack }];
 	}

--- a/src/lib/components/HtmlPreviewModal.svelte
+++ b/src/lib/components/HtmlPreviewModal.svelte
@@ -5,9 +5,10 @@
 	import CarbonClose from "~icons/carbon/close";
 	import {
 		buildArtifactSrcdoc,
+		capturePreviewError,
 		composeFixRequest,
-		MAX_CAPTURED_PREVIEW_ERRORS,
-		type PreviewError,
+		normalizePreviewError,
+		type CapturedPreviewError,
 	} from "$lib/utils/previewSrcdoc";
 	import { parseExternalUrl } from "$lib/utils/externalLink";
 	import type { ArtifactKind } from "$lib/utils/artifacts";
@@ -29,7 +30,7 @@
 
 	let iframeEl: HTMLIFrameElement | undefined = $state();
 	let channel = $state(`preview_${Math.random().toString(36).slice(2)}`);
-	let errors: PreviewError[] = $state([]);
+	let errors: CapturedPreviewError[] = $state([]);
 	let externalLinkUrl = $state<URL | null>(null);
 
 	let srcdoc = $derived(buildArtifactSrcdoc(kind, html, channel));
@@ -37,7 +38,7 @@
 	type PreviewMessage = {
 		type: string;
 		channel: string;
-		detail?: { message?: unknown; stack?: string; href?: unknown };
+		detail?: { message?: unknown; stack?: unknown; href?: unknown };
 	};
 
 	function onMessage(ev: MessageEvent) {
@@ -56,9 +57,7 @@
 			return;
 		}
 		if (data.type !== "chatui.preview.error") return;
-		if (errors.length >= MAX_CAPTURED_PREVIEW_ERRORS) return;
-		const detail = (data.detail ?? {}) as { message?: unknown; stack?: string };
-		errors = [...errors, { message: String(detail.message ?? "Error"), stack: detail.stack }];
+		errors = capturePreviewError(errors, normalizePreviewError(data.detail));
 	}
 
 	onMount(() => {

--- a/src/lib/components/chat/ArtifactPanel.svelte
+++ b/src/lib/components/chat/ArtifactPanel.svelte
@@ -9,6 +9,7 @@
 		buildArtifactSrcdoc,
 		composeFixRequest,
 		isDeployableKind,
+		MAX_CAPTURED_PREVIEW_ERRORS,
 		type PreviewError,
 	} from "$lib/utils/previewSrcdoc";
 	import { captureArtifactScreenshot, pngDataUrlToFile } from "$lib/utils/artifactCapture";
@@ -333,6 +334,7 @@
 			return;
 		}
 		if (data.type !== "chatui.preview.error") return;
+		if (errors.length >= MAX_CAPTURED_PREVIEW_ERRORS) return;
 		const detail = (data.detail ?? {}) as { message?: unknown; stack?: string };
 		errors = [...errors, { message: String(detail.message ?? "Error"), stack: detail.stack }];
 	}

--- a/src/lib/components/chat/ArtifactPanel.svelte
+++ b/src/lib/components/chat/ArtifactPanel.svelte
@@ -7,10 +7,11 @@
 	import { diffLines, diffStats, renderDiffHtml } from "$lib/utils/artifactDiff";
 	import {
 		buildArtifactSrcdoc,
+		capturePreviewError,
 		composeFixRequest,
 		isDeployableKind,
-		MAX_CAPTURED_PREVIEW_ERRORS,
-		type PreviewError,
+		normalizePreviewError,
+		type CapturedPreviewError,
 	} from "$lib/utils/previewSrcdoc";
 	import { captureArtifactScreenshot, pngDataUrlToFile } from "$lib/utils/artifactCapture";
 	import { parseExternalUrl } from "$lib/utils/externalLink";
@@ -286,7 +287,7 @@
 	// ----- live preview -----
 	const previewChannel = `artifact_${Math.random().toString(36).slice(2)}`;
 	let iframeEl: HTMLIFrameElement | undefined = $state();
-	let errors: PreviewError[] = $state([]);
+	let errors: CapturedPreviewError[] = $state([]);
 	let externalLinkUrl = $state<URL | null>(null);
 
 	let srcdoc = $derived.by(() => {
@@ -315,7 +316,7 @@
 	type PreviewMessage = {
 		type: string;
 		channel: string;
-		detail?: { message?: unknown; stack?: string; href?: unknown };
+		detail?: { message?: unknown; stack?: unknown; href?: unknown };
 	};
 
 	function onWindowMessage(ev: MessageEvent) {
@@ -334,9 +335,7 @@
 			return;
 		}
 		if (data.type !== "chatui.preview.error") return;
-		if (errors.length >= MAX_CAPTURED_PREVIEW_ERRORS) return;
-		const detail = (data.detail ?? {}) as { message?: unknown; stack?: string };
-		errors = [...errors, { message: String(detail.message ?? "Error"), stack: detail.stack }];
+		errors = capturePreviewError(errors, normalizePreviewError(data.detail));
 	}
 
 	// Sends the fix request as a chat message right away. On mobile the panel

--- a/src/lib/utils/composeFixRequest.spec.ts
+++ b/src/lib/utils/composeFixRequest.spec.ts
@@ -14,9 +14,56 @@ describe("composeFixRequest", () => {
 		);
 	});
 
-	it("summarizes extra errors as a count", () => {
-		expect(composeFixRequest([{ message: "a" }, { message: "b" }, { message: "c" }])).toBe(
-			"it's not working: a (+2 more) - can you fix it?"
+	it("collapses repeats of the same error into a count", () => {
+		const error = { message: "boom", stack: "Error: boom\n  at loop:1" };
+		expect(composeFixRequest([error, error, error])).toBe(
+			"it's not working: boom (repeated 3 times)\nError: boom\n  at loop:1 - can you fix it?"
 		);
+	});
+
+	it("lists every distinct error with its stack", () => {
+		const out = composeFixRequest([
+			{ message: "a", stack: "Error: a\n  at a:1" },
+			{ message: "b", stack: "Error: b\n  at b:1" },
+			{ message: "b", stack: "Error: b\n  at b:1" },
+			{ message: "c" },
+		]);
+		expect(out).toBe(
+			"it's not working, I see 3 errors:\n" +
+				"1. a\nError: a\n  at a:1\n" +
+				"2. b (repeated 2 times)\nError: b\n  at b:1\n" +
+				"3. c\n" +
+				"can you fix them?"
+		);
+	});
+
+	it("treats same message with different stacks as distinct errors", () => {
+		const out = composeFixRequest([
+			{ message: "undefined is not a function", stack: "  at siteA:1" },
+			{ message: "undefined is not a function", stack: "  at siteB:2" },
+		]);
+		expect(out).toContain("I see 2 errors:");
+	});
+
+	it("caps the list at 5 distinct errors and counts the rest", () => {
+		const errors = Array.from({ length: 8 }, (_, i) => ({ message: `error ${i}` }));
+		const out = composeFixRequest(errors);
+		expect(out).toContain("I see 8 errors:");
+		expect(out).toContain("5. error 4");
+		expect(out).not.toContain("error 5");
+		expect(out).toContain("(+3 more distinct errors)");
+	});
+
+	it("trims stacks to their top frames", () => {
+		const stack = Array.from({ length: 12 }, (_, i) => `  at frame:${i}`).join("\n");
+		const out = composeFixRequest([{ message: "deep", stack }]);
+		expect(out).toContain("  at frame:4");
+		expect(out).not.toContain("  at frame:5");
+	});
+
+	it("truncates a pathologically long error", () => {
+		const out = composeFixRequest([{ message: "x".repeat(5000) }]);
+		expect(out.length).toBeLessThan(800);
+		expect(out).toContain("…");
 	});
 });

--- a/src/lib/utils/composeFixRequest.spec.ts
+++ b/src/lib/utils/composeFixRequest.spec.ts
@@ -1,33 +1,130 @@
 import { describe, expect, it } from "vitest";
-import { composeFixRequest } from "$lib/utils/previewSrcdoc";
+import {
+	capturePreviewError,
+	composeFixRequest,
+	MAX_COUNTED_REPEATS,
+	MAX_DISTINCT_CAPTURED_ERRORS,
+	normalizePreviewError,
+	type CapturedPreviewError,
+} from "$lib/utils/previewSrcdoc";
+
+function capture(errors: { message: string; stack?: string }[]): CapturedPreviewError[] {
+	return errors.reduce<CapturedPreviewError[]>((acc, e) => capturePreviewError(acc, e), []);
+}
+
+describe("normalizePreviewError", () => {
+	it("keeps string stacks and coerces messages", () => {
+		expect(normalizePreviewError({ message: "boom", stack: "  at a:1" })).toEqual({
+			message: "boom",
+			stack: "  at a:1",
+		});
+	});
+
+	it("drops non-string stacks instead of crashing later rendering", () => {
+		expect(normalizePreviewError({ message: "boom", stack: {} })).toEqual({
+			message: "boom",
+			stack: undefined,
+		});
+		expect(normalizePreviewError({ message: "boom", stack: 42 }).stack).toBeUndefined();
+	});
+
+	it("survives arbitrary payload shapes", () => {
+		expect(normalizePreviewError(null)).toEqual({ message: "Error", stack: undefined });
+		expect(normalizePreviewError("boom")).toEqual({ message: "Error", stack: undefined });
+		expect(normalizePreviewError({ message: { evil: true } }).message).toBe("[object Object]");
+	});
+
+	it("trims oversized fields", () => {
+		const huge = "x".repeat(100_000);
+		const out = normalizePreviewError({ message: huge, stack: huge });
+		expect(out.message.length).toBeLessThanOrEqual(4000);
+		expect(out.stack?.length).toBeLessThanOrEqual(4000);
+	});
+});
+
+describe("capturePreviewError", () => {
+	it("counts repeats of the same signature instead of storing them again", () => {
+		const error = { message: "boom", stack: "  at loop:1" };
+		const out = capture([error, error, error]);
+		expect(out).toHaveLength(1);
+		expect(out[0].count).toBe(3);
+	});
+
+	it("treats same message with different stacks as distinct", () => {
+		const out = capture([
+			{ message: "boom", stack: "  at a:1" },
+			{ message: "boom", stack: "  at b:2" },
+		]);
+		expect(out).toHaveLength(2);
+	});
+
+	it("still admits and counts known signatures once the distinct cap is full", () => {
+		const noisy = { message: "noisy" };
+		let out = capture([noisy]);
+		for (let i = 0; i < MAX_DISTINCT_CAPTURED_ERRORS + 10; i++) {
+			out = capturePreviewError(out, { message: `unique ${i}` });
+		}
+		expect(out).toHaveLength(MAX_DISTINCT_CAPTURED_ERRORS);
+		// A late repeat of the first (noisy) signature still bumps its count
+		out = capturePreviewError(out, noisy);
+		expect(out[0].count).toBe(2);
+		// A never-seen signature past the cap is dropped
+		out = capturePreviewError(out, { message: "too late" });
+		expect(out).toHaveLength(MAX_DISTINCT_CAPTURED_ERRORS);
+	});
+
+	it("returns a new array so state assignment triggers reactivity", () => {
+		const first = capture([{ message: "boom" }]);
+		const second = capturePreviewError(first, { message: "boom" });
+		expect(second).not.toBe(first);
+		expect(first[0].count).toBe(1);
+	});
+
+	it("saturates repeat counting so endless repeats stop producing new state", () => {
+		const noisy = { message: "noisy" };
+		let out = capture([noisy]);
+		for (let i = 0; i < MAX_COUNTED_REPEATS + 50; i++) {
+			out = capturePreviewError(out, noisy);
+		}
+		expect(out[0].count).toBe(MAX_COUNTED_REPEATS);
+		// Once saturated, the same reference comes back: a reactive no-op
+		expect(capturePreviewError(out, noisy)).toBe(out);
+		// New signatures are still admitted after saturation
+		expect(capturePreviewError(out, { message: "other" })).toHaveLength(2);
+	});
+});
 
 describe("composeFixRequest", () => {
 	it("composes a single error with its stack", () => {
 		expect(
-			composeFixRequest([{ message: "x is not defined", stack: "ReferenceError: x\n  at app:1" }])
+			composeFixRequest(
+				capture([{ message: "x is not defined", stack: "ReferenceError: x\n  at app:1" }])
+			)
 		).toBe("it's not working: x is not defined\nReferenceError: x\n  at app:1 - can you fix it?");
 	});
 
 	it("composes a single error without a stack", () => {
-		expect(composeFixRequest([{ message: "boom" }])).toBe(
+		expect(composeFixRequest(capture([{ message: "boom" }]))).toBe(
 			"it's not working: boom - can you fix it?"
 		);
 	});
 
-	it("collapses repeats of the same error into a count", () => {
+	it("renders repeats of a single error as a count", () => {
 		const error = { message: "boom", stack: "Error: boom\n  at loop:1" };
-		expect(composeFixRequest([error, error, error])).toBe(
+		expect(composeFixRequest(capture([error, error, error]))).toBe(
 			"it's not working: boom (repeated 3 times)\nError: boom\n  at loop:1 - can you fix it?"
 		);
 	});
 
 	it("lists every distinct error with its stack", () => {
-		const out = composeFixRequest([
-			{ message: "a", stack: "Error: a\n  at a:1" },
-			{ message: "b", stack: "Error: b\n  at b:1" },
-			{ message: "b", stack: "Error: b\n  at b:1" },
-			{ message: "c" },
-		]);
+		const out = composeFixRequest(
+			capture([
+				{ message: "a", stack: "Error: a\n  at a:1" },
+				{ message: "b", stack: "Error: b\n  at b:1" },
+				{ message: "b", stack: "Error: b\n  at b:1" },
+				{ message: "c" },
+			])
+		);
 		expect(out).toBe(
 			"it's not working, I see 3 errors:\n" +
 				"1. a\nError: a\n  at a:1\n" +
@@ -37,17 +134,10 @@ describe("composeFixRequest", () => {
 		);
 	});
 
-	it("treats same message with different stacks as distinct errors", () => {
-		const out = composeFixRequest([
-			{ message: "undefined is not a function", stack: "  at siteA:1" },
-			{ message: "undefined is not a function", stack: "  at siteB:2" },
-		]);
-		expect(out).toContain("I see 2 errors:");
-	});
-
 	it("caps the list at 5 distinct errors and counts the rest", () => {
-		const errors = Array.from({ length: 8 }, (_, i) => ({ message: `error ${i}` }));
-		const out = composeFixRequest(errors);
+		const out = composeFixRequest(
+			capture(Array.from({ length: 8 }, (_, i) => ({ message: `error ${i}` })))
+		);
 		expect(out).toContain("I see 8 errors:");
 		expect(out).toContain("5. error 4");
 		expect(out).not.toContain("error 5");
@@ -56,14 +146,19 @@ describe("composeFixRequest", () => {
 
 	it("trims stacks to their top frames", () => {
 		const stack = Array.from({ length: 12 }, (_, i) => `  at frame:${i}`).join("\n");
-		const out = composeFixRequest([{ message: "deep", stack }]);
+		const out = composeFixRequest(capture([{ message: "deep", stack }]));
 		expect(out).toContain("  at frame:4");
 		expect(out).not.toContain("  at frame:5");
 	});
 
 	it("truncates a pathologically long error", () => {
-		const out = composeFixRequest([{ message: "x".repeat(5000) }]);
+		const out = composeFixRequest(capture([{ message: "x".repeat(5000) }]));
 		expect(out.length).toBeLessThan(800);
 		expect(out).toContain("…");
+	});
+
+	it("marks saturated repeat counts as a lower bound", () => {
+		const saturated: CapturedPreviewError[] = [{ message: "noisy", count: MAX_COUNTED_REPEATS }];
+		expect(composeFixRequest(saturated)).toContain(`(repeated ${MAX_COUNTED_REPEATS}+ times)`);
 	});
 });

--- a/src/lib/utils/previewSrcdoc.ts
+++ b/src/lib/utils/previewSrcdoc.ts
@@ -32,19 +32,69 @@ export interface PreviewError {
 	stack?: string;
 }
 
-/**
- * Cap on stored preview errors: a handler that throws every frame or click
- * emits the same error endlessly, and each append rebuilds the captured list.
- * Beyond this the extras carry no new signal for a fix request anyway.
- */
-export const MAX_CAPTURED_PREVIEW_ERRORS = 100;
+/** A distinct captured error signature plus how many times it was emitted. */
+export interface CapturedPreviewError extends PreviewError {
+	count: number;
+}
 
-const MAX_DISTINCT_ERRORS = 5;
+/**
+ * Cap on distinct stored signatures. Repeats of a known signature only bump
+ * its count, so a handler that throws every frame can never crowd out a later
+ * unrelated failure; this only bounds pathological pages whose every error is
+ * unique (e.g. a timestamp baked into the message).
+ */
+export const MAX_DISTINCT_CAPTURED_ERRORS = 20;
+/**
+ * Count saturation per signature. Once reached, further repeats return the
+ * input array unchanged, so the state assignment in the collectors becomes a
+ * reactive no-op and an error throwing every frame stops churning the UI.
+ */
+export const MAX_COUNTED_REPEATS = 999;
+/** Per-field cap at capture, well above what a fix request ever renders. */
+const MAX_CAPTURED_FIELD_CHARS = 4000;
+
+const MAX_LISTED_ERRORS = 5;
 const MAX_STACK_LINES = 5;
 const MAX_ERROR_CHARS = 700;
 
-function renderError({ error, count }: { error: PreviewError; count: number }): string {
-	const times = count > 1 ? ` (repeated ${count} times)` : "";
+/**
+ * Normalize an untrusted error payload from the preview channel. The iframe
+ * forwards whatever the page threw or rejected with, so `stack` can be any
+ * shape; anything but a string is dropped rather than rendered.
+ */
+export function normalizePreviewError(detail: unknown): PreviewError {
+	const raw = (detail ?? {}) as { message?: unknown; stack?: unknown };
+	return {
+		message: String(raw.message ?? "Error").slice(0, MAX_CAPTURED_FIELD_CHARS),
+		stack: typeof raw.stack === "string" ? raw.stack.slice(0, MAX_CAPTURED_FIELD_CHARS) : undefined,
+	};
+}
+
+/**
+ * Fold an incoming error into the captured list: a repeat of a known
+ * signature increments that entry's count (until saturation), a new signature
+ * appends until the distinct cap. Returns the input array untouched when
+ * nothing changed, and a new array otherwise, so Svelte state consumers can
+ * assign the result directly and only pay for real changes.
+ */
+export function capturePreviewError(
+	captured: CapturedPreviewError[],
+	incoming: PreviewError
+): CapturedPreviewError[] {
+	const index = captured.findIndex(
+		(e) => e.message === incoming.message && e.stack === incoming.stack
+	);
+	if (index !== -1) {
+		if (captured[index].count >= MAX_COUNTED_REPEATS) return captured;
+		return captured.map((e, i) => (i === index ? { ...e, count: e.count + 1 } : e));
+	}
+	if (captured.length >= MAX_DISTINCT_CAPTURED_ERRORS) return captured;
+	return [...captured, { ...incoming, count: 1 }];
+}
+
+function renderError(error: CapturedPreviewError): string {
+	const shownCount = error.count >= MAX_COUNTED_REPEATS ? `${MAX_COUNTED_REPEATS}+` : error.count;
+	const times = error.count > 1 ? ` (repeated ${shownCount} times)` : "";
 	// Keep only the top of the stack: for single-file artifacts the first
 	// frames carry the useful location, and deep stacks would drown the list
 	const stack = error.stack?.split("\n").slice(0, MAX_STACK_LINES).join("\n") ?? "";
@@ -53,28 +103,17 @@ function renderError({ error, count }: { error: PreviewError; count: number }): 
 }
 
 /** The chat message sent when the user asks the model to fix captured preview errors. */
-export function composeFixRequest(errors: PreviewError[]): string {
-	// Collapse repeats (a throwing rAF/event handler emits the same error over
-	// and over) so each distinct failure is listed once, with a count
-	const distinct = new Map<string, { error: PreviewError; count: number }>();
-	for (const error of errors) {
-		const key = `${error.message}\n${error.stack ?? ""}`;
-		const entry = distinct.get(key);
-		if (entry) entry.count += 1;
-		else distinct.set(key, { error, count: 1 });
-	}
-	const entries = [...distinct.values()];
-
-	if (entries.length <= 1) {
-		const summary = entries.length ? renderError(entries[0]) : "Unknown error";
+export function composeFixRequest(errors: CapturedPreviewError[]): string {
+	if (errors.length <= 1) {
+		const summary = errors.length ? renderError(errors[0]) : "Unknown error";
 		return `it's not working: ${summary} - can you fix it?`;
 	}
 
-	const shown = entries.slice(0, MAX_DISTINCT_ERRORS);
-	const omitted = entries.length - shown.length;
+	const shown = errors.slice(0, MAX_LISTED_ERRORS);
+	const omitted = errors.length - shown.length;
 	const list = shown.map((entry, i) => `${i + 1}. ${renderError(entry)}`).join("\n");
 	const tail = omitted > 0 ? `\n(+${omitted} more distinct error${omitted > 1 ? "s" : ""})` : "";
-	return `it's not working, I see ${entries.length} errors:\n${list}${tail}\ncan you fix them?`;
+	return `it's not working, I see ${errors.length} errors:\n${list}${tail}\ncan you fix them?`;
 }
 
 function buildPreviewHookScript(channel: string): string {

--- a/src/lib/utils/previewSrcdoc.ts
+++ b/src/lib/utils/previewSrcdoc.ts
@@ -32,15 +32,49 @@ export interface PreviewError {
 	stack?: string;
 }
 
+/**
+ * Cap on stored preview errors: a handler that throws every frame or click
+ * emits the same error endlessly, and each append rebuilds the captured list.
+ * Beyond this the extras carry no new signal for a fix request anyway.
+ */
+export const MAX_CAPTURED_PREVIEW_ERRORS = 100;
+
+const MAX_DISTINCT_ERRORS = 5;
+const MAX_STACK_LINES = 5;
+const MAX_ERROR_CHARS = 700;
+
+function renderError({ error, count }: { error: PreviewError; count: number }): string {
+	const times = count > 1 ? ` (repeated ${count} times)` : "";
+	// Keep only the top of the stack: for single-file artifacts the first
+	// frames carry the useful location, and deep stacks would drown the list
+	const stack = error.stack?.split("\n").slice(0, MAX_STACK_LINES).join("\n") ?? "";
+	const rendered = `${error.message}${times}${stack ? `\n${stack}` : ""}`;
+	return rendered.length > MAX_ERROR_CHARS ? `${rendered.slice(0, MAX_ERROR_CHARS)}…` : rendered;
+}
+
 /** The chat message sent when the user asks the model to fix captured preview errors. */
 export function composeFixRequest(errors: PreviewError[]): string {
-	const first = errors[0];
-	const summary = first
-		? `${first.message}${first.stack ? `\n${first.stack}` : ""}`
-		: "Unknown error";
-	return errors.length > 1
-		? `it's not working: ${summary} (+${errors.length - 1} more) - can you fix it?`
-		: `it's not working: ${summary} - can you fix it?`;
+	// Collapse repeats (a throwing rAF/event handler emits the same error over
+	// and over) so each distinct failure is listed once, with a count
+	const distinct = new Map<string, { error: PreviewError; count: number }>();
+	for (const error of errors) {
+		const key = `${error.message}\n${error.stack ?? ""}`;
+		const entry = distinct.get(key);
+		if (entry) entry.count += 1;
+		else distinct.set(key, { error, count: 1 });
+	}
+	const entries = [...distinct.values()];
+
+	if (entries.length <= 1) {
+		const summary = entries.length ? renderError(entries[0]) : "Unknown error";
+		return `it's not working: ${summary} - can you fix it?`;
+	}
+
+	const shown = entries.slice(0, MAX_DISTINCT_ERRORS);
+	const omitted = entries.length - shown.length;
+	const list = shown.map((entry, i) => `${i + 1}. ${renderError(entry)}`).join("\n");
+	const tail = omitted > 0 ? `\n(+${omitted} more distinct error${omitted > 1 ? "s" : ""})` : "";
+	return `it's not working, I see ${entries.length} errors:\n${list}${tail}\ncan you fix them?`;
 }
 
 function buildPreviewHookScript(channel: string): string {


### PR DESCRIPTION
## What

Follow-up to #2459. The "ask to fix" message previously included only the first captured preview error and summarized the rest as "(+N more)", which withheld exactly the information the model needs now that fix requests send directly, with no review step in the composer. A page throwing one pointer-lock error six times produced "error (+5 more)" and the model never saw whether those five were the same error or five different ones.

`composeFixRequest` now:

- collapses repeats of the same error (a throwing interval or event handler emits identical errors endlessly) into one entry with a count, e.g. "(repeated 21 times)"
- lists every distinct error as a numbered list with its stack, capped at 5 distinct entries with a "(+N more distinct errors)" tail
- trims stacks to their top 5 frames and truncates pathologically long entries at 700 chars, so a hostile or broken page cannot blow up the message

Both error collectors (artifact panel and the HTML preview modal) also stop capturing past 100 stored errors, so a handler throwing every frame cannot grow component state unboundedly.

## Example

Before: `it's not working: Failed to execute 'requestPointerLock' ... (+5 more) - can you fix it?`

After:

```
it's not working, I see 2 errors:
1. Uncaught ReferenceError: missingInit is not defined
ReferenceError: missingInit is not defined
    at about:srcdoc:71:7
2. Uncaught ReferenceError: brokenTick is not defined (repeated 21 times)
ReferenceError: brokenTick is not defined
    at about:srcdoc:72:19
can you fix them?
```

## Notes for review

- Verified live in the browser with an artifact throwing one load error plus a repeating interval error; the sent message matches the example above.
- Single-error messages keep the exact previous format.
- The spec (`composeFixRequest.spec.ts`) covers dedupe counts, distinct-stack separation, the 5-entry cap, stack trimming, and length truncation. `npm run check` and the full suite (494 tests) pass on the rebased branch.