### PR TITLE
Keep artifact preview state across fullscreen

### DIFF
--- a/src/lib/components/chat/ArtifactPanel.svelte
+++ b/src/lib/components/chat/ArtifactPanel.svelte
@@ -576,14 +576,25 @@
 	});
 
 	// The overlay is a dialog rendered in place, so it manages focus itself:
-	// move focus onto it when it opens and hand it back (usually to the
-	// maximize button) when it closes.
+	// move focus onto it when it opens and hand it back to the trigger
+	// (usually the maximize button) when it closes. The trigger is captured in
+	// openFullscreen, before any effect runs: the inert effect above blurs the
+	// header the trigger sits in, so by effect time activeElement is already
+	// the body.
+	let fullscreenReturnEl: HTMLElement | null = null;
+	function openFullscreen() {
+		const active = document.activeElement;
+		fullscreenReturnEl = active instanceof HTMLElement ? active : null;
+		fullscreenOpen = true;
+	}
 	$effect(() => {
 		if (!fullscreenOpen) return;
-		const previous = document.activeElement;
 		fullscreenEl?.focus();
 		return () => {
-			if (previous instanceof HTMLElement && previous.isConnected) previous.focus();
+			// The inert effect's cleanup has already run (creation order), so the
+			// trigger is focusable again
+			if (fullscreenReturnEl?.isConnected) fullscreenReturnEl.focus();
+			fullscreenReturnEl = null;
 		};
 	});
 
@@ -719,7 +730,7 @@
 						type="button"
 						class="btn rounded-md p-1.5 text-xs hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-800 dark:hover:text-gray-300"
 						title="Open fullscreen"
-						onclick={() => (fullscreenOpen = true)}
+						onclick={openFullscreen}
 					>
 						<CarbonMaximize />
 					</button>

--- a/src/lib/components/chat/ArtifactPanel.svelte
+++ b/src/lib/components/chat/ArtifactPanel.svelte
@@ -29,10 +29,10 @@
 	import MarkdownRenderer from "./MarkdownRenderer.svelte";
 	import CopyToClipBoardBtn from "../CopyToClipBoardBtn.svelte";
 	import ExternalLinkModal from "../ExternalLinkModal.svelte";
-	import HtmlPreviewModal from "../HtmlPreviewModal.svelte";
 	import DeployToSpaceModal from "./DeployToSpaceModal.svelte";
 	import ScreenshotAnnotationModal from "./ScreenshotAnnotationModal.svelte";
 
+	import CarbonClose from "~icons/carbon/close";
 	import CarbonCloseLarge from "~icons/carbon/close-large";
 	import CarbonChevronLeft from "~icons/carbon/chevron-left";
 	import CarbonChevronRight from "~icons/carbon/chevron-right";
@@ -418,11 +418,41 @@
 	}
 
 	// ----- actions -----
+	// Fullscreen promotes the panel's own iframe to a viewport-filling overlay
+	// with CSS alone. It must stay the same element: remounting (or reparenting,
+	// which is why a portaled modal can't be used here) reloads the document and
+	// throws away the artifact's runtime state — scroll, form input, game
+	// progress — which should survive entering and leaving fullscreen.
 	let fullscreenOpen = $state(false);
+	let fullscreenEl: HTMLElement | undefined = $state();
 	// Gates refresh + fullscreen, which both act on the live iframe preview
 	let livePreviewSupported = $derived(
 		!!version && version.complete && version.type !== "markdown" && version.type !== "code"
 	);
