### PR TITLE
fix(chart): fail rendering instead of opening the port when a policy rule has no peers

### DIFF
--- a/chart/templates/network-policy.yaml
+++ b/chart/templates/network-policy.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   {{- if .Values.networkPolicy.ingress.enabled }}
+  {{- if not .Values.networkPolicy.ingress.allowedBlocks }}
+  {{- fail "networkPolicy.ingress.enabled needs networkPolicy.ingress.allowedBlocks: a rule with no peers under `from` matches every source, so an empty list would open the port instead of restricting it" }}
+  {{- end }}
   ingress:
     ## Load balancer ENIs only, on the container port: application traffic and
     ## health checks both come from there. Kubelet probes are exempt from
@@ -67,6 +70,9 @@ spec:
         {{- end }}
     {{- end }}
     {{- range $rule := .Values.networkPolicy.extraEgress }}
+    {{- if not $rule.blocks }}
+    {{- fail "every networkPolicy.extraEgress entry needs blocks: a rule with no peers under `to` matches every destination" }}
+    {{- end }}
     ## Private destination on a single port (a database, for instance).
     - ports:
         - port: {{ $rule.port }}


### PR DESCRIPTION
## The bug

Spotted by the automated review on #2491, and it is real. With `networkPolicy.ingress.enabled: true` and `allowedBlocks` left at its default (empty list), the template rendered:

```yaml
ingress:
  - from:
    ports:
      - port: 3000
```

A rule whose `from` list is empty **matches every source** (Kubernetes NetworkPolicy semantics). So instead of black-holing traffic — which is what the values comment claimed would happen — it would open the port to the entire cluster and VPC, while the policy still *looks* restrictive. That is a fail-open in a security control, which is worse than no policy at all because it invites false confidence.

The same shape applies to `extraEgress`: an entry with no `blocks` renders `to:` empty, which matches every destination.

## The fix

Fail the render instead of guessing. `helm template` and the deployment layer now abort with an explicit message when a rule would be generated with no peers:

- `networkPolicy.ingress.enabled` without `allowedBlocks`
- an `extraEgress` entry without `blocks`

Failing loudly is deliberate: silently dropping the rule would be fail-closed (traffic black-holed with no explanation), and silently rendering it is fail-open. An error at render time is the only outcome that cannot be mistaken for success.

## Not currently exploitable

Every live deployment supplies non-empty lists, so no environment is open today — the bug was latent, waiting for a new environment or a typo.

## Verified

- `ingress.enabled` without blocks → render fails with the message above
- `extraEgress` entry without `blocks` → render fails
- the production shape (blocks + metrics namespace + internal blocks + database rule) → renders unchanged
