### PR TITLE
Set explicit max_tokens for DeepSeek-V4-Flash-0731

### DIFF
--- a/chart/env/dev.yaml
+++ b/chart/env/dev.yaml
@@ -82,7 +82,7 @@ envVars:
   MODELS: >
     [
       { "id": "omni", "supportsArtifacts": true },
-      { "id": "deepseek-ai/DeepSeek-V4-Flash-0731", "description": "Updated V4-Flash with adjustable thinking, stronger coding, and agentic tool use.", "supportsReasoning": true, "supportsArtifacts": true },
+      { "id": "deepseek-ai/DeepSeek-V4-Flash-0731", "description": "Updated V4-Flash with adjustable thinking, stronger coding, and agentic tool use.", "parameters": { "max_tokens": 49152 }, "supportsReasoning": true, "supportsArtifacts": true },
       { "id": "thinkingmachines/Inkling-Small", "description": "Compact multimodal 276B MoE with 12B active params and adjustable reasoning effort.", "supportsReasoning": true, "supportsArtifacts": true },
       { "id": "NousResearch/Hermes-3-Llama-3.1-70B", "description": "Steerable 70B Llama fine-tune for roleplay, agents, and function calling.", "supportsArtifacts": true },
       { "id": "Qwen/Qwen3-30B-A3B", "description": "Efficient hybrid 30B MoE with 3B active params and switchable thinking mode." },

--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -92,7 +92,7 @@ envVars:
   MODELS: >
     [
       { "id": "omni", "supportsArtifacts": true },
-      { "id": "deepseek-ai/DeepSeek-V4-Flash-0731", "description": "Updated V4-Flash with adjustable thinking, stronger coding, and agentic tool use.", "supportsReasoning": true, "supportsArtifacts": true },
+      { "id": "deepseek-ai/DeepSeek-V4-Flash-0731", "description": "Updated V4-Flash with adjustable thinking, stronger coding, and agentic tool use.", "parameters": { "max_tokens": 49152 }, "supportsReasoning": true, "supportsArtifacts": true },
       { "id": "thinkingmachines/Inkling-Small", "description": "Compact multimodal 276B MoE with 12B active params and adjustable reasoning effort.", "supportsReasoning": true, "supportsArtifacts": true },
       { "id": "NousResearch/Hermes-3-Llama-3.1-70B", "description": "Steerable 70B Llama fine-tune for roleplay, agents, and function calling.", "supportsArtifacts": true },
       { "id": "Qwen/Qwen3-30B-A3B", "description": "Efficient hybrid 30B MoE with 3B active params and switchable thinking mode." },


### PR DESCRIPTION
## Problem

The `deepseek-ai/DeepSeek-V4-Flash-0731` entry added in #2479 has no `parameters` block, unlike the older `deepseek-ai/DeepSeek-V4-Flash` entry which sets `max_tokens: 49152`. Without an explicit value the request relies on each provider's default output cap.

On baseten (currently the fastest provider for this model on the router) that default is 4096 output tokens, and the model's thinking mode is enabled by default there. A coding or artifact request burns most of the 4096 budget on reasoning and gets cut off mid-answer. The stream ends with `finish_reason: "length"`, which is surfaced as a normal completion: the user sees a truncated reply (for artifact requests, a broken artifact) with no error.

## Verification

Reproduced against the router with the exact request shape chat-ui sends (system prompt, tools, streaming, no `max_tokens`):

- pinned to baseten, generation stops at exactly `completion_tokens: 4096` with `finish_reason: "length"`; usage reports ~4100 reasoning tokens, so thinking alone can exhaust the cap
- same request with `max_tokens: 49152` completes with `finish_reason: "stop"`

## Change

Adds `"parameters": { "max_tokens": 49152 }` to the model entry in `chart/env/prod.yaml` and `chart/env/dev.yaml`, matching the older V4-Flash entry.