### PR TITLE
feat: add prod-v2 values override for a second deployment target

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -75,4 +75,4 @@ jobs:
           display-workflow-run-url-interval: 10s
           ref: refs/heads/main
           token: ${{ secrets.GIT_TOKEN_INFRA_DEPLOYMENT }}
-          inputs: '{"path": "hub/chat-ui/chat-ui.yaml", "value": ${{ env.VALUES }}, "url": "${{ github.event.head_commit.url }}"}'
+          inputs: '{"path": "hub*/chat-ui/*.yaml", "value": ${{ env.VALUES }}, "url": "${{ github.event.head_commit.url }}"}'

--- a/chart/env/prod-v2.yaml
+++ b/chart/env/prod-v2.yaml
@@ -1,0 +1,18 @@
+# Override applied ON TOP of env/prod.yaml while chat-ui runs on the
+# hub-utils-prod-us-east-1 cluster (namespace chat-ui): ALB identity, the
+# operator-credentials namespace, and the internal ingress change. Once the
+# migration is over, fold these keys into env/prod.yaml and delete this file.
+infisical:
+  operatorSecretNamespace: "chat-ui"
+
+ingress:
+  annotations:
+    alb.ingress.kubernetes.io/load-balancer-name: "hub-utils-int-prod-cloudfront"
+    alb.ingress.kubernetes.io/group.name: "hub-utils-int-prod-cloudfront"
+    alb.ingress.kubernetes.io/tags: "Env=prod,Project=hub-utils,Terraform=true"
+
+# The internal path serves single-digit requests/day and its ALB group name
+# would collide with the hub-prod-owned hub-prod-internal-public ALB; it is
+# not recreated on the dedicated cluster.
+ingressInternal:
+  enabled: false


### PR DESCRIPTION
Part of an internal infra migration (dedicated cluster): minimal override layered on top of `env/prod.yaml` by a second Argo app while both run in parallel —

- the ingress joins a different shared ALB (name/group/tags only)
- the operator secret reference points at the app's own namespace
- the internal ingress (single-digit requests/day) is not recreated on the new cluster (its ALB group name is owned by the legacy cluster)
- CI deploy path widened to a glob so both app manifests get the image bump during coexistence

Inert until the companion (internal) infra-deployments PR lands. `env/prod.yaml` untouched.
