### PR TITLE
feat(chart): support ingress restriction in the NetworkPolicy

### DIFF
--- a/chart/templates/network-policy.yaml
+++ b/chart/templates/network-policy.yaml
@@ -5,6 +5,30 @@ metadata:
   name: {{ include "name" . }}
   namespace: {{ .Release.Namespace }}
 spec:
+  {{- if .Values.networkPolicy.ingress.enabled }}
+  ingress:
+    ## Load balancer ENIs only, on the container port: application traffic and
+    ## health checks both come from there. Kubelet probes are exempt from
+    ## policies, so they keep working. Addresses come from the deployment layer.
+    - from:
+        {{- range $cidr := .Values.networkPolicy.ingress.allowedBlocks }}
+        - ipBlock:
+            cidr: {{ $cidr | quote }}
+        {{- end }}
+      ports:
+        - port: {{ .Values.networkPolicy.appPort }}
+          protocol: TCP
+    {{- if .Values.networkPolicy.ingress.metricsFromNamespace }}
+    ## Metrics scraping, from the monitoring namespace only.
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.networkPolicy.ingress.metricsFromNamespace | quote }}
+      ports:
+        - port: {{ .Values.networkPolicy.metricsPort }}
+          protocol: TCP
+    {{- end }}
+  {{- end }}
   egress:
     ## Cluster DNS. TCP/53 is needed for answers that do not fit in 512 bytes,
     ## and the link-local address is where a node-local resolver listens.
@@ -67,5 +91,8 @@ spec:
   podSelector:
     matchLabels: {{ include "labels.standard" . | nindent 6 }}
   policyTypes:
+    {{- if .Values.networkPolicy.ingress.enabled }}
+    - Ingress
+    {{- end }}
     - Egress
 {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -19,6 +19,17 @@ networkPolicy:
   ##     blocks: ["10.0.0.0/24"]
   ## Addresses are supplied by the deployment layer, not committed here.
   extraEgress: []
+  ## Container ports, used by the ingress rules.
+  appPort: 3000
+  metricsPort: 5565
+  ## Restricting ingress is opt-in per environment: the blocks are the load
+  ## balancer's own ranges, supplied by the deployment layer, and a wrong list
+  ## black-holes traffic. metricsFromNamespace opens the metrics port to a
+  ## single namespace (leave empty to keep it closed).
+  ingress:
+    enabled: false
+    allowedBlocks: []
+    metricsFromNamespace: ""
 
 service:
   type: NodePort


### PR DESCRIPTION
Adds two optional ingress rules to the policy, both gated behind `networkPolicy.ingress.enabled` and **off by default** — so this is a no-op for every existing deployment:

- the load balancer's own ranges on the app port (`allowedBlocks`, supplied by the deployment layer — internal addresses do not belong in a public repo)
- metrics scraping restricted to a single namespace (`metricsFromNamespace`), since the metrics port has no business being reachable from anywhere else

Context: the deployment this chart backs currently accepts connections from any pod in the cluster and anything routable in the VPC, not just its load balancer.

Safety note for whoever enables it: kubelet probes originate from the node, and in that environment node and pod addresses share the same subnets, so no CIDR can express "the node". The policy agent exempts probe traffic — verified in a throwaway namespace (a pod with httpGet + tcpSocket probes stayed Ready under a policy allowing only TEST-NET) and confirmed on seven other deployments since. Rollback is a one-line values flip.