### PR TITLE
Carry MCP tool annotations through to the tool mapping

### DIFF
--- a/src/lib/server/mcp/tools.test.ts
+++ b/src/lib/server/mcp/tools.test.ts
@@ -292,3 +292,106 @@ describe("getOpenAiToolsForMcp per-server cache", () => {
 		expect(mapping.search_Server_B.server).toBe("Server B");
 	});
 });
+
+describe("getOpenAiToolsForMcp tool annotations", () => {
+	beforeEach(() => {
+		resetMcpToolsCache();
+		mcpMock.listToolsCalls.length = 0;
+		mcpMock.responses.clear();
+	});
+
+	it("carries declared hints through to the mapping", async () => {
+		mcpMock.responses.set(SERVER_A.url, {
+			tools: [
+				{
+					...searchTool,
+					annotations: {
+						readOnlyHint: true,
+						destructiveHint: false,
+						idempotentHint: true,
+						openWorldHint: true,
+					},
+				},
+			],
+		});
+
+		const { mapping } = await getOpenAiToolsForMcp([SERVER_A]);
+
+		expect(mapping.search.annotations).toEqual({
+			readOnlyHint: true,
+			destructiveHint: false,
+			idempotentHint: true,
+			openWorldHint: true,
+		});
+	});
+
+	// Absence must stay distinguishable from a declaration: the spec's default is destructive.
+	it("leaves annotations absent when the server declares none", async () => {
+		mcpMock.responses.set(SERVER_A.url, { tools: [searchTool] });
+
+		const { mapping } = await getOpenAiToolsForMcp([SERVER_A]);
+
+		expect(mapping.search.annotations).toBeUndefined();
+	});
+
+	it("keeps only the hints the server actually declared", async () => {
+		mcpMock.responses.set(SERVER_A.url, {
+			tools: [{ ...searchTool, annotations: { readOnlyHint: true } }],
+		});
+
+		const { mapping } = await getOpenAiToolsForMcp([SERVER_A]);
+
+		expect(mapping.search.annotations).toEqual({ readOnlyHint: true });
+		expect(mapping.search.annotations).not.toHaveProperty("destructiveHint");
+	});
+
+	it("ignores non-boolean hint values rather than reading them as declarations", async () => {
+		mcpMock.responses.set(SERVER_A.url, {
+			tools: [
+				{
+					...searchTool,
+					annotations: { readOnlyHint: "yes", destructiveHint: 0, idempotentHint: true },
+				},
+			],
+		});
+
+		const { mapping } = await getOpenAiToolsForMcp([SERVER_A]);
+
+		expect(mapping.search.annotations).toEqual({ idempotentHint: true });
+	});
+
+	it("still uses the title annotation as a description fallback", async () => {
+		mcpMock.responses.set(SERVER_A.url, {
+			tools: [{ name: "search", annotations: { title: "Search things", readOnlyHint: true } }],
+		});
+
+		const { tools, mapping } = await getOpenAiToolsForMcp([SERVER_A]);
+
+		expect(tools[0].function.description).toBe("Search things");
+		expect(mapping.search.annotations).toEqual({ readOnlyHint: true });
+	});
+
+	// One tool with an unknown field takes down the whole tools array on strict providers.
+	it("keeps annotations out of the tool definition sent to the provider", async () => {
+		mcpMock.responses.set(SERVER_A.url, {
+			tools: [{ ...searchTool, annotations: { readOnlyHint: true } }],
+		});
+
+		const { tools } = await getOpenAiToolsForMcp([SERVER_A]);
+
+		expect(tools[0].function).not.toHaveProperty("annotations");
+		expect(tools[0]).not.toHaveProperty("annotations");
+	});
+
+	it("survives the cache round trip", async () => {
+		mcpMock.responses.set(SERVER_A.url, {
+			tools: [{ ...searchTool, annotations: { destructiveHint: true } }],
+		});
+
+		await getOpenAiToolsForMcp([SERVER_A]);
+		const cached = await getOpenAiToolsForMcp([SERVER_A]);
+
+		expect(mcpMock.listToolsCalls).toEqual([SERVER_A.url]);
+		expect(cached.mapping.search.annotations).toEqual({ destructiveHint: true });
+	});
+});

