### PR TITLE
feat(mcp): add resources support

### DIFF
--- a/scripts/mock-resources-mcp.mjs
+++ b/scripts/mock-resources-mcp.mjs
@@ -1,16 +1,10 @@
 /**
  * Throwaway MCP server for exercising resources support by hand — delete when done.
  *
- * Exposes one tool (so the server looks realistic) and four resources chosen to hit
- * every branch of the read path:
- *
  *   file:///briefing.md   text, with an unguessable fact  — proves the model READ it
  *   note:///{id}          URI template                    — proves template routing
  *   image:///logo.png     binary blob                     — must be described, not inlined
  *   file:///huge.log      44k chars                       — must truncate at 32k
- *
- * The fact in briefing.md is the point: no model can produce "PELICAN-7734" from
- * training data, so if it turns up in the answer, the resource was genuinely read.
  *
  * Run:  node scripts/mock-resources-mcp.mjs
  * Then add http://127.0.0.1:8792/mcp as an MCP server in the UI.
@@ -22,7 +16,6 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 
 const PORT = Number(process.env.MOCK_RESOURCES_MCP_PORT ?? 8792);
 
-/** Smallest valid PNG (1x1, transparent). */
 const PNG_1X1 =
 	"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
 
@@ -39,12 +32,9 @@ function buildServer() {
 		{ capabilities: { tools: {}, resources: {} } }
 	);
 