+	// A new version streaming in (or the artifact disappearing) unmounts the
+	// preview, and the whole panel can close from under the overlay too (on
+	// mobile, confirming a screenshot annotation closes it). Leave fullscreen
+	// with them: a stuck-true fullscreenOpen would keep the global Escape
+	// listener swallowing keys and resurrect the overlay the next time the
+	// panel opens.
+	$effect(() => {
+		if (fullscreenOpen && (!srcdoc || !artifactPanel.open)) fullscreenOpen = false;
+	});
+	// The preview is on screen for the preview tab, or for fullscreen opened
+	// from the code tab (where it mounts fresh).
+	let previewShown = $derived(!!srcdoc && (effectiveTab === "preview" || fullscreenOpen));
+	// Every (re)mount of the preview starts a fresh document, but only srcdoc
+	// changes run the reset effects above — so a remount with the same srcdoc
+	// (switching away to the code tab and back, or opening fullscreen from the
+	// code tab) would keep the previous run's captured errors and a stale
+	// previewLoaded. Reset both when the preview comes back on screen. Toggling
+	// fullscreen from the preview tab doesn't re-run this (previewShown stays
+	// true), which is what keeps captured errors carrying into fullscreen.
+	$effect(() => {
+		if (!previewShown) return;
+		errors = [];
+		previewLoaded = false;
+	});
 	// Bumped to remount the iframe, restarting the preview with a fresh document
 	let previewReloadNonce = $state(0);
 	function refreshPreview() {
@@ -496,9 +526,70 @@
 			isDeployableKind(version.type)
 	);
 