--- a/src/lib/server/mcp/tools.ts
+++ b/src/lib/server/mcp/tools.ts
@@ -11,10 +11,23 @@ export type OpenAiTool = {
 	function: { name: string; description?: string; parameters?: Record<string, unknown> };
 };
 
+/**
+ * Behaviour hints a server declares for a tool. Advisory — the server chooses what to
+ * claim. Deliberately not resolved against the spec's defaults (an undeclared tool is
+ * `destructiveHint: true`), so a caller can tell "declared safe" from "said nothing".
+ */
+export type McpToolAnnotations = {
+	readOnlyHint?: boolean;
+	destructiveHint?: boolean;
+	idempotentHint?: boolean;
+	openWorldHint?: boolean;
+};
+
 export interface McpToolMapping {
 	fnName: string;
 	server: string;
 	tool: string;
+	annotations?: McpToolAnnotations;
 }
 
 // Tool listings are cached per server (url + headers), not per server set, so
@@ -26,6 +39,7 @@ type CachedServerTool = {
 	name: string;
 	description?: string;
 	parameters?: Record<string, unknown>;
+	annotations?: McpToolAnnotations;
 };
 
 interface ServerCacheEntry {
@@ -144,8 +158,27 @@ type ListedTool = {
 	name?: string;
 	inputSchema?: Record<string, unknown>;
 	description?: string;
-	annotations?: { title?: string };
+	annotations?: Record<string, unknown>;
 };
+
+const ANNOTATION_HINTS = [
+	"readOnlyHint",
+	"destructiveHint",
+	"idempotentHint",
+	"openWorldHint",
+] as const;
+
+/** Booleans only: a truthy string must not be stored as a declared hint. */
+function readAnnotations(raw: unknown): McpToolAnnotations | undefined {
+	if (!isPlainObject(raw)) return undefined;
+
+	const annotations: McpToolAnnotations = {};
+	for (const hint of ANNOTATION_HINTS) {
+		const value = raw[hint];
+		if (typeof value === "boolean") annotations[hint] = value;
+	}
+	return Object.keys(annotations).length > 0 ? annotations : undefined;
+}
 
 async function listServerTools(
 	server: McpServerConfig,
@@ -201,12 +234,14 @@ async function fetchServerTools(
 		if (typeof tool.name !== "string" || tool.name.trim().length === 0) {
 			continue;
 		}
+		const title = typeof tool.annotations?.title === "string" ? tool.annotations.title : undefined;
 		normalized.push({
 			name: tool.name,
-			description: tool.description ?? tool.annotations?.title,
+			description: tool.description ?? title,
 			parameters: isPlainObject(tool.inputSchema)
 				? sanitizeJsonSchema(tool.inputSchema)
 				: undefined,
+			annotations: readAnnotations(tool.annotations),
 		});
 	}
 	return normalized;
@@ -290,11 +325,13 @@ export async function getOpenAiToolsForMcp(
 				}
 			}
 
+			// Annotations stay off the tool definition: strict providers reject unknown fields.
 			pushToolDefinition(plainName, tool.description, tool.parameters);
 			mapping[plainName] = {
 				fnName: plainName,
 				server: server.name,
 				tool: tool.name,
+				...(tool.annotations ? { annotations: tool.annotations } : {}),
 			};
 		}
 	}


### PR DESCRIPTION
`tools/list` returns per-tool behaviour hints — readOnlyHint, destructiveHint, idempotentHint, openWorldHint — and the listing discarded all of them, keeping only `annotations.title` as a description fallback. They are the natural input to an approval policy, which cannot be written until the data reaches it.

Hints now ride on McpToolMapping, next to the server and tool they belong to. Only real booleans are kept, so a server sending a truthy string cannot be read as having declared a hint, and they are deliberately not merged with the spec's defaults: a caller needs to tell "declared safe" from "said nothing", because an undeclared tool defaults to destructive, not safe.

Annotations stay out of the OpenAI tool definition — they are not part of the function schema and strict providers reject unknown fields.