-	// A tool, so this is not a resources-only server and the tool array stays mixed.
-	server.registerTool(
-		"ping",
-		{ description: "Returns pong.", inputSchema: {} },
-		() => ({ content: [{ type: "text", text: "pong" }] })
-	);
+	server.registerTool("ping", { description: "Returns pong.", inputSchema: {} }, () => ({
+		content: [{ type: "text", text: "pong" }],
+	}));
 
 	server.registerResource(
 		"briefing",
@@ -95,10 +85,13 @@ function buildServer() {
 	server.registerResource(
 		"huge",
 		"file:///huge.log",
-		{ title: "Huge log", description: "44k characters, to exercise truncation.", mimeType: "text/plain" },
+		{
+			title: "Huge log",
+			description: "44k characters, to exercise truncation.",
+			mimeType: "text/plain",
+		},
 		(uri) => {
 			console.log("[mock-resources-mcp] read", uri.href, "(oversized)");
-			// The tail marker must NOT survive truncation — that is how you tell it worked.
 			return {
 				contents: [
 					{
@@ -125,7 +118,6 @@ const httpServer = createServer((req, res) => {
 		}
 
 		if (url.pathname === "/mcp") {
-			// Stateless: a fresh server + transport per request, torn down after.
 			const server = buildServer();
 			const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
 			res.on("close", () => {

--- a/scripts/mock-resources-mcp.mjs
+++ b/scripts/mock-resources-mcp.mjs
@@ -7,14 +7,14 @@
  *   file:///huge.log      44k chars                       — must truncate at 32k
  *
  * Run:  node scripts/mock-resources-mcp.mjs
- * Then add http://127.0.0.1:8792/mcp as an MCP server in the UI.
+ * Then add http://127.0.0.1:8793/mcp as an MCP server in the UI.
  * Requires MCP_ALLOW_INSECURE_URLS=true, or chat-ui rejects the loopback URL.
  */
 import { createServer } from "node:http";
 import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 
-const PORT = Number(process.env.MOCK_RESOURCES_MCP_PORT ?? 8792);
+const PORT = Number(process.env.MOCK_RESOURCES_MCP_PORT ?? 8793);
 
 const PNG_1X1 =
 	"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";

--- a/scripts/mock-resources-mcp.mjs
+++ b/scripts/mock-resources-mcp.mjs
@@ -1,0 +1,159 @@
+/**
+ * Throwaway MCP server for exercising resources support by hand — delete when done.
+ *
+ * Exposes one tool (so the server looks realistic) and four resources chosen to hit
+ * every branch of the read path:
+ *
+ *   file:///briefing.md   text, with an unguessable fact  — proves the model READ it
+ *   note:///{id}          URI template                    — proves template routing
+ *   image:///logo.png     binary blob                     — must be described, not inlined
+ *   file:///huge.log      44k chars                       — must truncate at 32k
+ *
+ * The fact in briefing.md is the point: no model can produce "PELICAN-7734" from
+ * training data, so if it turns up in the answer, the resource was genuinely read.
+ *
+ * Run:  node scripts/mock-resources-mcp.mjs
+ * Then add http://127.0.0.1:8792/mcp as an MCP server in the UI.
+ * Requires MCP_ALLOW_INSECURE_URLS=true, or chat-ui rejects the loopback URL.
+ */
+import { createServer } from "node:http";
+import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+
+const PORT = Number(process.env.MOCK_RESOURCES_MCP_PORT ?? 8792);
+
+/** Smallest valid PNG (1x1, transparent). */
+const PNG_1X1 =
+	"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
+
+const BRIEFING = `# Q3 Internal Briefing
+
+The Northwind migration completed on 14 March.
+Rollback codeword: PELICAN-7734.
+Owner: the Platform team. Budget code: NW-0042.
+`;
+
+function buildServer() {
+	const server = new McpServer(
+		{ name: "mock-resources-mcp", version: "1.0.0" },
+		{ capabilities: { tools: {}, resources: {} } }
+	);
+
+	// A tool, so this is not a resources-only server and the tool array stays mixed.
+	server.registerTool(
+		"ping",
+		{ description: "Returns pong.", inputSchema: {} },
+		() => ({ content: [{ type: "text", text: "pong" }] })
+	);
+
+	server.registerResource(
+		"briefing",
+		"file:///briefing.md",
+		{
+			title: "Q3 internal briefing",
+			description: "Internal briefing note containing the rollback codeword.",
+			mimeType: "text/markdown",
+		},
+		(uri) => {
+			console.log("[mock-resources-mcp] read", uri.href);
+			return { contents: [{ uri: uri.href, mimeType: "text/markdown", text: BRIEFING }] };
+		}
+	);
+
+	server.registerResource(
+		"note",
+		new ResourceTemplate("note:///{id}", { list: undefined }),
+		{
+			title: "Scratch note",
+			description: "An arbitrary note, addressed by id. Try note:///alpha.",
+			mimeType: "text/plain",
+		},
+		(uri, { id }) => {
+			console.log("[mock-resources-mcp] read", uri.href);
+			return {
+				contents: [
+					{
+						uri: uri.href,
+						mimeType: "text/plain",
+						text: `Note "${id}": the duty engineer this week is Sam Okafor.`,
+					},
+				],
+			};
+		}
+	);
+
+	server.registerResource(
+		"logo",
+		"image:///logo.png",
+		{ title: "Logo", description: "A tiny PNG.", mimeType: "image/png" },
+		(uri) => {
+			console.log("[mock-resources-mcp] read", uri.href, "(binary)");
+			return { contents: [{ uri: uri.href, mimeType: "image/png", blob: PNG_1X1 }] };
+		}
+	);
+
+	server.registerResource(
+		"huge",
+		"file:///huge.log",
+		{ title: "Huge log", description: "44k characters, to exercise truncation.", mimeType: "text/plain" },
+		(uri) => {
+			console.log("[mock-resources-mcp] read", uri.href, "(oversized)");
+			// The tail marker must NOT survive truncation — that is how you tell it worked.
+			return {
+				contents: [
+					{
+						uri: uri.href,
+						mimeType: "text/plain",
+						text: `${"log line filler. ".repeat(2_750)}\nTAIL-MARKER-SHOULD-BE-CUT`,
+					},
+				],
+			};
+		}
+	);
+
+	return server;
+}
+
+const httpServer = createServer((req, res) => {
+	void (async () => {
+		const url = new URL(req.url ?? "/", `http://127.0.0.1:${PORT}`);
+
+		if (url.pathname === "/health") {
+			res.writeHead(200, { "content-type": "application/json" });
+			res.end(JSON.stringify({ ok: true }));
+			return;
+		}
+
+		if (url.pathname === "/mcp") {
+			// Stateless: a fresh server + transport per request, torn down after.
+			const server = buildServer();
+			const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+			res.on("close", () => {
+				void transport.close();
+				void server.close();
+			});
+			await server.connect(transport);
+			await transport.handleRequest(req, res);
+			return;
+		}
+
+		res.writeHead(404, { "content-type": "application/json" });
+		res.end(JSON.stringify({ error: "not found", path: url.pathname }));
+	})().catch((err) => {
+		console.error("[mock-resources-mcp]", err);
+		if (!res.headersSent) {
+			res.writeHead(500, { "content-type": "application/json" });
+			res.end(JSON.stringify({ error: String(err) }));
+		} else {
+			res.end();
+		}
+	});
+});
+
+httpServer.listen(PORT, "127.0.0.1", () => {
+	console.log(`[mock-resources-mcp] listening on http://127.0.0.1:${PORT}/mcp`);
+	console.log("[mock-resources-mcp] tool: ping");
+	console.log(
+		"[mock-resources-mcp] resources: file:///briefing.md, image:///logo.png, file:///huge.log, note:///{id}"
+	);
+});

--- a/src/lib/components/mcp/ServerCard.svelte
+++ b/src/lib/components/mcp/ServerCard.svelte
@@ -7,6 +7,7 @@
 	import IconRefresh from "~icons/carbon/renew";
 	import IconTrash from "~icons/carbon/trash-can";
 	import LucideHammer from "~icons/lucide/hammer";
+	import LucideFileText from "~icons/lucide/file-text";
 	import IconSettings from "~icons/carbon/settings";
 	import Switch from "$lib/components/Switch.svelte";
 	import { getMcpServerFaviconUrl } from "$lib/utils/favicon";
@@ -132,6 +133,14 @@
 						{server.tools.length === 1 ? "tool" : "tools"}
 					</span>
 				{/if}
+
+				{#if server.resources && server.resources.length > 0}
+					<span class="inline-flex items-center gap-1 text-xs text-gray-600 dark:text-gray-400">
+						<LucideFileText class="size-3" />
+						{server.resources.length}
+						{server.resources.length === 1 ? "resource" : "resources"}
+					</span>
+				{/if}
 			</div>
 		{/if}
 
@@ -193,6 +202,27 @@
 							<span class="font-medium text-gray-900 dark:text-gray-100">{tool.name}</span>
 							{#if tool.description}
 								<span class="text-gray-500 dark:text-gray-500">- {tool.description}</span>
+							{/if}
+						</li>
+					{/each}
+				</ul>
+			</details>
+		{/if}
+
+		<!-- Resources List (Expandable) -->
+		{#if server.resources && server.resources.length > 0}
+			<details class="mt-3">
+				<summary class="cursor-pointer text-xs font-medium text-gray-700 dark:text-gray-300">
+					Available Resources ({server.resources.length})
+				</summary>
+				<ul class="mt-2 space-y-1 text-xs">
+					{#each server.resources as resource}
+						<li class="text-gray-600 dark:text-gray-400">
+							<span class="font-medium break-all text-gray-900 dark:text-gray-100">
+								{resource.name || resource.uri || resource.uriTemplate}
+							</span>
+							{#if resource.description}
+								<span class="text-gray-500 dark:text-gray-500">- {resource.description}</span>
 							{/if}
 						</li>
 					{/each}

--- a/src/lib/server/mcp/httpClient.ts
+++ b/src/lib/server/mcp/httpClient.ts
@@ -3,7 +3,7 @@ import { StreamableHTTPError } from "@modelcontextprotocol/sdk/client/streamable
 import { getClient, evictFromPool, retainClient, releaseClient } from "./clientPool";
 import { config } from "$lib/server/config";
 
-function isConnectionClosedError(err: unknown): boolean {
+export function isConnectionClosedError(err: unknown): boolean {
 	const message = err instanceof Error ? err.message : String(err);
 	return message.includes("-32000") || message.toLowerCase().includes("connection closed");
 }
@@ -11,7 +11,7 @@ function isConnectionClosedError(err: unknown): boolean {
 // Per the MCP Streamable HTTP spec, a 404 on a request carrying a session ID means the
 // session expired and the client MUST start a new session with a new InitializeRequest —
 // which is exactly what reconnecting with a fresh client does.
-function isSessionExpiredError(err: unknown): boolean {
+export function isSessionExpiredError(err: unknown): boolean {
 	return err instanceof StreamableHTTPError && err.code === 404;
 }
 

--- a/src/lib/server/mcp/resources.spec.ts
+++ b/src/lib/server/mcp/resources.spec.ts
@@ -212,3 +212,57 @@ describe("readMcpResource", () => {
 		});
 	});
 });
+
+describe("readMcpResource ambiguity", () => {
+	const shared = { uri: "file:///readme.md" };
+
+	it("refuses to guess when two servers expose the same URI", async () => {
+		mocks.catalogs = [catalog({ resources: [shared] }), catalog({ resources: [shared] })];
+
+		const result = await readMcpResource([SERVER_A, SERVER_B], "file:///readme.md");
+
+		expect(result.isError).toBe(true);
+		expect(result.text).toContain('"Docs", "Files"');
+		expect(mocks.readsBy).toEqual([]);
+	});
+
+	it("reads the named server when the caller disambiguates", async () => {
+		mocks.catalogs = [catalog({ resources: [shared] }), catalog({ resources: [shared] })];
+		mocks.readResource = async () => ({ contents: [{ text: "from Files" }] });
+
+		const result = await readMcpResource([SERVER_A, SERVER_B], "file:///readme.md", {
+			server: "Files",
+		});
+
+		expect(result).toEqual({ text: "from Files", isError: false });
+		expect(mocks.readsBy).toEqual(["Files"]);
+	});
+
+	it("reports a server argument that does not expose the URI", async () => {
+		mocks.catalogs = [catalog({ resources: [shared] }), catalog({})];
+
+		const result = await readMcpResource([SERVER_A, SERVER_B], "file:///readme.md", {
+			server: "Files",
+		});
+
+		expect(result.isError).toBe(true);
+		expect(result.text).toContain('"Files" does not expose');
+		expect(mocks.readsBy).toEqual([]);
+	});
+});
+
+describe("listMcpResources template cap", () => {
+	it("caps templates and reports the total", async () => {
+		mocks.catalogs = [
+			catalog({
+				templates: Array.from({ length: 80 }, (_, i) => ({ uriTemplate: `doc://{id}/${i}` })),
+			}),
+		];
+
+		const listing = await listMcpResources([SERVER_A]);
+
+		expect(listing).toContain("Resource URI templates (50 of 80 shown;");
+		expect(listing).toContain("doc://{id}/49");
+		expect(listing).not.toContain("doc://{id}/50 ");
+	});
+});

--- a/src/lib/server/mcp/resources.spec.ts
+++ b/src/lib/server/mcp/resources.spec.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { listMcpResources, readMcpResource } from "./resources";
+import type { McpServerConfig } from "./httpClient";
+import type { ServerCatalog } from "./tools";
+
+const mocks = vi.hoisted(() => ({
+	catalogs: [] as unknown[],
+	// Servers whose client was asked to read, in call order, so routing is assertable.
+	readsBy: [] as string[],
+	readResource: async (_params: { uri: string }): Promise<unknown> => ({ contents: [] }),
+}));
+
+vi.mock("./tools", () => ({ getMcpCatalog: async () => mocks.catalogs }));
+
+vi.mock("./clientPool", () => ({
+	getClient: async (server: McpServerConfig) => ({
+		readResource: (params: { uri: string }) => {
+			mocks.readsBy.push(server.name);
+			return mocks.readResource(params);
+		},
+	}),
+	retainClient: () => {},
+	releaseClient: () => {},
+	evictFromPool: () => undefined,
+}));
+
+vi.mock("./httpClient", () => ({
+	getMcpToolTimeoutMs: () => 1_000,
+	isConnectionClosedError: () => false,
+	isSessionExpiredError: () => false,
+}));
+
+vi.mock("$lib/server/logger", () => ({
+	logger: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} },
+}));
+
+const SERVER_A: McpServerConfig = { name: "Docs", url: "https://a.example/mcp" };
+const SERVER_B: McpServerConfig = { name: "Files", url: "https://b.example/mcp" };
+
+const empty: ServerCatalog = { tools: [], resources: [], templates: [] };
+
+function catalog(partial: Partial<ServerCatalog>): ServerCatalog {
+	return { ...empty, ...partial };
+}
+
+beforeEach(() => {
+	mocks.catalogs = [];
+	mocks.readsBy.length = 0;
+	mocks.readResource = async () => ({ contents: [] });
+});
+
+describe("listMcpResources", () => {
+	it("says so plainly when nothing is exposed", async () => {
+		mocks.catalogs = [empty];
+
+		expect(await listMcpResources([SERVER_A])).toBe(
+			"No resources are exposed by the connected MCP servers."
+		);
+	});
+
+	it("renders each resource with its URI, name, type, owning server and description", async () => {
+		mocks.catalogs = [
+			catalog({
+				resources: [
+					{
+						uri: "file:///readme.md",
+						name: "readme",
+						mimeType: "text/markdown",
+						description: "Project overview",
+					},
+				],
+			}),
+		];
+
+		const listing = await listMcpResources([SERVER_A]);
+
+		expect(listing).toContain("Available MCP resources (1):");
+		expect(listing).toContain(
+			"- file:///readme.md | name: readme | type: text/markdown | server: Docs"
+		);
+		expect(listing).toContain("Project overview");
+	});
+
+	it("labels each resource with the server it came from", async () => {
+		mocks.catalogs = [
+			catalog({ resources: [{ uri: "doc://a" }] }),
+			catalog({ resources: [{ uri: "file:///b" }] }),
+		];
+
+		const listing = await listMcpResources([SERVER_A, SERVER_B]);
+
+		expect(listing).toContain("- doc://a | server: Docs");
+		expect(listing).toContain("- file:///b | server: Files");
+	});
+
+	it("lists URI templates in their own section", async () => {
+		mocks.catalogs = [
+			catalog({ templates: [{ uriTemplate: "file:///{path}", name: "project file" }] }),
+		];
+
+		const listing = await listMcpResources([SERVER_A]);
+
+		expect(listing).toContain("Resource URI templates");
+		expect(listing).toContain("- file:///{path} | name: project file | server: Docs");
+	});
+
+	// An unbounded listing would spend the context window before the model reads anything.
+	it("caps the listing and reports the total it was drawn from", async () => {
+		mocks.catalogs = [
+			catalog({
+				resources: Array.from({ length: 250 }, (_, i) => ({ uri: `doc://${i}` })),
+			}),
+		];
+
+		const listing = await listMcpResources([SERVER_A]);
+
+		expect(listing).toContain("Available MCP resources (200 of 250 shown):");
+		expect(listing).toContain("doc://199");
+		expect(listing).not.toContain("doc://200 ");
+	});
+});
+
+describe("readMcpResource", () => {
+	it("routes a URI to the server that enumerated it", async () => {
+		mocks.catalogs = [
+			catalog({ resources: [{ uri: "doc://a" }] }),
+			catalog({ resources: [{ uri: "file:///b" }] }),
+		];
+		mocks.readResource = async () => ({ contents: [{ uri: "file:///b", text: "hello" }] });
+
+		const result = await readMcpResource([SERVER_A, SERVER_B], "file:///b");
+
+		expect(result).toEqual({ text: "hello", isError: false });
+		expect(mocks.readsBy).toEqual(["Files"]);
+	});
+
+	it("routes an unenumerated URI via a matching template", async () => {
+		mocks.catalogs = [
+			catalog({ resources: [{ uri: "doc://a" }] }),
+			catalog({ templates: [{ uriTemplate: "file:///{path}" }] }),
+		];
+		mocks.readResource = async () => ({ contents: [{ text: "from template" }] });
+
+		const result = await readMcpResource([SERVER_A, SERVER_B], "file:///deep/nested.md");
+
+		expect(result.isError).toBe(false);
+		expect(mocks.readsBy).toEqual(["Files"]);
+	});
+
+	// A typo must cost one message, not a round trip against every connected server.
+	it("reports an unresolvable URI without contacting any server", async () => {
+		mocks.catalogs = [catalog({ resources: [{ uri: "doc://a" }] })];
+
+		const result = await readMcpResource([SERVER_A], "file:///nope.md");
+
+		expect(result.isError).toBe(true);
+		expect(result.text).toContain("No connected MCP server exposes");
+		expect(mocks.readsBy).toEqual([]);
+	});
+
+	it("does not let a template match a URI of a different shape", async () => {
+		mocks.catalogs = [catalog({ templates: [{ uriTemplate: "file:///{path}" }] })];
+
+		const result = await readMcpResource([SERVER_A], "https://example.com/x");
+
+		expect(result.isError).toBe(true);
+		expect(mocks.readsBy).toEqual([]);
+	});
+
+	it("rejects a missing uri argument before resolving anything", async () => {
+		mocks.catalogs = [catalog({ resources: [{ uri: "doc://a" }] })];
+
+		expect(await readMcpResource([SERVER_A], "")).toEqual({
+			text: "A `uri` argument is required.",
+			isError: true,
+		});
+	});
+
+	it("joins multiple text contents", async () => {
+		mocks.catalogs = [catalog({ resources: [{ uri: "doc://a" }] })];
+		mocks.readResource = async () => ({ contents: [{ text: "one" }, { text: "two" }] });
+
+		expect((await readMcpResource([SERVER_A], "doc://a")).text).toBe("one\n\ntwo");
+	});
+
+	// base64 bytes the model cannot read would otherwise eat the whole context window.
+	it("describes binary content instead of inlining it", async () => {
+		mocks.catalogs = [catalog({ resources: [{ uri: "doc://a" }] })];
+		const blob = "A".repeat(4_000);
+		mocks.readResource = async () => ({ contents: [{ mimeType: "image/png", blob }] });
+
+		const result = await readMcpResource([SERVER_A], "doc://a");
+
+		expect(result.isError).toBe(false);
+		expect(result.text).toBe("[Binary content: image/png, ~3000 bytes, not inlined.]");
+		expect(result.text).not.toContain(blob);
+	});
+
+	it("truncates an oversized resource and says how much was withheld", async () => {
+		mocks.catalogs = [catalog({ resources: [{ uri: "doc://a" }] })];
+		mocks.readResource = async () => ({ contents: [{ text: "x".repeat(40_000) }] });
+
+		const result = await readMcpResource([SERVER_A], "doc://a");
+
+		expect(result.isError).toBe(false);
+		expect(result.text).toContain("[Truncated: the resource is 40000 characters, 32000 shown.]");
+	});
+
+	it("reports an empty read as empty rather than as a failure", async () => {
+		mocks.catalogs = [catalog({ resources: [{ uri: "doc://a" }] })];
+		mocks.readResource = async () => ({ contents: [] });
+
+		expect(await readMcpResource([SERVER_A], "doc://a")).toEqual({
+			text: 'The resource "doc://a" returned no readable content.',
+			isError: false,
+		});
+	});
+});

--- a/src/lib/server/mcp/resources.spec.ts
+++ b/src/lib/server/mcp/resources.spec.ts
@@ -5,7 +5,6 @@ import type { ServerCatalog } from "./tools";
 
 const mocks = vi.hoisted(() => ({
 	catalogs: [] as unknown[],
-	// Servers whose client was asked to read, in call order, so routing is assertable.
 	readsBy: [] as string[],
 	readResource: async (_params: { uri: string }): Promise<unknown> => ({ contents: [] }),
 }));
@@ -104,7 +103,6 @@ describe("listMcpResources", () => {
 		expect(listing).toContain("- file:///{path} | name: project file | server: Docs");
 	});
 
-	// An unbounded listing would spend the context window before the model reads anything.
 	it("caps the listing and reports the total it was drawn from", async () => {
 		mocks.catalogs = [
 			catalog({
@@ -147,7 +145,6 @@ describe("readMcpResource", () => {
 		expect(mocks.readsBy).toEqual(["Files"]);
 	});
 
-	// A typo must cost one message, not a round trip against every connected server.
 	it("reports an unresolvable URI without contacting any server", async () => {
 		mocks.catalogs = [catalog({ resources: [{ uri: "doc://a" }] })];
 
@@ -183,7 +180,6 @@ describe("readMcpResource", () => {
 		expect((await readMcpResource([SERVER_A], "doc://a")).text).toBe("one\n\ntwo");
 	});
 
-	// base64 bytes the model cannot read would otherwise eat the whole context window.
 	it("describes binary content instead of inlining it", async () => {
 		mocks.catalogs = [catalog({ resources: [{ uri: "doc://a" }] })];
 		const blob = "A".repeat(4_000);

--- a/src/lib/server/mcp/resources.ts
+++ b/src/lib/server/mcp/resources.ts
@@ -7,6 +7,8 @@ import { logger } from "$lib/server/logger";
 /** A resource is arbitrary server data; unbounded, one read can swallow the context window. */
 const MAX_RESOURCE_TEXT_CHARS = 32_000;
 const MAX_LISTED_RESOURCES = 200;
+/** Templates get their own budget so a long resource listing can never starve them out. */
+const MAX_LISTED_TEMPLATES = 50;
 
 export type McpResourceReadResult = {
 	text: string;
@@ -46,21 +48,19 @@ function describeResource(server: string, resource: CachedServerResource): strin
 	return resource.description ? `${line}\n    ${resource.description}` : line;
 }
 
-/** No match is reported back, never broadcast: a typo must not cost a round trip per server. */
-function resolveOwner(
+/** Every server that could serve `uri`; an enumerated match outranks a template one. */
+function resolveOwners(
 	servers: McpServerConfig[],
 	catalogs: ServerCatalog[],
 	uri: string
-): McpServerConfig | undefined {
-	for (const [index, server] of servers.entries()) {
-		if (catalogs[index].resources.some((resource) => resource.uri === uri)) return server;
-	}
-	for (const [index, server] of servers.entries()) {
-		for (const template of catalogs[index].templates) {
-			if (templateToRegExp(template.uriTemplate)?.test(uri)) return server;
-		}
-	}
-	return undefined;
+): McpServerConfig[] {
+	const enumerated = servers.filter((_, index) =>
+		catalogs[index].resources.some((resource) => resource.uri === uri)
+	);
+	if (enumerated.length > 0) return enumerated;
+	return servers.filter((_, index) =>
+		catalogs[index].templates.some((template) => templateToRegExp(template.uriTemplate)?.test(uri))
+	);
 }
 
 export async function listMcpResources(
@@ -85,8 +85,11 @@ export async function listMcpResources(
 	}
 
 	const templateLines: string[] = [];
+	let templateTotal = 0;
 	for (const [index, server] of servers.entries()) {
 		for (const template of catalogs[index].templates) {
+			templateTotal += 1;
+			if (templateLines.length >= MAX_LISTED_TEMPLATES) continue;
 			const parts = [`- ${template.uriTemplate}`];
 			if (template.name) parts.push(`name: ${template.name}`);
 			if (template.mimeType) parts.push(`type: ${template.mimeType}`);
@@ -109,11 +112,12 @@ export async function listMcpResources(
 		sections.push([heading, ...lines].join("\n"));
 	}
 	if (templateLines.length > 0) {
-		sections.push(
-			[`Resource URI templates (expand the {placeholders} to form a URI):`, ...templateLines].join(
-				"\n"
-			)
-		);
+		const shown =
+			templateTotal > templateLines.length ? `${templateLines.length} of ${templateTotal}` : null;
+		const heading = shown
+			? `Resource URI templates (${shown} shown; expand the {placeholders} to form a URI):`
+			: `Resource URI templates (expand the {placeholders} to form a URI):`;
+		sections.push([heading, ...templateLines].join("\n"));
 	}
 	return sections.join("\n\n");
 }
@@ -121,20 +125,37 @@ export async function listMcpResources(
 export async function readMcpResource(
 	servers: McpServerConfig[],
 	uri: string,
-	{ signal, timeoutMs }: { signal?: AbortSignal; timeoutMs?: number } = {}
+	{
+		signal,
+		timeoutMs,
+		server: serverName,
+	}: { signal?: AbortSignal; timeoutMs?: number; server?: string } = {}
 ): Promise<McpResourceReadResult> {
 	if (typeof uri !== "string" || uri.trim().length === 0) {
 		return { text: "A `uri` argument is required.", isError: true };
 	}
 
 	const catalogs = await getMcpCatalog(servers, { signal });
-	const server = resolveOwner(servers, catalogs, uri);
-	if (!server) {
+	const owners = resolveOwners(servers, catalogs, uri);
+	const candidates = serverName ? owners.filter((owner) => owner.name === serverName) : owners;
+
+	if (candidates.length === 0) {
 		return {
-			text: `No connected MCP server exposes the resource "${uri}". Call the resource listing function to see the available URIs.`,
+			text: serverName
+				? `The MCP server "${serverName}" does not expose the resource "${uri}". Call the resource listing function to see the available URIs.`
+				: `No connected MCP server exposes the resource "${uri}". Call the resource listing function to see the available URIs.`,
 			isError: true,
 		};
 	}
+	// Guessing between servers would silently return one server's document in another's name.
+	if (candidates.length > 1) {
+		const names = candidates.map((candidate) => `"${candidate.name}"`).join(", ");
+		return {
+			text: `The resource "${uri}" is exposed by more than one server (${names}). Retry with the \`server\` argument set to the one you want.`,
+			isError: true,
+		};
+	}
+	const server = candidates[0];
 
 	const effectiveTimeoutMs = timeoutMs ?? getMcpToolTimeoutMs();
 	let activeClient = await getClient(server, signal);

--- a/src/lib/server/mcp/resources.ts
+++ b/src/lib/server/mcp/resources.ts
@@ -1,0 +1,211 @@
+import type { McpServerConfig } from "./httpClient";
+import { isConnectionClosedError, isSessionExpiredError, getMcpToolTimeoutMs } from "./httpClient";
+import { getClient, evictFromPool, retainClient, releaseClient } from "./clientPool";
+import { getMcpCatalog, type CachedServerResource, type ServerCatalog } from "./tools";
+import { logger } from "$lib/server/logger";
+
+/**
+ * Cap on the text handed back to the model for one resource. A resource is arbitrary
+ * server-side data — a whole log file or dataset is a legitimate resource — and an
+ * unbounded read would blow the context window and the turn's budget with it.
+ */
+const MAX_RESOURCE_TEXT_CHARS = 32_000;
+
+/** Cap on the listing, for the same reason. Listings are far cheaper per entry than reads. */
+const MAX_LISTED_RESOURCES = 200;
+
+export type McpResourceReadResult = {
+	text: string;
+	isError: boolean;
+};
+
+type ResourceContent = {
+	uri?: unknown;
+	mimeType?: unknown;
+	text?: unknown;
+	blob?: unknown;
+};
+
+function truncate(text: string, limit: number): string {
+	if (text.length <= limit) return text;
+	return `${text.slice(0, limit)}\n\n[Truncated: the resource is ${text.length} characters, ${limit} shown.]`;
+}
+
+/**
+ * Compile a level-1 RFC 6570 template into an anchored matcher. Only used to work out which
+ * server owns a URI, so it deliberately does not try to extract variables — an over-broad
+ * match would still route to a server that can answer for the URI, and a server that cannot
+ * says so.
+ */
+function templateToRegExp(uriTemplate: string): RegExp | undefined {
+	const literals = uriTemplate.split(/\{[^{}]*\}/g);
+	if (literals.length < 2) return undefined;
+	const pattern = literals.map((part) => part.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join(".+?");
+	try {
+		return new RegExp(`^${pattern}$`);
+	} catch {
+		return undefined;
+	}
+}
+
+function describeResource(server: string, resource: CachedServerResource): string {
+	const parts = [`- ${resource.uri}`];
+	if (resource.name) parts.push(`name: ${resource.name}`);
+	if (resource.mimeType) parts.push(`type: ${resource.mimeType}`);
+	parts.push(`server: ${server}`);
+	const line = parts.join(" | ");
+	return resource.description ? `${line}\n    ${resource.description}` : line;
+}
+
+/**
+ * Which server can serve `uri`: an enumerated resource wins, then a template whose shape it
+ * fits. A URI matching nothing is reported as unresolvable rather than broadcast to every
+ * server, so a typo costs one message instead of a round trip per connected server.
+ */
+function resolveOwner(
+	servers: McpServerConfig[],
+	catalogs: ServerCatalog[],
+	uri: string
+): McpServerConfig | undefined {
+	for (const [index, server] of servers.entries()) {
+		if (catalogs[index].resources.some((resource) => resource.uri === uri)) return server;
+	}
+	for (const [index, server] of servers.entries()) {
+		for (const template of catalogs[index].templates) {
+			if (templateToRegExp(template.uriTemplate)?.test(uri)) return server;
+		}
+	}
+	return undefined;
+}
+
+export async function listMcpResources(
+	servers: McpServerConfig[],
+	{ signal }: { signal?: AbortSignal } = {}
+): Promise<string> {
+	const catalogs = await getMcpCatalog(servers, { signal });
+
+	const lines: string[] = [];
+	let total = 0;
+	let omitted = 0;
+
+	for (const [index, server] of servers.entries()) {
+		for (const resource of catalogs[index].resources) {
+			total += 1;
+			if (lines.length >= MAX_LISTED_RESOURCES) {
+				omitted += 1;
+				continue;
+			}
+			lines.push(describeResource(server.name, resource));
+		}
+	}
+
+	const templateLines: string[] = [];
+	for (const [index, server] of servers.entries()) {
+		for (const template of catalogs[index].templates) {
+			const parts = [`- ${template.uriTemplate}`];
+			if (template.name) parts.push(`name: ${template.name}`);
+			if (template.mimeType) parts.push(`type: ${template.mimeType}`);
+			parts.push(`server: ${server.name}`);
+			const line = parts.join(" | ");
+			templateLines.push(template.description ? `${line}\n    ${template.description}` : line);
+		}
+	}
+
+	if (lines.length === 0 && templateLines.length === 0) {
+		return "No resources are exposed by the connected MCP servers.";
+	}
+
+	const sections: string[] = [];
+	if (lines.length > 0) {
+		const heading =
+			omitted > 0
+				? `Available MCP resources (${lines.length} of ${total} shown):`
+				: `Available MCP resources (${total}):`;
+		sections.push([heading, ...lines].join("\n"));
+	}
+	if (templateLines.length > 0) {
+		sections.push(
+			[`Resource URI templates (expand the {placeholders} to form a URI):`, ...templateLines].join(
+				"\n"
+			)
+		);
+	}
+	return sections.join("\n\n");
+}
+
+export async function readMcpResource(
+	servers: McpServerConfig[],
+	uri: string,
+	{ signal, timeoutMs }: { signal?: AbortSignal; timeoutMs?: number } = {}
+): Promise<McpResourceReadResult> {
+	if (typeof uri !== "string" || uri.trim().length === 0) {
+		return { text: "A `uri` argument is required.", isError: true };
+	}
+
+	const catalogs = await getMcpCatalog(servers, { signal });
+	const server = resolveOwner(servers, catalogs, uri);
+	if (!server) {
+		return {
+			text: `No connected MCP server exposes the resource "${uri}". Call the resource listing function to see the available URIs.`,
+			isError: true,
+		};
+	}
+
+	const effectiveTimeoutMs = timeoutMs ?? getMcpToolTimeoutMs();
+	let activeClient = await getClient(server, signal);
+
+	// Mirrors callMcpTool: a pooled connection can be reaped by a proxy or lost to a server
+	// restart between calls, and the retry is on a genuinely fresh client.
+	const maxReconnectAttempts = 2;
+	let response;
+	for (let attempt = 0; ; attempt++) {
+		const currentClient = activeClient;
+		retainClient(currentClient);
+		try {
+			response = await currentClient.readResource({ uri }, { signal, timeout: effectiveTimeoutMs });
+			break;
+		} catch (err) {
+			if (
+				attempt >= maxReconnectAttempts ||
+				signal?.aborted ||
+				!(isConnectionClosedError(err) || isSessionExpiredError(err))
+			) {
+				throw err;
+			}
+			const stale = evictFromPool(server);
+			stale?.close?.().catch(() => {});
+			if (attempt > 0) {
+				await new Promise((resolve) => setTimeout(resolve, 1_000 * attempt));
+			}
+			activeClient = await getClient(server, signal);
+		} finally {
+			releaseClient(currentClient);
+		}
+	}
+
+	const contents = Array.isArray(response?.contents)
+		? (response.contents as ResourceContent[])
+		: [];
+
+	const rendered: string[] = [];
+	for (const content of contents) {
+		if (typeof content?.text === "string") {
+			rendered.push(content.text);
+			continue;
+		}
+		if (typeof content?.blob === "string") {
+			// Binary contents are base64; inlining them would spend the context window on bytes
+			// the model cannot read anyway, so report what is there instead.
+			const mimeType = typeof content.mimeType === "string" ? content.mimeType : "unknown type";
+			const approxBytes = Math.floor((content.blob.length * 3) / 4);
+			rendered.push(`[Binary content: ${mimeType}, ~${approxBytes} bytes, not inlined.]`);
+		}
+	}
+
+	if (rendered.length === 0) {
+		return { text: `The resource "${uri}" returned no readable content.`, isError: false };
+	}
+
+	logger.debug({ server: server.name, uri }, "[mcp] read resource");
+	return { text: truncate(rendered.join("\n\n"), MAX_RESOURCE_TEXT_CHARS), isError: false };
+}

--- a/src/lib/server/mcp/resources.ts
+++ b/src/lib/server/mcp/resources.ts
@@ -4,14 +4,8 @@ import { getClient, evictFromPool, retainClient, releaseClient } from "./clientP
 import { getMcpCatalog, type CachedServerResource, type ServerCatalog } from "./tools";
 import { logger } from "$lib/server/logger";
 
-/**
- * Cap on the text handed back to the model for one resource. A resource is arbitrary
- * server-side data — a whole log file or dataset is a legitimate resource — and an
- * unbounded read would blow the context window and the turn's budget with it.
- */
+/** A resource is arbitrary server data; unbounded, one read can swallow the context window. */
 const MAX_RESOURCE_TEXT_CHARS = 32_000;
-
-/** Cap on the listing, for the same reason. Listings are far cheaper per entry than reads. */
 const MAX_LISTED_RESOURCES = 200;
 
 export type McpResourceReadResult = {
@@ -31,12 +25,7 @@ function truncate(text: string, limit: number): string {
 	return `${text.slice(0, limit)}\n\n[Truncated: the resource is ${text.length} characters, ${limit} shown.]`;
 }
 
-/**
- * Compile a level-1 RFC 6570 template into an anchored matcher. Only used to work out which
- * server owns a URI, so it deliberately does not try to extract variables — an over-broad
- * match would still route to a server that can answer for the URI, and a server that cannot
- * says so.
- */
+/** Routing only, so variables are deliberately not extracted — an over-broad match is harmless. */
 function templateToRegExp(uriTemplate: string): RegExp | undefined {
 	const literals = uriTemplate.split(/\{[^{}]*\}/g);
 	if (literals.length < 2) return undefined;
@@ -57,11 +46,7 @@ function describeResource(server: string, resource: CachedServerResource): strin
 	return resource.description ? `${line}\n    ${resource.description}` : line;
 }
 
-/**
- * Which server can serve `uri`: an enumerated resource wins, then a template whose shape it
- * fits. A URI matching nothing is reported as unresolvable rather than broadcast to every
- * server, so a typo costs one message instead of a round trip per connected server.
- */
+/** No match is reported back, never broadcast: a typo must not cost a round trip per server. */
 function resolveOwner(
 	servers: McpServerConfig[],
 	catalogs: ServerCatalog[],
@@ -154,8 +139,7 @@ export async function readMcpResource(
 	const effectiveTimeoutMs = timeoutMs ?? getMcpToolTimeoutMs();
 	let activeClient = await getClient(server, signal);
 
-	// Mirrors callMcpTool: a pooled connection can be reaped by a proxy or lost to a server
-	// restart between calls, and the retry is on a genuinely fresh client.
+	// Mirrors callMcpTool: a pooled connection can be reaped by a proxy between calls.
 	const maxReconnectAttempts = 2;
 	let response;
 	for (let attempt = 0; ; attempt++) {
@@ -194,8 +178,7 @@ export async function readMcpResource(
 			continue;
 		}
 		if (typeof content?.blob === "string") {
-			// Binary contents are base64; inlining them would spend the context window on bytes
-			// the model cannot read anyway, so report what is there instead.
+			// Never inline: base64 the model cannot read would spend the context window on bytes.
 			const mimeType = typeof content.mimeType === "string" ? content.mimeType : "unknown type";
 			const approxBytes = Math.floor((content.blob.length * 3) / 4);
 			rendered.push(`[Binary content: ${mimeType}, ~${approxBytes} bytes, not inlined.]`);

--- a/src/lib/server/mcp/tools.test.ts
+++ b/src/lib/server/mcp/tools.test.ts
@@ -544,3 +544,64 @@ describe("getOpenAiToolsForMcp resource functions", () => {
 		expect(tools.map((t) => t.function.name)).toEqual(["search"]);
 	});
 });
+
+describe("getOpenAiToolsForMcp review fixes", () => {
+	beforeEach(() => {
+		resetMcpToolsCache();
+		mcpMock.listToolsCalls.length = 0;
+		mcpMock.listResourcesCalls.length = 0;
+		mcpMock.responses.clear();
+		mcpMock.resources.clear();
+	});
+
+	const readme = { uri: "file:///readme.md", name: "readme" };
+
+	it("still exposes resources when the server has no tools capability", async () => {
+		mcpMock.responses.set(SERVER_A.url, new Error("MCP error -32601: Method not found"));
+		mcpMock.resources.set(SERVER_A.url, { resources: [readme] });
+
+		const { tools } = await getOpenAiToolsForMcp([SERVER_A]);
+
+		expect(tools.map((t) => t.function.name)).toEqual(["list_mcp_resources", "read_mcp_resource"]);
+	});
+
+	// Swallowing this would cache an empty catalog for the whole TTL instead of retrying.
+	it("still fails a server whose listing yields neither tools nor resources", async () => {
+		mcpMock.responses.set(SERVER_A.url, new Error("boom"));
+
+		const { tools } = await getOpenAiToolsForMcp([SERVER_A]);
+
+		expect(tools).toEqual([]);
+		mcpMock.responses.set(SERVER_A.url, { tools: [searchTool] });
+		const retried = await getOpenAiToolsForMcp([SERVER_A]);
+		expect(retried.tools.map((t) => t.function.name)).toEqual(["search"]);
+	});
+
+	it("registers no resource functions rather than hijacking an occupied name", async () => {
+		const taken = ["read_mcp_resource"];
+		for (let n = 2; n < 100; n += 1) taken.push(`read_mcp_resource_${n}`);
+		mcpMock.responses.set(SERVER_A.url, {
+			tools: taken.map((name) => ({ name, description: "real", inputSchema: {} })),
+		});
+		mcpMock.resources.set(SERVER_A.url, { resources: [readme] });
+
+		const { tools, mapping } = await getOpenAiToolsForMcp([SERVER_A]);
+
+		expect(tools.map((t) => t.function.name)).not.toContain("list_mcp_resources");
+		for (const name of taken) {
+			expect(toolMapping(mapping, name).tool).toBe(name);
+		}
+	});
+
+	it("offers a server argument for disambiguating a shared URI", async () => {
+		mcpMock.responses.set(SERVER_A.url, { tools: [searchTool] });
+		mcpMock.resources.set(SERVER_A.url, { resources: [readme] });
+
+		const { tools } = await getOpenAiToolsForMcp([SERVER_A]);
+		const read = tools.find((t) => t.function.name === "read_mcp_resource");
+		const props = (read?.function.parameters as Record<string, Record<string, unknown>>).properties;
+
+		expect(Object.keys(props)).toEqual(["uri", "server"]);
+		expect(read?.function.parameters?.required).toEqual(["uri"]);
+	});
+});

--- a/src/lib/server/mcp/tools.test.ts
+++ b/src/lib/server/mcp/tools.test.ts
@@ -50,7 +50,6 @@ vi.mock("@modelcontextprotocol/sdk/client", () => ({
 	},
 }));
 
-/** Narrow away the resource-function variant; resource mappings are asserted on their own. */
 function toolMapping(mapping: Record<string, McpFunctionMapping>, name: string): McpToolMapping {
 	const entry = mapping[name];
 	if (!entry || isResourceFn(entry)) throw new Error(`no tool mapping named ${name}`);
@@ -450,7 +449,6 @@ describe("getOpenAiToolsForMcp resource functions", () => {
 		expect(tools.map((t) => t.function.name)).toEqual(["search"]);
 	});
 
-	// A server that never declares the capability would answer with method-not-found.
 	it("does not ask an undeclaring server for its resources", async () => {
 		mcpMock.responses.set(SERVER_A.url, { tools: [searchTool] });
 
@@ -482,8 +480,6 @@ describe("getOpenAiToolsForMcp resource functions", () => {
 		});
 	});
 
-	// Templates are how a server advertises resources it does not enumerate, so a server
-	// that only has templates still needs the functions.
 	it("exposes the functions for a server with only URI templates", async () => {
 		mcpMock.responses.set(SERVER_A.url, { tools: [searchTool] });
 		mcpMock.resources.set(SERVER_A.url, {
@@ -507,7 +503,6 @@ describe("getOpenAiToolsForMcp resource functions", () => {
 		expect(list?.function.description).toContain("Server A, Server B");
 	});
 
-	// A real tool owns its name; the synthetic one yields.
 	it("does not take a name a real tool already holds", async () => {
 		mcpMock.responses.set(SERVER_A.url, {
 			tools: [{ name: "read_mcp_resource", description: "a real tool", inputSchema: {} }],
@@ -529,7 +524,6 @@ describe("getOpenAiToolsForMcp resource functions", () => {
 		});
 	});
 
-	// The whole point of listing both over one connection.
 	it("lists resources over the same cached connection as tools", async () => {
 		mcpMock.responses.set(SERVER_A.url, { tools: [searchTool] });
 		mcpMock.resources.set(SERVER_A.url, { resources: [readme] });
@@ -541,7 +535,6 @@ describe("getOpenAiToolsForMcp resource functions", () => {
 		expect(mcpMock.listResourcesCalls).toEqual([SERVER_A.url]);
 	});
 
-	// The caller is primarily after tools; a broken resource listing must not cost them.
 	it("keeps a server's tools when its resource listing fails", async () => {
 		mcpMock.responses.set(SERVER_A.url, { tools: [searchTool] });
 		mcpMock.resources.set(SERVER_A.url, new Error("resources exploded"));

--- a/src/lib/server/mcp/tools.test.ts
+++ b/src/lib/server/mcp/tools.test.ts
@@ -1,12 +1,22 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { sanitizeJsonSchema, getOpenAiToolsForMcp, resetMcpToolsCache } from "./tools";
+import {
+	sanitizeJsonSchema,
+	getOpenAiToolsForMcp,
+	resetMcpToolsCache,
+	isResourceFn,
+	type McpFunctionMapping,
+	type McpToolMapping,
+} from "./tools";
 import type { McpServerConfig } from "./httpClient";
 
 // In-memory MCP servers keyed by URL: each listTools call is recorded so tests
 // can assert exactly which servers were (re-)listed vs served from the cache.
 const mcpMock = vi.hoisted(() => ({
 	listToolsCalls: [] as string[],
+	listResourcesCalls: [] as string[],
 	responses: new Map<string, { tools: unknown[] } | Error>(),
+	// Only URLs present here declare the `resources` capability.
+	resources: new Map<string, { resources?: unknown[]; resourceTemplates?: unknown[] } | Error>(),
 }));
 
 vi.mock("@modelcontextprotocol/sdk/client", () => ({
@@ -15,6 +25,9 @@ vi.mock("@modelcontextprotocol/sdk/client", () => ({
 		async connect(transport: { url?: unknown }) {
 			this.url = String(transport.url ?? "");
 		}
+		getServerCapabilities() {
+			return mcpMock.resources.has(this.url) ? { tools: {}, resources: {} } : { tools: {} };
+		}
 		async listTools() {
 			mcpMock.listToolsCalls.push(this.url);
 			const response = mcpMock.responses.get(this.url);
@@ -22,9 +35,27 @@ vi.mock("@modelcontextprotocol/sdk/client", () => ({
 			if (response instanceof Error) throw response;
 			return response;
 		}
+		async listResources() {
+			mcpMock.listResourcesCalls.push(this.url);
+			const response = mcpMock.resources.get(this.url);
+			if (response instanceof Error) throw response;
+			return { resources: response?.resources ?? [] };
+		}
+		async listResourceTemplates() {
+			const response = mcpMock.resources.get(this.url);
+			if (response instanceof Error) throw response;
+			return { resourceTemplates: response?.resourceTemplates ?? [] };
+		}
 		async close() {}
 	},
 }));
+
+/** Narrow away the resource-function variant; resource mappings are asserted on their own. */
+function toolMapping(mapping: Record<string, McpFunctionMapping>, name: string): McpToolMapping {
+	const entry = mapping[name];
+	if (!entry || isResourceFn(entry)) throw new Error(`no tool mapping named ${name}`);
+	return entry;
+}
 
 vi.mock("@modelcontextprotocol/sdk/client/streamableHttp.js", () => ({
 	StreamableHTTPClientTransport: class {
@@ -196,7 +227,9 @@ describe("getOpenAiToolsForMcp per-server cache", () => {
 	beforeEach(() => {
 		resetMcpToolsCache();
 		mcpMock.listToolsCalls.length = 0;
+		mcpMock.listResourcesCalls.length = 0;
 		mcpMock.responses.clear();
+		mcpMock.resources.clear();
 	});
 
 	afterEach(() => {
@@ -278,7 +311,7 @@ describe("getOpenAiToolsForMcp per-server cache", () => {
 		const renamed = await getOpenAiToolsForMcp([{ ...SERVER_A, name: "Renamed" }]);
 
 		expect(mcpMock.listToolsCalls).toEqual([SERVER_A.url]);
-		expect(renamed.mapping.search?.server).toBe("Renamed");
+		expect(toolMapping(renamed.mapping, "search").server).toBe("Renamed");
 	});
 
 	it("suffixes colliding tool names with the server name", async () => {
@@ -288,8 +321,8 @@ describe("getOpenAiToolsForMcp per-server cache", () => {
 		const { tools, mapping } = await getOpenAiToolsForMcp([SERVER_A, SERVER_B]);
 
 		expect(tools.map((t) => t.function.name)).toEqual(["search", "search_Server_B"]);
-		expect(mapping.search.server).toBe("Server A");
-		expect(mapping.search_Server_B.server).toBe("Server B");
+		expect(toolMapping(mapping, "search").server).toBe("Server A");
+		expect(toolMapping(mapping, "search_Server_B").server).toBe("Server B");
 	});
 });
 
@@ -297,7 +330,9 @@ describe("getOpenAiToolsForMcp tool annotations", () => {
 	beforeEach(() => {
 		resetMcpToolsCache();
 		mcpMock.listToolsCalls.length = 0;
+		mcpMock.listResourcesCalls.length = 0;
 		mcpMock.responses.clear();
+		mcpMock.resources.clear();
 	});
 
 	it("carries declared hints through to the mapping", async () => {
@@ -317,7 +352,7 @@ describe("getOpenAiToolsForMcp tool annotations", () => {
 
 		const { mapping } = await getOpenAiToolsForMcp([SERVER_A]);
 
-		expect(mapping.search.annotations).toEqual({
+		expect(toolMapping(mapping, "search").annotations).toEqual({
 			readOnlyHint: true,
 			destructiveHint: false,
 			idempotentHint: true,
@@ -331,7 +366,7 @@ describe("getOpenAiToolsForMcp tool annotations", () => {
 
 		const { mapping } = await getOpenAiToolsForMcp([SERVER_A]);
 
-		expect(mapping.search.annotations).toBeUndefined();
+		expect(toolMapping(mapping, "search").annotations).toBeUndefined();
 	});
 
 	it("keeps only the hints the server actually declared", async () => {
@@ -341,8 +376,8 @@ describe("getOpenAiToolsForMcp tool annotations", () => {
 
 		const { mapping } = await getOpenAiToolsForMcp([SERVER_A]);
 
-		expect(mapping.search.annotations).toEqual({ readOnlyHint: true });
-		expect(mapping.search.annotations).not.toHaveProperty("destructiveHint");
+		expect(toolMapping(mapping, "search").annotations).toEqual({ readOnlyHint: true });
+		expect(toolMapping(mapping, "search").annotations).not.toHaveProperty("destructiveHint");
 	});
 
 	it("ignores non-boolean hint values rather than reading them as declarations", async () => {
@@ -357,7 +392,7 @@ describe("getOpenAiToolsForMcp tool annotations", () => {
 
 		const { mapping } = await getOpenAiToolsForMcp([SERVER_A]);
 
-		expect(mapping.search.annotations).toEqual({ idempotentHint: true });
+		expect(toolMapping(mapping, "search").annotations).toEqual({ idempotentHint: true });
 	});
 
 	it("still uses the title annotation as a description fallback", async () => {
@@ -368,7 +403,7 @@ describe("getOpenAiToolsForMcp tool annotations", () => {
 		const { tools, mapping } = await getOpenAiToolsForMcp([SERVER_A]);
 
 		expect(tools[0].function.description).toBe("Search things");
-		expect(mapping.search.annotations).toEqual({ readOnlyHint: true });
+		expect(toolMapping(mapping, "search").annotations).toEqual({ readOnlyHint: true });
 	});
 
 	// One tool with an unknown field takes down the whole tools array on strict providers.
@@ -392,6 +427,127 @@ describe("getOpenAiToolsForMcp tool annotations", () => {
 		const cached = await getOpenAiToolsForMcp([SERVER_A]);
 
 		expect(mcpMock.listToolsCalls).toEqual([SERVER_A.url]);
-		expect(cached.mapping.search.annotations).toEqual({ destructiveHint: true });
+		expect(toolMapping(cached.mapping, "search").annotations).toEqual({ destructiveHint: true });
+	});
+});
+
+describe("getOpenAiToolsForMcp resource functions", () => {
+	beforeEach(() => {
+		resetMcpToolsCache();
+		mcpMock.listToolsCalls.length = 0;
+		mcpMock.listResourcesCalls.length = 0;
+		mcpMock.responses.clear();
+		mcpMock.resources.clear();
+	});
+
+	const readme = { uri: "file:///readme.md", name: "readme", mimeType: "text/markdown" };
+
+	it("adds no resource functions when no server exposes resources", async () => {
+		mcpMock.responses.set(SERVER_A.url, { tools: [searchTool] });
+
+		const { tools } = await getOpenAiToolsForMcp([SERVER_A]);
+
+		expect(tools.map((t) => t.function.name)).toEqual(["search"]);
+	});
+
+	// A server that never declares the capability would answer with method-not-found.
+	it("does not ask an undeclaring server for its resources", async () => {
+		mcpMock.responses.set(SERVER_A.url, { tools: [searchTool] });
+
+		await getOpenAiToolsForMcp([SERVER_A]);
+
+		expect(mcpMock.listResourcesCalls).toEqual([]);
+	});
+
+	it("exposes list and read functions once any server has resources", async () => {
+		mcpMock.responses.set(SERVER_A.url, { tools: [searchTool] });
+		mcpMock.resources.set(SERVER_A.url, { resources: [readme] });
+
+		const { tools, mapping } = await getOpenAiToolsForMcp([SERVER_A]);
+
+		expect(tools.map((t) => t.function.name)).toEqual([
+			"search",
+			"list_mcp_resources",
+			"read_mcp_resource",
+		]);
+		expect(mapping.list_mcp_resources).toEqual({
+			fnName: "list_mcp_resources",
+			kind: "resource",
+			action: "list",
+		});
+		expect(mapping.read_mcp_resource).toEqual({
+			fnName: "read_mcp_resource",
+			kind: "resource",
+			action: "read",
+		});
+	});
+
+	// Templates are how a server advertises resources it does not enumerate, so a server
+	// that only has templates still needs the functions.
+	it("exposes the functions for a server with only URI templates", async () => {
+		mcpMock.responses.set(SERVER_A.url, { tools: [searchTool] });
+		mcpMock.resources.set(SERVER_A.url, {
+			resourceTemplates: [{ uriTemplate: "file:///{path}", name: "project file" }],
+		});
+
+		const { tools } = await getOpenAiToolsForMcp([SERVER_A]);
+
+		expect(tools.map((t) => t.function.name)).toContain("list_mcp_resources");
+	});
+
+	it("names every server with resources in the list function description", async () => {
+		mcpMock.responses.set(SERVER_A.url, { tools: [searchTool] });
+		mcpMock.responses.set(SERVER_B.url, { tools: [fetchTool] });
+		mcpMock.resources.set(SERVER_A.url, { resources: [readme] });
+		mcpMock.resources.set(SERVER_B.url, { resources: [readme] });
+
+		const { tools } = await getOpenAiToolsForMcp([SERVER_A, SERVER_B]);
+		const list = tools.find((t) => t.function.name === "list_mcp_resources");
+
+		expect(list?.function.description).toContain("Server A, Server B");
+	});
+
+	// A real tool owns its name; the synthetic one yields.
+	it("does not take a name a real tool already holds", async () => {
+		mcpMock.responses.set(SERVER_A.url, {
+			tools: [{ name: "read_mcp_resource", description: "a real tool", inputSchema: {} }],
+		});
+		mcpMock.resources.set(SERVER_A.url, { resources: [readme] });
+
+		const { tools, mapping } = await getOpenAiToolsForMcp([SERVER_A]);
+
+		expect(tools.map((t) => t.function.name)).toEqual([
+			"read_mcp_resource",
+			"list_mcp_resources",
+			"read_mcp_resource_2",
+		]);
+		expect(toolMapping(mapping, "read_mcp_resource").tool).toBe("read_mcp_resource");
+		expect(mapping.read_mcp_resource_2).toEqual({
+			fnName: "read_mcp_resource_2",
+			kind: "resource",
+			action: "read",
+		});
+	});
+
+	// The whole point of listing both over one connection.
+	it("lists resources over the same cached connection as tools", async () => {
+		mcpMock.responses.set(SERVER_A.url, { tools: [searchTool] });
+		mcpMock.resources.set(SERVER_A.url, { resources: [readme] });
+
+		await getOpenAiToolsForMcp([SERVER_A]);
+		await getOpenAiToolsForMcp([SERVER_A]);
+
+		expect(mcpMock.listToolsCalls).toEqual([SERVER_A.url]);
+		expect(mcpMock.listResourcesCalls).toEqual([SERVER_A.url]);
+	});
+
+	// The caller is primarily after tools; a broken resource listing must not cost them.
+	it("keeps a server's tools when its resource listing fails", async () => {
+		mcpMock.responses.set(SERVER_A.url, { tools: [searchTool] });
+		mcpMock.resources.set(SERVER_A.url, new Error("resources exploded"));
+
+		const { tools } = await getOpenAiToolsForMcp([SERVER_A]);
+
+		expect(tools.map((t) => t.function.name)).toEqual(["search"]);
 	});
 });

--- a/src/lib/server/mcp/tools.ts
+++ b/src/lib/server/mcp/tools.ts
@@ -31,12 +31,7 @@ export interface McpToolMapping {
 	annotations?: McpToolAnnotations;
 }
 
-/**
- * Resources are reached through two synthetic functions rather than one function per
- * resource: a server may expose hundreds, and they would crowd out its real tools in the
- * array sent to the provider. Neither is bound to a single server — `list` spans them all
- * and `read` resolves its URI's owner at call time.
- */
+/** Two functions, not one per resource: a server may expose hundreds and crowd out its tools. */
 export interface McpResourceFnMapping {
 	fnName: string;
 	kind: "resource";
@@ -66,7 +61,6 @@ type CachedServerTool = {
 	annotations?: McpToolAnnotations;
 };
 
-/** A resource the server enumerates by concrete URI. */
 export type CachedServerResource = {
 	uri: string;
 	name?: string;
@@ -74,7 +68,6 @@ export type CachedServerResource = {
 	mimeType?: string;
 };
 
-/** A URI template, for resource families the server does not enumerate one by one. */
 export type CachedServerResourceTemplate = {
 	uriTemplate: string;
 	name?: string;
@@ -82,11 +75,7 @@ export type CachedServerResourceTemplate = {
 	mimeType?: string;
 };
 
-/**
- * Everything one connection to a server yields. Tools and resources share a cache entry
- * because they share a key and a TTL — listing them separately would double the connection
- * churn this cache exists to avoid.
- */
+/** Tools and resources share this entry; listing them separately doubles connection churn. */
 export type ServerCatalog = {
 	tools: CachedServerTool[];
 	resources: CachedServerResource[];
@@ -113,7 +102,6 @@ function sanitizeName(name: string) {
 	return name.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 64);
 }
 
-/** Free variant of a fixed function name, for names with no server to disambiguate them. */
 function reserveName(candidate: string, taken: Record<string, unknown>): string {
 	if (!(candidate in taken)) return candidate;
 	for (let n = 2; n < 10; n += 1) {
@@ -234,8 +222,6 @@ type ListedResource = {
 
 type ListedResourceTemplate = Omit<ListedResource, "uri"> & { uriTemplate?: unknown };
 
-// A server may enumerate far more resources than are useful to put in front of a model, and
-// listing is paginated. Both bounds are belt-and-braces: whichever trips first stops paging.
 const MAX_RESOURCE_PAGES = 10;
 const MAX_RESOURCES_PER_SERVER = 250;
 
@@ -243,11 +229,6 @@ function optionalString(value: unknown): string | undefined {
 	return typeof value === "string" && value.trim().length > 0 ? value : undefined;
 }
 
-/**
- * Walk a paginated MCP listing to exhaustion (within bounds). `listPage` is the SDK call;
- * `pick` pulls the page's array out of the envelope, since resources and templates use
- * different property names for it.
- */
 async function listAllPages<T>(
 	listPage: (params: { cursor?: string }) => Promise<unknown>,
 	pick: (page: Record<string, unknown>) => unknown
@@ -277,8 +258,6 @@ function normalizeResources(raw: ListedResource[]): CachedServerResource[] {
 		out.push({
 			uri,
 			name: optionalString(resource.name),
-			// `title` is the human-facing label; use it only when there is no description,
-			// so a resource that declares neither still says something useful to the model.
 			description: optionalString(resource.description) ?? optionalString(resource.title),
 			mimeType: optionalString(resource.mimeType),
 		});
@@ -301,18 +280,13 @@ function normalizeResourceTemplates(raw: ListedResourceTemplate[]): CachedServer
 	return out;
 }
 
-/**
- * Resource listing for a connected client. Returns empty rather than throwing: a server whose
- * resource listing is broken must still contribute its tools, which is what the caller is
- * primarily after.
- */
+/** Never throws: a broken resource listing must not cost the server its tools. */
 export async function listResourcesFor(
 	client: Client,
 	label: string,
 	opts: { signal?: AbortSignal } = {}
 ): Promise<Pick<ServerCatalog, "resources" | "templates">> {
-	// Declared capability first: a server that never declares `resources` would answer both
-	// calls below with method-not-found, so asking is a guaranteed wasted round trip.
+	// Without this an undeclaring server eats two guaranteed method-not-found round trips.
 	if (!client.getServerCapabilities()?.resources) {
 		return { resources: [], templates: [] };
 	}
@@ -322,8 +296,6 @@ export async function listResourcesFor(
 			(params) => client.listResources(params, { signal: opts.signal }),
 			(page) => page.resources
 		),
-		// Templates are optional even for a server that declares `resources`, so a rejection
-		// here is unremarkable and must not cost us the concrete resources.
 		listAllPages<ListedResourceTemplate>(
 			(params) => client.listResourceTemplates(params, { signal: opts.signal }),
 			(page) => page.resourceTemplates
@@ -437,11 +409,6 @@ async function fetchServerCatalog(
 	return { tools: normalized, resources: raw.resources, templates: raw.templates };
 }
 
-/**
- * Each server's catalog, index-aligned with `servers`. Only cold servers are fetched, in
- * parallel. A failed listing contributes nothing and caches nothing, so the next request
- * retries that server.
- */
 export async function getMcpCatalog(
 	servers: McpServerConfig[],
 	{ ttlMs = DEFAULT_TTL_MS, signal }: { ttlMs?: number; signal?: AbortSignal } = {}

--- a/src/lib/server/mcp/tools.ts
+++ b/src/lib/server/mcp/tools.ts
@@ -102,13 +102,13 @@ function sanitizeName(name: string) {
 	return name.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 64);
 }
 
-function reserveName(candidate: string, taken: Record<string, unknown>): string {
+function reserveName(candidate: string, taken: Record<string, unknown>): string | undefined {
 	if (!(candidate in taken)) return candidate;
-	for (let n = 2; n < 10; n += 1) {
-		const next = `${candidate}_${n}`.slice(0, 64);
-		if (!(next in taken)) return next;
+	for (let n = 2; n < 100; n += 1) {
+		const next = `${candidate}_${n}`;
+		if (next.length <= 64 && !(next in taken)) return next;
 	}
-	return `${candidate}_mcp`.slice(0, 64);
+	return undefined;
 }
 
 const TYPE_IMPLYING_KEYWORDS = ["enum", "const", "$ref", "anyOf", "oneOf", "allOf", "not"] as const;
@@ -360,9 +360,17 @@ async function listServerCatalog(
 			await client.connect(transport);
 		}
 
-		const response = await client.listTools({});
-		const tools = Array.isArray(response?.tools) ? (response.tools as ListedTool[]) : [];
+		// A resources-only server rejects here; only fail if there is nothing to show for it.
+		let tools: ListedTool[] = [];
+		let toolsError: unknown;
+		try {
+			const response = await client.listTools({});
+			tools = Array.isArray(response?.tools) ? (response.tools as ListedTool[]) : [];
+		} catch (err) {
+			toolsError = err;
+		}
 		const { resources, templates } = await listResourcesFor(client, server.name, opts);
+		if (toolsError && resources.length === 0 && templates.length === 0) throw toolsError;
 		try {
 			logger.debug(
 				{
@@ -508,9 +516,10 @@ export async function getOpenAiToolsForMcp(
 	const resourceServers = servers.filter(
 		(_, index) => catalogs[index].resources.length > 0 || catalogs[index].templates.length > 0
 	);
-	if (resourceServers.length > 0) {
-		const listFn = reserveName(RESOURCE_LIST_FN, mapping);
-		const readFn = reserveName(RESOURCE_READ_FN, mapping);
+	const listFn = resourceServers.length ? reserveName(RESOURCE_LIST_FN, mapping) : undefined;
+	const readFn = resourceServers.length ? reserveName(RESOURCE_READ_FN, mapping) : undefined;
+	// Better no resource access at all than a synthetic name hijacking a real tool's dispatch.
+	if (listFn && readFn) {
 		const serverList = resourceServers.map((server) => server.name).join(", ");
 
 		pushToolDefinition(
@@ -532,6 +541,10 @@ export async function getOpenAiToolsForMcp(
 					uri: {
 						type: "string",
 						description: `The resource URI exactly as reported by ${listFn}, e.g. "file:///notes.md".`,
+					},
+					server: {
+						type: "string",
+						description: `Owning server name. Only needed when ${listFn} shows the same URI on more than one server.`,
 					},
 				},
 				required: ["uri"],

--- a/src/lib/server/mcp/tools.ts
+++ b/src/lib/server/mcp/tools.ts
@@ -1,4 +1,5 @@
 import { createMcpClient } from "./client";
+import type { Client } from "@modelcontextprotocol/sdk/client";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 import type { McpServerConfig } from "./httpClient";
@@ -30,6 +31,29 @@ export interface McpToolMapping {
 	annotations?: McpToolAnnotations;
 }
 
+/**
+ * Resources are reached through two synthetic functions rather than one function per
+ * resource: a server may expose hundreds, and they would crowd out its real tools in the
+ * array sent to the provider. Neither is bound to a single server — `list` spans them all
+ * and `read` resolves its URI's owner at call time.
+ */
+export interface McpResourceFnMapping {
+	fnName: string;
+	kind: "resource";
+	action: "list" | "read";
+}
+
+export type McpFunctionMapping = McpToolMapping | McpResourceFnMapping;
+
+export function isResourceFn(
+	mapping: McpFunctionMapping | undefined
+): mapping is McpResourceFnMapping {
+	return mapping !== undefined && "kind" in mapping && mapping.kind === "resource";
+}
+
+export const RESOURCE_LIST_FN = "list_mcp_resources";
+export const RESOURCE_READ_FN = "read_mcp_resource";
+
 // Tool listings are cached per server (url + headers), not per server set, so
 // toggling one server never invalidates the others' entries. Headers are part
 // of the key because they change what a server returns (e.g. the forwarded HF
@@ -42,10 +66,39 @@ type CachedServerTool = {
 	annotations?: McpToolAnnotations;
 };
 
+/** A resource the server enumerates by concrete URI. */
+export type CachedServerResource = {
+	uri: string;
+	name?: string;
+	description?: string;
+	mimeType?: string;
+};
+
+/** A URI template, for resource families the server does not enumerate one by one. */
+export type CachedServerResourceTemplate = {
+	uriTemplate: string;
+	name?: string;
+	description?: string;
+	mimeType?: string;
+};
+
+/**
+ * Everything one connection to a server yields. Tools and resources share a cache entry
+ * because they share a key and a TTL — listing them separately would double the connection
+ * churn this cache exists to avoid.
+ */
+export type ServerCatalog = {
+	tools: CachedServerTool[];
+	resources: CachedServerResource[];
+	templates: CachedServerResourceTemplate[];
+};
+
+const EMPTY_CATALOG: ServerCatalog = { tools: [], resources: [], templates: [] };
+
 interface ServerCacheEntry {
 	fetchedAt: number;
 	ttlMs: number;
-	tools: CachedServerTool[];
+	catalog: ServerCatalog;
 }
 
 const DEFAULT_TTL_MS = 60_000;
@@ -58,6 +111,16 @@ const cache = new Map<string, ServerCacheEntry>();
 // Normalize any disallowed characters (including ".") to underscore and trim to 64 chars.
 function sanitizeName(name: string) {
 	return name.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 64);
+}
+
+/** Free variant of a fixed function name, for names with no server to disambiguate them. */
+function reserveName(candidate: string, taken: Record<string, unknown>): string {
+	if (!(candidate in taken)) return candidate;
+	for (let n = 2; n < 10; n += 1) {
+		const next = `${candidate}_${n}`.slice(0, 64);
+		if (!(next in taken)) return next;
+	}
+	return `${candidate}_mcp`.slice(0, 64);
 }
 
 const TYPE_IMPLYING_KEYWORDS = ["enum", "const", "$ref", "anyOf", "oneOf", "allOf", "not"] as const;
@@ -161,6 +224,130 @@ type ListedTool = {
 	annotations?: Record<string, unknown>;
 };
 
+type ListedResource = {
+	uri?: unknown;
+	name?: unknown;
+	title?: unknown;
+	description?: unknown;
+	mimeType?: unknown;
+};
+
+type ListedResourceTemplate = Omit<ListedResource, "uri"> & { uriTemplate?: unknown };
+
+// A server may enumerate far more resources than are useful to put in front of a model, and
+// listing is paginated. Both bounds are belt-and-braces: whichever trips first stops paging.
+const MAX_RESOURCE_PAGES = 10;
+const MAX_RESOURCES_PER_SERVER = 250;
+
+function optionalString(value: unknown): string | undefined {
+	return typeof value === "string" && value.trim().length > 0 ? value : undefined;
+}
+
+/**
+ * Walk a paginated MCP listing to exhaustion (within bounds). `listPage` is the SDK call;
+ * `pick` pulls the page's array out of the envelope, since resources and templates use
+ * different property names for it.
+ */
+async function listAllPages<T>(
+	listPage: (params: { cursor?: string }) => Promise<unknown>,
+	pick: (page: Record<string, unknown>) => unknown
+): Promise<T[]> {
+	const out: T[] = [];
+	let cursor: string | undefined;
+
+	for (let page = 0; page < MAX_RESOURCE_PAGES; page += 1) {
+		const response = await listPage(cursor ? { cursor } : {});
+		if (!isPlainObject(response)) break;
+
+		const items = pick(response);
+		if (Array.isArray(items)) out.push(...(items as T[]));
+
+		cursor = optionalString(response.nextCursor);
+		if (!cursor || out.length >= MAX_RESOURCES_PER_SERVER) break;
+	}
+
+	return out.slice(0, MAX_RESOURCES_PER_SERVER);
+}
+
+function normalizeResources(raw: ListedResource[]): CachedServerResource[] {
+	const out: CachedServerResource[] = [];
+	for (const resource of raw) {
+		const uri = optionalString(resource?.uri);
+		if (!uri) continue;
+		out.push({
+			uri,
+			name: optionalString(resource.name),
+			// `title` is the human-facing label; use it only when there is no description,
+			// so a resource that declares neither still says something useful to the model.
+			description: optionalString(resource.description) ?? optionalString(resource.title),
+			mimeType: optionalString(resource.mimeType),
+		});
+	}
+	return out;
+}
+
+function normalizeResourceTemplates(raw: ListedResourceTemplate[]): CachedServerResourceTemplate[] {
+	const out: CachedServerResourceTemplate[] = [];
+	for (const template of raw) {
+		const uriTemplate = optionalString(template?.uriTemplate);
+		if (!uriTemplate) continue;
+		out.push({
+			uriTemplate,
+			name: optionalString(template.name),
+			description: optionalString(template.description) ?? optionalString(template.title),
+			mimeType: optionalString(template.mimeType),
+		});
+	}
+	return out;
+}
+
+/**
+ * Resource listing for a connected client. Returns empty rather than throwing: a server whose
+ * resource listing is broken must still contribute its tools, which is what the caller is
+ * primarily after.
+ */
+export async function listResourcesFor(
+	client: Client,
+	label: string,
+	opts: { signal?: AbortSignal } = {}
+): Promise<Pick<ServerCatalog, "resources" | "templates">> {
+	// Declared capability first: a server that never declares `resources` would answer both
+	// calls below with method-not-found, so asking is a guaranteed wasted round trip.
+	if (!client.getServerCapabilities()?.resources) {
+		return { resources: [], templates: [] };
+	}
+
+	const listed = await Promise.allSettled([
+		listAllPages<ListedResource>(
+			(params) => client.listResources(params, { signal: opts.signal }),
+			(page) => page.resources
+		),
+		// Templates are optional even for a server that declares `resources`, so a rejection
+		// here is unremarkable and must not cost us the concrete resources.
+		listAllPages<ListedResourceTemplate>(
+			(params) => client.listResourceTemplates(params, { signal: opts.signal }),
+			(page) => page.resourceTemplates
+		),
+	]);
+
+	const [resourcesResult, templatesResult] = listed;
+	if (resourcesResult.status === "rejected") {
+		logger.debug(
+			{ server: label, err: String(resourcesResult.reason) },
+			"[mcp] failed to list resources for server"
+		);
+	}
+
+	return {
+		resources:
+			resourcesResult.status === "fulfilled" ? normalizeResources(resourcesResult.value) : [],
+		templates:
+			templatesResult.status === "fulfilled"
+				? normalizeResourceTemplates(templatesResult.value)
+				: [],
+	};
+}
+
 const ANNOTATION_HINTS = [
 	"readOnlyHint",
 	"destructiveHint",
@@ -180,10 +367,10 @@ function readAnnotations(raw: unknown): McpToolAnnotations | undefined {
 	return Object.keys(annotations).length > 0 ? annotations : undefined;
 }
 
-async function listServerTools(
+async function listServerCatalog(
 	server: McpServerConfig,
 	opts: { signal?: AbortSignal } = {}
-): Promise<ListedTool[]> {
+): Promise<{ tools: ListedTool[] } & Pick<ServerCatalog, "resources" | "templates">> {
 	const url = new URL(server.url);
 	const client = createMcpClient();
 	try {
@@ -203,6 +390,7 @@ async function listServerTools(
 
 		const response = await client.listTools({});
 		const tools = Array.isArray(response?.tools) ? (response.tools as ListedTool[]) : [];
+		const { resources, templates } = await listResourcesFor(client, server.name, opts);
 		try {
 			logger.debug(
 				{
@@ -210,11 +398,13 @@ async function listServerTools(
 					url: server.url,
 					count: tools.length,
 					toolNames: tools.map((t) => t?.name).filter(Boolean),
+					resourceCount: resources.length,
+					resourceTemplateCount: templates.length,
 				},
-				"[mcp] listed tools from server"
+				"[mcp] listed catalog from server"
 			);
 		} catch {}
-		return tools;
+		return { tools, resources, templates };
 	} finally {
 		try {
 			await client.close?.();
@@ -224,13 +414,13 @@ async function listServerTools(
 	}
 }
 
-async function fetchServerTools(
+async function fetchServerCatalog(
 	server: McpServerConfig,
 	opts: { signal?: AbortSignal } = {}
-): Promise<CachedServerTool[]> {
-	const raw = await listServerTools(server, opts);
+): Promise<ServerCatalog> {
+	const raw = await listServerCatalog(server, opts);
 	const normalized: CachedServerTool[] = [];
-	for (const tool of raw) {
+	for (const tool of raw.tools) {
 		if (typeof tool.name !== "string" || tool.name.trim().length === 0) {
 			continue;
 		}
@@ -244,46 +434,57 @@ async function fetchServerTools(
 			annotations: readAnnotations(tool.annotations),
 		});
 	}
-	return normalized;
+	return { tools: normalized, resources: raw.resources, templates: raw.templates };
+}
+
+/**
+ * Each server's catalog, index-aligned with `servers`. Only cold servers are fetched, in
+ * parallel. A failed listing contributes nothing and caches nothing, so the next request
+ * retries that server.
+ */
+export async function getMcpCatalog(
+	servers: McpServerConfig[],
+	{ ttlMs = DEFAULT_TTL_MS, signal }: { ttlMs?: number; signal?: AbortSignal } = {}
+): Promise<ServerCatalog[]> {
+	const now = Date.now();
+	evictExpired(now);
+
+	const listed = await Promise.all(
+		servers.map(async (server): Promise<ServerCatalog> => {
+			const key = serverCacheKey(server);
+			const cached = cache.get(key);
+			if (cached) {
+				return cached.catalog;
+			}
+			try {
+				const catalog = await fetchServerCatalog(server, { signal });
+				cache.set(key, { fetchedAt: now, ttlMs, catalog });
+				return catalog;
+			} catch (err) {
+				logger.debug(
+					{ server: server.name, url: server.url, err: String(err) },
+					"[mcp] failed to list catalog for server"
+				);
+				return EMPTY_CATALOG;
+			}
+		})
+	);
+	enforceCacheCap();
+	return listed;
 }
 
 export async function getOpenAiToolsForMcp(
 	servers: McpServerConfig[],
 	{ ttlMs = DEFAULT_TTL_MS, signal }: { ttlMs?: number; signal?: AbortSignal } = {}
-): Promise<{ tools: OpenAiTool[]; mapping: Record<string, McpToolMapping> }> {
-	const now = Date.now();
-	evictExpired(now);
-
-	// Resolve each server's tools from the per-server cache; only cold servers
-	// are fetched, in parallel. A failed listing contributes no tools and caches
-	// nothing, so the next request retries that server.
-	const listed = await Promise.all(
-		servers.map(async (server): Promise<CachedServerTool[]> => {
-			const key = serverCacheKey(server);
-			const cached = cache.get(key);
-			if (cached) {
-				return cached.tools;
-			}
-			try {
-				const tools = await fetchServerTools(server, { signal });
-				cache.set(key, { fetchedAt: now, ttlMs, tools });
-				return tools;
-			} catch (err) {
-				logger.debug(
-					{ server: server.name, url: server.url, err: String(err) },
-					"[mcp] failed to list tools for server"
-				);
-				return [];
-			}
-		})
-	);
-	enforceCacheCap();
+): Promise<{ tools: OpenAiTool[]; mapping: Record<string, McpFunctionMapping> }> {
+	const catalogs = await getMcpCatalog(servers, { ttlMs, signal });
+	const listed = catalogs.map((catalog) => catalog.tools);
 
 	// Function names depend on the request's server combination (collision
 	// suffixes), so definitions and mapping are rebuilt per request from the
 	// cached per-server listings.
 	const tools: OpenAiTool[] = [];
-	const mapping: Record<string, McpToolMapping> = {};
+	const mapping: Record<string, McpFunctionMapping> = {};
 
 	const seenNames = new Set<string>();
 
@@ -334,6 +535,43 @@ export async function getOpenAiToolsForMcp(
 				...(tool.annotations ? { annotations: tool.annotations } : {}),
 			};
 		}
+	}
+
+	// Resource functions come last so a real tool never loses its plain name to them.
+	const resourceServers = servers.filter(
+		(_, index) => catalogs[index].resources.length > 0 || catalogs[index].templates.length > 0
+	);
+	if (resourceServers.length > 0) {
+		const listFn = reserveName(RESOURCE_LIST_FN, mapping);
+		const readFn = reserveName(RESOURCE_READ_FN, mapping);
+		const serverList = resourceServers.map((server) => server.name).join(", ");
+
+		pushToolDefinition(
+			listFn,
+			`List the read-only data resources exposed by the connected MCP servers (${serverList}). ` +
+				`Returns each resource's URI, name, description and media type. Call this to discover a ` +
+				`URI, then pass that URI to ${readFn} to read its contents.`,
+			{ type: "object", properties: {}, additionalProperties: false }
+		);
+		mapping[listFn] = { fnName: listFn, kind: "resource", action: "list" };
+
+		pushToolDefinition(
+			readFn,
+			`Read the contents of an MCP resource by its URI. Get URIs from ${listFn}. Resources are ` +
+				`read-only reference data (files, documents, records), so reading one has no side effects.`,
+			{
+				type: "object",
+				properties: {
+					uri: {
+						type: "string",
+						description: `The resource URI exactly as reported by ${listFn}, e.g. "file:///notes.md".`,
+					},
+				},
+				required: ["uri"],
+				additionalProperties: false,
+			}
+		);
+		mapping[readFn] = { fnName: readFn, kind: "resource", action: "read" };
 	}
 
 	return { tools, mapping };

--- a/src/lib/server/textGeneration/__tests__/replayRoundTrip.spec.ts
+++ b/src/lib/server/textGeneration/__tests__/replayRoundTrip.spec.ts
@@ -55,8 +55,7 @@ vi.mock("$lib/server/urlSafety", async (importOriginal) => ({
 	isValidUrl: () => true,
 }));
 
-// Only the listing is scripted; the rest of the module (the mapping predicates the
-// invocation path calls on every tool call) must keep its real behavior.
+// Spread, not a literal: the invocation path calls other exports on every tool call.
 vi.mock("$lib/server/mcp/tools", async (importOriginal) => ({
 	...(await importOriginal<typeof import("$lib/server/mcp/tools")>()),
 	getOpenAiToolsForMcp: async () => ({

--- a/src/lib/server/textGeneration/__tests__/replayRoundTrip.spec.ts
+++ b/src/lib/server/textGeneration/__tests__/replayRoundTrip.spec.ts
@@ -55,7 +55,10 @@ vi.mock("$lib/server/urlSafety", async (importOriginal) => ({
 	isValidUrl: () => true,
 }));
 
-vi.mock("$lib/server/mcp/tools", () => ({
+// Only the listing is scripted; the rest of the module (the mapping predicates the
+// invocation path calls on every tool call) must keep its real behavior.
+vi.mock("$lib/server/mcp/tools", async (importOriginal) => ({
+	...(await importOriginal<typeof import("$lib/server/mcp/tools")>()),
 	getOpenAiToolsForMcp: async () => ({
 		tools: [
 			{

--- a/src/lib/server/textGeneration/mcp/toolInvocation.ts
+++ b/src/lib/server/textGeneration/mcp/toolInvocation.ts
@@ -4,13 +4,15 @@ import type { MessageUpdate } from "$lib/types/MessageUpdate";
 import { MessageToolUpdateType, MessageUpdateType } from "$lib/types/MessageUpdate";
 import { ToolResultStatus } from "$lib/types/Tool";
 import type { ChatCompletionMessageParam } from "openai/resources/chat/completions";
-import type { McpToolMapping } from "$lib/server/mcp/tools";
+import type { McpFunctionMapping, McpToolMapping } from "$lib/server/mcp/tools";
+import { isResourceFn } from "$lib/server/mcp/tools";
 import type { McpServerConfig } from "$lib/server/mcp/httpClient";
 import {
 	callMcpTool,
 	getMcpToolTimeoutMs,
 	type McpToolTextResponse,
 } from "$lib/server/mcp/httpClient";
+import { listMcpResources, readMcpResource } from "$lib/server/mcp/resources";
 import { getClient } from "$lib/server/mcp/clientPool";
 import { attachFileRefsToArgs, type FileRefResolver } from "./fileRefs";
 import type { Client } from "@modelcontextprotocol/sdk/client";
@@ -31,7 +33,7 @@ export interface NormalizedToolCall {
 
 export interface ExecuteToolCallsParams {
 	calls: NormalizedToolCall[];
-	mapping: Record<string, McpToolMapping>;
+	mapping: Record<string, McpFunctionMapping>;
 	servers: McpServerConfig[];
 	/** Returns `null` when the call's argument string could not be decoded — see `toolArgs.ts`. */
 	parseArgs: (raw: unknown) => Record<string, unknown> | null;
@@ -75,6 +77,22 @@ export function isValidJsonObject(raw: string): boolean {
 	} catch {
 		return false;
 	}
+}
+
+/** A user stop reaches us as a rejection, but must not be logged or reported as a failure. */
+function describeCallError(
+	err: unknown,
+	abortSignal?: AbortSignal
+): { message: string; isAbort: boolean } {
+	const errMsg = err instanceof Error ? err.message : String(err);
+	const errName = err instanceof Error ? err.name : "";
+	const isAbort =
+		Boolean(abortSignal?.aborted) ||
+		errName === "AbortError" ||
+		errName === "APIUserAbortError" ||
+		errMsg === "Request was aborted." ||
+		errMsg === "This operation was aborted";
+	return { message: isAbort ? "Aborted by user" : errMsg, isAbort };
 }
 
 const serverMap = (servers: McpServerConfig[]): Map<string, McpServerConfig> => {
@@ -162,9 +180,15 @@ export async function* executeToolCalls({
 		};
 	}
 
-	// Preload clients per distinct server used in this batch
+	// Preload clients per distinct server used in this batch. Resource functions are skipped:
+	// they are not bound to one server, and their own path pools its client when it resolves one.
 	const distinctServerNames = Array.from(
-		new Set(prepared.map((p) => mapping[p.call.name]?.server).filter(Boolean) as string[])
+		new Set(
+			prepared
+				.map((p) => mapping[p.call.name])
+				.filter((entry): entry is McpToolMapping => Boolean(entry) && !isResourceFn(entry))
+				.map((entry) => entry.server)
+		)
 	);
 	const clientMap = new Map<string, Client>();
 	await Promise.all(
@@ -275,6 +299,59 @@ export async function* executeToolCalls({
 			});
 			return;
 		}
+		if (isResourceFn(mappingEntry)) {
+			const fail = (message: string) => {
+				results.push({ index, error: message, uuid: p.uuid, paramsClean: p.paramsClean });
+				updatesQueue.push({
+					type: MessageUpdateType.Tool,
+					subtype: MessageToolUpdateType.Error,
+					uuid: p.uuid,
+					message,
+				});
+			};
+			try {
+				let output: string;
+				if (mappingEntry.action === "list") {
+					output = await listMcpResources(servers, { signal: abortSignal });
+				} else {
+					const uri = typeof argsObj.uri === "string" ? argsObj.uri : "";
+					const read = await readMcpResource(servers, uri, {
+						signal: abortSignal,
+						timeoutMs: effectiveTimeoutMs,
+					});
+					// An unresolvable URI is the model's mistake to correct on the next round,
+					// so it goes back as a tool error rather than a successful empty read.
+					if (read.isError) {
+						logger.warn({ uri, err: read.text }, "[mcp] resource read rejected");
+						fail(read.text);
+						return;
+					}
+					output = read.text;
+				}
+				results.push({ index, output, uuid: p.uuid, paramsClean: p.paramsClean });
+				updatesQueue.push({
+					type: MessageUpdateType.Tool,
+					subtype: MessageToolUpdateType.Result,
+					uuid: p.uuid,
+					result: {
+						status: ToolResultStatus.Success,
+						call: { name: p.call.name, parameters: p.paramsClean },
+						outputs: [{ text: output } as unknown as Record<string, unknown>],
+						display: true,
+					},
+				});
+			} catch (err) {
+				const { message, isAbort } = describeCallError(err, abortSignal);
+				if (isAbort) {
+					logger.debug({ action: mappingEntry.action }, "[mcp] resource call aborted by user");
+				} else {
+					logger.warn({ action: mappingEntry.action, err: message }, "[mcp] resource call failed");
+				}
+				fail(message);
+			}
+			return;
+		}
+
 		const serverCfg = serverLookup.get(mappingEntry.server);
 		if (!serverCfg) {
 			const message = `Unknown MCP server: ${mappingEntry.server}`;
@@ -366,15 +443,7 @@ export async function* executeToolCalls({
 				},
 			});
 		} catch (err) {
-			const errMsg = err instanceof Error ? err.message : String(err);
-			const errName = err instanceof Error ? err.name : "";
-			const isAbortError =
-				abortSignal?.aborted ||
-				errName === "AbortError" ||
-				errName === "APIUserAbortError" ||
-				errMsg === "Request was aborted." ||
-				errMsg === "This operation was aborted";
-			const message = isAbortError ? "Aborted by user" : errMsg;
+			const { message, isAbort: isAbortError } = describeCallError(err, abortSignal);
 
 			if (isAbortError) {
 				logger.debug(

--- a/src/lib/server/textGeneration/mcp/toolInvocation.ts
+++ b/src/lib/server/textGeneration/mcp/toolInvocation.ts
@@ -180,8 +180,7 @@ export async function* executeToolCalls({
 		};
 	}
 
-	// Preload clients per distinct server used in this batch. Resource functions are skipped:
-	// they are not bound to one server, and their own path pools its client when it resolves one.
+	// Preload clients per distinct server used in this batch (resource fns have no one server).
 	const distinctServerNames = Array.from(
 		new Set(
 			prepared
@@ -319,8 +318,6 @@ export async function* executeToolCalls({
 						signal: abortSignal,
 						timeoutMs: effectiveTimeoutMs,
 					});
-					// An unresolvable URI is the model's mistake to correct on the next round,
-					// so it goes back as a tool error rather than a successful empty read.
 					if (read.isError) {
 						logger.warn({ uri, err: read.text }, "[mcp] resource read rejected");
 						fail(read.text);

--- a/src/lib/server/textGeneration/mcp/toolInvocation.ts
+++ b/src/lib/server/textGeneration/mcp/toolInvocation.ts
@@ -317,6 +317,7 @@ export async function* executeToolCalls({
 					const read = await readMcpResource(servers, uri, {
 						signal: abortSignal,
 						timeoutMs: effectiveTimeoutMs,
+						...(typeof argsObj.server === "string" ? { server: argsObj.server } : {}),
 					});
 					if (read.isError) {
 						logger.warn({ uri, err: read.text }, "[mcp] resource read rejected");

--- a/src/lib/stores/mcpServers.ts
+++ b/src/lib/stores/mcpServers.ts
@@ -8,7 +8,7 @@ import { writable, derived, get } from "svelte/store";
 import { base } from "$app/paths";
 import { env as publicEnv } from "$env/dynamic/public";
 import { browser } from "$app/environment";
-import type { MCPServer, ServerStatus, MCPTool } from "$lib/types/Tool";
+import type { MCPServer, ServerStatus, MCPTool, MCPResource } from "$lib/types/Tool";
 
 // Namespace storage by app identity to avoid collisions across apps
 function toKeyPart(s: string | undefined): string {
@@ -302,7 +302,8 @@ export function updateServerStatus(
 	status: ServerStatus,
 	errorMessage?: string,
 	tools?: MCPTool[],
-	authRequired?: boolean
+	authRequired?: boolean,
+	resources?: MCPResource[]
 ) {
 	allMcpServers.update(($servers) =>
 		$servers.map((s) =>
@@ -312,6 +313,7 @@ export function updateServerStatus(
 						status,
 						errorMessage,
 						tools,
+						resources,
 						authRequired,
 					}
 				: s
@@ -337,7 +339,7 @@ export async function healthCheckServer(
 		const result = await response.json();
 
 		if (result.ready && result.tools) {
-			updateServerStatus(server.id, "connected", undefined, result.tools, false);
+			updateServerStatus(server.id, "connected", undefined, result.tools, false, result.resources);
 			return { ready: true, tools: result.tools };
 		} else {
 			updateServerStatus(server.id, "error", result.error, undefined, Boolean(result.authRequired));

--- a/src/lib/types/Tool.ts
+++ b/src/lib/types/Tool.ts
@@ -53,10 +53,7 @@ export interface MCPTool {
 	inputSchema?: unknown;
 }
 
-/**
- * A read-only datum a server exposes. `uri` is absent for a URI template, which stands for a
- * family of resources the server does not enumerate; `uriTemplate` is absent for a concrete one.
- */
+/** Exactly one of `uri` (a concrete resource) or `uriTemplate` (a family) is set. */
 export interface MCPResource {
 	uri?: string;
 	uriTemplate?: string;

--- a/src/lib/types/Tool.ts
+++ b/src/lib/types/Tool.ts
@@ -53,6 +53,18 @@ export interface MCPTool {
 	inputSchema?: unknown;
 }
 
+/**
+ * A read-only datum a server exposes. `uri` is absent for a URI template, which stands for a
+ * family of resources the server does not enumerate; `uriTemplate` is absent for a concrete one.
+ */
+export interface MCPResource {
+	uri?: string;
+	uriTemplate?: string;
+	name?: string;
+	description?: string;
+	mimeType?: string;
+}
+
 export interface MCPServer {
 	id: string;
 	name: string;
@@ -63,6 +75,7 @@ export interface MCPServer {
 	status?: ServerStatus;
 	isLocked?: boolean;
 	tools?: MCPTool[];
+	resources?: MCPResource[];
 	errorMessage?: string;
 	// Indicates server reports or appears to require OAuth or other auth
 	authRequired?: boolean;

--- a/src/routes/api/mcp/health/+server.ts
+++ b/src/routes/api/mcp/health/+server.ts
@@ -2,7 +2,8 @@ import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { createMcpClient } from "$lib/server/mcp/client";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
-import type { KeyValuePair } from "$lib/types/Tool";
+import type { KeyValuePair, MCPResource } from "$lib/types/Tool";
+import { listResourcesFor } from "$lib/server/mcp/tools";
 import { config } from "$lib/server/config";
 import { logger } from "$lib/server/logger";
 import type { RequestHandler } from "./$types";
@@ -21,8 +22,54 @@ interface HealthCheckResponse {
 		description?: string;
 		inputSchema?: unknown;
 	}>;
+	resources?: MCPResource[];
 	error?: string;
 	authRequired?: boolean;
+}
+
+/**
+ * What a connected server offers, and whether that makes it usable. Shared by both transport
+ * branches below so the two never drift.
+ *
+ * `listTools` is allowed to fail: a server may expose only resources, and the MCP spec does
+ * not require the tools capability. Such a server is healthy, so a rejection here is not
+ * grounds for falling through to the SSE retry.
+ */
+async function readCatalog(
+	client: Client,
+	url: string
+): Promise<HealthCheckResponse & { httpStatus: number }> {
+	let tools: HealthCheckResponse["tools"] = [];
+	try {
+		const toolsResponse = await client.listTools();
+		tools = (toolsResponse?.tools ?? []).map((tool) => ({
+			name: tool.name,
+			description: tool.description,
+			inputSchema: tool.inputSchema,
+		}));
+	} catch (error) {
+		logger.debug({ err: error }, `[MCP Health] ${url} exposes no tools`);
+	}
+
+	const { resources, templates } = await listResourcesFor(client, url);
+	const listedResources: MCPResource[] = [...resources, ...templates];
+
+	if (tools.length === 0 && listedResources.length === 0) {
+		return {
+			ready: false,
+			error: "Connected but no tools or resources available",
+			authRequired: false,
+			httpStatus: 503,
+		};
+	}
+
+	return {
+		ready: true,
+		tools,
+		resources: listedResources,
+		authRequired: false,
+		httpStatus: 200,
+	};
 }
 
 export const POST: RequestHandler = async ({ request, locals }) => {
@@ -117,44 +164,15 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 			await client.connect(transport);
 			logger.info({}, `[MCP Health] Connected successfully via HTTP`);
 
-			// Connection successful, get tools
-			const toolsResponse = await client.listTools();
-
-			// Disconnect after getting tools
+			const { httpStatus, ...response } = await readCatalog(client, url);
 			await client.close();
 
-			if (toolsResponse && toolsResponse.tools) {
-				const response: HealthCheckResponse = {
-					ready: true,
-					tools: toolsResponse.tools.map((tool) => ({
-						name: tool.name,
-						description: tool.description,
-						inputSchema: tool.inputSchema,
-					})),
-					authRequired: false,
-				};
-
-				const res = new Response(JSON.stringify(response), {
-					status: 200,
-					headers: { "Content-Type": "application/json" },
-				});
-				clearTimeout(timeoutId);
-				return res;
-			} else {
-				const res = new Response(
-					JSON.stringify({
-						ready: false,
-						error: "Connected but no tools available",
-						authRequired: false,
-					} as HealthCheckResponse),
-					{
-						status: 503,
-						headers: { "Content-Type": "application/json" },
-					}
-				);
-				clearTimeout(timeoutId);
-				return res;
-			}
+			const res = new Response(JSON.stringify(response satisfies HealthCheckResponse), {
+				status: httpStatus,
+				headers: { "Content-Type": "application/json" },
+			});
+			clearTimeout(timeoutId);
+			return res;
 		} catch (error) {
 			httpError = error instanceof Error ? error : new Error(String(error));
 			lastError = httpError;
@@ -180,44 +198,15 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 				await client.connect(sseTransport);
 				logger.info({}, `[MCP Health] Connected successfully via SSE`);
 
-				// Connection successful, get tools
-				const toolsResponse = await client.listTools();
-
-				// Disconnect after getting tools
+				const { httpStatus, ...response } = await readCatalog(client, url);
 				await client.close();
 
-				if (toolsResponse && toolsResponse.tools) {
-					const response: HealthCheckResponse = {
-						ready: true,
-						tools: toolsResponse.tools.map((tool) => ({
-							name: tool.name,
-							description: tool.description,
-							inputSchema: tool.inputSchema,
-						})),
-						authRequired: false,
-					};
-
-					const res = new Response(JSON.stringify(response), {
-						status: 200,
-						headers: { "Content-Type": "application/json" },
-					});
-					clearTimeout(timeoutId);
-					return res;
-				} else {
-					const res = new Response(
-						JSON.stringify({
-							ready: false,
-							error: "Connected but no tools available",
-							authRequired: false,
-						} as HealthCheckResponse),
-						{
-							status: 503,
-							headers: { "Content-Type": "application/json" },
-						}
-					);
-					clearTimeout(timeoutId);
-					return res;
-				}
+				const res = new Response(JSON.stringify(response satisfies HealthCheckResponse), {
+					status: httpStatus,
+					headers: { "Content-Type": "application/json" },
+				});
+				clearTimeout(timeoutId);
+				return res;
 			} catch (sseError) {
 				lastError = sseError instanceof Error ? sseError : new Error(String(sseError));
 				// Prefer the HTTP error when both failed so UI shows the primary failure (e.g., HTTP 500) instead

--- a/src/routes/api/mcp/health/+server.ts
+++ b/src/routes/api/mcp/health/+server.ts
@@ -27,14 +27,7 @@ interface HealthCheckResponse {
 	authRequired?: boolean;
 }
 
-/**
- * What a connected server offers, and whether that makes it usable. Shared by both transport
- * branches below so the two never drift.
- *
- * `listTools` is allowed to fail: a server may expose only resources, and the MCP spec does
- * not require the tools capability. Such a server is healthy, so a rejection here is not
- * grounds for falling through to the SSE retry.
- */
+/** `listTools` may fail — a resources-only server is valid, and must not trigger the SSE retry. */
 async function readCatalog(
 	client: Client,
 	url: string


### PR DESCRIPTION
MCP servers can expose read-only **resources** (files, documents, records) alongside their tools. chat-ui listed and called tools but never touched resources, so half of every connected server's surface was dark.

## Approach

Resources are model-controlled, reached through **two synthetic functions** merged into the OpenAI tool array:

- `list_mcp_resources` — enumerates URIs, names, descriptions and media types across enabled servers
- `read_mcp_resource` — reads one by URI

Two functions rather than one per resource: a server may expose hundreds, and they would crowd its real tools out of the array sent to the provider. Neither is bound to a single server — `read` resolves a URI's owner at call time (enumerated resource first, then a matching URI template) and reports an unresolvable URI back to the model rather than broadcasting a round trip to every connected server.

## Listing shares one connection

Tools and resources are now listed together over a **single connection per server** and share a cache entry — same key, same TTL. Listing them separately would have doubled the connection churn the listing cache exists to avoid. Servers that never declare the `resources` capability are not asked for them, so nothing changes for them but the log line.

## Guards

- **Pagination** is followed to exhaustion within bounds (10 pages / 250 resources per server).
- **Read output is capped** at 32k chars with an explicit truncation marker — a resource is arbitrary server data, and a whole log file is a legitimate one.
- **Binary contents are described, not inlined.** base64 the model cannot read would otherwise spend the context window on bytes.
- **A broken resource listing never costs a server its tools** — that is what the caller is primarily after.
- Reads reuse the pooled client with the same reconnect-on-closed handling as `callMcpTool` (detectors are now exported from `httpClient.ts` instead of duplicated).

## Behaviour change worth flagging

The health check previously marked a server ready whenever the response carried a `tools` field — including `tools: []`, since an empty array is truthy. It is now ready if it has **tools or resources**, and `listTools` is allowed to fail, because a resources-only server is valid per spec and would otherwise fail the health check outright. A server with neither now gets a 503 saying so, which is what the original message already intended.

## UI

Server cards show a resource count next to the tool count and an expandable list.

## Manual testing

`scripts/mock-resources-mcp.mjs` is a throwaway MCP server exposing one tool and four resources, one per branch of the read path: a text file, a URI template, a binary blob, and a 44k-char log.

1. Set `MCP_ALLOW_INSECURE_URLS=true` in `.env.local`, or chat-ui rejects the loopback URL.
2. `node scripts/mock-resources-mcp.mjs` (listens on 8793; override with `MOCK_RESOURCES_MCP_PORT`).
3. Start the app, **log in** — the health check is behind auth, and resources only populate after one.
4. Add `http://127.0.0.1:8793/mcp` in the MCP panel, enable it, hit **Health Check**.

Expected — the card reads `1 tool · 4 resources` with an expandable list. Then ask **"what's the rollback codeword?"**: the answer should contain `PELICAN-7734`, which exists only inside `file:///briefing.md`, so it can't be produced without a real read. The mock logs `read <uri>` on every read, which distinguishes "never called" from "called and failed".

Worth trying alongside: `note:///alpha` (routes via a template, never enumerated), `image:///logo.png` (described, not inlined as base64), `file:///huge.log` (truncated at 32k), and a made-up URI (rejected without contacting any server).
