### PR TITLE
chore: fold the prod-v2 overrides into prod.yaml

### DIFF
--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -21,18 +21,18 @@ ingress:
   annotations:
     alb.ingress.kubernetes.io/healthcheck-path: "/chat/healthcheck"
     alb.ingress.kubernetes.io/listen-ports: "[{\"HTTP\": 80}, {\"HTTPS\": 443}]"
-    alb.ingress.kubernetes.io/load-balancer-name: "hub-utils-prod-cloudfront"
-    alb.ingress.kubernetes.io/group.name: "hub-utils-prod-cloudfront"
+    alb.ingress.kubernetes.io/load-balancer-name: "hub-utils-int-prod-cloudfront"
+    alb.ingress.kubernetes.io/group.name: "hub-utils-int-prod-cloudfront"
     alb.ingress.kubernetes.io/scheme: "internal"
     alb.ingress.kubernetes.io/ssl-redirect: "443"
-    alb.ingress.kubernetes.io/tags: "Env=prod,Project=hub,Terraform=true"
+    alb.ingress.kubernetes.io/tags: "Env=prod,Project=hub-utils,Terraform=true"
     alb.ingress.kubernetes.io/target-group-attributes: deregistration_delay.timeout_seconds=30
     alb.ingress.kubernetes.io/target-type: "ip"
     alb.ingress.kubernetes.io/certificate-arn: "arn:aws:acm:us-east-1:707930574880:certificate/5b25b145-75db-4837-b9f3-7f238ba8a9c7,arn:aws:acm:us-east-1:707930574880:certificate/bfdf509c-f44b-400f-b9e1-6f7a861abe91"
     kubernetes.io/ingress.class: "alb"
 
 ingressInternal:
-  enabled: true
+  enabled: false
   path: "/chat"
   annotations:
     alb.ingress.kubernetes.io/healthcheck-path: "/chat/healthcheck"
@@ -40,7 +40,7 @@ ingressInternal:
     alb.ingress.kubernetes.io/group.name: "hub-prod-internal-public"
     alb.ingress.kubernetes.io/load-balancer-name: "hub-prod-internal-public"
     alb.ingress.kubernetes.io/ssl-redirect: "443"
-    alb.ingress.kubernetes.io/tags: "Env=prod,Project=hub,Terraform=true"
+    alb.ingress.kubernetes.io/tags: "Env=prod,Project=hub-utils,Terraform=true"
     alb.ingress.kubernetes.io/target-group-attributes: deregistration_delay.timeout_seconds=30
     alb.ingress.kubernetes.io/target-type: "ip"
     alb.ingress.kubernetes.io/certificate-arn: "arn:aws:acm:us-east-1:707930574880:certificate/5b25b145-75db-4837-b9f3-7f238ba8a9c7,arn:aws:acm:us-east-1:707930574880:certificate/bfdf509c-f44b-400f-b9e1-6f7a861abe91"
@@ -226,6 +226,7 @@ envVars:
 infisical:
   enabled: true
   env: "prod-us-east-1"
+  operatorSecretNamespace: "chat-ui"
 
 autoscaling:
   enabled: true


### PR DESCRIPTION
Migration cleanup: the ALB identity, the operator ref namespace and the internal-ingress toggle move into prod.yaml; env/prod-v2.yaml becomes a strict no-op (deleted in a follow-up once the renamed Argo app drops it from its valueFiles).