### PR TITLE
Add a refresh button to the artifact preview

### DIFF
--- a/src/lib/components/chat/ArtifactPanel.svelte
+++ b/src/lib/components/chat/ArtifactPanel.svelte
@@ -39,6 +39,7 @@
 	import CarbonCamera from "~icons/carbon/camera";
 	import CarbonDownload from "~icons/carbon/download";
 	import CarbonRocket from "~icons/carbon/rocket";
+	import CarbonRenew from "~icons/carbon/renew";
 	import CarbonMaximize from "~icons/carbon/maximize";
 	import LucideWrapText from "~icons/lucide/wrap-text";
 	import LucideDiff from "~icons/lucide/diff";
@@ -418,9 +419,23 @@
 
 	// ----- actions -----
 	let fullscreenOpen = $state(false);
-	let fullscreenSupported = $derived(
+	// Gates refresh + fullscreen, which both act on the live iframe preview
+	let livePreviewSupported = $derived(
 		!!version && version.complete && version.type !== "markdown" && version.type !== "code"
 	);
+	// Bumped to remount the iframe, restarting the preview with a fresh document
+	let previewReloadNonce = $state(0);
+	function refreshPreview() {
+		// Remounting mid-capture would leave the in-flight screenshot holding a
+		// detached iframe. The refresh button is disabled while capturing; this
+		// covers any non-pointer path.
+		if (capturing) return;
+		// The document restarts, so captured errors describe a run that no longer
+		// exists; previewLoaded gates capture until the new document commits
+		errors = [];
+		previewLoaded = false;
+		previewReloadNonce += 1;
+	}
 
 	function download() {
 		if (!version) return;
@@ -572,12 +587,12 @@
 				{#if canDeploy}
 					<button
 						type="button"
-						class="btn gap-1 rounded-md p-1.5 text-xs hover:bg-gray-100 hover:text-gray-600 @min-[580px]:pr-2 dark:hover:bg-gray-800 dark:hover:text-gray-300"
+						class="btn gap-1 rounded-md p-1.5 text-xs hover:bg-gray-100 hover:text-gray-600 @min-[610px]:pr-2 dark:hover:bg-gray-800 dark:hover:text-gray-300"
 						title={currentDeployment ? "Update Space" : "Deploy to Space"}
 						onclick={() => (deployModalOpen = true)}
 					>
 						<CarbonRocket />
-						<span class="hidden font-medium @min-[580px]:inline">
+						<span class="hidden font-medium @min-[610px]:inline">
 							{currentDeployment ? "Update" : "Deploy"}
 						</span>
 					</button>
@@ -595,7 +610,20 @@
 				>
 					<CarbonDownload />
 				</button>
-				{#if fullscreenSupported}
+				{#if livePreviewSupported}
+					<!-- Disabled (not hidden) on the code tab, where no live preview is
+					     mounted to reload — hiding it would shift the icon row on every
+					     tab switch. Also disabled mid-capture: remounting would pull the
+					     document out from under the in-flight screenshot. -->
+					<button
+						type="button"
+						class="btn rounded-md p-1.5 text-xs hover:bg-gray-100 hover:text-gray-600 disabled:cursor-not-allowed disabled:opacity-40 dark:hover:bg-gray-800 dark:hover:text-gray-300"
+						title="Refresh preview"
+						disabled={effectiveTab !== "preview" || capturing}
+						onclick={refreshPreview}
+					>
+						<CarbonRenew />
+					</button>
 					<button
 						type="button"
 						class="btn rounded-md p-1.5 text-xs hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-800 dark:hover:text-gray-300"
@@ -637,18 +665,21 @@
 				</div>
 			{:else if srcdoc}
 				<!-- Backing matches the panel theme so opening the preview doesn't flash
-				     white in dark mode while the document paints its own background -->
-				<iframe
-					bind:this={iframeEl}
-					title="Artifact preview"
-					class="h-full w-full bg-white dark:bg-gray-900 {resizing ? 'pointer-events-none' : ''}"
-					sandbox={PREVIEW_SANDBOX}
-					allow={PREVIEW_ALLOW}
-					allowfullscreen
-					referrerpolicy="no-referrer"
-					onload={() => (previewLoaded = true)}
-					{srcdoc}
-				></iframe>
+				     white in dark mode while the document paints its own background;
+				     keyed so the refresh action can remount it for a fresh document -->
+				{#key previewReloadNonce}
+					<iframe
+						bind:this={iframeEl}
+						title="Artifact preview"
+						class="h-full w-full bg-white dark:bg-gray-900 {resizing ? 'pointer-events-none' : ''}"
+						sandbox={PREVIEW_SANDBOX}
+						allow={PREVIEW_ALLOW}
+						allowfullscreen
+						referrerpolicy="no-referrer"
+						onload={() => (previewLoaded = true)}
+						{srcdoc}
+					></iframe>
+				{/key}
 			{/if}
 		{:else}
 			<!-- Same .prose pre styling as chat code blocks so the syntax theme matches


### PR DESCRIPTION
## What

First half of the split of #2499: a refresh button for the artifact preview, placed just before the fullscreen one.

- Refreshing remounts the preview iframe (keyed block) for a fresh document, and clears captured errors since they describe a run that no longer exists.
- Disabled rather than hidden on the Code tab (no live preview mounted there), so the icon row doesn't shift on tab switches. Also disabled mid-capture, so a remount can't pull the document out from under an in-flight screenshot.
- The Deploy label's container query moves from `580px` to `610px` to make room for the extra icon.

## Screenshots

From the original combined branch (the header row is identical in this PR):

| Panel >= 610px, Deploy keeps its label | Panel < 610px, Deploy collapses to icon |
| --- | --- |
| ![wide panel](https://raw.githubusercontent.com/huggingface/chat-ui/e504c6b3d6b3f64eaab53ac1b9d8bcf7c50d43cc/pr-assets/panel-wide.png) | ![narrow panel](https://raw.githubusercontent.com/huggingface/chat-ui/e504c6b3d6b3f64eaab53ac1b9d8bcf7c50d43cc/pr-assets/panel-narrow.png) |

| Mobile overlay | Code tab, refresh disabled |
| --- | --- |
| ![mobile](https://raw.githubusercontent.com/huggingface/chat-ui/e504c6b3d6b3f64eaab53ac1b9d8bcf7c50d43cc/pr-assets/mobile.png) | ![code tab](https://raw.githubusercontent.com/huggingface/chat-ui/e504c6b3d6b3f64eaab53ac1b9d8bcf7c50d43cc/pr-assets/panel-code-tab.png) |

## Test plan

- `npm run check`: 0 errors, 0 warnings
- `npm run lint` on the changed file: clean
- `npm run test`: 625 passed; the 2 failures (CORS headers in `misc.spec.ts`) fail identically on `main` with my local env and are unrelated