+	// Fullscreen Escape listens in the capture phase, at the same priority the
+	// old portaled Modal had. In the bubble phase it would race handlers like
+	// the conversation page's Esc-stops-generation (which preventDefaults
+	// while streaming) and lose, leaving the overlay stuck open. Registered
+	// only while fullscreen is up; the external-link confirm opened from a
+	// preview registers its own capture listener later (it mounts later), so
+	// deferring to it here keeps Esc dismissing just the confirm.
+	$effect(() => {
+		if (!fullscreenOpen) return;
+		const closeOnEscape = (e: KeyboardEvent) => {
+			if (e.key !== "Escape" || e.defaultPrevented) return;
+			if (externalLinkUrl) return; // the confirm's own listener handles it
+			e.preventDefault();
+			fullscreenOpen = false;
+		};
+		window.addEventListener("keydown", closeOnEscape, { capture: true });
+		return () => window.removeEventListener("keydown", closeOnEscape, { capture: true });
+	});
+
+	// While fullscreen is up, everything behind the overlay is made inert —
+	// each ancestor's siblings, walking up to the #app root — so the browser's
+	// own sequential focus navigation is confined to the overlay. A keydown
+	// Tab trap on this window could not do that: keydown inside the sandboxed
+	// iframe stays in that browsing context, so Shift+Tab from the iframe's
+	// first focusable would back out into the obscured panel chrome. The walk
+	// stops below #app, leaving body-level portals (the external-link confirm)
+	// interactive above the overlay; elements already inert are skipped so
+	// cleanup restores exactly what this effect changed.
+	$effect(() => {
+		if (!fullscreenOpen) return;
+		const boundary = document.getElementById("app") ?? document.body;
+		const madeInert: HTMLElement[] = [];
+		for (
+			let node: HTMLElement | null = fullscreenEl ?? null;
+			node && node !== boundary && node.parentElement;
+			node = node.parentElement
+		) {
+			for (const sibling of node.parentElement.children) {
+				if (sibling !== node && sibling instanceof HTMLElement && !sibling.inert) {
+					sibling.inert = true;
+					madeInert.push(sibling);
+				}
+			}
+		}
+		return () => {
+			for (const el of madeInert) el.inert = false;
+		};
+	});
+
+	// The overlay is a dialog rendered in place, so it manages focus itself:
+	// move focus onto it when it opens and hand it back (usually to the
+	// maximize button) when it closes.
+	$effect(() => {
+		if (!fullscreenOpen) return;
+		const previous = document.activeElement;
+		fullscreenEl?.focus();
+		return () => {
+			if (previous instanceof HTMLElement && previous.isConnected) previous.focus();
+		};
+	});
+
 	function handleKeydown(e: KeyboardEvent) {
-		// An Escape already consumed by a modal (external-link confirm, fullscreen
-		// preview) must not also close the panel
+		// An Escape already consumed elsewhere (modals and the fullscreen
+		// overlay all listen in the capture phase) must not also close the panel
 		if (e.defaultPrevented) return;
 		if (e.key === "Escape" && artifactPanel.open && !fullscreenOpen && !loading) {
 			e.preventDefault();
@@ -663,23 +754,6 @@
 						<MarkdownRenderer content={version.content} />
 					</div>
 				</div>
-			{:else if srcdoc}
-				<!-- Backing matches the panel theme so opening the preview doesn't flash
-				     white in dark mode while the document paints its own background;
-				     keyed so the refresh action can remount it for a fresh document -->
-				{#key previewReloadNonce}
-					<iframe
-						bind:this={iframeEl}
-						title="Artifact preview"
-						class="h-full w-full bg-white dark:bg-gray-900 {resizing ? 'pointer-events-none' : ''}"
-						sandbox={PREVIEW_SANDBOX}
-						allow={PREVIEW_ALLOW}
-						allowfullscreen
-						referrerpolicy="no-referrer"
-						onload={() => (previewLoaded = true)}
-						{srcdoc}
-					></iframe>
-				{/key}
 			{/if}
 		{:else}
 			<!-- Same .prose pre styling as chat code blocks so the syntax theme matches
@@ -733,6 +807,80 @@
 					class="pointer-events-none absolute inset-x-0 bottom-0 h-10 bg-linear-to-t from-white/90 to-transparent dark:from-gray-900/90"
 				></div>
 			{/if}
+		{/if}
+
+		<!-- Live iframe preview. Rendered whenever it should be on screen — the
+		     preview tab, or fullscreen opened from the code tab — and promoted to
+		     a viewport-filling overlay by a class swap alone when fullscreen: the
+		     iframe node survives the toggle, so the document keeps its runtime
+		     state (a separate modal would rebuild it from scratch). z-30 clears
+		     the panel's own chrome (resize handle z-20) on desktop and sits at
+		     the mobile overlay's own layer; portaled modals (z-40 at the root
+		     stacking context) still stack above it. -->
+		{#if previewShown}
+			<div
+				bind:this={fullscreenEl}
+				role={fullscreenOpen ? "dialog" : undefined}
+				aria-modal={fullscreenOpen ? true : undefined}
+				aria-label={fullscreenOpen ? "Fullscreen artifact preview" : undefined}
+				tabindex="-1"
+				class="bg-white outline-hidden dark:bg-gray-900 {fullscreenOpen
+					? 'fixed inset-0 z-30'
+					: 'absolute inset-0'}"
+			>
+				<!-- Backing matches the panel theme so opening the preview doesn't flash
+				     white in dark mode while the document paints its own background;
+				     keyed so the refresh action can remount it for a fresh document -->
+				{#key previewReloadNonce}
+					<iframe
+						bind:this={iframeEl}
+						title="Artifact preview"
+						class="h-full w-full bg-white dark:bg-gray-900 {resizing ? 'pointer-events-none' : ''}"
+						sandbox={PREVIEW_SANDBOX}
+						allow={PREVIEW_ALLOW}
+						allowfullscreen
+						referrerpolicy="no-referrer"
+						onload={() => (previewLoaded = true)}
+						{srcdoc}
+					></iframe>
+				{/key}
+				{#if fullscreenOpen}
+					<div class="absolute top-4 right-6 flex items-center gap-1.5">
+						<button
+							type="button"
+							class="btn flex h-7 items-center rounded-lg border border-gray-500/60 bg-gray-800 px-2 text-xs text-white shadow-xs backdrop-blur-sm transition-none hover:border-gray-500 hover:bg-gray-700 active:shadow-inner disabled:cursor-not-allowed disabled:opacity-50"
+							title="Refresh preview"
+							disabled={capturing}
+							onclick={refreshPreview}
+						>
+							<CarbonRenew class="size-3.5" />
+						</button>
+						<button
+							type="button"
+							class="btn flex h-7 items-center gap-1 rounded-lg border border-gray-500/60 bg-gray-800 px-2 text-xs text-white shadow-xs backdrop-blur-sm transition-none hover:border-gray-500 hover:bg-gray-700 active:shadow-inner"
+							title="Close preview (Esc)"
+							onclick={() => (fullscreenOpen = false)}
+						>
+							<CarbonClose class="size-3.5" />
+							Close preview
+						</button>
+					</div>
+					{#if errors.length > 0 && onsend && !loading}
+						<button
+							type="button"
+							class="absolute right-4 bottom-4 btn flex items-center gap-2 rounded-full border-2 border-red-500/60 bg-red-800/90 px-4 py-1.5 text-sm text-white shadow-lg"
+							title="Send the errors and ask for a fix"
+							onclick={() => {
+								// Leave fullscreen only once the message is actually on its
+								// way, so the errors backing the request stay up otherwise
+								if (sendFixRequest(composeFixRequest(errors))) fullscreenOpen = false;
+							}}
+						>
+							<span>Error caught ({errors.length}) — ask to fix</span>
+						</button>
+					{/if}
+				{/if}
+			</div>
 		{/if}
 	</div>
 
@@ -826,15 +974,28 @@
 {/snippet}
 
 {#if artifactPanel.open && artifact}
-	{#if isDesktop}
-		<aside
-			bind:this={asideEl}
-			class="pointer-events-auto relative z-10 flex h-full flex-none flex-col overflow-hidden border-l border-gray-100 bg-white dark:border-gray-800 dark:bg-gray-900"
-			style="width: {artifactPanel.widthPx !== null
-				? `${artifactPanel.widthPx}px`
-				: ARTIFACT_PANEL_DEFAULT_FRACTION}; min-width: max(20%, 300px); max-width: 80%;"
-			aria-label="Artifact panel"
-		>
+	<!-- One persistent container reshaped by breakpoint classes, NOT two
+	     alternate branches: a branch swap would remount panelContent — and the
+	     live preview iframe with it — so crossing the 768px breakpoint (e.g.
+	     rotating a tablet) would reload the artifact and lose its state, in
+	     fullscreen included. Desktop: resizable side panel. Mobile: viewport
+	     overlay with dialog semantics. -->
+	<aside
+		bind:this={asideEl}
+		role={isDesktop ? undefined : "dialog"}
+		class="pointer-events-auto flex flex-col bg-white dark:bg-gray-900 {isDesktop
+			? 'relative z-10 h-full flex-none overflow-hidden border-l border-gray-100 dark:border-gray-800'
+			: 'fixed inset-0 z-30'}"
+		style={isDesktop
+			? `width: ${
+					artifactPanel.widthPx !== null
+						? `${artifactPanel.widthPx}px`
+						: ARTIFACT_PANEL_DEFAULT_FRACTION
+				}; min-width: max(20%, 300px); max-width: 80%;`
+			: ""}
+		aria-label="Artifact panel"
+	>
+		{#if isDesktop}
 			<!-- resize handle (drag to resize, double-click to reset) -->
 			<div
 				role="separator"
@@ -848,28 +1009,9 @@
 				onpointercancel={onResizeEnd}
 				ondblclick={() => artifactPanel.resetWidth()}
 			></div>
-			{@render panelContent()}
-		</aside>
-	{:else}
-		<div
-			class="pointer-events-auto fixed inset-0 z-30 flex flex-col bg-white dark:bg-gray-900"
-			role="dialog"
-			aria-label="Artifact panel"
-		>
-			{@render panelContent()}
-		</div>
-	{/if}
-{/if}
-
-{#if fullscreenOpen && version}
-	<!-- The modal can't render a disabled state for its floating error button,
-	     so streaming gates the handler entirely -->
-	<HtmlPreviewModal
-		html={version.content}
-		kind={version.type}
-		onclose={() => (fullscreenOpen = false)}
-		onsend={onsend && !loading ? sendFixRequest : undefined}
-	/>
+		{/if}
+		{@render panelContent()}
+	</aside>
 {/if}
 
 {#if externalLinkUrl}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -111,18 +111,19 @@
 
 	// Global keyboard shortcut: New Chat (Ctrl/Cmd + Shift + O)
 	const onKeydown = (e: KeyboardEvent) => {
-		// Ignore when a modal has focus (app is inert)
-		const appEl = document.getElementById("app");
-		if (appEl?.hasAttribute("inert")) return;
-
 		const oPressed = e.key?.toLowerCase() === "o";
 		const metaOrCtrl = e.metaKey || e.ctrlKey;
-		if (oPressed && e.shiftKey && metaOrCtrl) {
-			e.preventDefault();
-			isAborted.set(true);
-			if (requireAuthUser()) return;
-			goto(`${base}/`, { invalidateAll: true });
-		}
+		if (!oPressed || !e.shiftKey || !metaOrCtrl) return;
+		// Ignore when a modal is open: portaled modals make the app inert
+		// (Modal.svelte), while in-place dialogs (the fullscreen artifact
+		// preview) sit inside #app so they can't use that signal and carry
+		// aria-modal instead
+		if (document.getElementById("app")?.hasAttribute("inert")) return;
+		if (document.querySelector('[aria-modal="true"]')) return;
+		e.preventDefault();
+		isAborted.set(true);
+		if (requireAuthUser()) return;
+		goto(`${base}/`, { invalidateAll: true });
 	};
 
 	onDestroy(() => {


### PR DESCRIPTION
## What

Second half of the split of #2499, stacked on #2503 (merge that one first; GitHub will retarget this PR to `main`).

Opening the artifact preview in fullscreen used to remount it in a separate modal (`HtmlPreviewModal`) with a freshly built srcdoc, so the artifact reloaded and lost all runtime state (scroll position, form input, game progress). There's no incremental fix inside that design: an iframe reloads whenever it's remounted or reparented, so a portaled modal can never carry the live document over.

- **Fullscreen now preserves the preview's state.** The panel's own iframe is promoted to a viewport-filling overlay purely by a wrapper class swap (`absolute inset-0` to `fixed inset-0`); the iframe element never remounts, so the document just resizes. The overlay recreates the modal's chrome (refresh, Close, ask-to-fix error pill), and captured errors now carry across panel/fullscreen since it's the same document. Opening fullscreen from the Code tab still works (the preview mounts fresh there, as before). `HtmlPreviewModal` itself is untouched, `CodeBlock` still uses it.
- **One persistent panel container** reshaped by breakpoint classes instead of separate desktop/mobile branches, so crossing the 768px breakpoint (e.g. rotating a tablet) no longer remounts the preview either.
- **Escape** listens in the capture phase, the same priority the old portaled `Modal` had, so the conversation page's Esc-stops-generation handler (which preventDefaults while streaming) can't leave the overlay stuck open. Fullscreen also exits automatically when the preview unmounts or the panel closes under it.
- **Focus containment** relies on making everything behind the overlay inert (walking ancestor siblings up to `#app`), which confines sequential focus to the overlay; a window-level Tab trap can't see traversal inside the sandboxed iframe. Focus moves onto the overlay on open and returns on close. Compared to the original combined PR this drops the focus-sentinel wrap-around machinery (~55 lines): inert already guarantees focus can't land in obscured content, which is the part `aria-modal` needs.
- Remounts with an unchanged srcdoc (switching to the Code tab and back) now reset captured errors and the load flag, which previously only srcdoc changes reset.

## Screenshot

Fullscreen overlay, refresh next to Close. The timer was started in the panel and reads 24:57 here: the same document kept running across the fullscreen toggle (the panel shot in #2503 shows it at 25:00 before starting):

![fullscreen](https://raw.githubusercontent.com/huggingface/chat-ui/e504c6b3d6b3f64eaab53ac1b9d8bcf7c50d43cc/pr-assets/fullscreen.png)

## Test plan

- `npm run check`: 0 errors, 0 warnings
- `npm run lint` on the changed file: clean
- `npm run test`: 625 passed; the 2 failures (CORS headers in `misc.spec.ts`) fail identically on `main` with my local env and are unrelated
- The behavior (state kept across the fullscreen round-trip, Escape closes, refresh remounts) was verified with Playwright against a local dev server on the original combined branch; this PR differs from it only by the removed sentinel code
