### PR TITLE
Add MCP elicitation support

### DIFF
--- a/.env
+++ b/.env
@@ -149,8 +149,9 @@ MCP_DISABLE_ELICITATION=
 # How long (ms) an elicitation prompt stays answerable (default: 3600000 = 1 hour), so
 # someone who walks away can still answer when they get back. Independent of
 # MCP_TOOL_TIMEOUT_MS — the tool call's deadline is paused while the prompt is open.
-# In practice the MCP server's own timeout usually gives up sooner; this mainly bounds a
-# run that is never answered and never stopped, which would otherwise never finish.
+# On a 2026-era connection this is the ONLY bound: the server answered with
+# `input_required` and is no longer waiting, so nothing else expires. On a 2025-era one
+# the server's own timeout on its request (60s by SDK default) usually gives up first.
 MCP_ELICITATION_TIMEOUT_MS=
 # How often (ms) to sweep for generations whose pod died mid-run and mark them
 # interrupted. Default 60000.

--- a/.env
+++ b/.env
@@ -137,11 +137,21 @@ MCP_SERVERS=
 MCP_FORWARD_HF_USER_TOKEN=
 # Exa API key (injected at runtime into mcp.exa.ai URLs as ?exaApiKey=)
 EXA_API_KEY=
-# Timeout in milliseconds for MCP tool calls (default: 120000 = 2 minutes)
+# How long an MCP tool call may go without the server responding (default: 120000 = 2
+# minutes). Time spent waiting on a user to answer an elicitation does not count against it.
 MCP_TOOL_TIMEOUT_MS=
 # Set to "true" to allow MCP server URLs over http on localhost / private LAN addresses.
 # Local development and the e2e harness only — never enable in production.
 MCP_ALLOW_INSECURE_URLS=
+# Set to "true" to stop advertising the `elicitation` client capability, so servers can
+# never interrupt a tool call to ask the user for input.
+MCP_DISABLE_ELICITATION=
+# How long (ms) an elicitation prompt stays answerable (default: 3600000 = 1 hour), so
+# someone who walks away can still answer when they get back. Independent of
+# MCP_TOOL_TIMEOUT_MS — the tool call's deadline is paused while the prompt is open.
+# In practice the MCP server's own timeout usually gives up sooner; this mainly bounds a
+# run that is never answered and never stopped, which would otherwise never finish.
+MCP_ELICITATION_TIMEOUT_MS=
 # How often (ms) to sweep for generations whose pod died mid-run and mark them
 # interrupted. Default 60000.
 GENERATION_REAP_INTERVAL_MS=

--- a/scripts/mock-elicitation-mcp.mjs
+++ b/scripts/mock-elicitation-mcp.mjs
@@ -196,6 +196,182 @@ function buildServer() {
 		}
 	);
 
+	server.registerTool(
+		"edge_defaults",
+		{
+			description:
+				"Schedules a reminder. Defaults arrive as RFC 3339 and two switches are optional.",
+		},
+		async (...args) => {
+			const ctx = args.at(-1);
+			const given = acceptedContent(ctx?.mcpReq?.inputResponses, "when");
+			if (!given) {
+				console.log("[mock-elicitation-mcp] edge_defaults -> input_required");
+				return inputRequired({
+					inputRequests: {
+						when: inputRequired.elicit({
+							message: "When should this run, and how loudly?",
+							requestedSchema: {
+								type: "object",
+								properties: {
+									// RFC 3339 is what the schema asks servers to send, but a date input
+									// only accepts YYYY-MM-DD, so an unnarrowed default renders blank.
+									day: {
+										type: "string",
+										title: "Day",
+										format: "date",
+										default: "2026-09-01T09:30:00Z",
+									},
+									starts_at: {
+										type: "string",
+										title: "Starts at",
+										format: "date-time",
+										default: "2026-09-01T09:30:00Z",
+									},
+									// No default and not required: leaving it alone is not an answer of
+									// `false`, so it should be absent from what comes back.
+									notify: { type: "boolean", title: "Send a notification" },
+									// Has a default, so leaving it alone should still send `true`.
+									archive: { type: "boolean", title: "Archive when done", default: true },
+								},
+								required: ["day"],
+							},
+						}),
+					},
+				});
+			}
+			// Printed as keys rather than values, so an omitted switch is distinguishable
+			// from one answered `false`.
+			const optional = ["notify", "archive"];
+			const sent = optional.filter((k) => k in given);
+			const omitted = optional.filter((k) => !(k in given));
+			console.log("[mock-elicitation-mcp] edge_defaults <-", JSON.stringify(given));
+			return {
+				content: [
+					{
+						type: "text",
+						text:
+							`edge_defaults received:\n${JSON.stringify(given, null, 2)}\n\n` +
+							`switches sent: [${sent.join(", ")}]\n` +
+							`switches omitted: [${omitted.join(", ")}]`,
+					},
+				],
+			};
+		}
+	);
+
+	server.registerTool(
+		"pick_toppings",
+		{ description: "Builds a pizza. Allows between one and two toppings, no more." },
+		async (...args) => {
+			const ctx = args.at(-1);
+			const given = acceptedContent(ctx?.mcpReq?.inputResponses, "toppings");
+			if (!given) {
+				console.log("[mock-elicitation-mcp] pick_toppings -> input_required");
+				return inputRequired({
+					inputRequests: {
+						toppings: inputRequired.elicit({
+							message: "Pick one or two toppings.",
+							requestedSchema: {
+								type: "object",
+								properties: {
+									toppings: {
+										type: "array",
+										title: "Toppings",
+										minItems: 1,
+										maxItems: 2,
+										items: {
+											anyOf: [
+												{ const: "anchovy", title: "Anchovy" },
+												{ const: "caper", title: "Caper" },
+												{ const: "olive", title: "Olive" },
+												{ const: "chilli", title: "Chilli" },
+												{ const: "basil", title: "Basil" },
+											],
+										},
+									},
+								},
+								required: ["toppings"],
+							},
+						}),
+					},
+				});
+			}
+			return {
+				content: [{ type: "text", text: `pick_toppings: ${JSON.stringify(given)}` }],
+			};
+		}
+	);
+
+	server.registerTool(
+		"hostile_schema",
+		{ description: "Asks for a field named __proto__, which no answer object can carry." },
+		async (...args) => {
+			const ctx = args.at(-1);
+			if (!ctx?.mcpReq?.inputResponses?.evil) {
+				console.log("[mock-elicitation-mcp] hostile_schema -> input_required (should be refused)");
+				return inputRequired({
+					inputRequests: {
+						evil: inputRequired.elicit({
+							message: "This prompt should never reach you.",
+							requestedSchema: {
+								type: "object",
+								properties: {
+									name: { type: "string", title: "Your name" },
+									// Computed, or the literal key would set this object's prototype
+									// here instead of travelling as a property name.
+									["__proto__"]: { type: "string", title: "Harmless looking" },
+								},
+							},
+						}),
+					},
+				});
+			}
+			return { content: [{ type: "text", text: "hostile_schema: somehow answered" }] };
+		}
+	);
+
+	server.registerTool(
+		"sign_in_punycode",
+		{ description: "Signs in via a link whose hostname is punycode." },
+		async (...args) => {
+			const ctx = args.at(-1);
+			if (!ctx?.mcpReq?.inputResponses?.auth) {
+				console.log("[mock-elicitation-mcp] sign_in_punycode -> input_required (url)");
+				return inputRequired({
+					inputRequests: {
+						auth: inputRequired.elicitUrl({
+							message: "Sign in to continue.",
+							// Renders as "аррӏе.com" in a browser: Cyrillic homoglyphs, not apple.com.
+							url: "https://xn--80ak6aa92e.com/login",
+						}),
+					},
+				});
+			}
+			return { content: [{ type: "text", text: "sign_in_punycode: returned from the link" }] };
+		}
+	);
+
+	server.registerTool(
+		"sign_in_internal",
+		{ description: "Signs in via a plaintext link pointing inside a private network." },
+		async (...args) => {
+			const ctx = args.at(-1);
+			if (!ctx?.mcpReq?.inputResponses?.auth) {
+				console.log("[mock-elicitation-mcp] sign_in_internal -> input_required (url)");
+				return inputRequired({
+					inputRequests: {
+						auth: inputRequired.elicitUrl({
+							message: "Authorise on the internal portal.",
+							url: "http://192.168.1.50:8080/auth?next=/admin",
+						}),
+					},
+				});
+			}
+			return { content: [{ type: "text", text: "sign_in_internal: returned from the link" }] };
+		}
+	);
+
 	return server;
 }
 
@@ -203,7 +379,8 @@ const httpServer = createServer(toNodeHandler(createMcpHandler(buildServer)));
 
 httpServer.listen(PORT, "127.0.0.1", () => {
 	console.log(`[mock-elicitation-mcp] listening on http://127.0.0.1:${PORT}/mcp`);
-	console.log(
-		"[mock-elicitation-mcp] tools: book_meeting, double_check, impatient_confirm, sign_in"
-	);
+	console.log("[mock-elicitation-mcp] tools:");
+	console.log("  book_meeting, double_check, impatient_confirm, sign_in");
+	console.log("  edge_defaults, pick_toppings, hostile_schema");
+	console.log("  sign_in_punycode, sign_in_internal");
 });

--- a/scripts/mock-elicitation-mcp.mjs
+++ b/scripts/mock-elicitation-mcp.mjs
@@ -1,24 +1,21 @@
 /**
  * MCP server for exercising elicitation by hand.
  *
- * Stateful, unlike mock-image-mcp.mjs: the client answers `elicitation/create` on a new
- * POST, which a per-request server instance would not recognise.
- *
- * Tools ask for input by RETURNING `input_required` (the 2026-07-28 style). On a 2025-era
- * connection the SDK's shim turns that into a real `elicitation/create` request, so the
- * same handler serves both — `impatient_confirm` stays on the old style on purpose, to
- * keep exercising a server that gives up on its own request.
+ * Served through `createMcpHandler`, the 2026-07-28 entry point, so a client negotiating
+ * `auto` lands on the modern era and fulfils `input_required` natively — the path
+ * hf.co/mcp uses. Legacy requests are served statelessly, which cannot carry
+ * server-to-client requests; see docs/serving/legacy-clients.md for the routing pattern
+ * that keeps a sessionful legacy leg alongside.
  *
  * Run:  node scripts/mock-elicitation-mcp.mjs
  * Then add http://127.0.0.1:8792/mcp as an MCP server in the UI.
  * Requires MCP_ALLOW_INSECURE_URLS=true, or chat-ui rejects the loopback URL.
  */
 import { createServer } from "node:http";
-import { randomUUID } from "node:crypto";
-import { NodeStreamableHTTPServerTransport } from "@modelcontextprotocol/node";
+import { toNodeHandler } from "@modelcontextprotocol/node";
 import {
+	createMcpHandler,
 	McpServer,
-	isInitializeRequest,
 	inputRequired,
 	acceptedContent,
 } from "@modelcontextprotocol/server";
@@ -33,10 +30,7 @@ const report = (tool, result) =>
 	(result.content ? `\n${JSON.stringify(result.content, null, 2)}` : "");
 
 function buildServer() {
-	const server = new McpServer(
-		{ name: "mock-elicitation-mcp", version: "1.0.0" },
-		{ capabilities: { tools: {} } }
-	);
+	const server = new McpServer({ name: "mock-elicitation-mcp", version: "1.0.0" });
 
 	server.registerTool(
 		"book_meeting",
@@ -154,7 +148,10 @@ function buildServer() {
 			inputSchema: {},
 		},
 		async () => {
-			console.log("[mock-elicitation-mcp] impatient_confirm -> asking, 5s timeout");
+			// The pre-MRTR style: the server sends the request. On a 2025-era connection this
+			// exercises the client's "server stopped waiting" path; on modern it fails fast,
+			// because a server cannot raise an unsolicited request there at all.
+			console.log("[mock-elicitation-mcp] impatient_confirm -> server-initiated, 5s timeout");
 			try {
 				const result = await server.server.elicitInput(
 					{
@@ -200,76 +197,7 @@ function buildServer() {
 	return server;
 }
 
-/** sessionId -> transport, so an elicitation answer reaches the instance that asked. */
-const sessions = new Map();
-
-async function readBody(req) {
-	const chunks = [];
-	for await (const chunk of req) chunks.push(chunk);
-	if (chunks.length === 0) return undefined;
-	return JSON.parse(Buffer.concat(chunks).toString("utf8"));
-}
-
-const httpServer = createServer((req, res) => {
-	void (async () => {
-		const url = new URL(req.url ?? "/", `http://127.0.0.1:${PORT}`);
-
-		if (url.pathname === "/health") {
-			res.writeHead(200, { "content-type": "application/json" });
-			res.end(JSON.stringify({ ok: true, sessions: sessions.size }));
-			return;
-		}
-
-		if (url.pathname !== "/mcp") {
-			res.writeHead(404, { "content-type": "application/json" });
-			res.end(JSON.stringify({ error: "not found", path: url.pathname }));
-			return;
-		}
-
-		const sessionId = req.headers["mcp-session-id"];
-		const existing = typeof sessionId === "string" ? sessions.get(sessionId) : undefined;
-
-		if (existing) {
-			await existing.handleRequest(
-				req,
-				res,
-				req.method === "POST" ? await readBody(req) : undefined
-			);
-			return;
-		}
-
-		const body = req.method === "POST" ? await readBody(req) : undefined;
-		if (!isInitializeRequest(body)) {
-			res.writeHead(400, { "content-type": "application/json" });
-			res.end(JSON.stringify({ error: "no session; send initialize first" }));
-			return;
-		}
-
-		const transport = new NodeStreamableHTTPServerTransport({
-			sessionIdGenerator: () => randomUUID(),
-			onsessioninitialized: (id) => {
-				console.log(`[mock-elicitation-mcp] session ${id} opened`);
-				sessions.set(id, transport);
-			},
-		});
-		transport.onclose = () => {
-			if (transport.sessionId) {
-				console.log(`[mock-elicitation-mcp] session ${transport.sessionId} closed`);
-				sessions.delete(transport.sessionId);
-			}
-		};
-		await buildServer().connect(transport);
-		await transport.handleRequest(req, res, body);
-	})().catch((err) => {
-		console.error("[mock-elicitation-mcp]", err);
-		if (!res.headersSent) {
-			res.writeHead(500, { "content-type": "application/json" });
-			res.end(JSON.stringify({ error: String(err) }));
-		} else {
-			res.end();
-		}
-	});
-});
+const httpServer = createServer(toNodeHandler(createMcpHandler(buildServer)));
 
 httpServer.listen(PORT, "127.0.0.1", () => {
 	console.log(`[mock-elicitation-mcp] listening on http://127.0.0.1:${PORT}/mcp`);

--- a/scripts/mock-elicitation-mcp.mjs
+++ b/scripts/mock-elicitation-mcp.mjs
@@ -1,15 +1,8 @@
 /**
  * MCP server for exercising elicitation by hand.
  *
- * Stateful on purpose. The client answers `elicitation/create` with a *new* HTTP POST, so
- * a stateless server (a fresh instance per request, as in mock-image-mcp.mjs) would hand
- * that answer to an instance that never asked anything and the call would hang.
- *
- * Four tools, one per path worth seeing:
- *   book_meeting      every field kind the spec allows, generous timeout — the happy path
- *   double_check      two prompts in one call        — the deadline must stay paused across both
- *   impatient_confirm 5s timeout on its own request  — the "server stopped waiting" path
- *   sign_in           URL mode                       — the link, not a form
+ * Stateful, unlike mock-image-mcp.mjs: the client answers `elicitation/create` on a new
+ * POST, which a per-request server instance would not recognise.
  *
  * Run:  node scripts/mock-elicitation-mcp.mjs
  * Then add http://127.0.0.1:8792/mcp as an MCP server in the UI.
@@ -23,8 +16,7 @@ import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
 
 const PORT = Number(process.env.MOCK_ELICITATION_MCP_PORT ?? 8792);
 
-// Long enough to test walking away. The MCP SDK's default is 60s, which is why an
-// untouched server usually gives up long before chat-ui's own expiry.
+// Long enough to test walking away; the MCP SDK default is 60s.
 const PATIENT_MS = 60 * 60_000;
 
 const report = (tool, result) =>
@@ -148,8 +140,6 @@ function buildServer() {
 				);
 				return { content: [{ type: "text", text: report("impatient_confirm", result) }] };
 			} catch (err) {
-				// The client should now close the prompt on its own rather than leave a form
-				// up that can no longer be answered.
 				console.log("[mock-elicitation-mcp] impatient_confirm gave up:", String(err));
 				return {
 					content: [{ type: "text", text: "Gave up waiting for confirmation." }],

--- a/scripts/mock-elicitation-mcp.mjs
+++ b/scripts/mock-elicitation-mcp.mjs
@@ -4,15 +4,24 @@
  * Stateful, unlike mock-image-mcp.mjs: the client answers `elicitation/create` on a new
  * POST, which a per-request server instance would not recognise.
  *
+ * Tools ask for input by RETURNING `input_required` (the 2026-07-28 style). On a 2025-era
+ * connection the SDK's shim turns that into a real `elicitation/create` request, so the
+ * same handler serves both — `impatient_confirm` stays on the old style on purpose, to
+ * keep exercising a server that gives up on its own request.
+ *
  * Run:  node scripts/mock-elicitation-mcp.mjs
  * Then add http://127.0.0.1:8792/mcp as an MCP server in the UI.
  * Requires MCP_ALLOW_INSECURE_URLS=true, or chat-ui rejects the loopback URL.
  */
 import { createServer } from "node:http";
 import { randomUUID } from "node:crypto";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
-import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
+import { NodeStreamableHTTPServerTransport } from "@modelcontextprotocol/node";
+import {
+	McpServer,
+	isInitializeRequest,
+	inputRequired,
+	acceptedContent,
+} from "@modelcontextprotocol/server";
 
 const PORT = Number(process.env.MOCK_ELICITATION_MCP_PORT ?? 8792);
 
@@ -34,88 +43,107 @@ function buildServer() {
 		{
 			description:
 				"Books a meeting. Asks the user for the details it needs before booking anything.",
-			inputSchema: {},
 		},
-		async () => {
-			console.log("[mock-elicitation-mcp] book_meeting -> asking for details");
-			const result = await server.server.elicitInput(
-				{
-					message: "I need a few details before I can book this meeting.",
-					requestedSchema: {
-						type: "object",
-						properties: {
-							title: { type: "string", title: "Meeting title", minLength: 3, maxLength: 60 },
-							email: { type: "string", title: "Your email", format: "email" },
-							day: { type: "string", title: "Date", format: "date" },
-							attendees: { type: "integer", title: "Attendees", minimum: 1, maximum: 50 },
-							room: {
-								type: "string",
-								title: "Room",
-								oneOf: [
-									{ const: "small", title: "Huddle room (4)" },
-									{ const: "large", title: "Boardroom (20)" },
-								],
-							},
-							extras: {
-								type: "array",
-								title: "Extras",
-								maxItems: 2,
-								items: {
-									anyOf: [
-										{ const: "coffee", title: "Coffee" },
-										{ const: "projector", title: "Projector" },
-										{ const: "notes", title: "Note taker" },
-									],
+		async (...args) => {
+			const ctx = args.at(-1);
+			const given = acceptedContent(ctx?.mcpReq?.inputResponses, "details");
+			if (!given) {
+				console.log("[mock-elicitation-mcp] book_meeting -> input_required");
+				return inputRequired({
+					inputRequests: {
+						details: inputRequired.elicit({
+							message: "I need a few details before I can book this meeting.",
+							requestedSchema: {
+								type: "object",
+								properties: {
+									title: { type: "string", title: "Meeting title", minLength: 3, maxLength: 60 },
+									email: { type: "string", title: "Your email", format: "email" },
+									day: { type: "string", title: "Date", format: "date" },
+									attendees: { type: "integer", title: "Attendees", minimum: 1, maximum: 50 },
+									room: {
+										type: "string",
+										title: "Room",
+										oneOf: [
+											{ const: "small", title: "Huddle room (4)" },
+											{ const: "large", title: "Boardroom (20)" },
+										],
+									},
+									extras: {
+										type: "array",
+										title: "Extras",
+										maxItems: 2,
+										items: {
+											anyOf: [
+												{ const: "coffee", title: "Coffee" },
+												{ const: "projector", title: "Projector" },
+												{ const: "notes", title: "Note taker" },
+											],
+										},
+									},
+									recurring: { type: "boolean", title: "Repeat weekly", default: false },
 								},
+								required: ["title", "day"],
 							},
-							recurring: { type: "boolean", title: "Repeat weekly", default: false },
-						},
-						required: ["title", "day"],
+						}),
 					},
-				},
-				{ timeout: PATIENT_MS }
-			);
-			console.log("[mock-elicitation-mcp] book_meeting <-", result.action);
-			return { content: [{ type: "text", text: report("book_meeting", result) }] };
+				});
+			}
+			console.log("[mock-elicitation-mcp] book_meeting <- re-entered");
+			return {
+				content: [{ type: "text", text: `book_meeting: ${JSON.stringify(given, null, 2)}` }],
+			};
 		}
 	);
 
 	server.registerTool(
 		"double_check",
-		{
-			description: "Performs a destructive action, confirming twice before doing it.",
-			inputSchema: {},
-		},
-		async () => {
-			console.log("[mock-elicitation-mcp] double_check -> prompt 1");
-			const first = await server.server.elicitInput(
-				{
-					message: "This will delete 412 records. Type DELETE to continue.",
-					requestedSchema: {
-						type: "object",
-						properties: { confirm: { type: "string", title: "Confirmation" } },
-						required: ["confirm"],
+		{ description: "Performs a destructive action, confirming twice before doing it." },
+		async (...args) => {
+			const ctx = args.at(-1);
+			// Each round carries only its own answers, so the step lives in `requestState` —
+			// the opaque string the client echoes back byte-exact. An accessor, not a field.
+			const step = ctx?.mcpReq?.requestState?.() ?? "start";
+			const responses = ctx?.mcpReq?.inputResponses;
+
+			if (step === "start") {
+				console.log("[mock-elicitation-mcp] double_check -> round 1");
+				return inputRequired({
+					requestState: "awaiting-confirm",
+					inputRequests: {
+						confirm: inputRequired.elicit({
+							message: "This will delete 412 records. Type DELETE to continue.",
+							requestedSchema: {
+								type: "object",
+								properties: { confirm: { type: "string", title: "Confirmation" } },
+								required: ["confirm"],
+							},
+						}),
 					},
-				},
-				{ timeout: PATIENT_MS }
-			);
-			if (first.action !== "accept" || first.content?.confirm !== "DELETE") {
-				return { content: [{ type: "text", text: "Aborted at the first confirmation." }] };
+				});
 			}
 
-			console.log("[mock-elicitation-mcp] double_check -> prompt 2");
-			const second = await server.server.elicitInput(
-				{
-					message: "Last chance. Really delete them?",
-					requestedSchema: {
-						type: "object",
-						properties: { sure: { type: "boolean", title: "Yes, delete them" } },
-						required: ["sure"],
+			if (step === "awaiting-confirm") {
+				if (acceptedContent(responses, "confirm")?.confirm !== "DELETE") {
+					return { content: [{ type: "text", text: "Aborted at the first confirmation." }] };
+				}
+				console.log("[mock-elicitation-mcp] double_check -> round 2");
+				return inputRequired({
+					requestState: "awaiting-sure",
+					inputRequests: {
+						sure: inputRequired.elicit({
+							message: "Last chance. Really delete them?",
+							requestedSchema: {
+								type: "object",
+								properties: { sure: { type: "boolean", title: "Yes, delete them" } },
+								required: ["sure"],
+							},
+						}),
 					},
-				},
-				{ timeout: PATIENT_MS }
-			);
-			return { content: [{ type: "text", text: report("double_check", second) }] };
+				});
+			}
+
+			const sure = acceptedContent(responses, "sure");
+			return { content: [{ type: "text", text: `double_check: ${JSON.stringify(sure)}` }] };
 		}
 	);
 
@@ -151,22 +179,21 @@ function buildServer() {
 
 	server.registerTool(
 		"sign_in",
-		{
-			description: "Signs the user in to the external service before continuing.",
-			inputSchema: {},
-		},
-		async () => {
-			console.log("[mock-elicitation-mcp] sign_in -> URL mode");
-			const result = await server.server.elicitInput(
-				{
-					mode: "url",
-					message: "Sign in to Example Corp, then come back here.",
-					elicitationId: randomUUID(),
-					url: "https://example.com/oauth/authorize?client_id=demo",
-				},
-				{ timeout: PATIENT_MS }
-			);
-			return { content: [{ type: "text", text: report("sign_in", result) }] };
+		{ description: "Signs the user in to the external service before continuing." },
+		async (...args) => {
+			const ctx = args.at(-1);
+			if (!ctx?.mcpReq?.inputResponses?.auth) {
+				console.log("[mock-elicitation-mcp] sign_in -> input_required (url)");
+				return inputRequired({
+					inputRequests: {
+						auth: inputRequired.elicitUrl({
+							message: "Sign in to Example Corp, then come back here.",
+							url: "https://example.com/oauth/authorize?client_id=demo",
+						}),
+					},
+				});
+			}
+			return { content: [{ type: "text", text: "sign_in: returned from the link" }] };
 		}
 	);
 
@@ -218,7 +245,7 @@ const httpServer = createServer((req, res) => {
 			return;
 		}
 
-		const transport = new StreamableHTTPServerTransport({
+		const transport = new NodeStreamableHTTPServerTransport({
 			sessionIdGenerator: () => randomUUID(),
 			onsessioninitialized: (id) => {
 				console.log(`[mock-elicitation-mcp] session ${id} opened`);

--- a/scripts/mock-elicitation-mcp.mjs
+++ b/scripts/mock-elicitation-mcp.mjs
@@ -108,7 +108,9 @@ function buildServer() {
 							message: "This will delete 412 records. Type DELETE to continue.",
 							requestedSchema: {
 								type: "object",
-								properties: { confirm: { type: "string", title: "Confirmation" } },
+								properties: {
+									confirm: { type: "string", title: 'Type "DELETE" to reach round two' },
+								},
 								required: ["confirm"],
 							},
 						}),

--- a/scripts/mock-elicitation-mcp.mjs
+++ b/scripts/mock-elicitation-mcp.mjs
@@ -1,0 +1,262 @@
+/**
+ * MCP server for exercising elicitation by hand.
+ *
+ * Stateful on purpose. The client answers `elicitation/create` with a *new* HTTP POST, so
+ * a stateless server (a fresh instance per request, as in mock-image-mcp.mjs) would hand
+ * that answer to an instance that never asked anything and the call would hang.
+ *
+ * Four tools, one per path worth seeing:
+ *   book_meeting      every field kind the spec allows, generous timeout — the happy path
+ *   double_check      two prompts in one call        — the deadline must stay paused across both
+ *   impatient_confirm 5s timeout on its own request  — the "server stopped waiting" path
+ *   sign_in           URL mode                       — the link, not a form
+ *
+ * Run:  node scripts/mock-elicitation-mcp.mjs
+ * Then add http://127.0.0.1:8792/mcp as an MCP server in the UI.
+ * Requires MCP_ALLOW_INSECURE_URLS=true, or chat-ui rejects the loopback URL.
+ */
+import { createServer } from "node:http";
+import { randomUUID } from "node:crypto";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
+
+const PORT = Number(process.env.MOCK_ELICITATION_MCP_PORT ?? 8792);
+
+// Long enough to test walking away. The MCP SDK's default is 60s, which is why an
+// untouched server usually gives up long before chat-ui's own expiry.
+const PATIENT_MS = 60 * 60_000;
+
+const report = (tool, result) =>
+	`${tool}: user chose "${result.action}"` +
+	(result.content ? `\n${JSON.stringify(result.content, null, 2)}` : "");
+
+function buildServer() {
+	const server = new McpServer(
+		{ name: "mock-elicitation-mcp", version: "1.0.0" },
+		{ capabilities: { tools: {} } }
+	);
+
+	server.registerTool(
+		"book_meeting",
+		{
+			description:
+				"Books a meeting. Asks the user for the details it needs before booking anything.",
+			inputSchema: {},
+		},
+		async () => {
+			console.log("[mock-elicitation-mcp] book_meeting -> asking for details");
+			const result = await server.server.elicitInput(
+				{
+					message: "I need a few details before I can book this meeting.",
+					requestedSchema: {
+						type: "object",
+						properties: {
+							title: { type: "string", title: "Meeting title", minLength: 3, maxLength: 60 },
+							email: { type: "string", title: "Your email", format: "email" },
+							day: { type: "string", title: "Date", format: "date" },
+							attendees: { type: "integer", title: "Attendees", minimum: 1, maximum: 50 },
+							room: {
+								type: "string",
+								title: "Room",
+								oneOf: [
+									{ const: "small", title: "Huddle room (4)" },
+									{ const: "large", title: "Boardroom (20)" },
+								],
+							},
+							extras: {
+								type: "array",
+								title: "Extras",
+								maxItems: 2,
+								items: {
+									anyOf: [
+										{ const: "coffee", title: "Coffee" },
+										{ const: "projector", title: "Projector" },
+										{ const: "notes", title: "Note taker" },
+									],
+								},
+							},
+							recurring: { type: "boolean", title: "Repeat weekly", default: false },
+						},
+						required: ["title", "day"],
+					},
+				},
+				{ timeout: PATIENT_MS }
+			);
+			console.log("[mock-elicitation-mcp] book_meeting <-", result.action);
+			return { content: [{ type: "text", text: report("book_meeting", result) }] };
+		}
+	);
+
+	server.registerTool(
+		"double_check",
+		{
+			description: "Performs a destructive action, confirming twice before doing it.",
+			inputSchema: {},
+		},
+		async () => {
+			console.log("[mock-elicitation-mcp] double_check -> prompt 1");
+			const first = await server.server.elicitInput(
+				{
+					message: "This will delete 412 records. Type DELETE to continue.",
+					requestedSchema: {
+						type: "object",
+						properties: { confirm: { type: "string", title: "Confirmation" } },
+						required: ["confirm"],
+					},
+				},
+				{ timeout: PATIENT_MS }
+			);
+			if (first.action !== "accept" || first.content?.confirm !== "DELETE") {
+				return { content: [{ type: "text", text: "Aborted at the first confirmation." }] };
+			}
+
+			console.log("[mock-elicitation-mcp] double_check -> prompt 2");
+			const second = await server.server.elicitInput(
+				{
+					message: "Last chance. Really delete them?",
+					requestedSchema: {
+						type: "object",
+						properties: { sure: { type: "boolean", title: "Yes, delete them" } },
+						required: ["sure"],
+					},
+				},
+				{ timeout: PATIENT_MS }
+			);
+			return { content: [{ type: "text", text: report("double_check", second) }] };
+		}
+	);
+
+	server.registerTool(
+		"impatient_confirm",
+		{
+			description: "Asks for a confirmation but only waits five seconds for it.",
+			inputSchema: {},
+		},
+		async () => {
+			console.log("[mock-elicitation-mcp] impatient_confirm -> asking, 5s timeout");
+			try {
+				const result = await server.server.elicitInput(
+					{
+						message: "Answer within five seconds or I will give up.",
+						requestedSchema: {
+							type: "object",
+							properties: { ok: { type: "boolean", title: "Go ahead" } },
+						},
+					},
+					{ timeout: 5_000 }
+				);
+				return { content: [{ type: "text", text: report("impatient_confirm", result) }] };
+			} catch (err) {
+				// The client should now close the prompt on its own rather than leave a form
+				// up that can no longer be answered.
+				console.log("[mock-elicitation-mcp] impatient_confirm gave up:", String(err));
+				return {
+					content: [{ type: "text", text: "Gave up waiting for confirmation." }],
+					isError: true,
+				};
+			}
+		}
+	);
+
+	server.registerTool(
+		"sign_in",
+		{
+			description: "Signs the user in to the external service before continuing.",
+			inputSchema: {},
+		},
+		async () => {
+			console.log("[mock-elicitation-mcp] sign_in -> URL mode");
+			const result = await server.server.elicitInput(
+				{
+					mode: "url",
+					message: "Sign in to Example Corp, then come back here.",
+					elicitationId: randomUUID(),
+					url: "https://example.com/oauth/authorize?client_id=demo",
+				},
+				{ timeout: PATIENT_MS }
+			);
+			return { content: [{ type: "text", text: report("sign_in", result) }] };
+		}
+	);
+
+	return server;
+}
+
+/** sessionId -> transport, so an elicitation answer reaches the instance that asked. */
+const sessions = new Map();
+
+async function readBody(req) {
+	const chunks = [];
+	for await (const chunk of req) chunks.push(chunk);
+	if (chunks.length === 0) return undefined;
+	return JSON.parse(Buffer.concat(chunks).toString("utf8"));
+}
+
+const httpServer = createServer((req, res) => {
+	void (async () => {
+		const url = new URL(req.url ?? "/", `http://127.0.0.1:${PORT}`);
+
+		if (url.pathname === "/health") {
+			res.writeHead(200, { "content-type": "application/json" });
+			res.end(JSON.stringify({ ok: true, sessions: sessions.size }));
+			return;
+		}
+
+		if (url.pathname !== "/mcp") {
+			res.writeHead(404, { "content-type": "application/json" });
+			res.end(JSON.stringify({ error: "not found", path: url.pathname }));
+			return;
+		}
+
+		const sessionId = req.headers["mcp-session-id"];
+		const existing = typeof sessionId === "string" ? sessions.get(sessionId) : undefined;
+
+		if (existing) {
+			await existing.handleRequest(
+				req,
+				res,
+				req.method === "POST" ? await readBody(req) : undefined
+			);
+			return;
+		}
+
+		const body = req.method === "POST" ? await readBody(req) : undefined;
+		if (!isInitializeRequest(body)) {
+			res.writeHead(400, { "content-type": "application/json" });
+			res.end(JSON.stringify({ error: "no session; send initialize first" }));
+			return;
+		}
+
+		const transport = new StreamableHTTPServerTransport({
+			sessionIdGenerator: () => randomUUID(),
+			onsessioninitialized: (id) => {
+				console.log(`[mock-elicitation-mcp] session ${id} opened`);
+				sessions.set(id, transport);
+			},
+		});
+		transport.onclose = () => {
+			if (transport.sessionId) {
+				console.log(`[mock-elicitation-mcp] session ${transport.sessionId} closed`);
+				sessions.delete(transport.sessionId);
+			}
+		};
+		await buildServer().connect(transport);
+		await transport.handleRequest(req, res, body);
+	})().catch((err) => {
+		console.error("[mock-elicitation-mcp]", err);
+		if (!res.headersSent) {
+			res.writeHead(500, { "content-type": "application/json" });
+			res.end(JSON.stringify({ error: String(err) }));
+		} else {
+			res.end();
+		}
+	});
+});
+
+httpServer.listen(PORT, "127.0.0.1", () => {
+	console.log(`[mock-elicitation-mcp] listening on http://127.0.0.1:${PORT}/mcp`);
+	console.log(
+		"[mock-elicitation-mcp] tools: book_meeting, double_check, impatient_confirm, sign_in"
+	);
+});

--- a/src/lib/components/chat/ChatMessage.svelte
+++ b/src/lib/components/chat/ChatMessage.svelte
@@ -154,7 +154,7 @@
 	type ElicitationBlock = {
 		type: "elicitation";
 		request: ElicitationRequestPayload;
-		expiresAt: number;
+		expiresAt?: number;
 		resolved?: MessageElicitationResolvedUpdate;
 	};
 

--- a/src/lib/components/chat/ChatMessage.svelte
+++ b/src/lib/components/chat/ChatMessage.svelte
@@ -23,8 +23,19 @@
 	import ToolUpdate from "./ToolUpdate.svelte";
 	import ToolCallsSummary from "./ToolCallsSummary.svelte";
 	import ArtifactCard from "./ArtifactCard.svelte";
-	import { isMessageToolUpdate } from "$lib/utils/messageUpdates";
-	import { MessageUpdateType, type MessageToolUpdate } from "$lib/types/MessageUpdate";
+	import ElicitationForm from "./ElicitationForm.svelte";
+	import {
+		isMessageToolUpdate,
+		isMessageElicitationRequestUpdate,
+		isMessageElicitationResolvedUpdate,
+	} from "$lib/utils/messageUpdates";
+	import {
+		MessageUpdateType,
+		type MessageToolUpdate,
+		type MessageElicitationResolvedUpdate,
+	} from "$lib/types/MessageUpdate";
+	import type { ElicitationRequestPayload } from "$lib/types/McpElicitation";
+	import { page } from "$app/state";
 	import ImageLightbox from "./ImageLightbox.svelte";
 	import { splitArtifactSegments, stripArtifacts } from "$lib/utils/artifacts";
 	import type { ArtifactOperation } from "$lib/utils/artifacts";
@@ -140,11 +151,19 @@
 		stripArtifacts(message.content.replace(THINK_BLOCK_REGEX, "")).trim()
 	);
 
+	type ElicitationBlock = {
+		type: "elicitation";
+		request: ElicitationRequestPayload;
+		expiresAt: number;
+		resolved?: MessageElicitationResolvedUpdate;
+	};
+
 	type Block =
 		| { type: "text"; content: string }
 		| { type: "think"; content: string; closed: boolean }
 		| { type: "tool"; uuid: string; updates: MessageToolUpdate[] }
-		| { type: "artifact"; op: ArtifactOperation; opIndex: number };
+		| { type: "artifact"; op: ArtifactOperation; opIndex: number }
+		| ElicitationBlock;
 
 	type ToolBlock = Extract<Block, { type: "tool" }>;
 	type ProcessBlock = Extract<Block, { type: "think" } | { type: "tool" }>;
@@ -152,7 +171,8 @@
 	type RenderUnit =
 		| { kind: "text"; content: string }
 		| { kind: "group"; blocks: ProcessBlock[]; toolCount: number }
-		| { kind: "artifact"; op: ArtifactOperation; opIndex: number };
+		| { kind: "artifact"; op: ArtifactOperation; opIndex: number }
+		| ({ kind: "elicitation" } & Omit<ElicitationBlock, "type">);
 
 	// Expand any text block containing <think>…</think> into dedicated think blocks
 	// so reasoning can be grouped/collapsed separately from the answer text.
@@ -264,6 +284,20 @@
 				} else {
 					res.push({ type: "tool" as const, uuid: update.uuid, updates: [update] });
 				}
+			} else if (isMessageElicitationRequestUpdate(update)) {
+				res.push({
+					type: "elicitation" as const,
+					request: update.request,
+					expiresAt: update.expiresAt,
+				});
+			} else if (isMessageElicitationResolvedUpdate(update)) {
+				// Settles the form already in the transcript rather than adding a block, so a
+				// replayed conversation shows the outcome on the prompt it belongs to.
+				const target = res.find(
+					(b): b is ElicitationBlock =>
+						b.type === "elicitation" && b.request.elicitationId === update.elicitationId
+				);
+				if (target) target.resolved = update;
 			} else if (update.type === MessageUpdateType.FinalAnswer) {
 				sawFinalAnswer = true;
 				const finalText = update.text ?? "";
@@ -326,6 +360,16 @@
 			} else if (block.type === "artifact") {
 				flush();
 				units.push({ kind: "artifact", op: block.op, opIndex: block.opIndex });
+			} else if (block.type === "elicitation") {
+				// Never folded into the collapsible tool summary: it is the one block the
+				// user has to be able to act on.
+				flush();
+				units.push({
+					kind: "elicitation",
+					request: block.request,
+					expiresAt: block.expiresAt,
+					resolved: block.resolved,
+				});
 			} else {
 				flush();
 				units.push({ kind: "text", content: block.content });
@@ -341,7 +385,7 @@
 	let isProcessStreaming = $derived.by(() => {
 		if (!isLast || !loading) return false;
 		const last = blocks.at(-1);
-		return !!last && (last.type === "think" || last.type === "tool");
+		return !!last && (last.type === "think" || last.type === "tool" || last.type === "elicitation");
 	});
 
 	$effect(() => {
@@ -422,6 +466,15 @@
 							{/if}
 						{:else if block.type === "artifact"}
 							<ArtifactCard op={block.op} messageId={message.id} opIndex={block.opIndex} />
+						{:else if block.type === "elicitation"}
+							<div data-exclude-from-copy>
+								<ElicitationForm
+									conversationId={page.params.id ?? ""}
+									request={block.request}
+									expiresAt={block.expiresAt}
+									resolved={block.resolved}
+								/>
+							</div>
 						{:else}
 							<div data-exclude-from-copy class="not-last:mb-1 has-[+.prose]:mb-2! [.prose+&]:mt-3">
 								{#if block.type === "think"}
@@ -448,6 +501,15 @@
 							{/if}
 						{:else if unit.kind === "artifact"}
 							<ArtifactCard op={unit.op} messageId={message.id} opIndex={unit.opIndex} />
+						{:else if unit.kind === "elicitation"}
+							<div data-exclude-from-copy>
+								<ElicitationForm
+									conversationId={page.params.id ?? ""}
+									request={unit.request}
+									expiresAt={unit.expiresAt}
+									resolved={unit.resolved}
+								/>
+							</div>
 						{:else if unit.kind === "group"}
 							<div data-exclude-from-copy class="not-last:mb-1 has-[+.prose]:mb-2! [.prose+&]:mt-3">
 								{#if unit.blocks.length > 1}

--- a/src/lib/components/chat/ChatMessage.svelte
+++ b/src/lib/components/chat/ChatMessage.svelte
@@ -291,8 +291,7 @@
 					expiresAt: update.expiresAt,
 				});
 			} else if (isMessageElicitationResolvedUpdate(update)) {
-				// Settles the form already in the transcript rather than adding a block, so a
-				// replayed conversation shows the outcome on the prompt it belongs to.
+				// Settles the existing block rather than adding one.
 				const target = res.find(
 					(b): b is ElicitationBlock =>
 						b.type === "elicitation" && b.request.elicitationId === update.elicitationId
@@ -361,8 +360,7 @@
 				flush();
 				units.push({ kind: "artifact", op: block.op, opIndex: block.opIndex });
 			} else if (block.type === "elicitation") {
-				// Never folded into the collapsible tool summary: it is the one block the
-				// user has to be able to act on.
+				// Never folded into the collapsible summary: the user has to be able to act on it.
 				flush();
 				units.push({
 					kind: "elicitation",

--- a/src/lib/components/chat/ElicitationForm.svelte
+++ b/src/lib/components/chat/ElicitationForm.svelte
@@ -24,6 +24,20 @@
 
 	const fields = $derived(request.fields ?? []);
 
+	/**
+	 * `date` and `datetime-local` inputs only accept `YYYY-MM-DD[THH:mm]`, so an RFC 3339
+	 * default — which is what the schema asks servers to send — renders as blank unless it
+	 * is narrowed to the shape the control understands.
+	 */
+	function forDateInput(value: string, format: "date" | "date-time"): string {
+		const parsed = new Date(value);
+		if (Number.isNaN(parsed.getTime())) return format === "date" ? value.slice(0, 10) : "";
+		const pad = (n: number) => String(n).padStart(2, "0");
+		const day = `${parsed.getFullYear()}-${pad(parsed.getMonth() + 1)}-${pad(parsed.getDate())}`;
+		if (format === "date") return day;
+		return `${day}T${pad(parsed.getHours())}:${pad(parsed.getMinutes())}`;
+	}
+
 	function initialValues(source: ElicitationField[]): Record<string, ElicitationValue> {
 		const out: Record<string, ElicitationValue> = {};
 		for (const field of source) {
@@ -33,6 +47,12 @@
 				out[field.name] = Array.isArray(field.default) ? [...field.default] : [];
 			} else if (field.kind === "select") {
 				out[field.name] = typeof field.default === "string" ? field.default : "";
+			} else if (
+				field.kind === "string" &&
+				(field.format === "date" || field.format === "date-time") &&
+				field.default !== undefined
+			) {
+				out[field.name] = forDateInput(field.default, field.format);
 			} else {
 				// Kept as a string while typing; parsed back on submit.
 				out[field.name] = field.default !== undefined ? String(field.default) : "";
@@ -44,6 +64,8 @@
 	// Seeded once: re-deriving would discard whatever the user has typed.
 	// svelte-ignore state_referenced_locally
 	let values = $state<Record<string, ElicitationValue>>(initialValues(request.fields ?? []));
+	/** Optional fields the user actually interacted with; see `payload`. */
+	let touched = $state(new Set<string>());
 	let submitting = $state(false);
 	let error = $state<string | null>(null);
 	/** Settles the form without waiting for the run to echo the outcome back. */
@@ -69,6 +91,39 @@
 		return `${seconds}s left`;
 	});
 
+	/** Hosts that only exist inside a network the user did not choose to expose. */
+	const isPrivateHost = (host: string) =>
+		host === "localhost" ||
+		host.endsWith(".localhost") ||
+		host.endsWith(".local") ||
+		host.endsWith(".internal") ||
+		host === "::1" ||
+		host === "[::1]" ||
+		/^127\./.test(host) ||
+		/^10\./.test(host) ||
+		/^192\.168\./.test(host) ||
+		/^172\.(1[6-9]|2\d|3[01])\./.test(host) ||
+		/^169\.254\./.test(host);
+
+	/** The spec asks clients to flag ambiguous or suspicious link targets, punycode included. */
+	let urlWarnings = $derived.by(() => {
+		if (!request.url) return [];
+		let parsed: URL;
+		try {
+			parsed = new URL(request.url);
+		} catch {
+			return ["This link could not be read."];
+		}
+		const out: string[] = [];
+		if (/(^|\.)xn--/i.test(parsed.hostname)) {
+			out.push("This address uses punycode, which can be made to imitate another domain.");
+		}
+		if (parsed.protocol !== "https:") out.push("This link is not encrypted.");
+		if (isPrivateHost(parsed.hostname))
+			out.push("This link points into a private or local network.");
+		return out;
+	});
+
 	let linkHost = $derived.by(() => {
 		if (!request.url) return "";
 		try {
@@ -85,6 +140,11 @@
 
 	const isChecked = (name: string): boolean => values[name] === true;
 
+	const pickedCount = (name: string): number => {
+		const value = values[name];
+		return Array.isArray(value) ? value.length : 0;
+	};
+
 	const isPicked = (name: string, option: string): boolean => {
 		const value = values[name];
 		return Array.isArray(value) && value.includes(option);
@@ -92,6 +152,7 @@
 
 	function set(name: string, value: ElicitationValue) {
 		values = { ...values, [name]: value };
+		touched = new Set(touched).add(name);
 	}
 
 	function toggleOption(name: string, option: string, checked: boolean) {
@@ -104,6 +165,16 @@
 		for (const field of fields) {
 			const value = values[field.name];
 			if (value === "" || value === undefined || value === null) continue;
+			// A checkbox nobody touched is not an answer of "false" — leaving it out lets
+			// the server apply its own default.
+			if (
+				field.kind === "boolean" &&
+				!field.required &&
+				field.default === undefined &&
+				!touched.has(field.name)
+			) {
+				continue;
+			}
 			if (field.kind === "number") {
 				const parsed = typeof value === "number" ? value : Number(value);
 				if (Number.isFinite(parsed)) out[field.name] = parsed;
@@ -276,6 +347,9 @@
 					<p class="mt-1.5 font-mono text-xs break-all text-gray-400 dark:text-gray-500">
 						{request.url}
 					</p>
+					{#each urlWarnings as warning (warning)}
+						<p class="mt-1.5 text-xs text-amber-700 dark:text-amber-500">{warning}</p>
+					{/each}
 				</div>
 			{:else if fields.length > 0}
 				<form
@@ -366,20 +440,30 @@
 									{/each}
 								</select>
 							{:else if field.kind === "select"}
+								{@const atLimit =
+									field.maxItems !== undefined && pickedCount(field.name) >= field.maxItems}
 								<div class="space-y-1" role="group" aria-labelledby={`${id}-label`}>
 									{#each field.options as option (option.value)}
+										{@const picked = isPicked(field.name, option.value)}
 										<label class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
 											<input
 												type="checkbox"
 												value={option.value}
-												checked={isPicked(field.name, option.value)}
+												checked={picked}
 												onchange={(event) =>
 													toggleOption(field.name, option.value, event.currentTarget.checked)}
-												disabled={!open}
+												disabled={!open || (atLimit && !picked)}
 											/>
 											{option.label}
 										</label>
 									{/each}
+									{#if field.maxItems !== undefined}
+										<p class="text-xs text-gray-500 dark:text-gray-400">
+											Choose up to {field.maxItems}{field.minItems
+												? `, at least ${field.minItems}`
+												: ""}.
+										</p>
+									{/if}
 								</div>
 							{/if}
 						</div>
@@ -419,6 +503,15 @@
 						class="rounded-lg border border-gray-300 px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-100 disabled:opacity-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
 					>
 						Decline
+					</button>
+					<!-- Distinct from Decline: the spec requires a way to dismiss without choosing. -->
+					<button
+						type="button"
+						onclick={() => send("cancel")}
+						disabled={submitting}
+						class="rounded-lg px-3 py-1.5 text-sm text-gray-500 hover:bg-gray-100 disabled:opacity-50 dark:text-gray-400 dark:hover:bg-gray-700"
+					>
+						Dismiss
 					</button>
 				</div>
 			{/if}

--- a/src/lib/components/chat/ElicitationForm.svelte
+++ b/src/lib/components/chat/ElicitationForm.svelte
@@ -106,6 +106,12 @@
 				if (Number.isFinite(parsed)) out[field.name] = parsed;
 				continue;
 			}
+			// `datetime-local` has no offset, but the schema asked for RFC 3339.
+			if (field.kind === "string" && field.format === "date-time" && typeof value === "string") {
+				const parsed = new Date(value);
+				if (!Number.isNaN(parsed.getTime())) out[field.name] = parsed.toISOString();
+				continue;
+			}
 			out[field.name] = value;
 		}
 		return out;
@@ -211,13 +217,16 @@
 								<span>{field.title ?? field.name}</span>
 							</label>
 						{:else}
-							<label
-								for={id}
+							{@const grouped = field.kind === "select" && field.multiple}
+							<svelte:element
+								this={grouped ? "span" : "label"}
+								id={`${id}-label`}
+								for={grouped ? undefined : id}
 								class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
 							>
 								{field.title ?? field.name}
 								{#if field.required}<span class="text-red-500">*</span>{/if}
-							</label>
+							</svelte:element>
 						{/if}
 
 						{#if field.description}
@@ -272,7 +281,7 @@
 								{/each}
 							</select>
 						{:else if field.kind === "select"}
-							<div class="space-y-1">
+							<div class="space-y-1" role="group" aria-labelledby={`${id}-label`}>
 								{#each field.options as option (option.value)}
 									<label class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
 										<input

--- a/src/lib/components/chat/ElicitationForm.svelte
+++ b/src/lib/components/chat/ElicitationForm.svelte
@@ -9,12 +9,13 @@
 	import { base } from "$app/paths";
 	import CarbonLaunch from "~icons/carbon/launch";
 	import BlockWrapper from "./BlockWrapper.svelte";
+	import { elicitationToResume } from "$lib/stores/elicitationResume";
 
 	interface Props {
 		conversationId: string;
 		request: ElicitationRequestPayload;
-		/** Epoch ms. */
-		expiresAt: number;
+		/** Epoch ms; absent for a 2026-era prompt, which nothing is waiting on. */
+		expiresAt?: number;
 		resolved?: MessageElicitationResolvedUpdate;
 	}
 
@@ -49,17 +50,18 @@
 
 	let now = $state(Date.now());
 	let outcome = $derived(resolved?.action ?? submitted);
-	let expired = $derived(!outcome && now >= expiresAt);
+	let expired = $derived(!outcome && expiresAt !== undefined && now >= expiresAt);
 	let open = $derived(!outcome && !expired);
 
 	$effect(() => {
-		if (!open) return;
+		if (!open || expiresAt === undefined) return;
 		const period = expiresAt - now > 120_000 ? 30_000 : 1_000;
 		const timer = setInterval(() => (now = Date.now()), period);
 		return () => clearInterval(timer);
 	});
 
 	let timeLeft = $derived.by(() => {
+		if (expiresAt === undefined) return "";
 		const seconds = Math.max(0, Math.ceil((expiresAt - now) / 1000));
 		if (seconds >= 3_600) return `${Math.floor(seconds / 3_600)}h left`;
 		if (seconds >= 120) return `${Math.floor(seconds / 60)}m left`;
@@ -132,12 +134,15 @@
 					...(action === "accept" && request.mode === "form" ? { content: payload() } : {}),
 				}),
 			});
+			const body = await res.json().catch(() => null);
 			if (!res.ok) {
-				const body = await res.json().catch(() => null);
 				error = typeof body?.message === "string" ? body.message : "Could not send your answer.";
 				return;
 			}
 			submitted = action;
+			// A parked call has nothing waiting on it, so answering only records the answer —
+			// the run that continues it has to be started.
+			if (body?.resume) elicitationToResume.set(request.elicitationId);
 		} catch {
 			error = "Could not send your answer.";
 		} finally {

--- a/src/lib/components/chat/ElicitationForm.svelte
+++ b/src/lib/components/chat/ElicitationForm.svelte
@@ -8,6 +8,7 @@
 	import type { MessageElicitationResolvedUpdate } from "$lib/types/MessageUpdate";
 	import { base } from "$app/paths";
 	import CarbonLaunch from "~icons/carbon/launch";
+	import CarbonChevronRight from "~icons/carbon/chevron-right";
 	import BlockWrapper from "./BlockWrapper.svelte";
 	import { elicitationToResume } from "$lib/stores/elicitationResume";
 
@@ -153,210 +154,274 @@
 	// Submitting through the form is what runs the browser's own field validation.
 	const formId = $derived(`elicit-form-${request.elicitationId}`);
 
+	let showAnswers = $state(false);
+
+	/** What was submitted: from this session if we just sent it, else from the transcript. */
+	let answered = $derived(resolved?.content ?? (submitted === "accept" ? payload() : undefined));
+
+	let settledLabel = $derived.by(() => {
+		if (outcome === "accept") return request.mode === "url" ? "Opened link" : "Answered";
+		if (outcome === "decline") return "Declined";
+		if (resolved?.resolution === "aborted") return "Cancelled with the response";
+		if (resolved?.resolution === "withdrawn") return `${request.server} stopped waiting`;
+		if (expired || resolved?.resolution === "expired") return "Expired unanswered";
+		return "Cancelled";
+	});
+
+	const labelFor = (name: string) => fields.find((f) => f.name === name)?.title ?? name;
+
+	const shown = (value: ElicitationValue) =>
+		Array.isArray(value) ? value.join(", ") : String(value);
+
 	const inputClass =
 		"w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-white";
 </script>
 
-<BlockWrapper>
-	<div
-		class="rounded-xl border border-gray-200 bg-gray-50/60 p-4 dark:border-gray-700 dark:bg-gray-800/40"
-	>
-		<div class="flex flex-wrap items-baseline gap-x-2 gap-y-1">
-			<span class="text-sm font-medium text-gray-700 dark:text-gray-200">
-				{request.mode === "url" ? "Action needed" : "Input requested"}
-			</span>
-			<span class="text-xs text-gray-500 dark:text-gray-400">
-				from <code
-					class="rounded-sm bg-blue-50 px-1 py-px font-mono text-blue-700 dark:bg-blue-900/30 dark:text-blue-300"
+{#if !open}
+	<BlockWrapper>
+		<div class="flex max-w-full flex-col items-start gap-1 select-none">
+			<button
+				type="button"
+				class="group/header flex max-w-full cursor-pointer items-center gap-1 text-left whitespace-nowrap focus:outline-hidden"
+				onclick={() => (showAnswers = !showAnswers)}
+				aria-label={showAnswers ? "Collapse" : "Expand"}
+			>
+				<span
+					class="shrink-0 text-sm font-medium text-gray-500 transition-colors group-hover/header:text-gray-600 dark:text-gray-400 dark:group-hover/header:text-gray-300"
+				>
+					{settledLabel}
+				</span>
+				<code
+					class="min-w-0 truncate rounded-sm bg-blue-50 px-1 py-px font-mono text-xs text-blue-700 opacity-90 dark:bg-blue-900/30 dark:text-blue-300"
 					>{request.server}</code
 				>
-			</span>
-			{#if open}
-				<span class="ml-auto text-xs text-gray-400 tabular-nums dark:text-gray-500">
-					{timeLeft}
-				</span>
-			{/if}
+				<CarbonChevronRight
+					class="size-3.5 shrink-0 transition-all duration-200 group-hover/header:text-gray-600 dark:group-hover/header:text-gray-300 {showAnswers
+						? 'rotate-90 text-gray-600 dark:text-gray-300'
+						: 'text-gray-400'}"
+				/>
+			</button>
 		</div>
 
-		<p class="mt-2 text-sm whitespace-pre-wrap text-gray-600 dark:text-gray-300">
-			{request.message}
-		</p>
-
-		{#if request.mode === "url" && request.url}
-			<div class="mt-3">
-				<a
-					href={request.url}
-					target="_blank"
-					rel="noopener noreferrer nofollow"
-					class="inline-flex items-center gap-1.5 rounded-lg bg-gray-900 px-3 py-2 text-sm text-white hover:bg-gray-700 dark:bg-gray-200 dark:text-gray-900 dark:hover:bg-white"
-				>
-					<CarbonLaunch class="size-3.5" />
-					Open {linkHost}
-				</a>
-				<p class="mt-1.5 font-mono text-xs break-all text-gray-400 dark:text-gray-500">
-					{request.url}
-				</p>
+		{#if showAnswers}
+			<div class="mt-2 mb-4 space-y-3 text-gray-500 dark:text-gray-400">
+				<div class="space-y-1">
+					<div class="text-[10px] font-semibold text-gray-400 uppercase dark:text-gray-500">
+						Asked
+					</div>
+					<p class="text-xs whitespace-pre-wrap">{request.message}</p>
+					{#if request.url}
+						<p class="font-mono text-xs break-all">{request.url}</p>
+					{/if}
+				</div>
+				{#if answered && Object.keys(answered).length > 0}
+					<div class="space-y-1">
+						<div class="text-[10px] font-semibold text-gray-400 uppercase dark:text-gray-500">
+							Answered
+						</div>
+						<dl class="rounded-lg bg-gray-100 p-2 text-xs dark:bg-gray-800/70">
+							{#each Object.entries(answered) as [name, value] (name)}
+								<div class="flex gap-2 py-px">
+									<dt class="shrink-0 font-medium text-gray-500 dark:text-gray-400">
+										{labelFor(name)}
+									</dt>
+									<dd class="min-w-0 break-words text-gray-700 dark:text-gray-300">
+										{shown(value)}
+									</dd>
+								</div>
+							{/each}
+						</dl>
+					</div>
+				{/if}
 			</div>
-		{:else if fields.length > 0}
-			<form
-				id={formId}
-				class="mt-3 space-y-3"
-				onsubmit={(event) => {
-					event.preventDefault();
-					send("accept");
-				}}
-			>
-				{#each fields as field (field.name)}
-					{@const id = `elicit-${request.elicitationId}-${field.name}`}
-					<div>
-						{#if field.kind === "boolean"}
-							<label class="flex items-start gap-2 text-sm text-gray-700 dark:text-gray-300">
+		{/if}
+	</BlockWrapper>
+{:else}
+	<BlockWrapper>
+		<div
+			class="rounded-xl border border-gray-200 bg-gray-50/60 p-4 dark:border-gray-700 dark:bg-gray-800/40"
+		>
+			<div class="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+				<span class="text-sm font-medium text-gray-700 dark:text-gray-200">
+					{request.mode === "url" ? "Action needed" : "Input requested"}
+				</span>
+				<span class="text-xs text-gray-500 dark:text-gray-400">
+					from <code
+						class="rounded-sm bg-blue-50 px-1 py-px font-mono text-blue-700 dark:bg-blue-900/30 dark:text-blue-300"
+						>{request.server}</code
+					>
+				</span>
+				{#if open}
+					<span class="ml-auto text-xs text-gray-400 tabular-nums dark:text-gray-500">
+						{timeLeft}
+					</span>
+				{/if}
+			</div>
+
+			<p class="mt-2 text-sm whitespace-pre-wrap text-gray-600 dark:text-gray-300">
+				{request.message}
+			</p>
+
+			{#if request.mode === "url" && request.url}
+				<div class="mt-3">
+					<a
+						href={request.url}
+						target="_blank"
+						rel="noopener noreferrer nofollow"
+						class="inline-flex items-center gap-1.5 rounded-lg bg-gray-900 px-3 py-2 text-sm text-white hover:bg-gray-700 dark:bg-gray-200 dark:text-gray-900 dark:hover:bg-white"
+					>
+						<CarbonLaunch class="size-3.5" />
+						Open {linkHost}
+					</a>
+					<p class="mt-1.5 font-mono text-xs break-all text-gray-400 dark:text-gray-500">
+						{request.url}
+					</p>
+				</div>
+			{:else if fields.length > 0}
+				<form
+					id={formId}
+					class="mt-3 space-y-3"
+					onsubmit={(event) => {
+						event.preventDefault();
+						send("accept");
+					}}
+				>
+					{#each fields as field (field.name)}
+						{@const id = `elicit-${request.elicitationId}-${field.name}`}
+						<div>
+							{#if field.kind === "boolean"}
+								<label class="flex items-start gap-2 text-sm text-gray-700 dark:text-gray-300">
+									<input
+										{id}
+										type="checkbox"
+										checked={isChecked(field.name)}
+										onchange={(event) => set(field.name, event.currentTarget.checked)}
+										disabled={!open}
+										class="mt-0.5"
+									/>
+									<span>{field.title ?? field.name}</span>
+								</label>
+							{:else}
+								{@const grouped = field.kind === "select" && field.multiple}
+								<svelte:element
+									this={grouped ? "span" : "label"}
+									id={`${id}-label`}
+									for={grouped ? undefined : id}
+									class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
+								>
+									{field.title ?? field.name}
+									{#if field.required}<span class="text-red-500">*</span>{/if}
+								</svelte:element>
+							{/if}
+
+							{#if field.description}
+								<p class="mb-1 text-xs text-gray-500 dark:text-gray-400">{field.description}</p>
+							{/if}
+
+							{#if field.kind === "string"}
 								<input
 									{id}
-									type="checkbox"
-									checked={isChecked(field.name)}
-									onchange={(event) => set(field.name, event.currentTarget.checked)}
+									type={field.format === "email"
+										? "email"
+										: field.format === "date"
+											? "date"
+											: field.format === "date-time"
+												? "datetime-local"
+												: field.format === "uri"
+													? "url"
+													: "text"}
+									value={textValue(field.name)}
+									oninput={(event) => set(field.name, event.currentTarget.value)}
+									required={field.required}
+									minlength={field.minLength}
+									maxlength={field.maxLength}
 									disabled={!open}
-									class="mt-0.5"
+									class={inputClass}
 								/>
-								<span>{field.title ?? field.name}</span>
-							</label>
-						{:else}
-							{@const grouped = field.kind === "select" && field.multiple}
-							<svelte:element
-								this={grouped ? "span" : "label"}
-								id={`${id}-label`}
-								for={grouped ? undefined : id}
-								class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
-							>
-								{field.title ?? field.name}
-								{#if field.required}<span class="text-red-500">*</span>{/if}
-							</svelte:element>
-						{/if}
+							{:else if field.kind === "number"}
+								<input
+									{id}
+									type="number"
+									value={textValue(field.name)}
+									oninput={(event) => set(field.name, event.currentTarget.value)}
+									required={field.required}
+									min={field.minimum}
+									max={field.maximum}
+									step={field.integer ? 1 : "any"}
+									disabled={!open}
+									class={inputClass}
+								/>
+							{:else if field.kind === "select" && !field.multiple}
+								<select
+									{id}
+									value={textValue(field.name)}
+									onchange={(event) => set(field.name, event.currentTarget.value)}
+									required={field.required}
+									disabled={!open}
+									class={inputClass}
+								>
+									<option value="" disabled={field.required}>Choose…</option>
+									{#each field.options as option (option.value)}
+										<option value={option.value}>{option.label}</option>
+									{/each}
+								</select>
+							{:else if field.kind === "select"}
+								<div class="space-y-1" role="group" aria-labelledby={`${id}-label`}>
+									{#each field.options as option (option.value)}
+										<label class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+											<input
+												type="checkbox"
+												value={option.value}
+												checked={isPicked(field.name, option.value)}
+												onchange={(event) =>
+													toggleOption(field.name, option.value, event.currentTarget.checked)}
+												disabled={!open}
+											/>
+											{option.label}
+										</label>
+									{/each}
+								</div>
+							{/if}
+						</div>
+					{/each}
+				</form>
+			{/if}
 
-						{#if field.description}
-							<p class="mb-1 text-xs text-gray-500 dark:text-gray-400">{field.description}</p>
-						{/if}
+			{#if error}
+				<p class="mt-3 text-xs text-red-600 dark:text-red-400">{error}</p>
+			{/if}
 
-						{#if field.kind === "string"}
-							<input
-								{id}
-								type={field.format === "email"
-									? "email"
-									: field.format === "date"
-										? "date"
-										: field.format === "date-time"
-											? "datetime-local"
-											: field.format === "uri"
-												? "url"
-												: "text"}
-								value={textValue(field.name)}
-								oninput={(event) => set(field.name, event.currentTarget.value)}
-								required={field.required}
-								minlength={field.minLength}
-								maxlength={field.maxLength}
-								disabled={!open}
-								class={inputClass}
-							/>
-						{:else if field.kind === "number"}
-							<input
-								{id}
-								type="number"
-								value={textValue(field.name)}
-								oninput={(event) => set(field.name, event.currentTarget.value)}
-								required={field.required}
-								min={field.minimum}
-								max={field.maximum}
-								step={field.integer ? 1 : "any"}
-								disabled={!open}
-								class={inputClass}
-							/>
-						{:else if field.kind === "select" && !field.multiple}
-							<select
-								{id}
-								value={textValue(field.name)}
-								onchange={(event) => set(field.name, event.currentTarget.value)}
-								required={field.required}
-								disabled={!open}
-								class={inputClass}
-							>
-								<option value="" disabled={field.required}>Choose…</option>
-								{#each field.options as option (option.value)}
-									<option value={option.value}>{option.label}</option>
-								{/each}
-							</select>
-						{:else if field.kind === "select"}
-							<div class="space-y-1" role="group" aria-labelledby={`${id}-label`}>
-								{#each field.options as option (option.value)}
-									<label class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
-										<input
-											type="checkbox"
-											value={option.value}
-											checked={isPicked(field.name, option.value)}
-											onchange={(event) =>
-												toggleOption(field.name, option.value, event.currentTarget.checked)}
-											disabled={!open}
-										/>
-										{option.label}
-									</label>
-								{/each}
-							</div>
-						{/if}
-					</div>
-				{/each}
-			</form>
-		{/if}
-
-		{#if error}
-			<p class="mt-3 text-xs text-red-600 dark:text-red-400">{error}</p>
-		{/if}
-
-		{#if open}
-			<div class="mt-4 flex flex-wrap gap-2">
-				{#if request.mode === "form" && fields.length > 0}
-					<button
-						type="submit"
-						form={formId}
-						disabled={submitting}
-						class="rounded-lg bg-gray-900 px-3 py-1.5 text-sm text-white hover:bg-gray-700 disabled:opacity-50 dark:bg-gray-200 dark:text-gray-900 dark:hover:bg-white"
-					>
-						Send
-					</button>
-				{:else}
+			{#if open}
+				<div class="mt-4 flex flex-wrap gap-2">
+					{#if request.mode === "form" && fields.length > 0}
+						<button
+							type="submit"
+							form={formId}
+							disabled={submitting}
+							class="rounded-lg bg-gray-900 px-3 py-1.5 text-sm text-white hover:bg-gray-700 disabled:opacity-50 dark:bg-gray-200 dark:text-gray-900 dark:hover:bg-white"
+						>
+							Send
+						</button>
+					{:else}
+						<button
+							type="button"
+							onclick={() => send("accept")}
+							disabled={submitting}
+							class="rounded-lg bg-gray-900 px-3 py-1.5 text-sm text-white hover:bg-gray-700 disabled:opacity-50 dark:bg-gray-200 dark:text-gray-900 dark:hover:bg-white"
+						>
+							I've done this
+						</button>
+					{/if}
 					<button
 						type="button"
-						onclick={() => send("accept")}
+						onclick={() => send("decline")}
 						disabled={submitting}
-						class="rounded-lg bg-gray-900 px-3 py-1.5 text-sm text-white hover:bg-gray-700 disabled:opacity-50 dark:bg-gray-200 dark:text-gray-900 dark:hover:bg-white"
+						class="rounded-lg border border-gray-300 px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-100 disabled:opacity-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
 					>
-						I've done this
+						Decline
 					</button>
-				{/if}
-				<button
-					type="button"
-					onclick={() => send("decline")}
-					disabled={submitting}
-					class="rounded-lg border border-gray-300 px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-100 disabled:opacity-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
-				>
-					Decline
-				</button>
-			</div>
-		{:else}
-			<p class="mt-3 text-xs text-gray-500 dark:text-gray-400">
-				{#if outcome === "accept"}
-					Sent.
-				{:else if outcome === "decline"}
-					Declined.
-				{:else if resolved?.resolution === "aborted"}
-					Cancelled when the response was stopped.
-				{:else if resolved?.resolution === "withdrawn"}
-					{request.server} stopped waiting for an answer.
-				{:else if expired || resolved?.resolution === "expired"}
-					This request expired without an answer.
-				{:else}
-					Cancelled.
-				{/if}
-			</p>
-		{/if}
-	</div>
-</BlockWrapper>
+				</div>
+			{/if}
+		</div>
+	</BlockWrapper>
+{/if}

--- a/src/lib/components/chat/ElicitationForm.svelte
+++ b/src/lib/components/chat/ElicitationForm.svelte
@@ -11,6 +11,7 @@
 	import CarbonChevronRight from "~icons/carbon/chevron-right";
 	import BlockWrapper from "./BlockWrapper.svelte";
 	import { elicitationToResume } from "$lib/stores/elicitationResume";
+	import { forDateInput } from "$lib/utils/elicitationDate";
 
 	interface Props {
 		conversationId: string;
@@ -23,20 +24,6 @@
 	let { conversationId, request, expiresAt, resolved }: Props = $props();
 
 	const fields = $derived(request.fields ?? []);
-
-	/**
-	 * `date` and `datetime-local` inputs only accept `YYYY-MM-DD[THH:mm]`, so an RFC 3339
-	 * default — which is what the schema asks servers to send — renders as blank unless it
-	 * is narrowed to the shape the control understands.
-	 */
-	function forDateInput(value: string, format: "date" | "date-time"): string {
-		const parsed = new Date(value);
-		if (Number.isNaN(parsed.getTime())) return format === "date" ? value.slice(0, 10) : "";
-		const pad = (n: number) => String(n).padStart(2, "0");
-		const day = `${parsed.getFullYear()}-${pad(parsed.getMonth() + 1)}-${pad(parsed.getDate())}`;
-		if (format === "date") return day;
-		return `${day}T${pad(parsed.getHours())}:${pad(parsed.getMinutes())}`;
-	}
 
 	function initialValues(source: ElicitationField[]): Record<string, ElicitationValue> {
 		const out: Record<string, ElicitationValue> = {};

--- a/src/lib/components/chat/ElicitationForm.svelte
+++ b/src/lib/components/chat/ElicitationForm.svelte
@@ -13,9 +13,8 @@
 	interface Props {
 		conversationId: string;
 		request: ElicitationRequestPayload;
-		/** Epoch ms; past it the server has stopped waiting and the answer is refused. */
+		/** Epoch ms. */
 		expiresAt: number;
-		/** Present once the run recorded an outcome — including one nobody supplied. */
 		resolved?: MessageElicitationResolvedUpdate;
 	}
 
@@ -33,20 +32,19 @@
 			} else if (field.kind === "select") {
 				out[field.name] = typeof field.default === "string" ? field.default : "";
 			} else {
-				// Numbers live as strings while typing, and are parsed back on submit.
+				// Kept as a string while typing; parsed back on submit.
 				out[field.name] = field.default !== undefined ? String(field.default) : "";
 			}
 		}
 		return out;
 	}
 
-	// Seeded once on purpose: a block's request is fixed for its lifetime, and re-deriving
-	// would throw away whatever the user has typed so far.
+	// Seeded once: re-deriving would discard whatever the user has typed.
 	// svelte-ignore state_referenced_locally
 	let values = $state<Record<string, ElicitationValue>>(initialValues(request.fields ?? []));
 	let submitting = $state(false);
 	let error = $state<string | null>(null);
-	/** Set as soon as our own POST succeeds, so the form settles without waiting for the run's echo. */
+	/** Settles the form without waiting for the run to echo the outcome back. */
 	let submitted = $state<ElicitationAction | null>(null);
 
 	let now = $state(Date.now());
@@ -56,15 +54,11 @@
 
 	$effect(() => {
 		if (!open) return;
-		// Per-second only once the countdown is actually showing seconds; a prompt open for
-		// an hour has no reason to re-render 3600 times.
 		const period = expiresAt - now > 120_000 ? 30_000 : 1_000;
 		const timer = setInterval(() => (now = Date.now()), period);
 		return () => clearInterval(timer);
 	});
 
-	// Coarse while there is plenty of time — a prompt can stay open for an hour, and a raw
-	// second count that high reads as pressure rather than information.
 	let timeLeft = $derived.by(() => {
 		const seconds = Math.max(0, Math.ceil((expiresAt - now) / 1000));
 		if (seconds >= 3_600) return `${Math.floor(seconds / 3_600)}h left`;
@@ -72,8 +66,6 @@
 		return `${seconds}s left`;
 	});
 
-	// Only the host, and only for display: the full URL is shown as text below it so a
-	// long path cannot push the actual destination out of sight.
 	let linkHost = $derived.by(() => {
 		if (!request.url) return "";
 		try {
@@ -126,8 +118,7 @@
 		try {
 			const res = await fetch(`${base}/conversation/${conversationId}/elicitation`, {
 				method: "POST",
-				// Asking for JSON keeps a rejection readable: without it SvelteKit answers
-				// `error()` with an HTML page, which is not something to show in a chat bubble.
+				// Without Accept, SvelteKit answers `error()` with an HTML page.
 				headers: { "Content-Type": "application/json", Accept: "application/json" },
 				body: JSON.stringify({
 					elicitationId: request.elicitationId,
@@ -148,8 +139,7 @@
 		}
 	}
 
-	// Submitting through the form (rather than clicking a plain button) is what makes the
-	// browser run `required`, `min`, `maxlength` and friends before anything is sent.
+	// Submitting through the form is what runs the browser's own field validation.
 	const formId = $derived(`elicit-form-${request.elicitationId}`);
 
 	const inputClass =
@@ -164,7 +154,6 @@
 			<span class="text-sm font-medium text-gray-700 dark:text-gray-200">
 				{request.mode === "url" ? "Action needed" : "Input requested"}
 			</span>
-			<!-- Named, because the question is the server's and not the app's. -->
 			<span class="text-xs text-gray-500 dark:text-gray-400">
 				from <code
 					class="rounded-sm bg-blue-50 px-1 py-px font-mono text-blue-700 dark:bg-blue-900/30 dark:text-blue-300"

--- a/src/lib/components/chat/ElicitationForm.svelte
+++ b/src/lib/components/chat/ElicitationForm.svelte
@@ -1,0 +1,359 @@
+<script lang="ts">
+	import type {
+		ElicitationAction,
+		ElicitationField,
+		ElicitationRequestPayload,
+		ElicitationValue,
+	} from "$lib/types/McpElicitation";
+	import type { MessageElicitationResolvedUpdate } from "$lib/types/MessageUpdate";
+	import { base } from "$app/paths";
+	import CarbonLaunch from "~icons/carbon/launch";
+	import BlockWrapper from "./BlockWrapper.svelte";
+
+	interface Props {
+		conversationId: string;
+		request: ElicitationRequestPayload;
+		/** Epoch ms; past it the server has stopped waiting and the answer is refused. */
+		expiresAt: number;
+		/** Present once the run recorded an outcome — including one nobody supplied. */
+		resolved?: MessageElicitationResolvedUpdate;
+	}
+
+	let { conversationId, request, expiresAt, resolved }: Props = $props();
+
+	const fields = $derived(request.fields ?? []);
+
+	function initialValues(source: ElicitationField[]): Record<string, ElicitationValue> {
+		const out: Record<string, ElicitationValue> = {};
+		for (const field of source) {
+			if (field.kind === "boolean") {
+				out[field.name] = field.default ?? false;
+			} else if (field.kind === "select" && field.multiple) {
+				out[field.name] = Array.isArray(field.default) ? [...field.default] : [];
+			} else if (field.kind === "select") {
+				out[field.name] = typeof field.default === "string" ? field.default : "";
+			} else {
+				// Numbers live as strings while typing, and are parsed back on submit.
+				out[field.name] = field.default !== undefined ? String(field.default) : "";
+			}
+		}
+		return out;
+	}
+
+	// Seeded once on purpose: a block's request is fixed for its lifetime, and re-deriving
+	// would throw away whatever the user has typed so far.
+	// svelte-ignore state_referenced_locally
+	let values = $state<Record<string, ElicitationValue>>(initialValues(request.fields ?? []));
+	let submitting = $state(false);
+	let error = $state<string | null>(null);
+	/** Set as soon as our own POST succeeds, so the form settles without waiting for the run's echo. */
+	let submitted = $state<ElicitationAction | null>(null);
+
+	let now = $state(Date.now());
+	let outcome = $derived(resolved?.action ?? submitted);
+	let expired = $derived(!outcome && now >= expiresAt);
+	let open = $derived(!outcome && !expired);
+
+	$effect(() => {
+		if (!open) return;
+		// Per-second only once the countdown is actually showing seconds; a prompt open for
+		// an hour has no reason to re-render 3600 times.
+		const period = expiresAt - now > 120_000 ? 30_000 : 1_000;
+		const timer = setInterval(() => (now = Date.now()), period);
+		return () => clearInterval(timer);
+	});
+
+	// Coarse while there is plenty of time — a prompt can stay open for an hour, and a raw
+	// second count that high reads as pressure rather than information.
+	let timeLeft = $derived.by(() => {
+		const seconds = Math.max(0, Math.ceil((expiresAt - now) / 1000));
+		if (seconds >= 3_600) return `${Math.floor(seconds / 3_600)}h left`;
+		if (seconds >= 120) return `${Math.floor(seconds / 60)}m left`;
+		return `${seconds}s left`;
+	});
+
+	// Only the host, and only for display: the full URL is shown as text below it so a
+	// long path cannot push the actual destination out of sight.
+	let linkHost = $derived.by(() => {
+		if (!request.url) return "";
+		try {
+			return new URL(request.url).host;
+		} catch {
+			return request.url;
+		}
+	});
+
+	const textValue = (name: string): string => {
+		const value = values[name];
+		return typeof value === "string" || typeof value === "number" ? String(value) : "";
+	};
+
+	const isChecked = (name: string): boolean => values[name] === true;
+
+	const isPicked = (name: string, option: string): boolean => {
+		const value = values[name];
+		return Array.isArray(value) && value.includes(option);
+	};
+
+	function set(name: string, value: ElicitationValue) {
+		values = { ...values, [name]: value };
+	}
+
+	function toggleOption(name: string, option: string, checked: boolean) {
+		const current = Array.isArray(values[name]) ? (values[name] as string[]) : [];
+		set(name, checked ? [...current, option] : current.filter((v) => v !== option));
+	}
+
+	function payload(): Record<string, ElicitationValue> {
+		const out: Record<string, ElicitationValue> = {};
+		for (const field of fields) {
+			const value = values[field.name];
+			if (value === "" || value === undefined || value === null) continue;
+			if (field.kind === "number") {
+				const parsed = typeof value === "number" ? value : Number(value);
+				if (Number.isFinite(parsed)) out[field.name] = parsed;
+				continue;
+			}
+			out[field.name] = value;
+		}
+		return out;
+	}
+
+	async function send(action: ElicitationAction) {
+		if (submitting || !open) return;
+		submitting = true;
+		error = null;
+		try {
+			const res = await fetch(`${base}/conversation/${conversationId}/elicitation`, {
+				method: "POST",
+				// Asking for JSON keeps a rejection readable: without it SvelteKit answers
+				// `error()` with an HTML page, which is not something to show in a chat bubble.
+				headers: { "Content-Type": "application/json", Accept: "application/json" },
+				body: JSON.stringify({
+					elicitationId: request.elicitationId,
+					action,
+					...(action === "accept" && request.mode === "form" ? { content: payload() } : {}),
+				}),
+			});
+			if (!res.ok) {
+				const body = await res.json().catch(() => null);
+				error = typeof body?.message === "string" ? body.message : "Could not send your answer.";
+				return;
+			}
+			submitted = action;
+		} catch {
+			error = "Could not send your answer.";
+		} finally {
+			submitting = false;
+		}
+	}
+
+	// Submitting through the form (rather than clicking a plain button) is what makes the
+	// browser run `required`, `min`, `maxlength` and friends before anything is sent.
+	const formId = $derived(`elicit-form-${request.elicitationId}`);
+
+	const inputClass =
+		"w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-white";
+</script>
+
+<BlockWrapper>
+	<div
+		class="rounded-xl border border-gray-200 bg-gray-50/60 p-4 dark:border-gray-700 dark:bg-gray-800/40"
+	>
+		<div class="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+			<span class="text-sm font-medium text-gray-700 dark:text-gray-200">
+				{request.mode === "url" ? "Action needed" : "Input requested"}
+			</span>
+			<!-- Named, because the question is the server's and not the app's. -->
+			<span class="text-xs text-gray-500 dark:text-gray-400">
+				from <code
+					class="rounded-sm bg-blue-50 px-1 py-px font-mono text-blue-700 dark:bg-blue-900/30 dark:text-blue-300"
+					>{request.server}</code
+				>
+			</span>
+			{#if open}
+				<span class="ml-auto text-xs text-gray-400 tabular-nums dark:text-gray-500">
+					{timeLeft}
+				</span>
+			{/if}
+		</div>
+
+		<p class="mt-2 text-sm whitespace-pre-wrap text-gray-600 dark:text-gray-300">
+			{request.message}
+		</p>
+
+		{#if request.mode === "url" && request.url}
+			<div class="mt-3">
+				<a
+					href={request.url}
+					target="_blank"
+					rel="noopener noreferrer nofollow"
+					class="inline-flex items-center gap-1.5 rounded-lg bg-gray-900 px-3 py-2 text-sm text-white hover:bg-gray-700 dark:bg-gray-200 dark:text-gray-900 dark:hover:bg-white"
+				>
+					<CarbonLaunch class="size-3.5" />
+					Open {linkHost}
+				</a>
+				<p class="mt-1.5 font-mono text-xs break-all text-gray-400 dark:text-gray-500">
+					{request.url}
+				</p>
+			</div>
+		{:else if fields.length > 0}
+			<form
+				id={formId}
+				class="mt-3 space-y-3"
+				onsubmit={(event) => {
+					event.preventDefault();
+					send("accept");
+				}}
+			>
+				{#each fields as field (field.name)}
+					{@const id = `elicit-${request.elicitationId}-${field.name}`}
+					<div>
+						{#if field.kind === "boolean"}
+							<label class="flex items-start gap-2 text-sm text-gray-700 dark:text-gray-300">
+								<input
+									{id}
+									type="checkbox"
+									checked={isChecked(field.name)}
+									onchange={(event) => set(field.name, event.currentTarget.checked)}
+									disabled={!open}
+									class="mt-0.5"
+								/>
+								<span>{field.title ?? field.name}</span>
+							</label>
+						{:else}
+							<label
+								for={id}
+								class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
+							>
+								{field.title ?? field.name}
+								{#if field.required}<span class="text-red-500">*</span>{/if}
+							</label>
+						{/if}
+
+						{#if field.description}
+							<p class="mb-1 text-xs text-gray-500 dark:text-gray-400">{field.description}</p>
+						{/if}
+
+						{#if field.kind === "string"}
+							<input
+								{id}
+								type={field.format === "email"
+									? "email"
+									: field.format === "date"
+										? "date"
+										: field.format === "date-time"
+											? "datetime-local"
+											: field.format === "uri"
+												? "url"
+												: "text"}
+								value={textValue(field.name)}
+								oninput={(event) => set(field.name, event.currentTarget.value)}
+								required={field.required}
+								minlength={field.minLength}
+								maxlength={field.maxLength}
+								disabled={!open}
+								class={inputClass}
+							/>
+						{:else if field.kind === "number"}
+							<input
+								{id}
+								type="number"
+								value={textValue(field.name)}
+								oninput={(event) => set(field.name, event.currentTarget.value)}
+								required={field.required}
+								min={field.minimum}
+								max={field.maximum}
+								step={field.integer ? 1 : "any"}
+								disabled={!open}
+								class={inputClass}
+							/>
+						{:else if field.kind === "select" && !field.multiple}
+							<select
+								{id}
+								value={textValue(field.name)}
+								onchange={(event) => set(field.name, event.currentTarget.value)}
+								required={field.required}
+								disabled={!open}
+								class={inputClass}
+							>
+								<option value="" disabled={field.required}>Choose…</option>
+								{#each field.options as option (option.value)}
+									<option value={option.value}>{option.label}</option>
+								{/each}
+							</select>
+						{:else if field.kind === "select"}
+							<div class="space-y-1">
+								{#each field.options as option (option.value)}
+									<label class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+										<input
+											type="checkbox"
+											value={option.value}
+											checked={isPicked(field.name, option.value)}
+											onchange={(event) =>
+												toggleOption(field.name, option.value, event.currentTarget.checked)}
+											disabled={!open}
+										/>
+										{option.label}
+									</label>
+								{/each}
+							</div>
+						{/if}
+					</div>
+				{/each}
+			</form>
+		{/if}
+
+		{#if error}
+			<p class="mt-3 text-xs text-red-600 dark:text-red-400">{error}</p>
+		{/if}
+
+		{#if open}
+			<div class="mt-4 flex flex-wrap gap-2">
+				{#if request.mode === "form" && fields.length > 0}
+					<button
+						type="submit"
+						form={formId}
+						disabled={submitting}
+						class="rounded-lg bg-gray-900 px-3 py-1.5 text-sm text-white hover:bg-gray-700 disabled:opacity-50 dark:bg-gray-200 dark:text-gray-900 dark:hover:bg-white"
+					>
+						Send
+					</button>
+				{:else}
+					<button
+						type="button"
+						onclick={() => send("accept")}
+						disabled={submitting}
+						class="rounded-lg bg-gray-900 px-3 py-1.5 text-sm text-white hover:bg-gray-700 disabled:opacity-50 dark:bg-gray-200 dark:text-gray-900 dark:hover:bg-white"
+					>
+						I've done this
+					</button>
+				{/if}
+				<button
+					type="button"
+					onclick={() => send("decline")}
+					disabled={submitting}
+					class="rounded-lg border border-gray-300 px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-100 disabled:opacity-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
+				>
+					Decline
+				</button>
+			</div>
+		{:else}
+			<p class="mt-3 text-xs text-gray-500 dark:text-gray-400">
+				{#if outcome === "accept"}
+					Sent.
+				{:else if outcome === "decline"}
+					Declined.
+				{:else if resolved?.resolution === "aborted"}
+					Cancelled when the response was stopped.
+				{:else if resolved?.resolution === "withdrawn"}
+					{request.server} stopped waiting for an answer.
+				{:else if expired || resolved?.resolution === "expired"}
+					This request expired without an answer.
+				{:else}
+					Cancelled.
+				{/if}
+			</p>
+		{/if}
+	</div>
+</BlockWrapper>

--- a/src/lib/components/chat/ElicitationForm.svelte
+++ b/src/lib/components/chat/ElicitationForm.svelte
@@ -214,7 +214,9 @@
 			submitted = action;
 			// A parked call has nothing waiting on it, so answering only records the answer —
 			// the run that continues it has to be started.
-			if (body?.resume) elicitationToResume.set(request.elicitationId);
+			if (body?.resume) {
+				elicitationToResume.set({ conversationId, elicitationId: request.elicitationId });
+			}
 		} catch {
 			error = "Could not send your answer.";
 		} finally {

--- a/src/lib/components/chat/ElicitationForm.svelte.test.ts
+++ b/src/lib/components/chat/ElicitationForm.svelte.test.ts
@@ -1,0 +1,132 @@
+import ElicitationForm from "./ElicitationForm.svelte";
+import { render } from "vitest-browser-svelte";
+import { describe, expect, it, beforeEach, vi, afterEach } from "vitest";
+import type { ElicitationField, ElicitationRequestPayload } from "$lib/types/McpElicitation";
+
+/** Answers are POSTed, so what reaches the server is the assertion worth making. */
+let sent: Array<Record<string, unknown>>;
+
+beforeEach(() => {
+	sent = [];
+	vi.stubGlobal("fetch", async (_url: string, init?: RequestInit) => {
+		sent.push(JSON.parse(String(init?.body)));
+		return new Response(JSON.stringify({ ok: true, resume: false }), { status: 200 });
+	});
+});
+
+afterEach(() => vi.unstubAllGlobals());
+
+const formWith = (fields: ElicitationField[]): ElicitationRequestPayload => ({
+	elicitationId: "11111111-1111-4111-8111-111111111111",
+	server: "Mock",
+	mode: "form",
+	message: "Answer please.",
+	fields,
+});
+
+const mount = (fields: ElicitationField[]) =>
+	render(ElicitationForm, { conversationId: "abc", request: formWith(fields) });
+
+const submit = async (baseElement: HTMLElement) => {
+	const send = [...baseElement.querySelectorAll("button")].find((b) =>
+		/send|submit/i.test(b.textContent ?? "")
+	);
+	send?.click();
+	await vi.waitFor(() => expect(sent).toHaveLength(1));
+	return sent[0].content as Record<string, unknown> | undefined;
+};
+
+describe("an optional checkbox nobody touched", () => {
+	const notify: ElicitationField = {
+		kind: "boolean",
+		name: "notify",
+		title: "Notify",
+		required: false,
+	};
+
+	it("is left out rather than answered false", async () => {
+		const content = await submit(mount([notify]).baseElement);
+		expect(content).not.toHaveProperty("notify");
+	});
+
+	it("is sent once the user actually unticks it", async () => {
+		const { baseElement } = mount([{ ...notify, default: true }]);
+		const box = baseElement.querySelector<HTMLInputElement>('input[type="checkbox"]');
+		box?.click();
+		expect(await submit(baseElement)).toMatchObject({ notify: false });
+	});
+
+	it("still sends the server's default when left alone", async () => {
+		const content = await submit(mount([{ ...notify, default: true }]).baseElement);
+		expect(content).toMatchObject({ notify: true });
+	});
+});
+
+describe("a multi-select at its maxItems", () => {
+	const toppings: ElicitationField = {
+		kind: "select",
+		name: "toppings",
+		title: "Toppings",
+		required: true,
+		multiple: true,
+		maxItems: 2,
+		options: ["a", "b", "c"].map((v) => ({ value: v, label: v.toUpperCase() })),
+	};
+
+	it("disables the unpicked options instead of waiting for submit", async () => {
+		const { baseElement } = mount([toppings]);
+		const boxes = () => [
+			...baseElement.querySelectorAll<HTMLInputElement>('input[type="checkbox"]'),
+		];
+
+		expect(boxes().every((b) => !b.disabled)).toBe(true);
+
+		boxes()[0].click();
+		boxes()[1].click();
+
+		await vi.waitFor(() => expect(boxes()[2].disabled).toBe(true));
+		// The two already picked stay live, or the choice could not be undone.
+		expect(boxes()[0].disabled).toBe(false);
+		expect(boxes()[1].disabled).toBe(false);
+	});
+});
+
+describe("a date default the server sent as RFC 3339", () => {
+	it("fills the control rather than rendering blank", async () => {
+		const { baseElement } = mount([
+			{
+				kind: "string",
+				name: "starts_at",
+				title: "Starts at",
+				required: false,
+				format: "date-time",
+				default: "2026-09-01T09:30:00Z",
+			},
+		]);
+		const input = baseElement.querySelector<HTMLInputElement>('input[type="datetime-local"]');
+		expect(input?.value).toMatch(/^2026-09-0[12]T\d{2}:\d{2}$/);
+	});
+
+	it("submits it back as RFC 3339, not the timezone-less local value", async () => {
+		const { baseElement } = mount([
+			{
+				kind: "string",
+				name: "starts_at",
+				required: false,
+				format: "date-time",
+				default: "2026-09-01T09:30:00Z",
+			},
+		]);
+		expect(await submit(baseElement)).toMatchObject({ starts_at: "2026-09-01T09:30:00.000Z" });
+	});
+
+	it("leaves a date-only default on its own day", async () => {
+		// It parses as UTC midnight, so a local round-trip would show the day before
+		// to everyone west of UTC.
+		const { baseElement } = mount([
+			{ kind: "string", name: "day", required: false, format: "date", default: "2026-09-01" },
+		]);
+		const input = baseElement.querySelector<HTMLInputElement>('input[type="date"]');
+		expect(input?.value).toBe("2026-09-01");
+	});
+});

--- a/src/lib/server/database.ts
+++ b/src/lib/server/database.ts
@@ -317,13 +317,11 @@ export class Database {
 			.createIndex({ createdAt: 1 }, { expireAfterSeconds: 24 * 60 * 60 })
 			.catch((e) => logger.error(e, "Error creating TTL index for generationEvents by createdAt"));
 
-		// The waiting pod polls by id, and the answering pod writes by id.
 		mcpElicitations
 			.createIndex({ elicitationId: 1 }, { unique: true })
 			.catch((e) => logger.error(e, "Error creating index for mcpElicitations by elicitationId"));
-		// Must stay well clear of MCP_ELICITATION_TIMEOUT_MS (an hour by default), or a row
-		// is swept while its form is still on screen and answering it 404s. Expiry is decided
-		// by `expiresAt`, which the answer path checks; this only reclaims space.
+		// Must stay well clear of MCP_ELICITATION_TIMEOUT_MS, or a row is swept while its
+		// form is still on screen and answering it 404s.
 		mcpElicitations
 			.createIndex({ createdAt: 1 }, { expireAfterSeconds: 24 * 60 * 60 })
 			.catch((e) => logger.error(e, "Error creating TTL index for mcpElicitations by createdAt"));

--- a/src/lib/server/database.ts
+++ b/src/lib/server/database.ts
@@ -320,11 +320,11 @@ export class Database {
 		mcpElicitations
 			.createIndex({ elicitationId: 1 }, { unique: true })
 			.catch((e) => logger.error(e, "Error creating index for mcpElicitations by elicitationId"));
-		// Must stay well clear of MCP_ELICITATION_TIMEOUT_MS, or a row is swept while its
-		// form is still on screen and answering it 404s.
+		// Keyed off expiry, not creation: MCP_ELICITATION_TIMEOUT_MS is unbounded, and a row
+		// swept while its form is still on screen makes answering it 404.
 		mcpElicitations
-			.createIndex({ createdAt: 1 }, { expireAfterSeconds: 24 * 60 * 60 })
-			.catch((e) => logger.error(e, "Error creating TTL index for mcpElicitations by createdAt"));
+			.createIndex({ expiresAt: 1 }, { expireAfterSeconds: 24 * 60 * 60 })
+			.catch((e) => logger.error(e, "Error creating TTL index for mcpElicitations by expiresAt"));
 
 		sharedConversations.createIndex({ hash: 1 }, { unique: true }).catch((e) => logger.error(e));
 		settings

--- a/src/lib/server/database.ts
+++ b/src/lib/server/database.ts
@@ -3,6 +3,7 @@ import type { Conversation } from "$lib/types/Conversation";
 import type { SharedConversation } from "$lib/types/SharedConversation";
 import type { AbortedGeneration } from "$lib/types/AbortedGeneration";
 import type { Generation, GenerationEvent } from "$lib/types/Generation";
+import type { McpElicitation } from "$lib/types/McpElicitation";
 import type { Settings } from "$lib/types/Settings";
 import type { User } from "$lib/types/User";
 import type { MessageEvent } from "$lib/types/MessageEvent";
@@ -130,6 +131,7 @@ export class Database {
 		const abortedGenerations = db.collection<AbortedGeneration>("abortedGenerations");
 		const generations = db.collection<Generation>("generations");
 		const generationEvents = db.collection<GenerationEvent>("generationEvents");
+		const mcpElicitations = db.collection<McpElicitation>("mcpElicitations");
 		const semaphores = db.collection<Semaphore>("semaphores");
 		const tokenCaches = db.collection<TokenCache>("tokens");
 		const configCollection = db.collection<ConfigKey>("config");
@@ -160,6 +162,7 @@ export class Database {
 			abortedGenerations,
 			generations,
 			generationEvents,
+			mcpElicitations,
 			settings,
 			users,
 			sessions,
@@ -187,6 +190,7 @@ export class Database {
 			abortedGenerations,
 			generations,
 			generationEvents,
+			mcpElicitations,
 			settings,
 			users,
 			sessions,
@@ -312,6 +316,17 @@ export class Database {
 		generationEvents
 			.createIndex({ createdAt: 1 }, { expireAfterSeconds: 24 * 60 * 60 })
 			.catch((e) => logger.error(e, "Error creating TTL index for generationEvents by createdAt"));
+
+		// The waiting pod polls by id, and the answering pod writes by id.
+		mcpElicitations
+			.createIndex({ elicitationId: 1 }, { unique: true })
+			.catch((e) => logger.error(e, "Error creating index for mcpElicitations by elicitationId"));
+		// Must stay well clear of MCP_ELICITATION_TIMEOUT_MS (an hour by default), or a row
+		// is swept while its form is still on screen and answering it 404s. Expiry is decided
+		// by `expiresAt`, which the answer path checks; this only reclaims space.
+		mcpElicitations
+			.createIndex({ createdAt: 1 }, { expireAfterSeconds: 24 * 60 * 60 })
+			.catch((e) => logger.error(e, "Error creating TTL index for mcpElicitations by createdAt"));
 
 		sharedConversations.createIndex({ hash: 1 }, { unique: true }).catch((e) => logger.error(e));
 		settings

--- a/src/lib/server/endpoints/openai/endpointOai.ts
+++ b/src/lib/server/endpoints/openai/endpointOai.ts
@@ -15,6 +15,7 @@ import type { Endpoint } from "../endpoints";
 import type OpenAI from "openai";
 import { createImageProcessorOptionsValidator, makeImageProcessor } from "../images";
 import { prepareMessagesWithFiles } from "$lib/server/textGeneration/utils/prepareFiles";
+import { withoutContentLength } from "$lib/server/undiciCompat";
 // uuid import removed (no tool call ids)
 
 export const endpointOAIParametersSchema = z.object({
@@ -78,7 +79,7 @@ export async function endpointOai(
 
 	// Custom fetch wrapper to capture response headers for router metadata
 	const customFetch = async (url: RequestInfo, init?: RequestInit): Promise<Response> => {
-		const response = await fetch(url, init);
+		const response = await fetch(url, withoutContentLength(init));
 
 		// Capture router headers if present (fallback for non-streaming)
 		const routeHeader = response.headers.get("X-Router-Route");

--- a/src/lib/server/generation/finalize.ts
+++ b/src/lib/server/generation/finalize.ts
@@ -44,9 +44,11 @@ export async function markGenerationInterrupted(
 		{ $set: { "messages.$.interrupted": true, "messages.$.updatedAt": now, updatedAt: now } }
 	);
 	// Nothing is left to poll these, so leaving them pending invites an answer into the void.
+	// Scoped by conversation as well: `generationId` is client-chosen, so on its own it would
+	// let a caller close a prompt belonging to a chat this run has nothing to do with.
 	await collections.mcpElicitations
 		.updateMany(
-			{ generationId, status: "pending" },
+			{ generationId, conversationId: run.conversationId, status: "pending" },
 			{ $set: { status: "resolved", action: "cancel", resolvedAt: now, updatedAt: now } }
 		)
 		.catch((err) =>

--- a/src/lib/server/generation/finalize.ts
+++ b/src/lib/server/generation/finalize.ts
@@ -43,6 +43,15 @@ export async function markGenerationInterrupted(
 		},
 		{ $set: { "messages.$.interrupted": true, "messages.$.updatedAt": now, updatedAt: now } }
 	);
+	// Nothing is left to poll these, so leaving them pending invites an answer into the void.
+	await collections.mcpElicitations
+		.updateMany(
+			{ generationId, status: "pending" },
+			{ $set: { status: "resolved", action: "cancel", resolvedAt: now, updatedAt: now } }
+		)
+		.catch((err) =>
+			logger.error({ err, generationId }, "[generation] failed to close pending elicitations")
+		);
 }
 
 export async function finalizeActiveRunsOnExit(): Promise<void> {

--- a/src/lib/server/mcp/callDeadline.spec.ts
+++ b/src/lib/server/mcp/callDeadline.spec.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createCallDeadline } from "./httpClient";
+
+/**
+ * The tool call deadline is enforced here rather than by the MCP SDK, whose timer only a
+ * server-sent progress notification can reset. These are the properties that buys us.
+ */
+describe("createCallDeadline", () => {
+	beforeEach(() => vi.useFakeTimers());
+	afterEach(() => vi.useRealTimers());
+
+	it("aborts once the server has been silent for the timeout", () => {
+		const deadline = createCallDeadline(1_000);
+
+		vi.advanceTimersByTime(999);
+		expect(deadline.signal.aborted).toBe(false);
+
+		vi.advanceTimersByTime(1);
+		expect(deadline.signal.aborted).toBe(true);
+		expect(String(deadline.signal.reason)).toContain("1000ms");
+	});
+
+	it("does not run while a user is being asked something", () => {
+		// The whole point: a person taking five minutes over a form must not kill the call
+		// that is waiting on their answer.
+		const deadline = createCallDeadline(1_000);
+
+		deadline.pause();
+		vi.advanceTimersByTime(60_000);
+		expect(deadline.signal.aborted).toBe(false);
+
+		deadline.resume();
+		vi.advanceTimersByTime(999);
+		expect(deadline.signal.aborted).toBe(false);
+
+		vi.advanceTimersByTime(1);
+		expect(deadline.signal.aborted).toBe(true);
+	});
+
+	it("stays stopped until the last prompt is answered", () => {
+		// One call can be asked more than one thing before it finishes.
+		const deadline = createCallDeadline(1_000);
+
+		deadline.pause();
+		deadline.pause();
+		deadline.resume();
+		vi.advanceTimersByTime(5_000);
+		expect(deadline.signal.aborted).toBe(false);
+
+		deadline.resume();
+		vi.advanceTimersByTime(1_000);
+		expect(deadline.signal.aborted).toBe(true);
+	});
+
+	it("gives the server a fresh budget after each answer", () => {
+		const deadline = createCallDeadline(1_000);
+
+		vi.advanceTimersByTime(900);
+		deadline.pause();
+		deadline.resume();
+
+		vi.advanceTimersByTime(900);
+		expect(deadline.signal.aborted).toBe(false);
+	});
+
+	it("follows the caller's abort straight through", () => {
+		const outer = new AbortController();
+		const deadline = createCallDeadline(60_000, outer.signal);
+
+		outer.abort("Aborted by user");
+
+		expect(deadline.signal.aborted).toBe(true);
+		expect(deadline.signal.reason).toBe("Aborted by user");
+	});
+
+	it("starts aborted when the caller already gave up", () => {
+		const deadline = createCallDeadline(60_000, AbortSignal.abort("gone"));
+
+		expect(deadline.signal.aborted).toBe(true);
+	});
+
+	it("stops firing once disposed", () => {
+		const deadline = createCallDeadline(1_000);
+
+		deadline.dispose();
+		vi.advanceTimersByTime(60_000);
+
+		expect(deadline.signal.aborted).toBe(false);
+	});
+});

--- a/src/lib/server/mcp/callDeadline.spec.ts
+++ b/src/lib/server/mcp/callDeadline.spec.ts
@@ -1,10 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { createCallDeadline } from "./httpClient";
 
-/**
- * The tool call deadline is enforced here rather than by the MCP SDK, whose timer only a
- * server-sent progress notification can reset. These are the properties that buys us.
- */
 describe("createCallDeadline", () => {
 	beforeEach(() => vi.useFakeTimers());
 	afterEach(() => vi.useRealTimers());
@@ -21,8 +17,7 @@ describe("createCallDeadline", () => {
 	});
 
 	it("does not run while a user is being asked something", () => {
-		// The whole point: a person taking five minutes over a form must not kill the call
-		// that is waiting on their answer.
+		// The whole point: a slow answer must not kill the call waiting on it.
 		const deadline = createCallDeadline(1_000);
 
 		deadline.pause();

--- a/src/lib/server/mcp/client.spec.ts
+++ b/src/lib/server/mcp/client.spec.ts
@@ -53,16 +53,13 @@ describe("createMcpClient", () => {
 	});
 
 	it("declares both elicitation modes on session clients", () => {
-		// A bare `elicitation: {}` reads as form-only, and the server SDK then refuses to
-		// send a URL elicitation — so the mode has to be named to be reachable.
+		// A bare `elicitation: {}` reads as form-only and URL mode is never sent.
 		createMcpClient("session");
 
 		expect(built(0).options.capabilities).toEqual({ elicitation: { form: {}, url: {} } });
 	});
 
 	it("never declares elicitation to a health probe", () => {
-		// No chat is behind a probe, so a server told to elicit would be waiting on a
-		// screen nobody is looking at.
 		createMcpClient("health");
 
 		expect(built(0).options.capabilities).toEqual({});
@@ -70,8 +67,7 @@ describe("createMcpClient", () => {
 	});
 
 	it("registers a handler for every capability it declares", () => {
-		// A capability declared without a handler makes servers issue a request the SDK
-		// can only answer with method-not-found.
+		// A capability without a handler gets servers a method-not-found.
 		createMcpClient("session");
 
 		expect(Object.keys(built(0).options.capabilities)).toHaveLength(built(0).handlers.size);

--- a/src/lib/server/mcp/client.spec.ts
+++ b/src/lib/server/mcp/client.spec.ts
@@ -1,55 +1,89 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
-const constructed = vi.hoisted(() => [] as Array<{ info: unknown; options: unknown }>);
+const constructed = vi.hoisted(
+	() => [] as Array<{ info: unknown; options: unknown; handlers: Map<unknown, unknown> }>
+);
 
 vi.mock("@modelcontextprotocol/client", () => ({
 	Client: class {
+		handlers = new Map<unknown, unknown>();
 		constructor(info: unknown, options: unknown) {
-			constructed.push({ info, options });
+			constructed.push({ info, options, handlers: this.handlers });
+		}
+		setRequestHandler(schema: unknown, handler: unknown) {
+			this.handlers.set(schema, handler);
 		}
 	},
 }));
 
-const { createMcpClient, MCP_CLIENT_CAPABILITIES } = await import("./client");
+const elicitationEnabled = vi.hoisted(() => ({ value: true }));
+vi.mock("./elicitationConfig", () => ({
+	isElicitationEnabled: () => elicitationEnabled.value,
+	getElicitationTimeoutMs: () => 120_000,
+}));
 
-function infoAndOptionsOf(index: number) {
+const { createMcpClient, mcpClientCapabilities } = await import("./client");
+
+function built(index: number) {
 	return constructed[index] as {
 		info: { name: string; version: string };
 		options: { capabilities: Record<string, unknown> };
+		handlers: Map<unknown, unknown>;
 	};
 }
 
 describe("createMcpClient", () => {
-	it("declares capabilities on every client it builds", () => {
+	beforeEach(() => {
 		constructed.length = 0;
-
-		createMcpClient();
-		createMcpClient("health");
-
-		// Same declaration everywhere, or which client the server met decides the outcome.
-		expect(infoAndOptionsOf(0).options.capabilities).toBe(MCP_CLIENT_CAPABILITIES);
-		expect(infoAndOptionsOf(1).options.capabilities).toBe(MCP_CLIENT_CAPABILITIES);
+		elicitationEnabled.value = true;
 	});
 
 	it("keeps the session and health identities distinct", () => {
-		constructed.length = 0;
-
 		createMcpClient("session");
 		createMcpClient("health");
 
-		expect(infoAndOptionsOf(0).info).toEqual({ name: "chat-ui-mcp", version: "0.1.0" });
-		expect(infoAndOptionsOf(1).info).toEqual({ name: "chat-ui-health-check", version: "1.0.0" });
+		expect(built(0).info).toEqual({ name: "chat-ui-mcp", version: "0.1.0" });
+		expect(built(1).info).toEqual({ name: "chat-ui-health-check", version: "1.0.0" });
 	});
 
 	it("builds a session client by default", () => {
-		constructed.length = 0;
-
 		createMcpClient();
 
-		expect(infoAndOptionsOf(0).info).toEqual({ name: "chat-ui-mcp", version: "0.1.0" });
+		expect(built(0).info).toEqual({ name: "chat-ui-mcp", version: "0.1.0" });
 	});
 
-	it("declares nothing it cannot yet answer", () => {
-		expect(MCP_CLIENT_CAPABILITIES).toEqual({});
+	it("declares both elicitation modes on session clients", () => {
+		// A bare `elicitation: {}` reads as form-only, and the server SDK then refuses to
+		// send a URL elicitation — so the mode has to be named to be reachable.
+		createMcpClient("session");
+
+		expect(built(0).options.capabilities).toEqual({ elicitation: { form: {}, url: {} } });
+	});
+
+	it("never declares elicitation to a health probe", () => {
+		// No chat is behind a probe, so a server told to elicit would be waiting on a
+		// screen nobody is looking at.
+		createMcpClient("health");
+
+		expect(built(0).options.capabilities).toEqual({});
+		expect(built(0).handlers.size).toBe(0);
+	});
+
+	it("registers a handler for every capability it declares", () => {
+		// A capability declared without a handler makes servers issue a request the SDK
+		// can only answer with method-not-found.
+		createMcpClient("session");
+
+		expect(Object.keys(built(0).options.capabilities)).toHaveLength(built(0).handlers.size);
+	});
+
+	it("declares nothing when elicitation is switched off", () => {
+		elicitationEnabled.value = false;
+
+		createMcpClient("session");
+
+		expect(built(0).options.capabilities).toEqual({});
+		expect(built(0).handlers.size).toBe(0);
+		expect(mcpClientCapabilities("session")).toEqual({});
 	});
 });

--- a/src/lib/server/mcp/client.ts
+++ b/src/lib/server/mcp/client.ts
@@ -2,17 +2,12 @@ import { Client, type ClientCapabilities } from "@modelcontextprotocol/client";
 import { isElicitationEnabled } from "./elicitationConfig";
 
 /**
- * A capability declared without a handler makes servers issue a request the SDK can only
- * answer with method-not-found. Add one only in the change that implements its handler.
- *
- * `elicitation` is declared for session clients only. A health probe has no chat behind
- * it, so a server that asked it for user input would be told to wait on a screen nobody
- * is looking at.
+ * Declare a capability only in the change that implements its handler, or servers issue
+ * requests the SDK can only answer with method-not-found. Health probes get none: there is
+ * no chat behind them to ask. Spell both elicitation modes out — a bare `elicitation: {}`
+ * reads as form-only and the server SDK then refuses to send a URL elicitation at all.
  */
 export function mcpClientCapabilities(kind: McpClientKind): ClientCapabilities {
-	// Both modes spelled out: a bare `elicitation: {}` is read as `{ form: {} }`, and the
-	// server SDK then refuses to send a URL elicitation at all ("Client does not support
-	// url elicitation") — the handler for it would never run.
 	return kind === "session" && isElicitationEnabled() ? { elicitation: { form: {}, url: {} } } : {};
 }
 

--- a/src/lib/server/mcp/client.ts
+++ b/src/lib/server/mcp/client.ts
@@ -31,6 +31,9 @@ export function createMcpClient(kind: McpClientKind = "session"): Client {
 		// The SDK defaults to `legacy`, i.e. never negotiating. Probe instead, and let the
 		// probe fall back on its own for the 2025-era servers that are still the majority.
 		versionNegotiation: { mode: "auto" },
+		// A 2026-era prompt outlives this call, so the driver must not block our handler
+		// waiting for one. `callMcpTool` opts each call into receiving `input_required`.
+		inputRequired: { autoFulfill: false },
 	});
 
 	if (capabilities.elicitation) {

--- a/src/lib/server/mcp/client.ts
+++ b/src/lib/server/mcp/client.ts
@@ -1,10 +1,20 @@
 import { Client, type ClientCapabilities } from "@modelcontextprotocol/client";
+import { isElicitationEnabled } from "./elicitationConfig";
+
 /**
- * Empty on purpose: a capability declared without a handler makes servers issue a
- * request the SDK can only answer with method-not-found. Add one only in the change
- * that implements its handler.
+ * A capability declared without a handler makes servers issue a request the SDK can only
+ * answer with method-not-found. Add one only in the change that implements its handler.
+ *
+ * `elicitation` is declared for session clients only. A health probe has no chat behind
+ * it, so a server that asked it for user input would be told to wait on a screen nobody
+ * is looking at.
  */
-export const MCP_CLIENT_CAPABILITIES: ClientCapabilities = {};
+export function mcpClientCapabilities(kind: McpClientKind): ClientCapabilities {
+	// Both modes spelled out: a bare `elicitation: {}` is read as `{ form: {} }`, and the
+	// server SDK then refuses to send a URL elicitation at all ("Client does not support
+	// url elicitation") — the handler for it would never run.
+	return kind === "session" && isElicitationEnabled() ? { elicitation: { form: {}, url: {} } } : {};
+}
 
 // Servers can tell these apart, so a health probe stays distinguishable from a session.
 const CLIENT_INFO = {
@@ -20,10 +30,22 @@ export type McpClientKind = keyof typeof CLIENT_INFO;
  * would look declared and never fire.
  */
 export function createMcpClient(kind: McpClientKind = "session"): Client {
-	return new Client(CLIENT_INFO[kind], {
-		capabilities: MCP_CLIENT_CAPABILITIES,
+	const capabilities = mcpClientCapabilities(kind);
+	const client = new Client(CLIENT_INFO[kind], {
+		capabilities,
 		// The SDK defaults to `legacy`, i.e. never negotiating. Probe instead, and let the
 		// probe fall back on its own for the 2025-era servers that are still the majority.
 		versionNegotiation: { mode: "auto" },
 	});
+
+	if (capabilities.elicitation) {
+		// Imported on demand, or every module building a client drags in a Mongo connection.
+		client.setRequestHandler("elicitation/create", async (request, ctx) => {
+			const { handleElicitationRequest } = await import("./elicitation");
+			// Fires on `notifications/cancelled`, i.e. the server gave up.
+			return handleElicitationRequest(client, request.params, ctx.mcpReq.signal);
+		});
+	}
+
+	return client;
 }

--- a/src/lib/server/mcp/clientPool.spec.ts
+++ b/src/lib/server/mcp/clientPool.spec.ts
@@ -1,11 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-const built = vi.hoisted(() => ({ clients: [] as { closed: boolean }[] }));
+const built = vi.hoisted(() => ({
+	clients: [] as { closed: boolean }[],
+	era: "legacy" as "legacy" | "modern",
+}));
 
 vi.mock("./client", () => ({
 	createMcpClient: () => {
 		const client = {
 			closed: false,
+			getProtocolEra: () => built.era,
 			async connect() {},
 			async close() {
 				this.closed = true;
@@ -25,13 +29,15 @@ vi.mock("@modelcontextprotocol/client", () => ({
 }));
 vi.mock("$lib/server/urlSafety", () => ({ mcpFetch: () => Promise.resolve(new Response()) }));
 
-const { getClient, retainClient, releaseClient, evictFromPool } = await import("./clientPool");
+const { getClient, retainClient, releaseClient, evictFromPool, getAttributableClient } =
+	await import("./clientPool");
 
 const SERVER = { name: "Shared", url: "https://shared.example/mcp" };
 
 describe("a pooled client shared by two conversations", () => {
 	beforeEach(() => {
 		built.clients.length = 0;
+		built.era = "legacy";
 	});
 
 	it("is not closed out from under a call another conversation is still making", async () => {
@@ -61,5 +67,36 @@ describe("a pooled client shared by two conversations", () => {
 		const evicted = evictFromPool(SERVER);
 
 		expect(evicted).toBe(client);
+	});
+});
+
+describe("a connection a prompt has to be attributed on", () => {
+	beforeEach(() => {
+		built.clients.length = 0;
+		built.era = "legacy";
+	});
+
+	it("is per-conversation on a legacy server", async () => {
+		const server = { name: "Legacy", url: "https://legacy.example/mcp" };
+
+		const a = await getAttributableClient(server, "conversation-a");
+		const b = await getAttributableClient(server, "conversation-b");
+
+		expect(a.client).not.toBe(b.client);
+		expect(a.isolation).not.toBe(b.isolation);
+
+		// The same conversation keeps its own connection rather than opening another.
+		expect((await getAttributableClient(server, "conversation-a")).client).toBe(a.client);
+	});
+
+	it("is shared on a modern server, which answers the call instead of pushing a prompt", async () => {
+		built.era = "modern";
+		const server = { name: "Modern", url: "https://modern.example/mcp" };
+
+		const a = await getAttributableClient(server, "conversation-a");
+		const b = await getAttributableClient(server, "conversation-b");
+
+		expect(a.client).toBe(b.client);
+		expect(a.isolation).toBeUndefined();
 	});
 });

--- a/src/lib/server/mcp/clientPool.spec.ts
+++ b/src/lib/server/mcp/clientPool.spec.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const built = vi.hoisted(() => ({ clients: [] as { closed: boolean }[] }));
+
+vi.mock("./client", () => ({
+	createMcpClient: () => {
+		const client = {
+			closed: false,
+			async connect() {},
+			async close() {
+				this.closed = true;
+			},
+		};
+		built.clients.push(client);
+		return client;
+	},
+}));
+vi.mock("@modelcontextprotocol/client", () => ({
+	StreamableHTTPClientTransport: class {
+		constructor(public url: unknown) {}
+	},
+	SSEClientTransport: class {
+		constructor(public url: unknown) {}
+	},
+}));
+vi.mock("$lib/server/urlSafety", () => ({ mcpFetch: () => Promise.resolve(new Response()) }));
+
+const { getClient, retainClient, releaseClient, evictFromPool } = await import("./clientPool");
+
+const SERVER = { name: "Shared", url: "https://shared.example/mcp" };
+
+describe("a pooled client shared by two conversations", () => {
+	beforeEach(() => {
+		built.clients.length = 0;
+	});
+
+	it("is not closed out from under a call another conversation is still making", async () => {
+		const client = await getClient(SERVER);
+		// Conversation B is mid-call on the same pooled connection.
+		retainClient(client);
+
+		// Conversation A decides the connection looks broken.
+		const evicted = evictFromPool(SERVER);
+
+		// A gets nothing to close, so B's call survives.
+		expect(evicted).toBeUndefined();
+		expect((client as unknown as { closed: boolean }).closed).toBe(false);
+
+		// The next caller gets a fresh connection rather than the retired one.
+		const replacement = await getClient(SERVER);
+		expect(replacement).not.toBe(client);
+
+		// B finishes, and only then is the retired connection closed.
+		releaseClient(client);
+		await vi.waitFor(() => expect((client as unknown as { closed: boolean }).closed).toBe(true));
+	});
+
+	it("hands back an idle client so the caller can close it", async () => {
+		const client = await getClient(SERVER);
+
+		const evicted = evictFromPool(SERVER);
+
+		expect(evicted).toBe(client);
+	});
+});

--- a/src/lib/server/mcp/clientPool.ts
+++ b/src/lib/server/mcp/clientPool.ts
@@ -57,16 +57,20 @@ function ensureSweeper() {
 	sweeper.unref?.();
 }
 
-function keyOf(server: McpServerConfig) {
+function keyOf(server: McpServerConfig, isolation?: string) {
 	const headers = Object.entries(server.headers ?? {})
 		.sort(([a], [b]) => a.localeCompare(b))
 		.map(([k, v]) => `${k}:${v}`)
 		.join("|\u0000|");
-	return `${server.url}|${headers}`;
+	return `${server.url}|${headers}|${isolation ?? ""}`;
 }
 
-export async function getClient(server: McpServerConfig, signal?: AbortSignal): Promise<Client> {
-	const key = keyOf(server);
+export async function getClient(
+	server: McpServerConfig,
+	signal?: AbortSignal,
+	isolation?: string
+): Promise<Client> {
+	const key = keyOf(server, isolation);
 	const existing = pool.get(key);
 	if (existing) {
 		if (Date.now() - existing.lastUsedAt <= PING_AFTER_IDLE_MS) {
@@ -157,8 +161,8 @@ export async function drainPool() {
  * Take a client out of circulation. Returns it only when nothing else is using it, so the
  * caller cannot close a connection another conversation is still talking over.
  */
-export function evictFromPool(server: McpServerConfig): Client | undefined {
-	const key = keyOf(server);
+export function evictFromPool(server: McpServerConfig, isolation?: string): Client | undefined {
+	const key = keyOf(server, isolation);
 	const entry = pool.get(key);
 	if (!entry) return undefined;
 	pool.delete(key);
@@ -168,4 +172,24 @@ export function evictFromPool(server: McpServerConfig): Client | undefined {
 	}
 	entries.delete(entry.client);
 	return entry.client;
+}
+
+/**
+ * A connection an unsolicited `elicitation/create` can be attributed on. A legacy server
+ * pushes one down the connection with nothing tying it to a call, so it can only be routed
+ * when every call on that connection belongs to the same conversation; sharing one instead
+ * means a prompt raised for one chat gets declined because another chat is also mid-call.
+ * A modern server answers the call itself, so it keeps the shared connection.
+ */
+export async function getAttributableClient(
+	server: McpServerConfig,
+	conversationId: string,
+	signal?: AbortSignal
+): Promise<{ client: Client; isolation?: string }> {
+	const isolation = `conversation:${conversationId}`;
+	if (!pool.has(keyOf(server, isolation))) {
+		const shared = await getClient(server, signal);
+		if (shared.getProtocolEra() === "modern") return { client: shared };
+	}
+	return { client: await getClient(server, signal, isolation), isolation };
 }

--- a/src/lib/server/mcp/clientPool.ts
+++ b/src/lib/server/mcp/clientPool.ts
@@ -4,9 +4,21 @@ import { createMcpClient } from "./client";
 import type { McpServerConfig } from "./httpClient";
 import { mcpFetch } from "$lib/server/urlSafety";
 
-type PoolEntry = { client: Client; lastUsedAt: number; activeCalls: number };
+type PoolEntry = {
+	client: Client;
+	lastUsedAt: number;
+	activeCalls: number;
+	/** Evicted from the pool; closed once its last in-flight call finishes. */
+	retired?: boolean;
+};
 
 const pool = new Map<string, PoolEntry>();
+
+/**
+ * Entries by client, so retain/release still find one after it leaves the pool, and
+ * evicted clients with calls still running can be closed by the last one to finish.
+ */
+const entries = new Map<Client, PoolEntry>();
 
 // Reuse a recently-used client as-is; ping it first if it has been idle longer than this,
 // since proxies / load balancers silently reap idle connections.
@@ -37,6 +49,7 @@ function ensureSweeper() {
 		for (const [key, entry] of pool) {
 			if (entry.activeCalls === 0 && now - entry.lastUsedAt > IDLE_TTL_MS) {
 				pool.delete(key);
+				entries.delete(entry.client);
 				void disposeClient(entry.client);
 			}
 		}
@@ -105,43 +118,54 @@ export async function getClient(server: McpServerConfig, signal?: AbortSignal): 
 		throw err;
 	}
 
-	pool.set(key, { client, lastUsedAt: Date.now(), activeCalls: 0 });
+	const entry: PoolEntry = { client, lastUsedAt: Date.now(), activeCalls: 0 };
+	pool.set(key, entry);
+	entries.set(client, entry);
 	ensureSweeper();
 	return client;
 }
 
 /** Mark a pooled client as having an in-flight call so the sweeper won't close it. */
 export function retainClient(client: Client) {
-	for (const entry of pool.values()) {
-		if (entry.client === client) {
-			entry.activeCalls++;
-			return;
-		}
-	}
+	const entry = entries.get(client);
+	if (entry) entry.activeCalls++;
 }
 
 export function releaseClient(client: Client) {
-	for (const entry of pool.values()) {
-		if (entry.client === client) {
-			entry.activeCalls = Math.max(0, entry.activeCalls - 1);
-			entry.lastUsedAt = Date.now();
-			return;
-		}
+	const entry = entries.get(client);
+	if (!entry) return;
+	entry.activeCalls = Math.max(0, entry.activeCalls - 1);
+	entry.lastUsedAt = Date.now();
+	// A client is only evicted because it looked broken to one caller. Closing it while
+	// another conversation is still mid-call would cancel that call too, so the last one
+	// out closes the door.
+	if (entry.retired && entry.activeCalls === 0) {
+		entries.delete(client);
+		void disposeClient(client);
 	}
 }
 
 export async function drainPool() {
 	for (const [key, entry] of pool) {
 		await disposeClient(entry.client);
+		entries.delete(entry.client);
 		pool.delete(key);
 	}
 }
 
+/**
+ * Take a client out of circulation. Returns it only when nothing else is using it, so the
+ * caller cannot close a connection another conversation is still talking over.
+ */
 export function evictFromPool(server: McpServerConfig): Client | undefined {
 	const key = keyOf(server);
 	const entry = pool.get(key);
-	if (entry) {
-		pool.delete(key);
+	if (!entry) return undefined;
+	pool.delete(key);
+	if (entry.activeCalls > 0) {
+		entry.retired = true;
+		return undefined;
 	}
-	return entry?.client;
+	entries.delete(entry.client);
+	return entry.client;
 }

--- a/src/lib/server/mcp/elicitation.spec.ts
+++ b/src/lib/server/mcp/elicitation.spec.ts
@@ -367,7 +367,8 @@ describe("submitElicitationAnswer", () => {
 			content: { name: "Ada" },
 		});
 
-		expect(result).toEqual({ ok: true });
+		// `resume: false` — a blocking prompt is already unblocked by the write itself.
+		expect(result).toEqual({ ok: true, resume: false });
 		const row = await collections.mcpElicitations.findOne({ elicitationId });
 		expect(row).toMatchObject({ status: "resolved", action: "accept", content: { name: "Ada" } });
 	});

--- a/src/lib/server/mcp/elicitation.spec.ts
+++ b/src/lib/server/mcp/elicitation.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { ObjectId } from "mongodb";
-import type { Client } from "@modelcontextprotocol/sdk/client";
+import type { Client } from "@modelcontextprotocol/client";
 import { collections, ready } from "$lib/server/database";
 import {
 	handleElicitationRequest,

--- a/src/lib/server/mcp/elicitation.spec.ts
+++ b/src/lib/server/mcp/elicitation.spec.ts
@@ -39,7 +39,6 @@ const newClient = () => ({}) as Client;
 function makeSink(conversationId: ObjectId, generationId: string) {
 	const updates: MessageUpdate[] = [];
 	const sink: ElicitationSink = {
-		id: generationId,
 		conversationId,
 		generationId,
 		emit: (update) => updates.push(update),
@@ -120,6 +119,23 @@ describe("elicitation routing", () => {
 		);
 
 		// Routing either way would show one user's prompt in the other's conversation.
+		expect(result).toEqual({ action: "cancel" });
+		expect(a.updates).toHaveLength(0);
+		expect(b.updates).toHaveLength(0);
+	});
+
+	it("cancels even when two generations claim the same id", async () => {
+		// generationId comes from the request body, so it cannot be the audience check.
+		const client = newClient();
+		const a = makeSink(new ObjectId(), "same-id");
+		const b = makeSink(new ObjectId(), "same-id");
+
+		const result = await withElicitationContext(client, context(a.sink), () =>
+			withElicitationContext(client, context(b.sink), () =>
+				handleElicitationRequest(client, FORM_PARAMS)
+			)
+		);
+
 		expect(result).toEqual({ action: "cancel" });
 		expect(a.updates).toHaveLength(0);
 		expect(b.updates).toHaveLength(0);

--- a/src/lib/server/mcp/elicitation.spec.ts
+++ b/src/lib/server/mcp/elicitation.spec.ts
@@ -1,0 +1,424 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { ObjectId } from "mongodb";
+import type { Client } from "@modelcontextprotocol/sdk/client";
+import { collections, ready } from "$lib/server/database";
+import {
+	handleElicitationRequest,
+	submitElicitationAnswer,
+	withElicitationContext,
+	type ElicitationSink,
+} from "./elicitation";
+import {
+	MessageElicitationUpdateType,
+	MessageUpdateType,
+	type MessageElicitationRequestUpdate,
+	type MessageElicitationResolvedUpdate,
+	type MessageUpdate,
+} from "$lib/types/MessageUpdate";
+
+const elicitationTimeoutMs = vi.hoisted(() => ({ value: 30_000 }));
+vi.mock("./elicitationConfig", () => ({
+	isElicitationEnabled: () => true,
+	getElicitationTimeoutMs: () => elicitationTimeoutMs.value,
+}));
+
+await ready;
+
+const FORM_PARAMS = {
+	message: "What is your name?",
+	requestedSchema: {
+		type: "object",
+		properties: { name: { type: "string" } },
+		required: ["name"],
+	},
+};
+
+// `withElicitationContext` only uses the client as a map key, so a bare object is enough.
+const newClient = () => ({}) as Client;
+
+function makeSink(conversationId: ObjectId, generationId: string) {
+	const updates: MessageUpdate[] = [];
+	const sink: ElicitationSink = {
+		id: generationId,
+		conversationId,
+		generationId,
+		emit: (update) => updates.push(update),
+	};
+	return { sink, updates };
+}
+
+/** Records pause/resume so tests can assert the tool call's clock actually stops. */
+const spyDeadline = () => {
+	const calls: string[] = [];
+	return {
+		calls,
+		pause: () => void calls.push("pause"),
+		resume: () => void calls.push("resume"),
+	};
+};
+
+const context = (
+	sink: ElicitationSink,
+	overrides: Partial<{
+		toolUuid: string;
+		signal: AbortSignal;
+		deadline: ReturnType<typeof spyDeadline>;
+	}> = {}
+) => ({
+	sink,
+	server: "Test Server",
+	toolUuid: "tool-1",
+	deadline: spyDeadline(),
+	...overrides,
+});
+
+const requestUpdates = (updates: MessageUpdate[]) =>
+	updates.filter(
+		(u): u is MessageElicitationRequestUpdate =>
+			u.type === MessageUpdateType.Elicitation && u.subtype === MessageElicitationUpdateType.Request
+	);
+
+const resolvedUpdate = (updates: MessageUpdate[]) =>
+	updates.find(
+		(u): u is MessageElicitationResolvedUpdate =>
+			u.type === MessageUpdateType.Elicitation &&
+			u.subtype === MessageElicitationUpdateType.Resolved
+	);
+
+async function waitForRequest(updates: MessageUpdate[]): Promise<MessageElicitationRequestUpdate> {
+	for (let i = 0; i < 200; i++) {
+		const [first] = requestUpdates(updates);
+		if (first) return first;
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
+	throw new Error("no elicitation request was emitted");
+}
+
+describe("elicitation routing", () => {
+	beforeEach(async () => {
+		elicitationTimeoutMs.value = 30_000;
+		await collections.mcpElicitations.deleteMany({});
+	});
+
+	it("cancels when no tool call is in flight on the connection", async () => {
+		// e.g. a server eliciting during a tool listing, where there is no chat to ask.
+		const result = await handleElicitationRequest(newClient(), FORM_PARAMS);
+
+		expect(result).toEqual({ action: "cancel" });
+		expect(await collections.mcpElicitations.countDocuments({})).toBe(0);
+	});
+
+	it("cancels rather than guess between two generations sharing a pooled client", async () => {
+		const client = newClient();
+		const a = makeSink(new ObjectId(), "gen-a");
+		const b = makeSink(new ObjectId(), "gen-b");
+
+		const result = await withElicitationContext(client, context(a.sink), () =>
+			withElicitationContext(client, context(b.sink), () =>
+				handleElicitationRequest(client, FORM_PARAMS)
+			)
+		);
+
+		// Routing either way would show one user's prompt in the other's conversation.
+		expect(result).toEqual({ action: "cancel" });
+		expect(a.updates).toHaveLength(0);
+		expect(b.updates).toHaveLength(0);
+	});
+
+	it("attributes the prompt to the tool call when only one is running", async () => {
+		const client = newClient();
+		const { sink, updates } = makeSink(new ObjectId(), "gen-1");
+
+		const pending = withElicitationContext(client, context(sink, { toolUuid: "tool-42" }), () =>
+			handleElicitationRequest(client, FORM_PARAMS)
+		);
+
+		const request = await waitForRequest(updates);
+		expect(request.toolUuid).toBe("tool-42");
+		expect(request.request).toMatchObject({
+			server: "Test Server",
+			mode: "form",
+			message: "What is your name?",
+		});
+
+		await submitElicitationAnswer({
+			elicitationId: request.request.elicitationId,
+			conversationId: sink.conversationId,
+			action: "accept",
+			content: { name: "Ada" },
+		});
+
+		expect(await pending).toEqual({ action: "accept", content: { name: "Ada" } });
+		expect(resolvedUpdate(updates)).toMatchObject({ action: "accept", resolution: "user" });
+	});
+
+	it("leaves the prompt unattributed when the same run has parallel calls", async () => {
+		const client = newClient();
+		const { sink, updates } = makeSink(new ObjectId(), "gen-1");
+
+		const pending = withElicitationContext(client, context(sink, { toolUuid: "tool-1" }), () =>
+			withElicitationContext(client, context(sink, { toolUuid: "tool-2" }), () =>
+				handleElicitationRequest(client, FORM_PARAMS)
+			)
+		);
+
+		const request = await waitForRequest(updates);
+		// Same audience, so it is safe to show — but which of the two calls asked is unknown.
+		expect(request.toolUuid).toBeUndefined();
+
+		await submitElicitationAnswer({
+			elicitationId: request.request.elicitationId,
+			conversationId: sink.conversationId,
+			action: "decline",
+		});
+
+		expect(await pending).toEqual({ action: "decline" });
+	});
+
+	it("stops the tool call's clock for as long as the prompt is open", async () => {
+		// Without this the call would expire underneath a user who takes their time, since
+		// MCP has no way to tell a server that a human is still thinking.
+		const client = newClient();
+		const { sink, updates } = makeSink(new ObjectId(), "gen-1");
+		const deadline = spyDeadline();
+
+		const pending = withElicitationContext(client, context(sink, { deadline }), () =>
+			handleElicitationRequest(client, FORM_PARAMS)
+		);
+
+		const request = await waitForRequest(updates);
+		expect(deadline.calls).toEqual(["pause"]);
+
+		await submitElicitationAnswer({
+			elicitationId: request.request.elicitationId,
+			conversationId: sink.conversationId,
+			action: "accept",
+			content: { name: "Ada" },
+		});
+		await pending;
+
+		expect(deadline.calls).toEqual(["pause", "resume"]);
+	});
+
+	it("restarts the clock even when nobody answers", async () => {
+		elicitationTimeoutMs.value = 300;
+		const client = newClient();
+		const { sink, updates } = makeSink(new ObjectId(), "gen-1");
+		const deadline = spyDeadline();
+
+		const result = await withElicitationContext(client, context(sink, { deadline }), () =>
+			handleElicitationRequest(client, FORM_PARAMS)
+		);
+
+		expect(result).toEqual({ action: "cancel" });
+		expect(resolvedUpdate(updates)).toMatchObject({ action: "cancel", resolution: "expired" });
+		expect(deadline.calls).toEqual(["pause", "resume"]);
+	});
+
+	it("stops every call in the round, not just the one it picked", async () => {
+		// Which of the parallel calls asked is unknowable, and they are all part of the
+		// round the user is answering for.
+		const client = newClient();
+		const { sink, updates } = makeSink(new ObjectId(), "gen-1");
+		const first = spyDeadline();
+		const second = spyDeadline();
+
+		const pending = withElicitationContext(client, context(sink, { deadline: first }), () =>
+			withElicitationContext(client, context(sink, { deadline: second }), () =>
+				handleElicitationRequest(client, FORM_PARAMS)
+			)
+		);
+
+		const request = await waitForRequest(updates);
+		expect(first.calls).toEqual(["pause"]);
+		expect(second.calls).toEqual(["pause"]);
+
+		await submitElicitationAnswer({
+			elicitationId: request.request.elicitationId,
+			conversationId: sink.conversationId,
+			action: "cancel",
+		});
+		await pending;
+
+		expect(first.calls).toEqual(["pause", "resume"]);
+		expect(second.calls).toEqual(["pause", "resume"]);
+	});
+
+	it("closes the prompt when the server withdraws its request", async () => {
+		// Servers put their own timeout on `elicitation/create` — 60s by SDK default — and
+		// send `notifications/cancelled` when it fires. Leaving the form up after that
+		// would invite an answer nobody is listening for.
+		const client = newClient();
+		const { sink, updates } = makeSink(new ObjectId(), "gen-1");
+		const server = new AbortController();
+
+		const pending = withElicitationContext(client, context(sink), () =>
+			handleElicitationRequest(client, FORM_PARAMS, server.signal)
+		);
+
+		await waitForRequest(updates);
+		server.abort();
+
+		expect(await pending).toEqual({ action: "cancel" });
+		expect(resolvedUpdate(updates)).toMatchObject({ resolution: "withdrawn" });
+	});
+
+	it("blames the user's stop, not the server, when both give up", async () => {
+		const client = newClient();
+		const { sink, updates } = makeSink(new ObjectId(), "gen-1");
+		const generation = new AbortController();
+		const server = new AbortController();
+
+		const pending = withElicitationContext(
+			client,
+			context(sink, { signal: generation.signal }),
+			() => handleElicitationRequest(client, FORM_PARAMS, server.signal)
+		);
+
+		await waitForRequest(updates);
+		// Stopping the response is what makes the server hang up, so the user's action is
+		// the honest explanation of the two.
+		generation.abort();
+		server.abort();
+
+		await pending;
+		expect(resolvedUpdate(updates)).toMatchObject({ resolution: "aborted" });
+	});
+
+	it("stops waiting when the generation is aborted", async () => {
+		const client = newClient();
+		const { sink, updates } = makeSink(new ObjectId(), "gen-1");
+		const controller = new AbortController();
+
+		const pending = withElicitationContext(
+			client,
+			context(sink, { signal: controller.signal }),
+			() => handleElicitationRequest(client, FORM_PARAMS)
+		);
+
+		await waitForRequest(updates);
+		controller.abort();
+
+		expect(await pending).toEqual({ action: "cancel" });
+		expect(resolvedUpdate(updates)).toMatchObject({ resolution: "aborted" });
+	});
+
+	it("declines an unsupported request without recording it", async () => {
+		const client = newClient();
+		const { sink, updates } = makeSink(new ObjectId(), "gen-1");
+
+		const result = await withElicitationContext(client, context(sink), () =>
+			handleElicitationRequest(client, { mode: "url", message: "Sign in", url: "javascript:1" })
+		);
+
+		expect(result).toEqual({ action: "cancel" });
+		expect(updates).toHaveLength(0);
+		expect(await collections.mcpElicitations.countDocuments({})).toBe(0);
+	});
+});
+
+describe("submitElicitationAnswer", () => {
+	const conversationId = new ObjectId();
+
+	const pendingRow = async (overrides: { expiresAt?: Date } = {}) => {
+		const elicitationId = crypto.randomUUID();
+		const now = new Date();
+		await collections.mcpElicitations.insertOne({
+			_id: new ObjectId(),
+			elicitationId,
+			conversationId,
+			status: "pending",
+			request: {
+				elicitationId,
+				server: "Test Server",
+				mode: "form",
+				message: "What is your name?",
+				fields: [{ kind: "string", name: "name", required: true }],
+			},
+			expiresAt: overrides.expiresAt ?? new Date(Date.now() + 60_000),
+			createdAt: now,
+			updatedAt: now,
+		});
+		return elicitationId;
+	};
+
+	beforeEach(async () => {
+		await collections.mcpElicitations.deleteMany({});
+	});
+
+	it("records a validated answer", async () => {
+		const elicitationId = await pendingRow();
+
+		const result = await submitElicitationAnswer({
+			elicitationId,
+			conversationId,
+			action: "accept",
+			content: { name: "Ada" },
+		});
+
+		expect(result).toEqual({ ok: true });
+		const row = await collections.mcpElicitations.findOne({ elicitationId });
+		expect(row).toMatchObject({ status: "resolved", action: "accept", content: { name: "Ada" } });
+	});
+
+	it("refuses an answer from another conversation", async () => {
+		// Holding the id is not authority to answer a prompt raised somewhere else.
+		const elicitationId = await pendingRow();
+
+		const result = await submitElicitationAnswer({
+			elicitationId,
+			conversationId: new ObjectId(),
+			action: "accept",
+			content: { name: "Mallory" },
+		});
+
+		expect(result).toMatchObject({ ok: false, status: 404 });
+	});
+
+	it("refuses an answer that does not match the requested schema", async () => {
+		const elicitationId = await pendingRow();
+
+		const result = await submitElicitationAnswer({
+			elicitationId,
+			conversationId,
+			action: "accept",
+			content: { unexpected: "value" },
+		});
+
+		expect(result).toMatchObject({ ok: false, status: 400 });
+		expect(await collections.mcpElicitations.findOne({ elicitationId })).toMatchObject({
+			status: "pending",
+		});
+	});
+
+	it("refuses a second answer", async () => {
+		const elicitationId = await pendingRow();
+
+		await submitElicitationAnswer({
+			elicitationId,
+			conversationId,
+			action: "accept",
+			content: { name: "Ada" },
+		});
+		const second = await submitElicitationAnswer({
+			elicitationId,
+			conversationId,
+			action: "decline",
+		});
+
+		expect(second).toMatchObject({ ok: false, status: 409 });
+	});
+
+	it("refuses an answer after the server stopped waiting", async () => {
+		const elicitationId = await pendingRow({ expiresAt: new Date(Date.now() - 1) });
+
+		const result = await submitElicitationAnswer({
+			elicitationId,
+			conversationId,
+			action: "accept",
+			content: { name: "Ada" },
+		});
+
+		expect(result).toMatchObject({ ok: false, status: 409 });
+	});
+});

--- a/src/lib/server/mcp/elicitation.spec.ts
+++ b/src/lib/server/mcp/elicitation.spec.ts
@@ -176,8 +176,7 @@ describe("elicitation routing", () => {
 	});
 
 	it("stops the tool call's clock for as long as the prompt is open", async () => {
-		// Without this the call would expire underneath a user who takes their time, since
-		// MCP has no way to tell a server that a human is still thinking.
+		// Without this the call expires underneath a user who takes their time.
 		const client = newClient();
 		const { sink, updates } = makeSink(new ObjectId(), "gen-1");
 		const deadline = spyDeadline();
@@ -216,8 +215,7 @@ describe("elicitation routing", () => {
 	});
 
 	it("stops every call in the round, not just the one it picked", async () => {
-		// Which of the parallel calls asked is unknowable, and they are all part of the
-		// round the user is answering for.
+		// Which of the parallel calls asked is unknowable.
 		const client = newClient();
 		const { sink, updates } = makeSink(new ObjectId(), "gen-1");
 		const first = spyDeadline();
@@ -245,9 +243,7 @@ describe("elicitation routing", () => {
 	});
 
 	it("closes the prompt when the server withdraws its request", async () => {
-		// Servers put their own timeout on `elicitation/create` — 60s by SDK default — and
-		// send `notifications/cancelled` when it fires. Leaving the form up after that
-		// would invite an answer nobody is listening for.
+		// Servers time out their own request (60s by SDK default) and cancel it.
 		const client = newClient();
 		const { sink, updates } = makeSink(new ObjectId(), "gen-1");
 		const server = new AbortController();
@@ -276,8 +272,7 @@ describe("elicitation routing", () => {
 		);
 
 		await waitForRequest(updates);
-		// Stopping the response is what makes the server hang up, so the user's action is
-		// the honest explanation of the two.
+		// Stopping the response is what makes the server hang up.
 		generation.abort();
 		server.abort();
 

--- a/src/lib/server/mcp/elicitation.ts
+++ b/src/lib/server/mcp/elicitation.ts
@@ -3,6 +3,7 @@ import { ObjectId } from "mongodb";
 import type { Client } from "@modelcontextprotocol/client";
 import { collections } from "$lib/server/database";
 import { logger } from "$lib/server/logger";
+import type { McpElicitation } from "$lib/types/McpElicitation";
 import type {
 	ElicitationAction,
 	ElicitationRequestPayload,
@@ -16,7 +17,8 @@ import {
 } from "$lib/types/MessageUpdate";
 import { normalizeElicitationRequest, validateElicitationContent } from "./elicitationSchema";
 import { getElicitationTimeoutMs } from "./elicitationConfig";
-import type { McpCallDeadline } from "./httpClient";
+import type { McpCallDeadline, McpInputRequired } from "./httpClient";
+import type { InputResponses } from "@modelcontextprotocol/client";
 
 const POLL_INTERVAL_MS = 400;
 
@@ -256,7 +258,8 @@ export async function handleElicitationRequest(
 		: { action: outcome.action };
 }
 
-export type SubmitResult = { ok: true } | { ok: false; status: 400 | 404 | 409; error: string };
+export type SubmitResult =
+	{ ok: true; resume: boolean } | { ok: false; status: 400 | 404 | 409; error: string };
 
 export async function submitElicitationAnswer({
 	elicitationId,
@@ -273,7 +276,7 @@ export async function submitElicitationAnswer({
 	const doc = await collections.mcpElicitations.findOne({ elicitationId, conversationId });
 	if (!doc) return { ok: false, status: 404, error: "Unknown elicitation." };
 	if (doc.status !== "pending") return { ok: false, status: 409, error: "Already answered." };
-	if (doc.expiresAt.getTime() <= Date.now()) {
+	if (doc.expiresAt && doc.expiresAt.getTime() <= Date.now()) {
 		return { ok: false, status: 409, error: "This request has expired." };
 	}
 
@@ -301,5 +304,91 @@ export async function submitElicitationAnswer({
 	);
 	if (updated.matchedCount === 0) return { ok: false, status: 409, error: "Already answered." };
 
-	return { ok: true };
+	return { ok: true, resume: doc.pending !== undefined };
+}
+
+/**
+ * Record a 2026-era prompt and show it. Returns without waiting: the server kept no state,
+ * so the answer can arrive from any process at any time and resume the call then.
+ */
+export async function openDurableElicitation({
+	sink,
+	server,
+	toolUuid,
+	pending,
+	inputRequired,
+}: {
+	sink: ElicitationSink;
+	server: string;
+	toolUuid: string;
+	pending: Omit<NonNullable<McpElicitation["pending"]>, "inputKey" | "requestState" | "server">;
+	inputRequired: McpInputRequired;
+}): Promise<{ opened: boolean; reason?: string }> {
+	const entries = Object.entries(inputRequired.inputRequests);
+	// One question per round keeps resume unambiguous; the spec permits more, but no
+	// server we have met asks for more, and answering half a round is not resumable.
+	if (entries.length !== 1) {
+		return { opened: false, reason: `expected one input request, got ${entries.length}` };
+	}
+	const [inputKey, request] = entries[0];
+	if (request.method !== "elicitation/create") {
+		return { opened: false, reason: `unsupported input request: ${request.method}` };
+	}
+
+	const normalized = normalizeElicitationRequest(request.params);
+	if (!normalized.ok) return { opened: false, reason: normalized.reason };
+
+	const elicitationId = randomUUID();
+	const payload: ElicitationRequestPayload = { ...normalized.payload, elicitationId, server };
+	const now = new Date();
+
+	try {
+		await collections.mcpElicitations.insertOne({
+			_id: new ObjectId(),
+			elicitationId,
+			conversationId: sink.conversationId,
+			...(sink.generationId ? { generationId: sink.generationId } : {}),
+			status: "pending",
+			request: payload,
+			pending: {
+				...pending,
+				server,
+				inputKey,
+				...(inputRequired.requestState !== undefined
+					? { requestState: inputRequired.requestState }
+					: {}),
+			},
+			createdAt: now,
+			updatedAt: now,
+		});
+	} catch (err) {
+		logger.error({ err, server }, "[mcp] failed to record durable elicitation");
+		return { opened: false, reason: "could not be recorded" };
+	}
+
+	sink.emit({
+		type: MessageUpdateType.Elicitation,
+		subtype: MessageElicitationUpdateType.Request,
+		request: payload,
+		toolUuid,
+	});
+	return { opened: true };
+}
+
+/** The answered prompt for a conversation, ready to re-issue its tool call. */
+export async function takeResumableElicitation(
+	conversationId: ObjectId,
+	elicitationId: string
+): Promise<{ row: McpElicitation; inputResponses: InputResponses } | null> {
+	const row = await collections.mcpElicitations.findOne({ elicitationId, conversationId });
+	if (!row?.pending || row.status !== "resolved" || !row.action) return null;
+	return {
+		row,
+		inputResponses: {
+			[row.pending.inputKey]: {
+				action: row.action,
+				...(row.content ? { content: row.content } : {}),
+			},
+		},
+	};
 }

--- a/src/lib/server/mcp/elicitation.ts
+++ b/src/lib/server/mcp/elicitation.ts
@@ -20,9 +20,8 @@ import type { McpCallDeadline } from "./httpClient";
 
 const POLL_INTERVAL_MS = 400;
 
-/** Where a prompt is shown and an answer is waited for: one live generation. */
 export interface ElicitationSink {
-	/** Stable per generation, so two calls from the same run are recognised as one audience. */
+	/** Stable per generation, so two calls from one run count as a single audience. */
 	id: string;
 	conversationId: ObjectId;
 	generationId?: string;
@@ -33,20 +32,11 @@ interface CallContext {
 	sink: ElicitationSink;
 	server: string;
 	toolUuid: string;
-	/** Stopped for as long as the user is being asked something, then restarted. */
 	deadline: Pick<McpCallDeadline, "pause" | "resume">;
 	signal?: AbortSignal;
 }
 
-/**
- * Tool calls currently running on each pooled client.
- *
- * MCP gives a server-initiated request no link back to the client request that provoked
- * it, and `clientPool` shares one client across every chat using the same server and
- * headers. So the only way to know whose screen an `elicitation/create` belongs on is to
- * look at what that client is doing right now — hence this registry, and hence the
- * refusal in `routeTo` when the answer is not unique.
- */
+/** MCP does not link an `elicitation/create` to the call that provoked it; this is the only clue. */
 const inFlight = new WeakMap<Client, Set<CallContext>>();
 
 export async function withElicitationContext<T>(
@@ -76,13 +66,9 @@ function routeTo(client: Client): Route | { refusal: string } {
 	}
 	const audiences = new Set(contexts.map((c) => c.sink.id));
 	if (audiences.size > 1) {
-		// Two different chats are using this pooled connection at once. Guessing would
-		// mean showing one user's prompt — and collecting their answer — in someone
-		// else's conversation, so refuse instead.
+		// Never guess: that puts one user's prompt, and their answer, in another's conversation.
 		return { refusal: "concurrent tool calls from different generations" };
 	}
-	// One audience, so every call here belongs to the round the user is answering for and
-	// all of their clocks stop together — we cannot tell which one actually asked.
 	return { context: contexts[0], siblings: contexts, attributable: contexts.length === 1 };
 }
 
@@ -105,12 +91,7 @@ const sleep = (ms: number, signal?: AbortSignal): Promise<void> =>
 		signal?.addEventListener("abort", onAbort, { once: true });
 	});
 
-/**
- * Give up on a prompt nobody answered, and record that we did.
- *
- * Conditional on the row still being pending so it can race the answer endpoint without
- * overwriting a real answer that landed a moment earlier.
- */
+/** Filtered on `pending` so racing the answer endpoint cannot overwrite a real answer. */
 async function abandon(
 	elicitationId: string,
 	resolution: Exclude<ElicitationResolution, "user">
@@ -129,8 +110,7 @@ async function abandon(
 		)
 		.catch(() => null);
 
-	// Nothing left to claim: an answer landed between the last poll and this write, and
-	// discarding it now would lose input the user has already given.
+	// Nothing to claim means an answer landed since the last poll; discarding it loses input.
 	if (claimed?.matchedCount === 0) {
 		const current = await collections.mcpElicitations.findOne({ elicitationId }).catch(() => null);
 		if (current?.status === "resolved" && current.action) {
@@ -144,13 +124,7 @@ async function abandon(
 	return { action: "cancel", resolution };
 }
 
-/**
- * Show a prompt and wait for the user, across pods.
- *
- * The answer arrives on whichever pod serves the user's POST, which need not be this one,
- * so the row in Mongo is the channel and polling is the delivery — the same shape
- * `abortedGenerations` uses for stop.
- */
+/** Polled, not pushed: the answer lands on whichever pod served the user's POST. */
 async function awaitAnswer(
 	elicitationId: string,
 	{
@@ -163,14 +137,12 @@ async function awaitAnswer(
 		generation && server ? AbortSignal.any([generation, server]) : (generation ?? server);
 
 	for (;;) {
-		// Checked in this order so the reason shown is the one that actually happened first:
-		// the user stopping the response, versus the server giving up on its own request.
+		// Order matters: stopping the response is what makes the server hang up.
 		if (generation?.aborted) return abandon(elicitationId, "aborted");
 		if (server?.aborted) return abandon(elicitationId, "withdrawn");
 		if (Date.now() >= deadlineAt) return abandon(elicitationId, "expired");
 
-		// `undefined` for a failed read, so a transient database blip is retried rather
-		// than mistaken for a row that is gone.
+		// `undefined` on failure, so a database blip is retried rather than read as a gone row.
 		const doc = await collections.mcpElicitations
 			.findOne({ elicitationId }, { projection: { status: 1, action: 1, content: 1 } })
 			.catch(() => undefined);
@@ -182,21 +154,13 @@ async function awaitAnswer(
 				resolution: "user",
 			};
 		}
-		// The row really is gone — dropped by the TTL sweep — so there is nothing to wait for.
 		if (doc === null) return { action: "cancel", resolution: "expired" };
 
 		await sleep(Math.min(POLL_INTERVAL_MS, Math.max(0, deadlineAt - Date.now())), signal);
 	}
 }
 
-/**
- * Answer an `elicitation/create`: show it to the user who triggered the tool call, wait,
- * and hand the result back to the server.
- *
- * Never throws. Every failure — unroutable, unrenderable, unanswered — becomes a `cancel`,
- * which the spec requires servers to handle, so a bad prompt degrades to a tool call that
- * proceeds without the extra input instead of a broken conversation.
- */
+/** Never throws: every failure becomes a `cancel`, which servers must already handle. */
 export async function handleElicitationRequest(
 	client: Client,
 	params: unknown,
@@ -226,7 +190,6 @@ export async function handleElicitationRequest(
 		server: context.server,
 	};
 
-	// Independent of the tool call's deadline, which is stopped for the duration below.
 	const expiresAt = new Date(Date.now() + getElicitationTimeoutMs());
 
 	const now = new Date();
@@ -255,8 +218,7 @@ export async function handleElicitationRequest(
 		...(attributable ? { toolUuid: context.toolUuid } : {}),
 	});
 
-	// Stop the tool call's clock for as long as a person is being asked something, so a
-	// slow answer never expires the call that is waiting on it.
+	// Without this the call expires underneath a user who takes their time answering it.
 	for (const sibling of siblings) sibling.deadline.pause();
 	let outcome: ElicitationOutcome;
 	try {
@@ -282,7 +244,6 @@ export async function handleElicitationRequest(
 		"[mcp] elicitation resolved"
 	);
 
-	// Content is meaningful only on accept; the spec has servers ignore it otherwise.
 	return outcome.action === "accept"
 		? { action: "accept", content: outcome.content ?? {} }
 		: { action: outcome.action };
@@ -290,10 +251,6 @@ export async function handleElicitationRequest(
 
 export type SubmitResult = { ok: true } | { ok: false; status: 400 | 404 | 409; error: string };
 
-/**
- * Record the user's answer. Called by the response endpoint on whichever pod served it,
- * which is usually not the pod waiting on the tool call.
- */
 export async function submitElicitationAnswer({
 	elicitationId,
 	conversationId,
@@ -305,8 +262,7 @@ export async function submitElicitationAnswer({
 	action: ElicitationAction;
 	content?: unknown;
 }): Promise<SubmitResult> {
-	// Scoped by conversation, so holding an id is not enough to answer a prompt raised in
-	// a conversation the caller does not own.
+	// Scoped by conversation: holding an id is not authority to answer someone else's prompt.
 	const doc = await collections.mcpElicitations.findOne({ elicitationId, conversationId });
 	if (!doc) return { ok: false, status: 404, error: "Unknown elicitation." };
 	if (doc.status !== "pending") return { ok: false, status: 409, error: "Already answered." };
@@ -323,8 +279,7 @@ export async function submitElicitationAnswer({
 		}
 	}
 
-	// `status: "pending"` in the filter makes a double submit a no-op rather than a
-	// second, different answer to a server that already got the first.
+	// `status: "pending"` makes a double submit a no-op rather than a second, different answer.
 	const updated = await collections.mcpElicitations.updateOne(
 		{ elicitationId, conversationId, status: "pending" },
 		{

--- a/src/lib/server/mcp/elicitation.ts
+++ b/src/lib/server/mcp/elicitation.ts
@@ -21,8 +21,6 @@ import type { McpCallDeadline } from "./httpClient";
 const POLL_INTERVAL_MS = 400;
 
 export interface ElicitationSink {
-	/** Stable per generation, so two calls from one run count as a single audience. */
-	id: string;
 	conversationId: ObjectId;
 	generationId?: string;
 	emit: (update: MessageUpdate) => void;
@@ -64,7 +62,9 @@ function routeTo(client: Client): Route | { refusal: string } {
 	if (contexts.length === 0) {
 		return { refusal: "no tool call is in flight on this connection" };
 	}
-	const audiences = new Set(contexts.map((c) => c.sink.id));
+	// Compared by identity, not by generationId: that is client-supplied, so two callers
+	// could claim the same one and collapse this check.
+	const audiences = new Set(contexts.map((c) => c.sink));
 	if (audiences.size > 1) {
 		// Never guess: that puts one user's prompt, and their answer, in another's conversation.
 		return { refusal: "concurrent tool calls from different generations" };
@@ -96,8 +96,8 @@ async function abandon(
 	elicitationId: string,
 	resolution: Exclude<ElicitationResolution, "user">
 ): Promise<ElicitationOutcome> {
-	const claimed = await collections.mcpElicitations
-		.updateOne(
+	const close = () =>
+		collections.mcpElicitations.updateOne(
 			{ elicitationId, status: "pending" },
 			{
 				$set: {
@@ -107,8 +107,15 @@ async function abandon(
 					updatedAt: new Date(),
 				},
 			}
-		)
-		.catch(() => null);
+		);
+
+	// Retried once: a row left pending is one a reloaded form can still submit into nothing.
+	const claimed = await close()
+		.catch(() => close())
+		.catch((err) => {
+			logger.error({ err, elicitationId }, "[mcp] failed to close elicitation");
+			return null;
+		});
 
 	// Nothing to claim means an answer landed since the last poll; discarding it loses input.
 	if (claimed?.matchedCount === 0) {

--- a/src/lib/server/mcp/elicitation.ts
+++ b/src/lib/server/mcp/elicitation.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "crypto";
 import { ObjectId } from "mongodb";
-import type { Client } from "@modelcontextprotocol/sdk/client";
+import type { Client } from "@modelcontextprotocol/client";
 import { collections } from "$lib/server/database";
 import { logger } from "$lib/server/logger";
 import type {

--- a/src/lib/server/mcp/elicitation.ts
+++ b/src/lib/server/mcp/elicitation.ts
@@ -246,6 +246,7 @@ export async function handleElicitationRequest(
 		elicitationId,
 		action: outcome.action,
 		resolution: outcome.resolution,
+		...(outcome.content ? { content: outcome.content } : {}),
 	});
 
 	logger.debug(

--- a/src/lib/server/mcp/elicitation.ts
+++ b/src/lib/server/mcp/elicitation.ts
@@ -1,0 +1,343 @@
+import { randomUUID } from "crypto";
+import { ObjectId } from "mongodb";
+import type { Client } from "@modelcontextprotocol/sdk/client";
+import { collections } from "$lib/server/database";
+import { logger } from "$lib/server/logger";
+import type {
+	ElicitationAction,
+	ElicitationRequestPayload,
+	ElicitationResolution,
+	ElicitationValue,
+} from "$lib/types/McpElicitation";
+import {
+	MessageElicitationUpdateType,
+	MessageUpdateType,
+	type MessageUpdate,
+} from "$lib/types/MessageUpdate";
+import { normalizeElicitationRequest, validateElicitationContent } from "./elicitationSchema";
+import { getElicitationTimeoutMs } from "./elicitationConfig";
+import type { McpCallDeadline } from "./httpClient";
+
+const POLL_INTERVAL_MS = 400;
+
+/** Where a prompt is shown and an answer is waited for: one live generation. */
+export interface ElicitationSink {
+	/** Stable per generation, so two calls from the same run are recognised as one audience. */
+	id: string;
+	conversationId: ObjectId;
+	generationId?: string;
+	emit: (update: MessageUpdate) => void;
+}
+
+interface CallContext {
+	sink: ElicitationSink;
+	server: string;
+	toolUuid: string;
+	/** Stopped for as long as the user is being asked something, then restarted. */
+	deadline: Pick<McpCallDeadline, "pause" | "resume">;
+	signal?: AbortSignal;
+}
+
+/**
+ * Tool calls currently running on each pooled client.
+ *
+ * MCP gives a server-initiated request no link back to the client request that provoked
+ * it, and `clientPool` shares one client across every chat using the same server and
+ * headers. So the only way to know whose screen an `elicitation/create` belongs on is to
+ * look at what that client is doing right now — hence this registry, and hence the
+ * refusal in `routeTo` when the answer is not unique.
+ */
+const inFlight = new WeakMap<Client, Set<CallContext>>();
+
+export async function withElicitationContext<T>(
+	client: Client,
+	context: CallContext,
+	run: () => Promise<T>
+): Promise<T> {
+	let contexts = inFlight.get(client);
+	if (!contexts) {
+		contexts = new Set();
+		inFlight.set(client, contexts);
+	}
+	contexts.add(context);
+	try {
+		return await run();
+	} finally {
+		contexts.delete(context);
+	}
+}
+
+type Route = { context: CallContext; siblings: CallContext[]; attributable: boolean };
+
+function routeTo(client: Client): Route | { refusal: string } {
+	const contexts = [...(inFlight.get(client) ?? [])];
+	if (contexts.length === 0) {
+		return { refusal: "no tool call is in flight on this connection" };
+	}
+	const audiences = new Set(contexts.map((c) => c.sink.id));
+	if (audiences.size > 1) {
+		// Two different chats are using this pooled connection at once. Guessing would
+		// mean showing one user's prompt — and collecting their answer — in someone
+		// else's conversation, so refuse instead.
+		return { refusal: "concurrent tool calls from different generations" };
+	}
+	// One audience, so every call here belongs to the round the user is answering for and
+	// all of their clocks stop together — we cannot tell which one actually asked.
+	return { context: contexts[0], siblings: contexts, attributable: contexts.length === 1 };
+}
+
+export type ElicitationOutcome = {
+	action: ElicitationAction;
+	content?: Record<string, ElicitationValue>;
+	resolution: ElicitationResolution;
+};
+
+const sleep = (ms: number, signal?: AbortSignal): Promise<void> =>
+	new Promise((resolve) => {
+		const onAbort = () => {
+			clearTimeout(timer);
+			resolve();
+		};
+		const timer = setTimeout(() => {
+			signal?.removeEventListener("abort", onAbort);
+			resolve();
+		}, ms);
+		signal?.addEventListener("abort", onAbort, { once: true });
+	});
+
+/**
+ * Give up on a prompt nobody answered, and record that we did.
+ *
+ * Conditional on the row still being pending so it can race the answer endpoint without
+ * overwriting a real answer that landed a moment earlier.
+ */
+async function abandon(
+	elicitationId: string,
+	resolution: Exclude<ElicitationResolution, "user">
+): Promise<ElicitationOutcome> {
+	const claimed = await collections.mcpElicitations
+		.updateOne(
+			{ elicitationId, status: "pending" },
+			{
+				$set: {
+					status: "resolved",
+					action: "cancel",
+					resolvedAt: new Date(),
+					updatedAt: new Date(),
+				},
+			}
+		)
+		.catch(() => null);
+
+	// Nothing left to claim: an answer landed between the last poll and this write, and
+	// discarding it now would lose input the user has already given.
+	if (claimed?.matchedCount === 0) {
+		const current = await collections.mcpElicitations.findOne({ elicitationId }).catch(() => null);
+		if (current?.status === "resolved" && current.action) {
+			return {
+				action: current.action,
+				...(current.content ? { content: current.content } : {}),
+				resolution: "user",
+			};
+		}
+	}
+	return { action: "cancel", resolution };
+}
+
+/**
+ * Show a prompt and wait for the user, across pods.
+ *
+ * The answer arrives on whichever pod serves the user's POST, which need not be this one,
+ * so the row in Mongo is the channel and polling is the delivery — the same shape
+ * `abortedGenerations` uses for stop.
+ */
+async function awaitAnswer(
+	elicitationId: string,
+	{
+		deadlineAt,
+		generation,
+		server,
+	}: { deadlineAt: number; generation?: AbortSignal; server?: AbortSignal }
+): Promise<ElicitationOutcome> {
+	const signal =
+		generation && server ? AbortSignal.any([generation, server]) : (generation ?? server);
+
+	for (;;) {
+		// Checked in this order so the reason shown is the one that actually happened first:
+		// the user stopping the response, versus the server giving up on its own request.
+		if (generation?.aborted) return abandon(elicitationId, "aborted");
+		if (server?.aborted) return abandon(elicitationId, "withdrawn");
+		if (Date.now() >= deadlineAt) return abandon(elicitationId, "expired");
+
+		// `undefined` for a failed read, so a transient database blip is retried rather
+		// than mistaken for a row that is gone.
+		const doc = await collections.mcpElicitations
+			.findOne({ elicitationId }, { projection: { status: 1, action: 1, content: 1 } })
+			.catch(() => undefined);
+
+		if (doc?.status === "resolved") {
+			return {
+				action: doc.action ?? "cancel",
+				...(doc.content ? { content: doc.content } : {}),
+				resolution: "user",
+			};
+		}
+		// The row really is gone — dropped by the TTL sweep — so there is nothing to wait for.
+		if (doc === null) return { action: "cancel", resolution: "expired" };
+
+		await sleep(Math.min(POLL_INTERVAL_MS, Math.max(0, deadlineAt - Date.now())), signal);
+	}
+}
+
+/**
+ * Answer an `elicitation/create`: show it to the user who triggered the tool call, wait,
+ * and hand the result back to the server.
+ *
+ * Never throws. Every failure — unroutable, unrenderable, unanswered — becomes a `cancel`,
+ * which the spec requires servers to handle, so a bad prompt degrades to a tool call that
+ * proceeds without the extra input instead of a broken conversation.
+ */
+export async function handleElicitationRequest(
+	client: Client,
+	params: unknown,
+	/** Fires when the server withdraws the request, i.e. its own timeout beat ours. */
+	serverSignal?: AbortSignal
+): Promise<{ action: ElicitationAction; content?: Record<string, ElicitationValue> }> {
+	const route = routeTo(client);
+	if ("refusal" in route) {
+		logger.warn({ reason: route.refusal }, "[mcp] declining elicitation it cannot attribute");
+		return { action: "cancel" };
+	}
+	const { context, siblings, attributable } = route;
+
+	const normalized = normalizeElicitationRequest(params);
+	if (!normalized.ok) {
+		logger.warn(
+			{ server: context.server, reason: normalized.reason },
+			"[mcp] declining unsupported elicitation"
+		);
+		return { action: "cancel" };
+	}
+
+	const elicitationId = randomUUID();
+	const request: ElicitationRequestPayload = {
+		...normalized.payload,
+		elicitationId,
+		server: context.server,
+	};
+
+	// Independent of the tool call's deadline, which is stopped for the duration below.
+	const expiresAt = new Date(Date.now() + getElicitationTimeoutMs());
+
+	const now = new Date();
+	try {
+		await collections.mcpElicitations.insertOne({
+			_id: new ObjectId(),
+			elicitationId,
+			conversationId: context.sink.conversationId,
+			...(context.sink.generationId ? { generationId: context.sink.generationId } : {}),
+			status: "pending",
+			request,
+			expiresAt,
+			createdAt: now,
+			updatedAt: now,
+		});
+	} catch (err) {
+		logger.error({ err, server: context.server }, "[mcp] failed to record elicitation");
+		return { action: "cancel" };
+	}
+
+	context.sink.emit({
+		type: MessageUpdateType.Elicitation,
+		subtype: MessageElicitationUpdateType.Request,
+		request,
+		expiresAt: expiresAt.getTime(),
+		...(attributable ? { toolUuid: context.toolUuid } : {}),
+	});
+
+	// Stop the tool call's clock for as long as a person is being asked something, so a
+	// slow answer never expires the call that is waiting on it.
+	for (const sibling of siblings) sibling.deadline.pause();
+	let outcome: ElicitationOutcome;
+	try {
+		outcome = await awaitAnswer(elicitationId, {
+			deadlineAt: expiresAt.getTime(),
+			generation: context.signal,
+			server: serverSignal,
+		});
+	} finally {
+		for (const sibling of siblings) sibling.deadline.resume();
+	}
+
+	context.sink.emit({
+		type: MessageUpdateType.Elicitation,
+		subtype: MessageElicitationUpdateType.Resolved,
+		elicitationId,
+		action: outcome.action,
+		resolution: outcome.resolution,
+	});
+
+	logger.debug(
+		{ server: context.server, action: outcome.action, resolution: outcome.resolution },
+		"[mcp] elicitation resolved"
+	);
+
+	// Content is meaningful only on accept; the spec has servers ignore it otherwise.
+	return outcome.action === "accept"
+		? { action: "accept", content: outcome.content ?? {} }
+		: { action: outcome.action };
+}
+
+export type SubmitResult = { ok: true } | { ok: false; status: 400 | 404 | 409; error: string };
+
+/**
+ * Record the user's answer. Called by the response endpoint on whichever pod served it,
+ * which is usually not the pod waiting on the tool call.
+ */
+export async function submitElicitationAnswer({
+	elicitationId,
+	conversationId,
+	action,
+	content,
+}: {
+	elicitationId: string;
+	conversationId: ObjectId;
+	action: ElicitationAction;
+	content?: unknown;
+}): Promise<SubmitResult> {
+	// Scoped by conversation, so holding an id is not enough to answer a prompt raised in
+	// a conversation the caller does not own.
+	const doc = await collections.mcpElicitations.findOne({ elicitationId, conversationId });
+	if (!doc) return { ok: false, status: 404, error: "Unknown elicitation." };
+	if (doc.status !== "pending") return { ok: false, status: 409, error: "Already answered." };
+	if (doc.expiresAt.getTime() <= Date.now()) {
+		return { ok: false, status: 409, error: "This request has expired." };
+	}
+
+	let validated: Record<string, ElicitationValue> | undefined;
+	if (action === "accept") {
+		if (doc.request.mode === "form") {
+			const result = validateElicitationContent(doc.request.fields ?? [], content ?? {});
+			if (!result.ok) return { ok: false, status: 400, error: result.error };
+			validated = result.content;
+		}
+	}
+
+	// `status: "pending"` in the filter makes a double submit a no-op rather than a
+	// second, different answer to a server that already got the first.
+	const updated = await collections.mcpElicitations.updateOne(
+		{ elicitationId, conversationId, status: "pending" },
+		{
+			$set: {
+				status: "resolved",
+				action,
+				resolvedAt: new Date(),
+				updatedAt: new Date(),
+				...(validated ? { content: validated } : {}),
+			},
+		}
+	);
+	if (updated.matchedCount === 0) return { ok: false, status: 409, error: "Already answered." };
+
+	return { ok: true };
+}

--- a/src/lib/server/mcp/elicitationConfig.ts
+++ b/src/lib/server/mcp/elicitationConfig.ts
@@ -7,7 +7,10 @@ export function isElicitationEnabled(): boolean {
 	return config.MCP_DISABLE_ELICITATION !== "true";
 }
 
-/** Bounds a run nobody answers and nobody stops, which would otherwise never finish. */
+/**
+ * On a 2026-era connection this is the only thing bounding a prompt: the server answered
+ * with `input_required` and is no longer waiting on anything.
+ */
 export function getElicitationTimeoutMs(): number {
 	const raw = config.MCP_ELICITATION_TIMEOUT_MS;
 	if (raw) {

--- a/src/lib/server/mcp/elicitationConfig.ts
+++ b/src/lib/server/mcp/elicitationConfig.ts
@@ -1,0 +1,31 @@
+import { config } from "$lib/server/config";
+
+const DEFAULT_TIMEOUT_MS = 60 * 60_000;
+
+/**
+ * Separate from `elicitation.ts` so `client.ts` can decide whether to declare the
+ * capability without pulling the database in behind it.
+ */
+export function isElicitationEnabled(): boolean {
+	return config.MCP_DISABLE_ELICITATION !== "true";
+}
+
+/**
+ * How long a prompt stays answerable. Independent of `MCP_TOOL_TIMEOUT_MS`: the tool
+ * call's own deadline is stopped while the prompt is open (see `createCallDeadline`), so
+ * this is the only thing bounding how long a user has.
+ *
+ * Long enough to be no real limit for someone who walked away, because in practice the
+ * server's own timeout on the request it sent us decides first (60s by MCP SDK default,
+ * and its cancellation closes the prompt). What this actually bounds is a run nobody ever
+ * answers and nobody stops: the heartbeat beats regardless of what a generation is doing,
+ * so without an expiry it would stay `running` — holding its pooled client — forever.
+ */
+export function getElicitationTimeoutMs(): number {
+	const raw = config.MCP_ELICITATION_TIMEOUT_MS;
+	if (raw) {
+		const parsed = parseInt(raw, 10);
+		if (!isNaN(parsed) && parsed > 0) return parsed;
+	}
+	return DEFAULT_TIMEOUT_MS;
+}

--- a/src/lib/server/mcp/elicitationConfig.ts
+++ b/src/lib/server/mcp/elicitationConfig.ts
@@ -2,25 +2,12 @@ import { config } from "$lib/server/config";
 
 const DEFAULT_TIMEOUT_MS = 60 * 60_000;
 
-/**
- * Separate from `elicitation.ts` so `client.ts` can decide whether to declare the
- * capability without pulling the database in behind it.
- */
+/** Split from `elicitation.ts` so `client.ts` can read it without pulling in the database. */
 export function isElicitationEnabled(): boolean {
 	return config.MCP_DISABLE_ELICITATION !== "true";
 }
 
-/**
- * How long a prompt stays answerable. Independent of `MCP_TOOL_TIMEOUT_MS`: the tool
- * call's own deadline is stopped while the prompt is open (see `createCallDeadline`), so
- * this is the only thing bounding how long a user has.
- *
- * Long enough to be no real limit for someone who walked away, because in practice the
- * server's own timeout on the request it sent us decides first (60s by MCP SDK default,
- * and its cancellation closes the prompt). What this actually bounds is a run nobody ever
- * answers and nobody stops: the heartbeat beats regardless of what a generation is doing,
- * so without an expiry it would stay `running` — holding its pooled client — forever.
- */
+/** Bounds a run nobody answers and nobody stops, which would otherwise never finish. */
 export function getElicitationTimeoutMs(): number {
 	const raw = config.MCP_ELICITATION_TIMEOUT_MS;
 	if (raw) {

--- a/src/lib/server/mcp/elicitationSchema.spec.ts
+++ b/src/lib/server/mcp/elicitationSchema.spec.ts
@@ -201,8 +201,7 @@ describe("validateElicitationContent", () => {
 	});
 
 	it("rejects a field the server never asked for", () => {
-		// Otherwise anyone posting to the endpoint could inject extra keys into what the
-		// server receives.
+		// Otherwise the endpoint lets anyone inject extra keys into what the server receives.
 		expect(validateElicitationContent(fields, { name: "Ada", admin: true })).toMatchObject({
 			ok: false,
 		});

--- a/src/lib/server/mcp/elicitationSchema.spec.ts
+++ b/src/lib/server/mcp/elicitationSchema.spec.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect } from "vitest";
+import { normalizeElicitationRequest, validateElicitationContent } from "./elicitationSchema";
+import type { ElicitationField } from "$lib/types/McpElicitation";
+
+const form = (properties: Record<string, unknown>, required?: string[]) => ({
+	message: "Tell me about yourself",
+	requestedSchema: { type: "object", properties, ...(required ? { required } : {}) },
+});
+
+const fieldsOf = (params: unknown): ElicitationField[] => {
+	const result = normalizeElicitationRequest(params);
+	if (!result.ok) throw new Error(`expected ok, got: ${result.reason}`);
+	return result.payload.fields ?? [];
+};
+
+describe("normalizeElicitationRequest", () => {
+	it("normalizes the primitive field types", () => {
+		const fields = fieldsOf(
+			form(
+				{
+					name: { type: "string", title: "Name", minLength: 2 },
+					age: { type: "integer", minimum: 0 },
+					score: { type: "number" },
+					agree: { type: "boolean", default: true },
+				},
+				["name"]
+			)
+		);
+
+		expect(fields).toEqual([
+			{ kind: "string", name: "name", title: "Name", required: true, minLength: 2 },
+			{ kind: "number", name: "age", required: false, integer: true, minimum: 0 },
+			{ kind: "number", name: "score", required: false, integer: false },
+			{ kind: "boolean", name: "agree", required: false, default: true },
+		]);
+	});
+
+	it("reads every spelling of a single select the spec allows", () => {
+		const [plain, legacy, titled] = fieldsOf(
+			form({
+				plain: { type: "string", enum: ["a", "b"] },
+				legacy: { type: "string", enum: ["a", "b"], enumNames: ["Alpha", "Beta"] },
+				titled: { type: "string", oneOf: [{ const: "a", title: "Alpha" }] },
+			})
+		);
+
+		expect(plain).toMatchObject({
+			kind: "select",
+			multiple: false,
+			options: [
+				{ value: "a", label: "a" },
+				{ value: "b", label: "b" },
+			],
+		});
+		expect(legacy).toMatchObject({
+			options: [
+				{ value: "a", label: "Alpha" },
+				{ value: "b", label: "Beta" },
+			],
+		});
+		expect(titled).toMatchObject({ options: [{ value: "a", label: "Alpha" }] });
+	});
+
+	it("reads both spellings of a multi select", () => {
+		const [plain, titled] = fieldsOf(
+			form({
+				plain: { type: "array", items: { type: "string", enum: ["a", "b"] }, maxItems: 1 },
+				titled: { type: "array", items: { anyOf: [{ const: "a", title: "Alpha" }] } },
+			})
+		);
+
+		expect(plain).toMatchObject({ kind: "select", multiple: true, maxItems: 1 });
+		expect(titled).toMatchObject({ multiple: true, options: [{ value: "a", label: "Alpha" }] });
+	});
+
+	it("falls back to option values when the parallel label array does not line up", () => {
+		// A mismatched enumNames would otherwise label an option with another one's name.
+		const [field] = fieldsOf(
+			form({ pick: { type: "string", enum: ["a", "b"], enumNames: ["Alpha"] } })
+		);
+
+		expect(field).toMatchObject({
+			options: [
+				{ value: "a", label: "a" },
+				{ value: "b", label: "b" },
+			],
+		});
+	});
+
+	it("drops a default that is not one of the options", () => {
+		const [field] = fieldsOf(form({ pick: { type: "string", enum: ["a"], default: "zzz" } }));
+
+		expect(field).not.toHaveProperty("default");
+	});
+
+	it("rejects the whole request when one field cannot be rendered", () => {
+		// Dropping it would hand the server an answer silently missing something it asked for.
+		const result = normalizeElicitationRequest(
+			form({ ok: { type: "string" }, nested: { type: "object" } })
+		);
+
+		expect(result).toMatchObject({ ok: false });
+	});
+
+	it("strips control characters out of server-authored display text", () => {
+		const [field] = fieldsOf(form({ name: { type: "string", title: "Name\n​Admin only" } }));
+
+		expect(field.title).toBe("Name  Admin only");
+	});
+
+	it("refuses url elicitation over a scheme that is not http(s)", () => {
+		for (const url of ["javascript:alert(1)", "data:text/html,hi", "file:///etc/passwd"]) {
+			expect(normalizeElicitationRequest({ mode: "url", message: "Sign in", url })).toMatchObject({
+				ok: false,
+			});
+		}
+	});
+
+	it("accepts an https url elicitation", () => {
+		const result = normalizeElicitationRequest({
+			mode: "url",
+			message: "Sign in",
+			url: "https://example.com/auth?x=1",
+		});
+
+		expect(result).toMatchObject({
+			ok: true,
+			payload: { mode: "url", url: "https://example.com/auth?x=1" },
+		});
+	});
+
+	it("rejects an unknown mode rather than guessing", () => {
+		expect(normalizeElicitationRequest({ mode: "voice", message: "hi" })).toMatchObject({
+			ok: false,
+		});
+	});
+
+	it("rejects a form with no message, no fields, or too many", () => {
+		expect(normalizeElicitationRequest(form({ a: { type: "string" } }))).toMatchObject({
+			ok: true,
+		});
+		expect(
+			normalizeElicitationRequest({ requestedSchema: { type: "object", properties: {} } })
+		).toMatchObject({ ok: false });
+		expect(normalizeElicitationRequest(form({}))).toMatchObject({ ok: false });
+
+		const many = Object.fromEntries(
+			Array.from({ length: 33 }, (_, i) => [`f${i}`, { type: "string" }])
+		);
+		expect(normalizeElicitationRequest(form(many))).toMatchObject({ ok: false });
+	});
+});
+
+describe("validateElicitationContent", () => {
+	const fields = fieldsOf(
+		form(
+			{
+				name: { type: "string", minLength: 2, maxLength: 5 },
+				email: { type: "string", format: "email" },
+				age: { type: "integer", minimum: 18, maximum: 120 },
+				agree: { type: "boolean" },
+				plan: { type: "string", enum: ["free", "pro"] },
+				tags: { type: "array", items: { type: "string", enum: ["a", "b"] }, maxItems: 1 },
+			},
+			["name"]
+		)
+	);
+
+	it("accepts a well-formed answer", () => {
+		const result = validateElicitationContent(fields, {
+			name: "Ada",
+			email: "ada@example.com",
+			age: 36,
+			agree: true,
+			plan: "pro",
+			tags: ["a"],
+		});
+
+		expect(result).toEqual({
+			ok: true,
+			content: {
+				name: "Ada",
+				email: "ada@example.com",
+				age: 36,
+				agree: true,
+				plan: "pro",
+				tags: ["a"],
+			},
+		});
+	});
+
+	it("omits fields left blank when they are optional", () => {
+		expect(validateElicitationContent(fields, { name: "Ada" })).toEqual({
+			ok: true,
+			content: { name: "Ada" },
+		});
+	});
+
+	it("requires the fields the server marked required", () => {
+		expect(validateElicitationContent(fields, { age: 20 })).toMatchObject({ ok: false });
+	});
+
+	it("rejects a field the server never asked for", () => {
+		// Otherwise anyone posting to the endpoint could inject extra keys into what the
+		// server receives.
+		expect(validateElicitationContent(fields, { name: "Ada", admin: true })).toMatchObject({
+			ok: false,
+		});
+	});
+
+	it("enforces the constraints the browser also enforces", () => {
+		const cases = [
+			{ name: "A" },
+			{ name: "Abcdef" },
+			{ name: "Ada", email: "nope" },
+			{ name: "Ada", age: 17 },
+			{ name: "Ada", age: 20.5 },
+			{ name: "Ada", agree: "yes" },
+			{ name: "Ada", plan: "enterprise" },
+			{ name: "Ada", tags: ["a", "b"] },
+			{ name: "Ada", tags: ["c"] },
+			{ name: "Ada", tags: ["a", "a"] },
+			{ name: 42 },
+		];
+
+		for (const answer of cases) {
+			expect(validateElicitationContent(fields, answer), JSON.stringify(answer)).toMatchObject({
+				ok: false,
+			});
+		}
+	});
+
+	it("rejects an answer that is not an object", () => {
+		expect(validateElicitationContent(fields, "Ada")).toMatchObject({ ok: false });
+	});
+});

--- a/src/lib/server/mcp/elicitationSchema.spec.ts
+++ b/src/lib/server/mcp/elicitationSchema.spec.ts
@@ -102,6 +102,33 @@ describe("normalizeElicitationRequest", () => {
 		expect(result).toMatchObject({ ok: false });
 	});
 
+	it("rejects a field name that would hit an inherited setter", () => {
+		// `out.__proto__ = x` assigns through the prototype instead of creating an answer key.
+		for (const name of ["__proto__", "constructor", "prototype"]) {
+			expect(normalizeElicitationRequest(form({ [name]: { type: "string" } }))).toMatchObject({
+				ok: false,
+			});
+		}
+	});
+
+	it("rejects options whose values collide", () => {
+		// The form keys its options by value, so duplicates break rendering outright.
+		expect(
+			normalizeElicitationRequest(form({ pick: { type: "string", enum: ["a", "a"] } }))
+		).toMatchObject({ ok: false });
+		expect(
+			normalizeElicitationRequest(
+				form({ pick: { type: "array", items: { type: "string", enum: ["a", "a"] } } })
+			)
+		).toMatchObject({ ok: false });
+	});
+
+	it("sanitizes an option label that falls back to its raw value", () => {
+		const [field] = fieldsOf(form({ pick: { type: "string", enum: ["ok\u0007bad"] } }));
+
+		expect(field).toMatchObject({ options: [{ value: "ok\u0007bad", label: "ok bad" }] });
+	});
+
 	it("strips control characters out of server-authored display text", () => {
 		const [field] = fieldsOf(form({ name: { type: "string", title: "Name\n​Admin only" } }));
 
@@ -227,6 +254,28 @@ describe("validateElicitationContent", () => {
 				ok: false,
 			});
 		}
+	});
+
+	it("rejects a calendar date that does not exist", () => {
+		// Date.parse rolls 2024-02-31 forward into March rather than rejecting it.
+		const dated = fieldsOf(form({ when: { type: "string", format: "date" } }, ["when"]));
+
+		expect(validateElicitationContent(dated, { when: "2024-02-31" })).toMatchObject({ ok: false });
+		expect(validateElicitationContent(dated, { when: "2024-02-29" })).toMatchObject({ ok: true });
+	});
+
+	it("requires a date-time to carry an offset, as RFC 3339 does", () => {
+		const stamped = fieldsOf(form({ at: { type: "string", format: "date-time" } }, ["at"]));
+
+		expect(validateElicitationContent(stamped, { at: "2024-03-01T10:00" })).toMatchObject({
+			ok: false,
+		});
+		expect(validateElicitationContent(stamped, { at: "2024-03-01T10:00:00Z" })).toMatchObject({
+			ok: true,
+		});
+		expect(validateElicitationContent(stamped, { at: "2024-03-01T10:00:00+02:00" })).toMatchObject({
+			ok: true,
+		});
 	});
 
 	it("rejects an answer that is not an object", () => {

--- a/src/lib/server/mcp/elicitationSchema.ts
+++ b/src/lib/server/mcp/elicitationSchema.ts
@@ -4,24 +4,13 @@ import type {
 	ElicitationValue,
 } from "$lib/types/McpElicitation";
 
-/**
- * Normalization and validation for `elicitation/create`.
- *
- * Everything crossing this boundary is authored by the MCP server, which is not
- * necessarily the operator's own: field names become object keys, labels become on-screen
- * text, and the whole payload gets persisted and replayed. Nothing here trusts its input.
- *
- * Kept free of database and SDK imports so both directions — request in, answer out — are
- * testable as plain functions.
- */
+/** Nothing here trusts its input: every value is authored by the MCP server. */
 
-// Caps on an untrusted payload. Generous enough that no plausible real form hits them.
 const MAX_FIELDS = 32;
 const MAX_OPTIONS = 100;
 const MAX_MESSAGE_CHARS = 2_000;
 const MAX_TITLE_CHARS = 200;
 const MAX_DESCRIPTION_CHARS = 1_000;
-/** Bounds what a single answer can add to the conversation document. */
 const MAX_ANSWER_CHARS = 10_000;
 
 const asRecord = (value: unknown): Record<string, unknown> | undefined =>
@@ -31,8 +20,7 @@ const asRecord = (value: unknown): Record<string, unknown> | undefined =>
 
 const asText = (value: unknown, max: number): string | undefined => {
 	if (typeof value !== "string") return undefined;
-	// Control characters would let a server smuggle line breaks into a label to fake
-	// chrome around the form; strip rather than reject so a stray tab is not fatal.
+	// Stripped so a label cannot smuggle line breaks in and fake chrome around the form.
 	const cleaned = value.replace(/[\p{Cc}\p{Cf}]/gu, " ").trim();
 	if (!cleaned) return undefined;
 	return cleaned.length > max ? `${cleaned.slice(0, max - 1)}…` : cleaned;
@@ -43,14 +31,12 @@ const asFiniteNumber = (value: unknown): number | undefined =>
 
 type Option = { value: string; label: string };
 
-/** `enum` + optional `enumNames`, the original and still most common spelling. */
 function optionsFromEnum(def: Record<string, unknown>): Option[] | undefined {
 	if (!Array.isArray(def.enum)) return undefined;
 	const values = def.enum.filter((v): v is string => typeof v === "string");
 	if (values.length !== def.enum.length) return undefined;
 	const names = Array.isArray(def.enumNames) ? def.enumNames : undefined;
-	// Only trust parallel labels when they actually line up; a mismatched array would
-	// otherwise silently label an option with another option's name.
+	// A mismatched array would silently label an option with another option's name.
 	const labelled = names?.length === values.length && names.every((n) => typeof n === "string");
 	return values.map((value, i) => ({
 		value,
@@ -58,7 +44,6 @@ function optionsFromEnum(def: Record<string, unknown>): Option[] | undefined {
 	}));
 }
 
-/** `oneOf`/`anyOf` of `{const, title}`, the current spelling for titled options. */
 function optionsFromConstList(list: unknown): Option[] | undefined {
 	if (!Array.isArray(list)) return undefined;
 	const options: Option[] = [];
@@ -162,12 +147,6 @@ export type NormalizeResult =
 	| { ok: true; payload: Omit<ElicitationRequestPayload, "elicitationId"> }
 	| { ok: false; reason: string };
 
-/**
- * Turn raw `elicitation/create` params into the payload the rest of the app uses, or
- * explain why they cannot be shown. A field that cannot be rendered fails the whole
- * request: dropping it would hand the server an answer that silently omits something it
- * asked for and marked required.
- */
 export function normalizeElicitationRequest(params: unknown): NormalizeResult {
 	const raw = asRecord(params);
 	if (!raw) return { ok: false, reason: "Malformed elicitation params." };
@@ -183,8 +162,7 @@ export function normalizeElicitationRequest(params: unknown): NormalizeResult {
 		} catch {
 			return { ok: false, reason: "URL elicitation has an unparseable url." };
 		}
-		// The user is about to be invited to click this. Anything but http(s) — `javascript:`,
-		// `data:`, a custom app scheme — is not something we hand a one-click affordance to.
+		// The user gets a one-click affordance for this, so no `javascript:`/`data:`/app schemes.
 		if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
 			return { ok: false, reason: `Unsupported URL scheme: ${parsed.protocol}` };
 		}
@@ -245,14 +223,7 @@ function checkFormat(value: string, format: string): boolean {
 export type ValidateResult =
 	{ ok: true; content: Record<string, ElicitationValue> } | { ok: false; error: string };
 
-/**
- * Check a submitted answer against the fields that were asked for.
- *
- * The browser enforces the same rules for usability, but this is the copy that counts —
- * the answer is posted by the client and goes straight to the MCP server, so an
- * unvalidated one would let anyone who can reach the endpoint hand the server whatever
- * shape they liked.
- */
+/** The copy that counts: the browser's checks are for usability, this answer reaches the server. */
 export function validateElicitationContent(
 	fields: ElicitationField[],
 	raw: unknown

--- a/src/lib/server/mcp/elicitationSchema.ts
+++ b/src/lib/server/mcp/elicitationSchema.ts
@@ -26,10 +26,21 @@ const asText = (value: unknown, max: number): string | undefined => {
 	return cleaned.length > max ? `${cleaned.slice(0, max - 1)}…` : cleaned;
 };
 
+/** `out[name] = x` on one of these hits an inherited setter instead of creating a key. */
+const UNSAFE_FIELD_NAMES = new Set(["__proto__", "constructor", "prototype"]);
+
 const asFiniteNumber = (value: unknown): number | undefined =>
 	typeof value === "number" && Number.isFinite(value) ? value : undefined;
 
 type Option = { value: string; label: string };
+
+/** An untitled option shows its raw value, which still has to be safe to display. */
+const labelOf = (value: string) =>
+	asText(value, MAX_TITLE_CHARS) ?? value.slice(0, MAX_TITLE_CHARS);
+
+/** The UI keys options by value, so duplicates would break rendering outright. */
+const uniqueValues = (options: Option[]) =>
+	new Set(options.map((o) => o.value)).size === options.length;
 
 function optionsFromEnum(def: Record<string, unknown>): Option[] | undefined {
 	if (!Array.isArray(def.enum)) return undefined;
@@ -40,7 +51,7 @@ function optionsFromEnum(def: Record<string, unknown>): Option[] | undefined {
 	const labelled = names?.length === values.length && names.every((n) => typeof n === "string");
 	return values.map((value, i) => ({
 		value,
-		label: (labelled ? asText(names?.[i], MAX_TITLE_CHARS) : undefined) ?? value,
+		label: (labelled ? asText(names?.[i], MAX_TITLE_CHARS) : undefined) ?? labelOf(value),
 	}));
 }
 
@@ -50,14 +61,17 @@ function optionsFromConstList(list: unknown): Option[] | undefined {
 	for (const entry of list) {
 		const obj = asRecord(entry);
 		if (!obj || typeof obj.const !== "string") return undefined;
-		options.push({ value: obj.const, label: asText(obj.title, MAX_TITLE_CHARS) ?? obj.const });
+		options.push({
+			value: obj.const,
+			label: asText(obj.title, MAX_TITLE_CHARS) ?? labelOf(obj.const),
+		});
 	}
 	return options;
 }
 
 function normalizeField(name: string, raw: unknown, required: boolean): ElicitationField | null {
 	const def = asRecord(raw);
-	if (!def) return null;
+	if (!def || UNSAFE_FIELD_NAMES.has(name)) return null;
 
 	const common = {
 		name,
@@ -89,6 +103,7 @@ function normalizeField(name: string, raw: unknown, required: boolean): Elicitat
 		const options = optionsFromConstList(def.oneOf) ?? optionsFromEnum(def);
 		if (options) {
 			if (options.length === 0 || options.length > MAX_OPTIONS) return null;
+			if (!uniqueValues(options)) return null;
 			const fallback = typeof def.default === "string" ? def.default : undefined;
 			return {
 				kind: "select",
@@ -125,6 +140,7 @@ function normalizeField(name: string, raw: unknown, required: boolean): Elicitat
 		if (!items) return null;
 		const options = optionsFromConstList(items.anyOf) ?? optionsFromEnum(items);
 		if (!options || options.length === 0 || options.length > MAX_OPTIONS) return null;
+		if (!uniqueValues(options)) return null;
 		const known = new Set(options.map((o) => o.value));
 		const fallback = Array.isArray(def.default)
 			? def.default.filter((v): v is string => typeof v === "string" && known.has(v))
@@ -203,11 +219,13 @@ export function normalizeElicitationRequest(params: unknown): NormalizeResult {
 
 const EMAIL = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const DATE = /^\d{4}-\d{2}-\d{2}$/;
-const DATE_TIME = /^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}(:\d{2}(\.\d+)?)?(Z|[+-]\d{2}:?\d{2})?$/;
+// RFC 3339, so the offset is required — the form converts before submitting.
+const DATE_TIME = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})$/;
 
 function checkFormat(value: string, format: string): boolean {
 	if (format === "email") return EMAIL.test(value);
-	if (format === "date") return DATE.test(value) && !Number.isNaN(Date.parse(value));
+	// Round-tripped, because Date.parse rolls impossible dates over (2024-02-31 -> March).
+	if (format === "date") return DATE.test(value) && new Date(value).toISOString().startsWith(value);
 	if (format === "date-time") return DATE_TIME.test(value) && !Number.isNaN(Date.parse(value));
 	if (format === "uri") {
 		try {

--- a/src/lib/server/mcp/elicitationSchema.ts
+++ b/src/lib/server/mcp/elicitationSchema.ts
@@ -1,0 +1,360 @@
+import type {
+	ElicitationField,
+	ElicitationRequestPayload,
+	ElicitationValue,
+} from "$lib/types/McpElicitation";
+
+/**
+ * Normalization and validation for `elicitation/create`.
+ *
+ * Everything crossing this boundary is authored by the MCP server, which is not
+ * necessarily the operator's own: field names become object keys, labels become on-screen
+ * text, and the whole payload gets persisted and replayed. Nothing here trusts its input.
+ *
+ * Kept free of database and SDK imports so both directions — request in, answer out — are
+ * testable as plain functions.
+ */
+
+// Caps on an untrusted payload. Generous enough that no plausible real form hits them.
+const MAX_FIELDS = 32;
+const MAX_OPTIONS = 100;
+const MAX_MESSAGE_CHARS = 2_000;
+const MAX_TITLE_CHARS = 200;
+const MAX_DESCRIPTION_CHARS = 1_000;
+/** Bounds what a single answer can add to the conversation document. */
+const MAX_ANSWER_CHARS = 10_000;
+
+const asRecord = (value: unknown): Record<string, unknown> | undefined =>
+	typeof value === "object" && value !== null && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: undefined;
+
+const asText = (value: unknown, max: number): string | undefined => {
+	if (typeof value !== "string") return undefined;
+	// Control characters would let a server smuggle line breaks into a label to fake
+	// chrome around the form; strip rather than reject so a stray tab is not fatal.
+	const cleaned = value.replace(/[\p{Cc}\p{Cf}]/gu, " ").trim();
+	if (!cleaned) return undefined;
+	return cleaned.length > max ? `${cleaned.slice(0, max - 1)}…` : cleaned;
+};
+
+const asFiniteNumber = (value: unknown): number | undefined =>
+	typeof value === "number" && Number.isFinite(value) ? value : undefined;
+
+type Option = { value: string; label: string };
+
+/** `enum` + optional `enumNames`, the original and still most common spelling. */
+function optionsFromEnum(def: Record<string, unknown>): Option[] | undefined {
+	if (!Array.isArray(def.enum)) return undefined;
+	const values = def.enum.filter((v): v is string => typeof v === "string");
+	if (values.length !== def.enum.length) return undefined;
+	const names = Array.isArray(def.enumNames) ? def.enumNames : undefined;
+	// Only trust parallel labels when they actually line up; a mismatched array would
+	// otherwise silently label an option with another option's name.
+	const labelled = names?.length === values.length && names.every((n) => typeof n === "string");
+	return values.map((value, i) => ({
+		value,
+		label: (labelled ? asText(names?.[i], MAX_TITLE_CHARS) : undefined) ?? value,
+	}));
+}
+
+/** `oneOf`/`anyOf` of `{const, title}`, the current spelling for titled options. */
+function optionsFromConstList(list: unknown): Option[] | undefined {
+	if (!Array.isArray(list)) return undefined;
+	const options: Option[] = [];
+	for (const entry of list) {
+		const obj = asRecord(entry);
+		if (!obj || typeof obj.const !== "string") return undefined;
+		options.push({ value: obj.const, label: asText(obj.title, MAX_TITLE_CHARS) ?? obj.const });
+	}
+	return options;
+}
+
+function normalizeField(name: string, raw: unknown, required: boolean): ElicitationField | null {
+	const def = asRecord(raw);
+	if (!def) return null;
+
+	const common = {
+		name,
+		title: asText(def.title, MAX_TITLE_CHARS),
+		description: asText(def.description, MAX_DESCRIPTION_CHARS),
+		required,
+	};
+
+	if (def.type === "boolean") {
+		return {
+			kind: "boolean",
+			...common,
+			...(typeof def.default === "boolean" ? { default: def.default } : {}),
+		};
+	}
+
+	if (def.type === "number" || def.type === "integer") {
+		return {
+			kind: "number",
+			...common,
+			integer: def.type === "integer",
+			...(asFiniteNumber(def.minimum) !== undefined ? { minimum: def.minimum as number } : {}),
+			...(asFiniteNumber(def.maximum) !== undefined ? { maximum: def.maximum as number } : {}),
+			...(asFiniteNumber(def.default) !== undefined ? { default: def.default as number } : {}),
+		};
+	}
+
+	if (def.type === "string") {
+		const options = optionsFromConstList(def.oneOf) ?? optionsFromEnum(def);
+		if (options) {
+			if (options.length === 0 || options.length > MAX_OPTIONS) return null;
+			const fallback = typeof def.default === "string" ? def.default : undefined;
+			return {
+				kind: "select",
+				...common,
+				multiple: false,
+				options,
+				...(fallback !== undefined && options.some((o) => o.value === fallback)
+					? { default: fallback }
+					: {}),
+			};
+		}
+		const format =
+			def.format === "email" || def.format === "uri" || def.format === "date"
+				? def.format
+				: def.format === "date-time"
+					? ("date-time" as const)
+					: undefined;
+		return {
+			kind: "string",
+			...common,
+			...(asFiniteNumber(def.minLength) !== undefined
+				? { minLength: def.minLength as number }
+				: {}),
+			...(asFiniteNumber(def.maxLength) !== undefined
+				? { maxLength: def.maxLength as number }
+				: {}),
+			...(format ? { format } : {}),
+			...(typeof def.default === "string" ? { default: def.default } : {}),
+		};
+	}
+
+	if (def.type === "array") {
+		const items = asRecord(def.items);
+		if (!items) return null;
+		const options = optionsFromConstList(items.anyOf) ?? optionsFromEnum(items);
+		if (!options || options.length === 0 || options.length > MAX_OPTIONS) return null;
+		const known = new Set(options.map((o) => o.value));
+		const fallback = Array.isArray(def.default)
+			? def.default.filter((v): v is string => typeof v === "string" && known.has(v))
+			: undefined;
+		return {
+			kind: "select",
+			...common,
+			multiple: true,
+			options,
+			...(asFiniteNumber(def.minItems) !== undefined ? { minItems: def.minItems as number } : {}),
+			...(asFiniteNumber(def.maxItems) !== undefined ? { maxItems: def.maxItems as number } : {}),
+			...(fallback?.length ? { default: fallback } : {}),
+		};
+	}
+
+	return null;
+}
+
+export type NormalizeResult =
+	| { ok: true; payload: Omit<ElicitationRequestPayload, "elicitationId"> }
+	| { ok: false; reason: string };
+
+/**
+ * Turn raw `elicitation/create` params into the payload the rest of the app uses, or
+ * explain why they cannot be shown. A field that cannot be rendered fails the whole
+ * request: dropping it would hand the server an answer that silently omits something it
+ * asked for and marked required.
+ */
+export function normalizeElicitationRequest(params: unknown): NormalizeResult {
+	const raw = asRecord(params);
+	if (!raw) return { ok: false, reason: "Malformed elicitation params." };
+
+	const message = asText(raw.message, MAX_MESSAGE_CHARS);
+	if (!message) return { ok: false, reason: "Elicitation is missing a message." };
+
+	if (raw.mode === "url") {
+		if (typeof raw.url !== "string") return { ok: false, reason: "URL elicitation has no url." };
+		let parsed: URL;
+		try {
+			parsed = new URL(raw.url);
+		} catch {
+			return { ok: false, reason: "URL elicitation has an unparseable url." };
+		}
+		// The user is about to be invited to click this. Anything but http(s) — `javascript:`,
+		// `data:`, a custom app scheme — is not something we hand a one-click affordance to.
+		if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+			return { ok: false, reason: `Unsupported URL scheme: ${parsed.protocol}` };
+		}
+		return { ok: true, payload: { server: "", mode: "url", message, url: parsed.toString() } };
+	}
+
+	if (raw.mode !== undefined && raw.mode !== "form") {
+		return { ok: false, reason: `Unsupported elicitation mode: ${String(raw.mode)}` };
+	}
+
+	const schema = asRecord(raw.requestedSchema);
+	const properties = asRecord(schema?.properties);
+	if (!schema || !properties) {
+		return { ok: false, reason: "Form elicitation has no requestedSchema.properties." };
+	}
+
+	const entries = Object.entries(properties);
+	if (entries.length === 0) return { ok: false, reason: "Form elicitation requested no fields." };
+	if (entries.length > MAX_FIELDS) {
+		return { ok: false, reason: `Form elicitation requested too many fields (${entries.length}).` };
+	}
+
+	const required = new Set(
+		(Array.isArray(schema.required) ? schema.required : []).filter(
+			(name): name is string => typeof name === "string"
+		)
+	);
+
+	const fields: ElicitationField[] = [];
+	for (const [name, def] of entries) {
+		const field = normalizeField(name, def, required.has(name));
+		if (!field) return { ok: false, reason: `Unsupported field schema for "${name}".` };
+		fields.push(field);
+	}
+
+	return { ok: true, payload: { server: "", mode: "form", message, fields } };
+}
+
+const EMAIL = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const DATE = /^\d{4}-\d{2}-\d{2}$/;
+const DATE_TIME = /^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}(:\d{2}(\.\d+)?)?(Z|[+-]\d{2}:?\d{2})?$/;
+
+function checkFormat(value: string, format: string): boolean {
+	if (format === "email") return EMAIL.test(value);
+	if (format === "date") return DATE.test(value) && !Number.isNaN(Date.parse(value));
+	if (format === "date-time") return DATE_TIME.test(value) && !Number.isNaN(Date.parse(value));
+	if (format === "uri") {
+		try {
+			new URL(value);
+			return true;
+		} catch {
+			return false;
+		}
+	}
+	return true;
+}
+
+export type ValidateResult =
+	{ ok: true; content: Record<string, ElicitationValue> } | { ok: false; error: string };
+
+/**
+ * Check a submitted answer against the fields that were asked for.
+ *
+ * The browser enforces the same rules for usability, but this is the copy that counts —
+ * the answer is posted by the client and goes straight to the MCP server, so an
+ * unvalidated one would let anyone who can reach the endpoint hand the server whatever
+ * shape they liked.
+ */
+export function validateElicitationContent(
+	fields: ElicitationField[],
+	raw: unknown
+): ValidateResult {
+	const submitted = asRecord(raw);
+	if (!submitted) return { ok: false, error: "Answer must be an object." };
+
+	const known = new Set(fields.map((f) => f.name));
+	for (const name of Object.keys(submitted)) {
+		if (!known.has(name)) return { ok: false, error: `Unknown field "${name}".` };
+	}
+
+	const content: Record<string, ElicitationValue> = {};
+	let totalChars = 0;
+
+	for (const field of fields) {
+		const value = submitted[field.name];
+		const missing = value === undefined || value === null || value === "";
+		if (missing) {
+			if (field.required) return { ok: false, error: `"${field.name}" is required.` };
+			continue;
+		}
+
+		switch (field.kind) {
+			case "string": {
+				if (typeof value !== "string") {
+					return { ok: false, error: `"${field.name}" must be a string.` };
+				}
+				if (field.minLength !== undefined && value.length < field.minLength) {
+					return { ok: false, error: `"${field.name}" is too short.` };
+				}
+				if (field.maxLength !== undefined && value.length > field.maxLength) {
+					return { ok: false, error: `"${field.name}" is too long.` };
+				}
+				if (field.format && !checkFormat(value, field.format)) {
+					return { ok: false, error: `"${field.name}" is not a valid ${field.format}.` };
+				}
+				totalChars += value.length;
+				content[field.name] = value;
+				break;
+			}
+			case "number": {
+				if (typeof value !== "number" || !Number.isFinite(value)) {
+					return { ok: false, error: `"${field.name}" must be a number.` };
+				}
+				if (field.integer && !Number.isInteger(value)) {
+					return { ok: false, error: `"${field.name}" must be a whole number.` };
+				}
+				if (field.minimum !== undefined && value < field.minimum) {
+					return { ok: false, error: `"${field.name}" is below the minimum.` };
+				}
+				if (field.maximum !== undefined && value > field.maximum) {
+					return { ok: false, error: `"${field.name}" is above the maximum.` };
+				}
+				content[field.name] = value;
+				break;
+			}
+			case "boolean": {
+				if (typeof value !== "boolean") {
+					return { ok: false, error: `"${field.name}" must be a boolean.` };
+				}
+				content[field.name] = value;
+				break;
+			}
+			case "select": {
+				const allowed = new Set(field.options.map((o) => o.value));
+				if (field.multiple) {
+					if (!Array.isArray(value) || value.some((v) => typeof v !== "string")) {
+						return { ok: false, error: `"${field.name}" must be a list of strings.` };
+					}
+					const picked = value as string[];
+					if (new Set(picked).size !== picked.length) {
+						return { ok: false, error: `"${field.name}" has duplicate selections.` };
+					}
+					for (const v of picked) {
+						if (!allowed.has(v))
+							return { ok: false, error: `"${field.name}" has an unknown option.` };
+					}
+					if (field.minItems !== undefined && picked.length < field.minItems) {
+						return { ok: false, error: `"${field.name}" needs more selections.` };
+					}
+					if (field.maxItems !== undefined && picked.length > field.maxItems) {
+						return { ok: false, error: `"${field.name}" has too many selections.` };
+					}
+					if (field.required && picked.length === 0) {
+						return { ok: false, error: `"${field.name}" is required.` };
+					}
+					totalChars += picked.join("").length;
+					content[field.name] = picked;
+				} else {
+					if (typeof value !== "string" || !allowed.has(value)) {
+						return { ok: false, error: `"${field.name}" has an unknown option.` };
+					}
+					totalChars += value.length;
+					content[field.name] = value;
+				}
+				break;
+			}
+		}
+	}
+
+	if (totalChars > MAX_ANSWER_CHARS) return { ok: false, error: "Answer is too large." };
+
+	return { ok: true, content };
+}

--- a/src/lib/server/mcp/httpClient.ts
+++ b/src/lib/server/mcp/httpClient.ts
@@ -23,7 +23,7 @@ export interface McpServerConfig {
 
 const DEFAULT_TIMEOUT_MS = 120_000;
 
-/** Time the *server* may go without responding; time spent waiting on a user is excluded. */
+/** Time the server may go without responding; waiting on a user does not count. */
 export function getMcpToolTimeoutMs(): number {
 	const envValue = config.MCP_TOOL_TIMEOUT_MS;
 	if (envValue) {
@@ -55,22 +55,12 @@ export type McpToolProgress = {
 	message?: string;
 };
 
-/**
- * Only a leak guard. The real deadline is `createCallDeadline` below; the SDK's own timer
- * has to be pushed out of the way because it cannot express "not while a user is thinking".
- */
+/** Leak guard only; the deadline below is the real one. */
 const ABSOLUTE_CEILING_MS = 6 * 60 * 60_000;
 
 /**
- * The deadline for one tool call, enforced here instead of by the SDK.
- *
- * `Protocol.request` arms a plain wall-clock timer when the request goes out, and only a
- * server-sent progress notification resets it — MCP has no "still waiting on the user"
- * signal a client can send. Owning the timer is what lets an elicitation stop the clock,
- * so a prompt can sit as long as it needs to without the call expiring underneath it.
- *
- * Aborting (rather than letting the SDK time out) also makes the SDK send
- * `notifications/cancelled`, so a server that is still working learns to stop.
+ * Owned here rather than left to the SDK, whose timer only a server-sent progress
+ * notification can reset — an elicitation needs to stop the clock while a user thinks.
  */
 export function createCallDeadline(timeoutMs: number, outer?: AbortSignal) {
 	const controller = new AbortController();
@@ -100,20 +90,15 @@ export function createCallDeadline(timeoutMs: number, outer?: AbortSignal) {
 
 	return {
 		signal: controller.signal,
-		/** Restore per-attempt semantics: a reconnect re-sends the request from scratch. */
 		restart() {
 			disarm();
 			arm();
 		},
-		/**
-		 * Waiting on a person is not the server being slow. Counted, because one call can
-		 * be asked more than one thing before it finishes.
-		 */
+		/** Counted: one call can be asked more than one thing before it finishes. */
 		pause() {
 			paused++;
 			disarm();
 		},
-		/** Restarts the full budget, exactly as a progress notification would. */
 		resume() {
 			paused = Math.max(0, paused - 1);
 			arm();
@@ -142,10 +127,7 @@ export async function callMcpTool(
 		signal?: AbortSignal;
 		client?: Client;
 		onProgress?: (progress: McpToolProgress) => void;
-		/**
-		 * Where to show a prompt if the server asks the user something mid-call. Omit and
-		 * any `elicitation/create` on this connection is declined.
-		 */
+		/** Omit and any `elicitation/create` on this connection is declined. */
 		elicitation?: { sink: ElicitationSink; toolUuid: string };
 	} = {}
 ): Promise<McpToolTextResponse> {

--- a/src/lib/server/mcp/httpClient.ts
+++ b/src/lib/server/mcp/httpClient.ts
@@ -1,5 +1,6 @@
 import { Client, SdkHttpError } from "@modelcontextprotocol/client";
 import { getClient, evictFromPool, retainClient, releaseClient } from "./clientPool";
+import { withElicitationContext, type ElicitationSink } from "./elicitation";
 import { config } from "$lib/server/config";
 
 function isConnectionClosedError(err: unknown): boolean {
@@ -22,6 +23,7 @@ export interface McpServerConfig {
 
 const DEFAULT_TIMEOUT_MS = 120_000;
 
+/** Time the *server* may go without responding; time spent waiting on a user is excluded. */
 export function getMcpToolTimeoutMs(): number {
 	const envValue = config.MCP_TOOL_TIMEOUT_MS;
 	if (envValue) {
@@ -53,6 +55,78 @@ export type McpToolProgress = {
 	message?: string;
 };
 
+/**
+ * Only a leak guard. The real deadline is `createCallDeadline` below; the SDK's own timer
+ * has to be pushed out of the way because it cannot express "not while a user is thinking".
+ */
+const ABSOLUTE_CEILING_MS = 6 * 60 * 60_000;
+
+/**
+ * The deadline for one tool call, enforced here instead of by the SDK.
+ *
+ * `Protocol.request` arms a plain wall-clock timer when the request goes out, and only a
+ * server-sent progress notification resets it — MCP has no "still waiting on the user"
+ * signal a client can send. Owning the timer is what lets an elicitation stop the clock,
+ * so a prompt can sit as long as it needs to without the call expiring underneath it.
+ *
+ * Aborting (rather than letting the SDK time out) also makes the SDK send
+ * `notifications/cancelled`, so a server that is still working learns to stop.
+ */
+export function createCallDeadline(timeoutMs: number, outer?: AbortSignal) {
+	const controller = new AbortController();
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	let paused = 0;
+
+	const disarm = () => {
+		if (timer) clearTimeout(timer);
+		timer = undefined;
+	};
+	const arm = () => {
+		if (timer || paused > 0 || controller.signal.aborted) return;
+		timer = setTimeout(
+			() => controller.abort(`Tool call exceeded ${timeoutMs}ms without a response`),
+			timeoutMs
+		);
+	};
+
+	const onOuterAbort = () => {
+		disarm();
+		controller.abort(outer?.reason);
+	};
+	if (outer?.aborted) controller.abort(outer.reason);
+	else outer?.addEventListener("abort", onOuterAbort, { once: true });
+
+	arm();
+
+	return {
+		signal: controller.signal,
+		/** Restore per-attempt semantics: a reconnect re-sends the request from scratch. */
+		restart() {
+			disarm();
+			arm();
+		},
+		/**
+		 * Waiting on a person is not the server being slow. Counted, because one call can
+		 * be asked more than one thing before it finishes.
+		 */
+		pause() {
+			paused++;
+			disarm();
+		},
+		/** Restarts the full budget, exactly as a progress notification would. */
+		resume() {
+			paused = Math.max(0, paused - 1);
+			arm();
+		},
+		dispose() {
+			disarm();
+			outer?.removeEventListener("abort", onOuterAbort);
+		},
+	};
+}
+
+export type McpCallDeadline = ReturnType<typeof createCallDeadline>;
+
 export async function callMcpTool(
 	server: McpServerConfig,
 	tool: string,
@@ -62,11 +136,17 @@ export async function callMcpTool(
 		signal,
 		client,
 		onProgress,
+		elicitation,
 	}: {
 		timeoutMs?: number;
 		signal?: AbortSignal;
 		client?: Client;
 		onProgress?: (progress: McpToolProgress) => void;
+		/**
+		 * Where to show a prompt if the server asks the user something mid-call. Omit and
+		 * any `elicitation/create` on this connection is declined.
+		 */
+		elicitation?: { sink: ElicitationSink; toolUuid: string };
 	} = {}
 ): Promise<McpToolTextResponse> {
 	const normalizedArgs =
@@ -78,57 +158,73 @@ export async function callMcpTool(
 	// via the request options below, not on the pooled transport itself.
 	let activeClient = client ?? (await getClient(server, signal));
 
+	const deadline = createCallDeadline(timeoutMs, signal);
+
 	const callToolOptions = {
-		signal,
-		timeout: timeoutMs,
+		signal: deadline.signal,
+		timeout: ABSOLUTE_CEILING_MS,
 		// Enable progress tokens so long-running tools keep extending the timeout.
 		onprogress: (progress: McpToolProgress) => {
+			deadline.restart();
 			onProgress?.({
 				progress: progress.progress,
 				total: progress.total,
 				message: progress.message,
 			});
 		},
-		resetTimeoutOnProgress: true,
-		// The spec requires a maximum total timeout even when progress resets the per-step one.
-		maxTotalTimeout: timeoutMs * 10,
 	};
 
 	// The connection can be closed at any point during a (potentially long-running) call,
 	// e.g. by a proxy idle timeout or a server restart, so retry on a fresh client.
 	const maxReconnectAttempts = 2;
 	let response;
-	for (let attempt = 0; ; attempt++) {
-		// Keep a stable reference for retain/release: `activeClient` is reassigned on retry.
-		const currentClient = activeClient;
-		retainClient(currentClient);
-		try {
-			response = await currentClient.callTool(
-				{ name: tool, arguments: normalizedArgs },
-				callToolOptions
-			);
-			break;
-		} catch (err) {
-			if (
-				attempt >= maxReconnectAttempts ||
-				signal?.aborted ||
-				!(isConnectionClosedError(err) || isSessionExpiredError(err))
-			) {
-				throw err;
-			}
+	try {
+		for (let attempt = 0; ; attempt++) {
+			// Keep a stable reference for retain/release: `activeClient` is reassigned on retry.
+			const currentClient = activeClient;
+			retainClient(currentClient);
+			deadline.restart();
+			const invoke = () =>
+				currentClient.callTool({ name: tool, arguments: normalizedArgs }, callToolOptions);
+			try {
+				response = elicitation
+					? await withElicitationContext(
+							currentClient,
+							{
+								sink: elicitation.sink,
+								server: server.name,
+								toolUuid: elicitation.toolUuid,
+								deadline,
+								signal,
+							},
+							invoke
+						)
+					: await invoke();
+				break;
+			} catch (err) {
+				if (
+					attempt >= maxReconnectAttempts ||
+					signal?.aborted ||
+					!(isConnectionClosedError(err) || isSessionExpiredError(err))
+				) {
+					throw err;
+				}
 
-			// Evict stale client and close it
-			const stale = evictFromPool(server);
-			stale?.close?.().catch(() => {});
+				// Evict stale client and close it
+				const stale = evictFromPool(server);
+				stale?.close?.().catch(() => {});
 
-			// Brief backoff before later retries (the server may be mid-restart)
-			if (attempt > 0) {
-				await new Promise((resolve) => setTimeout(resolve, 1_000 * attempt));
+				// Brief backoff before later retries (the server may be mid-restart)
+				if (attempt > 0) {
+					await new Promise((resolve) => setTimeout(resolve, 1_000 * attempt));
+				}
+				activeClient = await getClient(server, signal);
+			} finally {
+				releaseClient(currentClient);
 			}
-			activeClient = await getClient(server, signal);
-		} finally {
-			releaseClient(currentClient);
 		}
+	} finally {
+		deadline.dispose();
 	}
 
 	const parts = Array.isArray(response?.content) ? (response.content as Array<unknown>) : [];

--- a/src/lib/server/mcp/httpClient.ts
+++ b/src/lib/server/mcp/httpClient.ts
@@ -1,6 +1,12 @@
 import { Client, SdkHttpError, isInputRequiredResult } from "@modelcontextprotocol/client";
 import type { InputRequests, InputResponses } from "@modelcontextprotocol/client";
-import { getClient, evictFromPool, retainClient, releaseClient } from "./clientPool";
+import {
+	getClient,
+	getAttributableClient,
+	evictFromPool,
+	retainClient,
+	releaseClient,
+} from "./clientPool";
 import { withElicitationContext, type ElicitationSink } from "./elicitation";
 import { config } from "$lib/server/config";
 
@@ -153,8 +159,14 @@ export async function callMcpTool(
 			: undefined;
 
 	// Get a (possibly pooled) client. Cancellation and timeout are enforced per call
-	// via the request options below, not on the pooled transport itself.
-	let activeClient = client ?? (await getClient(server, signal));
+	// via the request options below, not on the pooled transport itself. A call that can
+	// be interrupted for input needs a connection its prompts can be attributed on, so the
+	// preloaded shared client is not reused for one.
+	const scoped = elicitation
+		? await getAttributableClient(server, elicitation.sink.conversationId.toString(), signal)
+		: undefined;
+	const isolation = scoped?.isolation;
+	let activeClient = scoped?.client ?? client ?? (await getClient(server, signal));
 
 	const deadline = createCallDeadline(timeoutMs, signal);
 
@@ -220,14 +232,14 @@ export async function callMcpTool(
 				}
 
 				// Evict stale client and close it
-				const stale = evictFromPool(server);
+				const stale = evictFromPool(server, isolation);
 				stale?.close?.().catch(() => {});
 
 				// Brief backoff before later retries (the server may be mid-restart)
 				if (attempt > 0) {
 					await new Promise((resolve) => setTimeout(resolve, 1_000 * attempt));
 				}
-				activeClient = await getClient(server, signal);
+				activeClient = await getClient(server, signal, isolation);
 			} finally {
 				releaseClient(currentClient);
 			}

--- a/src/lib/server/mcp/httpClient.ts
+++ b/src/lib/server/mcp/httpClient.ts
@@ -1,4 +1,5 @@
-import { Client, SdkHttpError } from "@modelcontextprotocol/client";
+import { Client, SdkHttpError, isInputRequiredResult } from "@modelcontextprotocol/client";
+import type { InputRequests, InputResponses } from "@modelcontextprotocol/client";
 import { getClient, evictFromPool, retainClient, releaseClient } from "./clientPool";
 import { withElicitationContext, type ElicitationSink } from "./elicitation";
 import { config } from "$lib/server/config";
@@ -35,7 +36,19 @@ export function getMcpToolTimeoutMs(): number {
 	return DEFAULT_TIMEOUT_MS;
 }
 
+/**
+ * What a 2026-era server returns instead of blocking: the questions it needs answered and
+ * the opaque state to echo back. Nothing is live once this is returned, so the answer can
+ * come from another process, another pod, or another day.
+ */
+export type McpInputRequired = {
+	inputRequests: InputRequests;
+	requestState?: string;
+};
+
 export type McpToolTextResponse = {
+	/** Set when the server wants input before it can finish. Modern era only. */
+	inputRequired?: McpInputRequired;
 	text: string;
 	/**
 	 * The server reported the call as failed. MCP returns tool failures as a normal
@@ -122,6 +135,7 @@ export async function callMcpTool(
 		client,
 		onProgress,
 		elicitation,
+		resume,
 	}: {
 		timeoutMs?: number;
 		signal?: AbortSignal;
@@ -129,6 +143,8 @@ export async function callMcpTool(
 		onProgress?: (progress: McpToolProgress) => void;
 		/** Omit and any `elicitation/create` on this connection is declined. */
 		elicitation?: { sink: ElicitationSink; toolUuid: string };
+		/** Answers to a previous `input_required`, replayed verbatim to continue that call. */
+		resume?: { inputResponses: InputResponses; requestState?: string };
 	} = {}
 ): Promise<McpToolTextResponse> {
 	const normalizedArgs =
@@ -145,6 +161,9 @@ export async function callMcpTool(
 	const callToolOptions = {
 		signal: deadline.signal,
 		timeout: ABSOLUTE_CEILING_MS,
+		// Hand an `input_required` back rather than letting the driver block on our
+		// handler: a 2026-era prompt is answered out of band, not inside this call.
+		allowInputRequired: true,
 		// Enable progress tokens so long-running tools keep extending the timeout.
 		onprogress: (progress: McpToolProgress) => {
 			deadline.restart();
@@ -167,7 +186,15 @@ export async function callMcpTool(
 			retainClient(currentClient);
 			deadline.restart();
 			const invoke = () =>
-				currentClient.callTool({ name: tool, arguments: normalizedArgs }, callToolOptions);
+				currentClient.callTool(
+					{
+						name: tool,
+						arguments: normalizedArgs,
+						...(resume ? { inputResponses: resume.inputResponses } : {}),
+						...(resume?.requestState !== undefined ? { requestState: resume.requestState } : {}),
+					},
+					callToolOptions
+				);
 			try {
 				response = elicitation
 					? await withElicitationContext(
@@ -207,6 +234,17 @@ export async function callMcpTool(
 		}
 	} finally {
 		deadline.dispose();
+	}
+
+	if (isInputRequiredResult(response)) {
+		return {
+			text: "",
+			isError: false,
+			inputRequired: {
+				inputRequests: response.inputRequests ?? {},
+				...(response.requestState !== undefined ? { requestState: response.requestState } : {}),
+			},
+		};
 	}
 
 	const parts = Array.isArray(response?.content) ? (response.content as Array<unknown>) : [];

--- a/src/lib/server/mcp/resumeElicitation.spec.ts
+++ b/src/lib/server/mcp/resumeElicitation.spec.ts
@@ -1,73 +1,34 @@
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { createServer, type Server } from "node:http";
-import type { AddressInfo } from "node:net";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { ObjectId } from "mongodb";
-import {
-	createMcpHandler,
-	McpServer,
-	inputRequired,
-	acceptedContent,
-} from "@modelcontextprotocol/server";
-import { toNodeHandler } from "@modelcontextprotocol/node";
 import { collections, ready } from "$lib/server/database";
-import { resumeParkedToolCall } from "./resumeElicitation";
 import {
 	isMessageElicitationRequestUpdate,
 	isMessageElicitationResolvedUpdate,
 } from "$lib/utils/messageUpdates";
 
+/**
+ * The tool call is stubbed rather than served over a socket: what is under test is which
+ * branch a resume takes, and a real server would drag protocol negotiation, the shared
+ * client pool and MCP_* config into a unit test.
+ */
+const calls = vi.hoisted(() => ({ queue: [] as unknown[], seen: [] as unknown[] }));
+vi.mock("./httpClient", () => ({
+	getMcpToolTimeoutMs: () => 1000,
+	callMcpTool: async (
+		_server: unknown,
+		tool: string,
+		args: unknown,
+		opts: { resume?: unknown }
+	) => {
+		calls.seen.push({ tool, args, resume: opts?.resume });
+		return calls.queue.shift() ?? { text: "", isError: false };
+	},
+}));
+
 await ready;
 
-/** A 2026-era server that asks twice, carrying its step in `requestState`. */
-const handler = createMcpHandler(() => {
-	const server = new McpServer({ name: "twice", version: "1.0.0" });
-	server.registerTool("confirm_twice", { description: "Confirms twice." }, async (...args) => {
-		const ctx = args.at(-1) as {
-			mcpReq?: {
-				inputResponses?: Record<string, unknown>;
-				requestState?: () => string | undefined;
-			};
-		};
-		const step = ctx?.mcpReq?.requestState?.() ?? "start";
-		if (step === "start") {
-			return inputRequired({
-				requestState: "asked-once",
-				inputRequests: {
-					first: inputRequired.elicit({
-						message: "Really?",
-						requestedSchema: { type: "object", properties: { ok: { type: "string" } } },
-					}),
-				},
-			});
-		}
-		if (step === "asked-once") {
-			return inputRequired({
-				requestState: "asked-twice",
-				inputRequests: {
-					second: inputRequired.elicit({
-						message: "Are you sure?",
-						requestedSchema: { type: "object", properties: { sure: { type: "string" } } },
-					}),
-				},
-			});
-		}
-		const got = acceptedContent(ctx?.mcpReq?.inputResponses, "second");
-		return { content: [{ type: "text" as const, text: `done ${JSON.stringify(got)}` }] };
-	});
-	return server;
-});
-
-let server: Server;
-let servers: { name: string; url: string }[];
-
-beforeAll(async () => {
-	server = createServer(toNodeHandler(handler));
-	await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
-	const { port } = server.address() as AddressInfo;
-	servers = [{ name: "Twice", url: `http://127.0.0.1:${port}/mcp` }];
-});
-
-afterAll(() => new Promise<void>((resolve) => server.close(() => resolve())));
+const SERVERS = [{ name: "Mock", url: "http://mock.invalid/mcp" }];
+const { resumeParkedToolCall } = await import("./resumeElicitation");
 
 async function park(
 	conversationId: ObjectId,
@@ -83,11 +44,11 @@ async function park(
 		status: "resolved",
 		action: "accept",
 		content,
-		request: { elicitationId, server: "Twice", mode: "form", message: "?", fields: [] },
+		request: { elicitationId, server: "Mock", mode: "form", message: "?", fields: [] },
 		pending: {
-			server: "Twice",
+			server: "Mock",
 			tool: "confirm_twice",
-			args: {},
+			args: { a: 1 },
 			inputKey,
 			messageId: "m1",
 			toolCallId: "c1",
@@ -100,23 +61,68 @@ async function park(
 	return elicitationId;
 }
 
+const askAgain = (message: string, requestState: string) => ({
+	text: "",
+	isError: false,
+	inputRequired: {
+		requestState,
+		inputRequests: {
+			second: {
+				method: "elicitation/create",
+				params: {
+					message,
+					requestedSchema: { type: "object", properties: { sure: { type: "string" } } },
+				},
+			},
+		},
+	},
+});
+
 describe("resuming a parked tool call", () => {
+	beforeEach(() => {
+		calls.queue.length = 0;
+		calls.seen.length = 0;
+	});
+
+	it("replays the answer and the opaque state to the same tool", async () => {
+		calls.queue.push({ text: "done", isError: false });
+		const conversationId = new ObjectId();
+		const id = await park(conversationId, "first", "asked-once", { ok: "yes" });
+
+		await resumeParkedToolCall({ conversationId, elicitationId: id, extraServers: SERVERS });
+
+		expect(calls.seen).toEqual([
+			{
+				tool: "confirm_twice",
+				args: { a: 1 },
+				resume: {
+					requestState: "asked-once",
+					inputResponses: { first: { action: "accept", content: { ok: "yes" } } },
+				},
+			},
+		]);
+	});
+
 	it("parks again when the tool asks a second time", async () => {
 		// Returning here instead would hand the model a round that never produced a result.
+		calls.queue.push(askAgain("Are you sure?", "asked-twice"));
 		const conversationId = new ObjectId();
-		const first = await park(conversationId, "first", "asked-once", { ok: "yes" });
+		const id = await park(conversationId, "first", "asked-once", { ok: "yes" });
 
 		const round1 = await resumeParkedToolCall({
 			conversationId,
-			elicitationId: first,
-			extraServers: servers,
+			elicitationId: id,
+			extraServers: SERVERS,
 		});
 
 		expect(round1.parkedAgain).toBe(true);
-		// The answered prompt is settled first, so a reloaded transcript stops showing it
-		// as an open form and can render what was submitted.
-		const settled = round1.updates.find(isMessageElicitationResolvedUpdate);
-		expect(settled).toMatchObject({ action: "accept", content: { ok: "yes" } });
+		// The answered prompt settles first, so a reloaded transcript stops showing it as an
+		// open form and can render what was submitted.
+		expect(round1.updates.find(isMessageElicitationResolvedUpdate)).toMatchObject({
+			action: "accept",
+			content: { ok: "yes" },
+		});
+
 		const prompt = round1.updates.find(isMessageElicitationRequestUpdate);
 		expect(prompt?.request.message).toBe("Are you sure?");
 		// A durable prompt carries no deadline, so the UI shows no countdown.
@@ -125,38 +131,53 @@ describe("resuming a parked tool call", () => {
 		const stored = await collections.mcpElicitations.findOne({
 			elicitationId: prompt?.request.elicitationId,
 		});
-		expect(stored?.pending?.requestState).toBe("asked-twice");
-		expect(stored?.pending?.inputKey).toBe("second");
+		expect(stored?.pending).toMatchObject({ requestState: "asked-twice", inputKey: "second" });
 	});
 
 	it("returns the tool result once the last question is answered", async () => {
+		calls.queue.push({ text: "all done", isError: false });
 		const conversationId = new ObjectId();
-		const last = await park(conversationId, "second", "asked-twice", { sure: "yes" });
+		const id = await park(conversationId, "second", "asked-twice", { sure: "yes" });
 
 		const done = await resumeParkedToolCall({
 			conversationId,
-			elicitationId: last,
-			extraServers: servers,
+			elicitationId: id,
+			extraServers: SERVERS,
 		});
 
 		expect(done.parkedAgain).toBeUndefined();
-		expect(done.updates.find(isMessageElicitationResolvedUpdate)).toMatchObject({
-			action: "accept",
+		expect(done.updates.find(isMessageElicitationResolvedUpdate)).toBeDefined();
+		const result = done.updates.find((u) => u.type === "tool" && u.subtype === "result") as
+			undefined | { result: { outputs: { text?: string }[] } };
+		expect(result?.result.outputs[0]?.text).toBe("all done");
+	});
+
+	it("surfaces a failing tool call as an error on the same block", async () => {
+		calls.queue.push({ text: "it broke", isError: true });
+		const conversationId = new ObjectId();
+		const id = await park(conversationId, "second", undefined, { sure: "yes" });
+
+		const done = await resumeParkedToolCall({
+			conversationId,
+			elicitationId: id,
+			extraServers: SERVERS,
 		});
-		const result = done.updates.find(
-			(u) => u.type === "tool" && u.subtype === "result"
-		) as unknown as { result?: { outputs?: { text?: string }[] } };
-		expect(result?.result?.outputs?.[0]?.text).toContain("done");
+
+		expect(done.updates.find((u) => u.type === "tool" && u.subtype === "error")).toMatchObject({
+			uuid: "u1",
+			message: "it broke",
+		});
 	});
 
 	it("reports a prompt it cannot resume rather than pretending", async () => {
 		const outcome = await resumeParkedToolCall({
 			conversationId: new ObjectId(),
 			elicitationId: crypto.randomUUID(),
-			extraServers: servers,
+			extraServers: SERVERS,
 		});
 
 		expect(outcome).toMatchObject({ resumed: false });
 		expect(outcome.updates).toHaveLength(0);
+		expect(calls.seen).toHaveLength(0);
 	});
 });

--- a/src/lib/server/mcp/resumeElicitation.spec.ts
+++ b/src/lib/server/mcp/resumeElicitation.spec.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { ObjectId } from "mongodb";
+import {
+	createMcpHandler,
+	McpServer,
+	inputRequired,
+	acceptedContent,
+} from "@modelcontextprotocol/server";
+import { toNodeHandler } from "@modelcontextprotocol/node";
+import { collections, ready } from "$lib/server/database";
+import { resumeParkedToolCall } from "./resumeElicitation";
+import { isMessageElicitationRequestUpdate } from "$lib/utils/messageUpdates";
+
+await ready;
+
+/** A 2026-era server that asks twice, carrying its step in `requestState`. */
+const handler = createMcpHandler(() => {
+	const server = new McpServer({ name: "twice", version: "1.0.0" });
+	server.registerTool("confirm_twice", { description: "Confirms twice." }, async (...args) => {
+		const ctx = args.at(-1) as {
+			mcpReq?: {
+				inputResponses?: Record<string, unknown>;
+				requestState?: () => string | undefined;
+			};
+		};
+		const step = ctx?.mcpReq?.requestState?.() ?? "start";
+		if (step === "start") {
+			return inputRequired({
+				requestState: "asked-once",
+				inputRequests: {
+					first: inputRequired.elicit({
+						message: "Really?",
+						requestedSchema: { type: "object", properties: { ok: { type: "string" } } },
+					}),
+				},
+			});
+		}
+		if (step === "asked-once") {
+			return inputRequired({
+				requestState: "asked-twice",
+				inputRequests: {
+					second: inputRequired.elicit({
+						message: "Are you sure?",
+						requestedSchema: { type: "object", properties: { sure: { type: "string" } } },
+					}),
+				},
+			});
+		}
+		const got = acceptedContent(ctx?.mcpReq?.inputResponses, "second");
+		return { content: [{ type: "text" as const, text: `done ${JSON.stringify(got)}` }] };
+	});
+	return server;
+});
+
+let server: Server;
+let servers: { name: string; url: string }[];
+
+beforeAll(async () => {
+	server = createServer(toNodeHandler(handler));
+	await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+	const { port } = server.address() as AddressInfo;
+	servers = [{ name: "Twice", url: `http://127.0.0.1:${port}/mcp` }];
+});
+
+afterAll(() => new Promise<void>((resolve) => server.close(() => resolve())));
+
+async function park(
+	conversationId: ObjectId,
+	inputKey: string,
+	requestState: string | undefined,
+	content: Record<string, string>
+) {
+	const elicitationId = crypto.randomUUID();
+	await collections.mcpElicitations.insertOne({
+		_id: new ObjectId(),
+		elicitationId,
+		conversationId,
+		status: "resolved",
+		action: "accept",
+		content,
+		request: { elicitationId, server: "Twice", mode: "form", message: "?", fields: [] },
+		pending: {
+			server: "Twice",
+			tool: "confirm_twice",
+			args: {},
+			inputKey,
+			messageId: "m1",
+			toolCallId: "c1",
+			toolUuid: "u1",
+			...(requestState !== undefined ? { requestState } : {}),
+		},
+		createdAt: new Date(),
+		updatedAt: new Date(),
+	});
+	return elicitationId;
+}
+
+describe("resuming a parked tool call", () => {
+	it("parks again when the tool asks a second time", async () => {
+		// Returning here instead would hand the model a round that never produced a result.
+		const conversationId = new ObjectId();
+		const first = await park(conversationId, "first", "asked-once", { ok: "yes" });
+
+		const round1 = await resumeParkedToolCall({
+			conversationId,
+			elicitationId: first,
+			extraServers: servers,
+		});
+
+		expect(round1.parkedAgain).toBe(true);
+		const prompt = round1.updates.find(isMessageElicitationRequestUpdate);
+		expect(prompt?.request.message).toBe("Are you sure?");
+		// A durable prompt carries no deadline, so the UI shows no countdown.
+		expect(prompt?.expiresAt).toBeUndefined();
+
+		const stored = await collections.mcpElicitations.findOne({
+			elicitationId: prompt?.request.elicitationId,
+		});
+		expect(stored?.pending?.requestState).toBe("asked-twice");
+		expect(stored?.pending?.inputKey).toBe("second");
+	});
+
+	it("returns the tool result once the last question is answered", async () => {
+		const conversationId = new ObjectId();
+		const last = await park(conversationId, "second", "asked-twice", { sure: "yes" });
+
+		const done = await resumeParkedToolCall({
+			conversationId,
+			elicitationId: last,
+			extraServers: servers,
+		});
+
+		expect(done.parkedAgain).toBeUndefined();
+		const update = done.updates[0] as unknown as {
+			result?: { outputs?: { text?: string }[] };
+		};
+		expect(update.result?.outputs?.[0]?.text).toContain("done");
+	});
+
+	it("reports a prompt it cannot resume rather than pretending", async () => {
+		const outcome = await resumeParkedToolCall({
+			conversationId: new ObjectId(),
+			elicitationId: crypto.randomUUID(),
+			extraServers: servers,
+		});
+
+		expect(outcome).toMatchObject({ resumed: false });
+		expect(outcome.updates).toHaveLength(0);
+	});
+});

--- a/src/lib/server/mcp/resumeElicitation.spec.ts
+++ b/src/lib/server/mcp/resumeElicitation.spec.ts
@@ -11,7 +11,10 @@ import {
 import { toNodeHandler } from "@modelcontextprotocol/node";
 import { collections, ready } from "$lib/server/database";
 import { resumeParkedToolCall } from "./resumeElicitation";
-import { isMessageElicitationRequestUpdate } from "$lib/utils/messageUpdates";
+import {
+	isMessageElicitationRequestUpdate,
+	isMessageElicitationResolvedUpdate,
+} from "$lib/utils/messageUpdates";
 
 await ready;
 
@@ -110,6 +113,10 @@ describe("resuming a parked tool call", () => {
 		});
 
 		expect(round1.parkedAgain).toBe(true);
+		// The answered prompt is settled first, so a reloaded transcript stops showing it
+		// as an open form and can render what was submitted.
+		const settled = round1.updates.find(isMessageElicitationResolvedUpdate);
+		expect(settled).toMatchObject({ action: "accept", content: { ok: "yes" } });
 		const prompt = round1.updates.find(isMessageElicitationRequestUpdate);
 		expect(prompt?.request.message).toBe("Are you sure?");
 		// A durable prompt carries no deadline, so the UI shows no countdown.
@@ -133,10 +140,13 @@ describe("resuming a parked tool call", () => {
 		});
 
 		expect(done.parkedAgain).toBeUndefined();
-		const update = done.updates[0] as unknown as {
-			result?: { outputs?: { text?: string }[] };
-		};
-		expect(update.result?.outputs?.[0]?.text).toContain("done");
+		expect(done.updates.find(isMessageElicitationResolvedUpdate)).toMatchObject({
+			action: "accept",
+		});
+		const result = done.updates.find(
+			(u) => u.type === "tool" && u.subtype === "result"
+		) as unknown as { result?: { outputs?: { text?: string }[] } };
+		expect(result?.result?.outputs?.[0]?.text).toContain("done");
 	});
 
 	it("reports a prompt it cannot resume rather than pretending", async () => {

--- a/src/lib/server/mcp/resumeElicitation.spec.ts
+++ b/src/lib/server/mcp/resumeElicitation.spec.ts
@@ -169,6 +169,31 @@ describe("resuming a parked tool call", () => {
 		});
 	});
 
+	it("will not resume another conversation's prompt", async () => {
+		// The id alone is not authority: a page open on a different conversation must not
+		// continue this one's tool call.
+		calls.queue.push({ text: "should never run", isError: false });
+		const owner = new ObjectId();
+		const id = await park(owner, "first", "asked-once", { ok: "yes" });
+
+		const outcome = await resumeParkedToolCall({
+			conversationId: new ObjectId(),
+			elicitationId: id,
+			extraServers: SERVERS,
+		});
+
+		expect(outcome).toMatchObject({ resumed: false });
+		expect(calls.seen).toHaveLength(0);
+		// and the real owner can still resume it afterwards
+		const mine = await resumeParkedToolCall({
+			conversationId: owner,
+			elicitationId: id,
+			extraServers: SERVERS,
+		});
+		expect(mine.resumed).toBe(true);
+		expect(calls.seen).toHaveLength(1);
+	});
+
 	it("reports a prompt it cannot resume rather than pretending", async () => {
 		const outcome = await resumeParkedToolCall({
 			conversationId: new ObjectId(),

--- a/src/lib/server/mcp/resumeElicitation.ts
+++ b/src/lib/server/mcp/resumeElicitation.ts
@@ -1,5 +1,4 @@
-import { ObjectId } from "mongodb";
-import { collections } from "$lib/server/database";
+import type { ObjectId } from "mongodb";
 import { logger } from "$lib/server/logger";
 import { callMcpTool, getMcpToolTimeoutMs } from "./httpClient";
 import { getMcpServers } from "./registry";
@@ -14,8 +13,9 @@ import type { McpServerConfig } from "./httpClient";
  *
  * The 2026-era server kept no state — `requestState` and the answers are the whole
  * continuation — so this runs anywhere, on any connection, however long afterwards.
- * Appends the result to the assistant message so ordinary history replay carries it into
- * the next completion; nothing here talks to the model.
+ * Returns the update rather than writing it: the caller feeds it through the run's normal
+ * update path, so it streams, persists, and lands in the writer's snapshot together —
+ * writing it separately would be overwritten by the next materialise.
  */
 export async function resumeParkedToolCall({
 	conversationId,
@@ -27,7 +27,7 @@ export async function resumeParkedToolCall({
 	elicitationId: string;
 	extraServers?: McpServerConfig[];
 	signal?: AbortSignal;
-}): Promise<{ resumed: boolean; reason?: string }> {
+}): Promise<{ resumed: boolean; reason?: string; update?: MessageUpdate }> {
 	const taken = await takeResumableElicitation(conversationId, elicitationId);
 	const pending = taken?.row.pending;
 	if (!taken || !pending) return { resumed: false, reason: "no answered prompt to resume" };
@@ -86,10 +86,5 @@ export async function resumeParkedToolCall({
 		};
 	}
 
-	await collections.conversations.updateOne(
-		{ _id: conversationId, "messages.id": pending.messageId },
-		{ $push: { "messages.$.updates": update }, $set: { updatedAt: new Date() } }
-	);
-
-	return { resumed: true };
+	return { resumed: true, update };
 }

--- a/src/lib/server/mcp/resumeElicitation.ts
+++ b/src/lib/server/mcp/resumeElicitation.ts
@@ -2,7 +2,7 @@ import type { ObjectId } from "mongodb";
 import { logger } from "$lib/server/logger";
 import { callMcpTool, getMcpToolTimeoutMs } from "./httpClient";
 import { getMcpServers } from "./registry";
-import { takeResumableElicitation } from "./elicitation";
+import { openDurableElicitation, takeResumableElicitation } from "./elicitation";
 import { ToolResultStatus } from "$lib/types/Tool";
 import { MessageToolUpdateType, MessageUpdateType } from "$lib/types/MessageUpdate";
 import type { MessageUpdate } from "$lib/types/MessageUpdate";
@@ -20,21 +20,31 @@ import type { McpServerConfig } from "./httpClient";
 export async function resumeParkedToolCall({
 	conversationId,
 	elicitationId,
+	generationId,
 	extraServers = [],
 	signal,
 }: {
 	conversationId: ObjectId;
 	elicitationId: string;
+	generationId?: string;
 	extraServers?: McpServerConfig[];
 	signal?: AbortSignal;
-}): Promise<{ resumed: boolean; reason?: string; update?: MessageUpdate }> {
+}): Promise<{
+	resumed: boolean;
+	reason?: string;
+	updates: MessageUpdate[];
+	/** The tool asked something else; the run ends again until that is answered too. */
+	parkedAgain?: boolean;
+}> {
 	const taken = await takeResumableElicitation(conversationId, elicitationId);
 	const pending = taken?.row.pending;
-	if (!taken || !pending) return { resumed: false, reason: "no answered prompt to resume" };
+	if (!taken || !pending) {
+		return { resumed: false, reason: "no answered prompt to resume", updates: [] };
+	}
 	const { inputResponses } = taken;
 
 	const server = [...getMcpServers(), ...extraServers].find((s) => s.name === pending.server);
-	if (!server) return { resumed: false, reason: `unknown server ${pending.server}` };
+	if (!server) return { resumed: false, reason: `unknown server ${pending.server}`, updates: [] };
 
 	let update: MessageUpdate;
 	try {
@@ -47,9 +57,33 @@ export async function resumeParkedToolCall({
 			},
 		});
 
-		// A second prompt in the same call is a second round; this pass answers one.
+		// A tool can ask more than once. Park again on the same call rather than handing
+		// the model a round that never finished.
 		if (response.inputRequired) {
-			return { resumed: false, reason: "the tool asked for more input" };
+			const collected: MessageUpdate[] = [];
+			const opened = await openDurableElicitation({
+				sink: {
+					conversationId,
+					...(generationId ? { generationId } : {}),
+					emit: (u) => collected.push(u),
+				},
+				server: pending.server,
+				toolUuid: pending.toolUuid,
+				pending: {
+					tool: pending.tool,
+					args: pending.args,
+					messageId: pending.messageId,
+					toolCallId: pending.toolCallId,
+					toolUuid: pending.toolUuid,
+				},
+				inputRequired: response.inputRequired,
+			});
+			if (opened.opened) return { resumed: true, updates: collected, parkedAgain: true };
+			return {
+				resumed: false,
+				reason: `could not show the next prompt: ${opened.reason}`,
+				updates: [],
+			};
 		}
 
 		update = response.isError
@@ -86,5 +120,5 @@ export async function resumeParkedToolCall({
 		};
 	}
 
-	return { resumed: true, update };
+	return { resumed: true, updates: [update] };
 }

--- a/src/lib/server/mcp/resumeElicitation.ts
+++ b/src/lib/server/mcp/resumeElicitation.ts
@@ -4,7 +4,11 @@ import { callMcpTool, getMcpToolTimeoutMs } from "./httpClient";
 import { getMcpServers } from "./registry";
 import { openDurableElicitation, takeResumableElicitation } from "./elicitation";
 import { ToolResultStatus } from "$lib/types/Tool";
-import { MessageToolUpdateType, MessageUpdateType } from "$lib/types/MessageUpdate";
+import {
+	MessageElicitationUpdateType,
+	MessageToolUpdateType,
+	MessageUpdateType,
+} from "$lib/types/MessageUpdate";
 import type { MessageUpdate } from "$lib/types/MessageUpdate";
 import type { McpServerConfig } from "./httpClient";
 
@@ -43,6 +47,17 @@ export async function resumeParkedToolCall({
 	}
 	const { inputResponses } = taken;
 
+	// Nothing emitted this while the run was over, so the transcript still shows an open
+	// form. Settling it here is what lets a reloaded page render the answer instead.
+	const settled: MessageUpdate = {
+		type: MessageUpdateType.Elicitation,
+		subtype: MessageElicitationUpdateType.Resolved,
+		elicitationId,
+		action: taken.row.action ?? "cancel",
+		resolution: "user",
+		...(taken.row.content ? { content: taken.row.content } : {}),
+	};
+
 	const server = [...getMcpServers(), ...extraServers].find((s) => s.name === pending.server);
 	if (!server) return { resumed: false, reason: `unknown server ${pending.server}`, updates: [] };
 
@@ -78,11 +93,13 @@ export async function resumeParkedToolCall({
 				},
 				inputRequired: response.inputRequired,
 			});
-			if (opened.opened) return { resumed: true, updates: collected, parkedAgain: true };
+			if (opened.opened) {
+				return { resumed: true, updates: [settled, ...collected], parkedAgain: true };
+			}
 			return {
 				resumed: false,
 				reason: `could not show the next prompt: ${opened.reason}`,
-				updates: [],
+				updates: [settled],
 			};
 		}
 
@@ -120,5 +137,5 @@ export async function resumeParkedToolCall({
 		};
 	}
 
-	return { resumed: true, updates: [update] };
+	return { resumed: true, updates: [settled, update] };
 }

--- a/src/lib/server/mcp/resumeElicitation.ts
+++ b/src/lib/server/mcp/resumeElicitation.ts
@@ -1,0 +1,95 @@
+import { ObjectId } from "mongodb";
+import { collections } from "$lib/server/database";
+import { logger } from "$lib/server/logger";
+import { callMcpTool, getMcpToolTimeoutMs } from "./httpClient";
+import { getMcpServers } from "./registry";
+import { takeResumableElicitation } from "./elicitation";
+import { ToolResultStatus } from "$lib/types/Tool";
+import { MessageToolUpdateType, MessageUpdateType } from "$lib/types/MessageUpdate";
+import type { MessageUpdate } from "$lib/types/MessageUpdate";
+import type { McpServerConfig } from "./httpClient";
+
+/**
+ * Re-issue the tool call a durable prompt parked, now that it has an answer.
+ *
+ * The 2026-era server kept no state — `requestState` and the answers are the whole
+ * continuation — so this runs anywhere, on any connection, however long afterwards.
+ * Appends the result to the assistant message so ordinary history replay carries it into
+ * the next completion; nothing here talks to the model.
+ */
+export async function resumeParkedToolCall({
+	conversationId,
+	elicitationId,
+	extraServers = [],
+	signal,
+}: {
+	conversationId: ObjectId;
+	elicitationId: string;
+	extraServers?: McpServerConfig[];
+	signal?: AbortSignal;
+}): Promise<{ resumed: boolean; reason?: string }> {
+	const taken = await takeResumableElicitation(conversationId, elicitationId);
+	const pending = taken?.row.pending;
+	if (!taken || !pending) return { resumed: false, reason: "no answered prompt to resume" };
+	const { inputResponses } = taken;
+
+	const server = [...getMcpServers(), ...extraServers].find((s) => s.name === pending.server);
+	if (!server) return { resumed: false, reason: `unknown server ${pending.server}` };
+
+	let update: MessageUpdate;
+	try {
+		const response = await callMcpTool(server, pending.tool, pending.args, {
+			signal,
+			timeoutMs: getMcpToolTimeoutMs(),
+			resume: {
+				inputResponses,
+				...(pending.requestState !== undefined ? { requestState: pending.requestState } : {}),
+			},
+		});
+
+		// A second prompt in the same call is a second round; this pass answers one.
+		if (response.inputRequired) {
+			return { resumed: false, reason: "the tool asked for more input" };
+		}
+
+		update = response.isError
+			? {
+					type: MessageUpdateType.Tool,
+					subtype: MessageToolUpdateType.Error,
+					uuid: pending.toolUuid,
+					message: response.text || "The tool reported an error with no message.",
+				}
+			: {
+					type: MessageUpdateType.Tool,
+					subtype: MessageToolUpdateType.Result,
+					uuid: pending.toolUuid,
+					result: {
+						status: ToolResultStatus.Success,
+						call: { name: pending.tool, parameters: {} },
+						outputs: [
+							{
+								text: response.text ?? "",
+								structured: response.structured,
+								content: response.content,
+							},
+						] as unknown as Record<string, unknown>[],
+						display: true,
+					},
+				};
+	} catch (err) {
+		logger.warn({ err, tool: pending.tool }, "[mcp] resumed tool call failed");
+		update = {
+			type: MessageUpdateType.Tool,
+			subtype: MessageToolUpdateType.Error,
+			uuid: pending.toolUuid,
+			message: err instanceof Error ? err.message : String(err),
+		};
+	}
+
+	await collections.conversations.updateOne(
+		{ _id: conversationId, "messages.id": pending.messageId },
+		{ $push: { "messages.$.updates": update }, $set: { updatedAt: new Date() } }
+	);
+
+	return { resumed: true };
+}

--- a/src/lib/server/mcp/tools.test.ts
+++ b/src/lib/server/mcp/tools.test.ts
@@ -12,6 +12,8 @@ const mcpMock = vi.hoisted(() => ({
 vi.mock("@modelcontextprotocol/client", () => ({
 	Client: class {
 		private url = "";
+		// Session clients register one per declared capability; listing never invokes them.
+		setRequestHandler() {}
 		async connect(transport: { url?: unknown }) {
 			this.url = String(transport.url ?? "");
 		}

--- a/src/lib/server/textGeneration/index.ts
+++ b/src/lib/server/textGeneration/index.ts
@@ -84,6 +84,7 @@ async function* textGenerationWithoutTitle(
 			abortSignal: ctx.abortController.signal,
 			abortController: ctx.abortController,
 			promptedAt: ctx.promptedAt,
+			generationId: ctx.generationId,
 		});
 
 		let step = await mcpGen.next();

--- a/src/lib/server/textGeneration/index.ts
+++ b/src/lib/server/textGeneration/index.ts
@@ -85,6 +85,7 @@ async function* textGenerationWithoutTitle(
 			abortController: ctx.abortController,
 			promptedAt: ctx.promptedAt,
 			generationId: ctx.generationId,
+			messageId: ctx.messageId,
 		});
 
 		let step = await mcpGen.next();

--- a/src/lib/server/textGeneration/mcp/runMcpFlow.ts
+++ b/src/lib/server/textGeneration/mcp/runMcpFlow.ts
@@ -27,6 +27,7 @@ import { prepareMessagesWithFiles } from "$lib/server/textGeneration/utils/prepa
 import { makeImageProcessor } from "$lib/server/endpoints/images";
 import { logger } from "$lib/server/logger";
 import { AbortedGenerations } from "$lib/server/abortedGenerations";
+import { withoutContentLength } from "$lib/server/undiciCompat";
 
 export type RunMcpFlowContext = Pick<
 	TextGenerationContext,
@@ -336,7 +337,7 @@ export async function* runMcpFlow({
 			input: RequestInfo | URL,
 			init?: RequestInit
 		): Promise<Response> => {
-			const res = await fetch(input, init);
+			const res = await fetch(input, withoutContentLength(init));
 			const p = res.headers.get("x-inference-provider");
 			if (p && !providerHeader) providerHeader = p;
 			return res;

--- a/src/lib/server/textGeneration/mcp/runMcpFlow.ts
+++ b/src/lib/server/textGeneration/mcp/runMcpFlow.ts
@@ -39,6 +39,7 @@ export type RunMcpFlowContext = Pick<
 	| "reasoningEffort"
 	| "reasoningOverride"
 	| "locals"
+	| "generationId"
 > & { messages: EndpointMessage[] };
 
 // Only "not_applicable" means MCP never ran and the caller should generate normally.
@@ -61,6 +62,7 @@ export async function* runMcpFlow({
 	reasoningEffort,
 	reasoningOverride,
 	locals,
+	generationId,
 	preprompt,
 	abortSignal,
 	abortController,
@@ -831,6 +833,7 @@ export async function* runMcpFlow({
 					// own message instead of moving them onto the final answer.
 					roundReasoning: reasoningForToolMsg,
 					roundContent: assistantContentForToolMsg,
+					elicitation: { conversationId: conv._id, generationId },
 				});
 				let toolMsgCount = 0;
 				let toolRunCount = 0;

--- a/src/lib/server/textGeneration/mcp/runMcpFlow.ts
+++ b/src/lib/server/textGeneration/mcp/runMcpFlow.ts
@@ -40,11 +40,18 @@ export type RunMcpFlowContext = Pick<
 	| "reasoningOverride"
 	| "locals"
 	| "generationId"
+	| "messageId"
 > & { messages: EndpointMessage[] };
 
 // Only "not_applicable" means MCP never ran and the caller should generate normally.
 // Every other result has already emitted its own final answer.
-export type McpFlowResult = "completed" | "not_applicable" | "aborted" | "exhausted";
+export type McpFlowResult =
+	| "completed"
+	| "not_applicable"
+	| "aborted"
+	| "exhausted"
+	/** A 2026-era prompt is open; the run ends here and resumes when it is answered. */
+	| "awaiting_input";
 
 const MAX_TOOL_ROUNDS = 10;
 
@@ -63,6 +70,7 @@ export async function* runMcpFlow({
 	reasoningOverride,
 	locals,
 	generationId,
+	messageId,
 	preprompt,
 	abortSignal,
 	abortController,
@@ -833,7 +841,7 @@ export async function* runMcpFlow({
 					// own message instead of moving them onto the final answer.
 					roundReasoning: reasoningForToolMsg,
 					roundContent: assistantContentForToolMsg,
-					elicitation: { conversationId: conv._id, generationId },
+					elicitation: { conversationId: conv._id, generationId, messageId },
 				});
 				let toolMsgCount = 0;
 				let toolRunCount = 0;
@@ -842,6 +850,10 @@ export async function* runMcpFlow({
 						producedOutput = true;
 						yield event.update;
 					} else {
+						if (event.summary.awaitingInput) {
+							logger.info({ loop }, "[mcp] parked on a durable prompt; run ends until answered");
+							return "awaiting_input";
+						}
 						messagesOpenAI = [
 							...messagesOpenAI,
 							assistantToolMessage,

--- a/src/lib/server/textGeneration/mcp/toolInvocation.ts
+++ b/src/lib/server/textGeneration/mcp/toolInvocation.ts
@@ -223,7 +223,6 @@ export async function* executeToolCalls({
 	const results: TaskResult[] = [];
 
 	const elicitationSink: ElicitationSink | undefined = elicitation && {
-		id: elicitation.generationId ?? `conversation:${elicitation.conversationId.toString()}`,
 		conversationId: elicitation.conversationId,
 		...(elicitation.generationId ? { generationId: elicitation.generationId } : {}),
 		emit: (update) => updatesQueue.push(update),

--- a/src/lib/server/textGeneration/mcp/toolInvocation.ts
+++ b/src/lib/server/textGeneration/mcp/toolInvocation.ts
@@ -49,10 +49,7 @@ export interface ExecuteToolCallsParams {
 	roundReasoning?: string;
 	/** Visible text streamed before this round's calls; persisted on the round's first Call update. */
 	roundContent?: string;
-	/**
-	 * Which chat to show a prompt in when a server asks the user for input mid-call.
-	 * Omit and elicitation requests on these calls are declined.
-	 */
+	/** Omit and elicitation requests raised by these calls are declined. */
 	elicitation?: { conversationId: ObjectId; generationId?: string };
 }
 
@@ -225,8 +222,6 @@ export async function* executeToolCalls({
 	const updatesQueue = createQueue<MessageUpdate>();
 	const results: TaskResult[] = [];
 
-	// A prompt raised by a server is just another update on this round's stream, so it
-	// reaches the browser — and the persisted event log — by the same path as progress.
 	const elicitationSink: ElicitationSink | undefined = elicitation && {
 		id: elicitation.generationId ?? `conversation:${elicitation.conversationId.toString()}`,
 		conversationId: elicitation.conversationId,

--- a/src/lib/server/textGeneration/mcp/toolInvocation.ts
+++ b/src/lib/server/textGeneration/mcp/toolInvocation.ts
@@ -12,7 +12,7 @@ import {
 	type McpToolTextResponse,
 } from "$lib/server/mcp/httpClient";
 import { getClient } from "$lib/server/mcp/clientPool";
-import type { ElicitationSink } from "$lib/server/mcp/elicitation";
+import { openDurableElicitation, type ElicitationSink } from "$lib/server/mcp/elicitation";
 import { attachFileRefsToArgs, type FileRefResolver } from "./fileRefs";
 import type { Client } from "@modelcontextprotocol/client";
 import type { ObjectId } from "mongodb";
@@ -50,13 +50,15 @@ export interface ExecuteToolCallsParams {
 	/** Visible text streamed before this round's calls; persisted on the round's first Call update. */
 	roundContent?: string;
 	/** Omit and elicitation requests raised by these calls are declined. */
-	elicitation?: { conversationId: ObjectId; generationId?: string };
+	elicitation?: { conversationId: ObjectId; generationId?: string; messageId?: string };
 }
 
 export interface ToolCallExecutionResult {
 	toolMessages: ChatCompletionMessageParam[];
 	toolRuns: ToolRun[];
 	finalAnswer?: { text: string; interrupted: boolean };
+	/** A 2026-era prompt is open; this round has no result until it is answered. */
+	awaitingInput?: boolean;
 }
 
 export type ToolExecutionEvent =
@@ -116,6 +118,7 @@ export async function* executeToolCalls({
 		structured?: unknown;
 		blocks?: unknown[];
 		error?: string;
+		awaiting?: boolean;
 		uuid: string;
 		paramsClean: Record<string, Primitive>;
 	};
@@ -221,6 +224,7 @@ export async function* executeToolCalls({
 
 	const updatesQueue = createQueue<MessageUpdate>();
 	const results: TaskResult[] = [];
+	let awaitingInput = false;
 
 	const elicitationSink: ElicitationSink | undefined = elicitation && {
 		conversationId: elicitation.conversationId,
@@ -330,6 +334,44 @@ export async function* executeToolCalls({
 					},
 				}
 			);
+			if (toolResponse.inputRequired) {
+				const opened = elicitationSink
+					? await openDurableElicitation({
+							sink: elicitationSink,
+							server: mappingEntry.server,
+							toolUuid: p.uuid,
+							pending: {
+								tool: mappingEntry.tool,
+								args: argsObj,
+								messageId: elicitation?.messageId ?? "",
+								toolCallId: p.call.id,
+								toolUuid: p.uuid,
+							},
+							inputRequired: toolResponse.inputRequired,
+						})
+					: { opened: false, reason: "no chat to ask" };
+
+				if (opened.opened) {
+					awaitingInput = true;
+					results.push({ index, awaiting: true, uuid: p.uuid, paramsClean: p.paramsClean });
+					return;
+				}
+
+				const message = `The tool asked for input that could not be shown (${opened.reason}).`;
+				logger.warn(
+					{ server: mappingEntry.server, tool: mappingEntry.tool, reason: opened.reason },
+					"[mcp] could not open a durable elicitation"
+				);
+				results.push({ index, error: message, uuid: p.uuid, paramsClean: p.paramsClean });
+				updatesQueue.push({
+					type: MessageUpdateType.Tool,
+					subtype: MessageToolUpdateType.Error,
+					uuid: p.uuid,
+					message,
+				});
+				return;
+			}
+
 			const { annotated } = processToolOutput(toolResponse.text ?? "");
 
 			if (toolResponse.isError) {
@@ -421,6 +463,7 @@ export async function* executeToolCalls({
 	for (const r of results) {
 		const name = prepared[r.index].call.name;
 		const id = prepared[r.index].call.id;
+		if (r.awaiting) continue;
 		if (!r.error) {
 			const output = r.output ?? "";
 			toolRuns.push({ name, parameters: r.paramsClean, output });
@@ -432,5 +475,8 @@ export async function* executeToolCalls({
 		}
 	}
 
-	yield { type: "complete", summary: { toolMessages, toolRuns } };
+	yield {
+		type: "complete",
+		summary: { toolMessages, toolRuns, ...(awaitingInput ? { awaitingInput: true } : {}) },
+	};
 }

--- a/src/lib/server/textGeneration/mcp/toolInvocation.ts
+++ b/src/lib/server/textGeneration/mcp/toolInvocation.ts
@@ -12,8 +12,10 @@ import {
 	type McpToolTextResponse,
 } from "$lib/server/mcp/httpClient";
 import { getClient } from "$lib/server/mcp/clientPool";
+import type { ElicitationSink } from "$lib/server/mcp/elicitation";
 import { attachFileRefsToArgs, type FileRefResolver } from "./fileRefs";
 import type { Client } from "@modelcontextprotocol/client";
+import type { ObjectId } from "mongodb";
 
 export type Primitive = string | number | boolean;
 
@@ -47,6 +49,11 @@ export interface ExecuteToolCallsParams {
 	roundReasoning?: string;
 	/** Visible text streamed before this round's calls; persisted on the round's first Call update. */
 	roundContent?: string;
+	/**
+	 * Which chat to show a prompt in when a server asks the user for input mid-call.
+	 * Omit and elicitation requests on these calls are declined.
+	 */
+	elicitation?: { conversationId: ObjectId; generationId?: string };
 }
 
 export interface ToolCallExecutionResult {
@@ -99,6 +106,7 @@ export async function* executeToolCalls({
 	toolTimeoutMs,
 	roundReasoning,
 	roundContent,
+	elicitation,
 }: ExecuteToolCallsParams): AsyncGenerator<ToolExecutionEvent, void, undefined> {
 	const effectiveTimeoutMs = toolTimeoutMs ?? getMcpToolTimeoutMs();
 	const toolMessages: ChatCompletionMessageParam[] = [];
@@ -217,6 +225,15 @@ export async function* executeToolCalls({
 	const updatesQueue = createQueue<MessageUpdate>();
 	const results: TaskResult[] = [];
 
+	// A prompt raised by a server is just another update on this round's stream, so it
+	// reaches the browser — and the persisted event log — by the same path as progress.
+	const elicitationSink: ElicitationSink | undefined = elicitation && {
+		id: elicitation.generationId ?? `conversation:${elicitation.conversationId.toString()}`,
+		conversationId: elicitation.conversationId,
+		...(elicitation.generationId ? { generationId: elicitation.generationId } : {}),
+		emit: (update) => updatesQueue.push(update),
+	};
+
 	const tasks = prepared.map(async (p, index) => {
 		// Check abort before starting each tool call
 		if (abortSignal?.aborted) {
@@ -306,6 +323,7 @@ export async function* executeToolCalls({
 					client,
 					signal: abortSignal,
 					timeoutMs: effectiveTimeoutMs,
+					...(elicitationSink ? { elicitation: { sink: elicitationSink, toolUuid: p.uuid } } : {}),
 					onProgress: (progress) => {
 						updatesQueue.push({
 							type: MessageUpdateType.Tool,

--- a/src/lib/server/textGeneration/types.ts
+++ b/src/lib/server/textGeneration/types.ts
@@ -29,4 +29,6 @@ export interface TextGenerationContext {
 	abortController: AbortController;
 	/** Also identifies the audience for an MCP elicitation raised mid tool call. */
 	generationId?: string;
+	/** The assistant message this run writes into; a durable prompt resumes against it. */
+	messageId?: string;
 }

--- a/src/lib/server/textGeneration/types.ts
+++ b/src/lib/server/textGeneration/types.ts
@@ -27,9 +27,6 @@ export interface TextGenerationContext {
 	artifactsOverride?: boolean;
 	locals: App.Locals | undefined;
 	abortController: AbortController;
-	/**
-	 * This run's id. Identifies the audience for an MCP elicitation, so a prompt raised
-	 * mid tool call is shown to the chat that triggered it and nobody else.
-	 */
+	/** Also identifies the audience for an MCP elicitation raised mid tool call. */
 	generationId?: string;
 }

--- a/src/lib/server/textGeneration/types.ts
+++ b/src/lib/server/textGeneration/types.ts
@@ -27,4 +27,9 @@ export interface TextGenerationContext {
 	artifactsOverride?: boolean;
 	locals: App.Locals | undefined;
 	abortController: AbortController;
+	/**
+	 * This run's id. Identifies the audience for an MCP elicitation, so a prompt raised
+	 * mid tool call is shown to the chat that triggered it and nobody else.
+	 */
+	generationId?: string;
 }

--- a/src/lib/server/undiciCompat.ts
+++ b/src/lib/server/undiciCompat.ts
@@ -1,0 +1,17 @@
+/**
+ * `urlSafety` imports undici, and undici's entrypoint installs itself as the process-wide
+ * dispatcher under a symbol Node's own `fetch` reads too — so once any MCP code has loaded,
+ * every `fetch` in the process is dispatched by this undici rather than Node's bundled one.
+ * Node appends its own content-length to one the caller already set, and this undici rejects
+ * the resulting `"113, 113"`, failing every model request with "invalid content-length
+ * header". The dispatcher is installed non-configurable, so it cannot be handed back.
+ *
+ * Dropping the header is lossless: Node computes the right one from the body.
+ */
+export function withoutContentLength(init?: RequestInit): RequestInit | undefined {
+	if (!init?.headers) return init;
+	const headers = new Headers(init.headers);
+	if (!headers.has("content-length")) return init;
+	headers.delete("content-length");
+	return { ...init, headers };
+}

--- a/src/lib/stores/elicitationResume.ts
+++ b/src/lib/stores/elicitationResume.ts
@@ -1,0 +1,8 @@
+import { writable } from "svelte/store";
+
+/**
+ * Set to the id of a durable prompt the user has just answered. The conversation page
+ * picks it up and starts the run that continues the parked tool call — the form is nested
+ * too deeply to hand it a callback, and nothing else needs to know.
+ */
+export const elicitationToResume = writable<string | null>(null);

--- a/src/lib/stores/elicitationResume.ts
+++ b/src/lib/stores/elicitationResume.ts
@@ -1,8 +1,13 @@
 import { writable } from "svelte/store";
 
 /**
- * Set to the id of a durable prompt the user has just answered. The conversation page
- * picks it up and starts the run that continues the parked tool call — the form is nested
- * too deeply to hand it a callback, and nothing else needs to know.
+ * A durable prompt the user has just answered, waiting for its conversation page to start
+ * the run that continues the parked tool call — the form is nested too deeply to hand it a
+ * callback. Carries the conversation because this store outlives navigation: the page
+ * component is reused across conversations, so an unscoped id would resume in whichever
+ * one happens to be open.
  */
-export const elicitationToResume = writable<string | null>(null);
+export const elicitationToResume = writable<{
+	conversationId: string;
+	elicitationId: string;
+} | null>(null);

--- a/src/lib/types/McpElicitation.ts
+++ b/src/lib/types/McpElicitation.ts
@@ -74,6 +74,23 @@ export interface McpElicitation extends Timestamps {
 	request: ElicitationRequestPayload;
 	action?: ElicitationAction;
 	content?: Record<string, ElicitationValue>;
-	expiresAt: Date;
+	/** Absent for a 2026-era prompt: nothing is waiting, so nothing expires. */
+	expiresAt?: Date;
 	resolvedAt?: Date;
+	/**
+	 * Everything needed to re-issue the tool call once answered. Present only for a
+	 * 2026-era prompt, where the server kept no state and any process can continue it.
+	 */
+	pending?: {
+		server: string;
+		tool: string;
+		args: Record<string, unknown>;
+		/** Opaque; echoed back byte-exact. */
+		requestState?: string;
+		/** Which key in the server's `inputRequests` this form answers. */
+		inputKey: string;
+		messageId: string;
+		toolCallId: string;
+		toolUuid: string;
+	};
 }

--- a/src/lib/types/McpElicitation.ts
+++ b/src/lib/types/McpElicitation.ts
@@ -2,12 +2,7 @@ import type { ObjectId } from "mongodb";
 import type { Conversation } from "./Conversation";
 import type { Timestamps } from "./Timestamps";
 
-/**
- * A form field, normalized from MCP's `PrimitiveSchemaDefinition`. The spec spells the
- * same select box six ways (`enum`, `enum`+`enumNames`, `oneOf`, and array variants of
- * each); collapsing them here means the browser, the response validator and the UI all
- * read one shape, and a new spec spelling only has to be taught to the normalizer.
- */
+/** Normalized from MCP's `PrimitiveSchemaDefinition`, which spells a select box six ways. */
 export type ElicitationField =
 	| {
 			kind: "string";
@@ -56,50 +51,29 @@ export type ElicitationValue = string | number | boolean | string[];
 
 export type ElicitationAction = "accept" | "decline" | "cancel";
 
-/**
- * Why a pending elicitation stopped waiting without the user answering. Surfaced in the
- * transcript so a form that vanished is explained rather than just gone.
- *
- * `withdrawn` is the common one in practice: the server put its own timeout on the
- * request it sent us (60s by MCP SDK default) and gave up before the user got back.
- */
+/** `withdrawn` is the server giving up on its own request, which it usually does first. */
 export type ElicitationResolution = "user" | "expired" | "aborted" | "withdrawn";
 
-/**
- * The part of an elicitation that is safe to show and to replay: every string here came
- * from the MCP server, so it is untrusted display text and must never be rendered as
- * markup.
- */
+/** Every string here is server-authored, so it is display text and never markup. */
 export interface ElicitationRequestPayload {
 	elicitationId: string;
-	/** Name of the MCP server asking, so the user can see who wants the data. */
 	server: string;
 	mode: "form" | "url";
 	message: string;
-	/** Present in `form` mode. */
 	fields?: ElicitationField[];
-	/** Present in `url` mode. Always http(s) — other schemes are rejected on arrival. */
 	url?: string;
 }
 
-/**
- * A pending request for user input, raised by an MCP server mid tool call.
- *
- * It lives in the database rather than in the process that is waiting because the pod
- * serving the user's answer need not be the pod running the generation — the same split
- * `abortedGenerations` exists for.
- */
+/** In the database because the pod serving the answer need not be the one waiting on it. */
 export interface McpElicitation extends Timestamps {
 	_id: ObjectId;
 	elicitationId: string;
 	conversationId: Conversation["_id"];
-	/** The run that raised it; absent only if the run had no writer. */
 	generationId?: string;
 	status: "pending" | "resolved";
 	request: ElicitationRequestPayload;
 	action?: ElicitationAction;
 	content?: Record<string, ElicitationValue>;
-	/** After this instant the answer is refused and the waiter gives up. */
 	expiresAt: Date;
 	resolvedAt?: Date;
 }

--- a/src/lib/types/McpElicitation.ts
+++ b/src/lib/types/McpElicitation.ts
@@ -1,0 +1,105 @@
+import type { ObjectId } from "mongodb";
+import type { Conversation } from "./Conversation";
+import type { Timestamps } from "./Timestamps";
+
+/**
+ * A form field, normalized from MCP's `PrimitiveSchemaDefinition`. The spec spells the
+ * same select box six ways (`enum`, `enum`+`enumNames`, `oneOf`, and array variants of
+ * each); collapsing them here means the browser, the response validator and the UI all
+ * read one shape, and a new spec spelling only has to be taught to the normalizer.
+ */
+export type ElicitationField =
+	| {
+			kind: "string";
+			name: string;
+			title?: string;
+			description?: string;
+			required: boolean;
+			minLength?: number;
+			maxLength?: number;
+			format?: "email" | "uri" | "date" | "date-time";
+			default?: string;
+	  }
+	| {
+			kind: "number";
+			name: string;
+			title?: string;
+			description?: string;
+			required: boolean;
+			integer: boolean;
+			minimum?: number;
+			maximum?: number;
+			default?: number;
+	  }
+	| {
+			kind: "boolean";
+			name: string;
+			title?: string;
+			description?: string;
+			required: boolean;
+			default?: boolean;
+	  }
+	| {
+			kind: "select";
+			name: string;
+			title?: string;
+			description?: string;
+			required: boolean;
+			multiple: boolean;
+			options: Array<{ value: string; label: string }>;
+			minItems?: number;
+			maxItems?: number;
+			default?: string | string[];
+	  };
+
+export type ElicitationValue = string | number | boolean | string[];
+
+export type ElicitationAction = "accept" | "decline" | "cancel";
+
+/**
+ * Why a pending elicitation stopped waiting without the user answering. Surfaced in the
+ * transcript so a form that vanished is explained rather than just gone.
+ *
+ * `withdrawn` is the common one in practice: the server put its own timeout on the
+ * request it sent us (60s by MCP SDK default) and gave up before the user got back.
+ */
+export type ElicitationResolution = "user" | "expired" | "aborted" | "withdrawn";
+
+/**
+ * The part of an elicitation that is safe to show and to replay: every string here came
+ * from the MCP server, so it is untrusted display text and must never be rendered as
+ * markup.
+ */
+export interface ElicitationRequestPayload {
+	elicitationId: string;
+	/** Name of the MCP server asking, so the user can see who wants the data. */
+	server: string;
+	mode: "form" | "url";
+	message: string;
+	/** Present in `form` mode. */
+	fields?: ElicitationField[];
+	/** Present in `url` mode. Always http(s) — other schemes are rejected on arrival. */
+	url?: string;
+}
+
+/**
+ * A pending request for user input, raised by an MCP server mid tool call.
+ *
+ * It lives in the database rather than in the process that is waiting because the pod
+ * serving the user's answer need not be the pod running the generation — the same split
+ * `abortedGenerations` exists for.
+ */
+export interface McpElicitation extends Timestamps {
+	_id: ObjectId;
+	elicitationId: string;
+	conversationId: Conversation["_id"];
+	/** The run that raised it; absent only if the run had no writer. */
+	generationId?: string;
+	status: "pending" | "resolved";
+	request: ElicitationRequestPayload;
+	action?: ElicitationAction;
+	content?: Record<string, ElicitationValue>;
+	/** After this instant the answer is refused and the waiter gives up. */
+	expiresAt: Date;
+	resolvedAt?: Date;
+}

--- a/src/lib/types/MessageUpdate.ts
+++ b/src/lib/types/MessageUpdate.ts
@@ -1,5 +1,10 @@
 import type { InferenceProvider } from "@huggingface/inference";
 import type { ToolCall, ToolResult } from "$lib/types/Tool";
+import type {
+	ElicitationAction,
+	ElicitationRequestPayload,
+	ElicitationResolution,
+} from "$lib/types/McpElicitation";
 
 export type MessageUpdate =
 	| MessageStatusUpdate
@@ -9,7 +14,8 @@ export type MessageUpdate =
 	| MessageFileUpdate
 	| MessageFinalAnswerUpdate
 	| MessageReasoningUpdate
-	| MessageRouterMetadataUpdate;
+	| MessageRouterMetadataUpdate
+	| MessageElicitationUpdate;
 
 export enum MessageUpdateType {
 	Status = "status",
@@ -20,6 +26,7 @@ export enum MessageUpdateType {
 	FinalAnswer = "finalAnswer",
 	Reasoning = "reasoning",
 	RouterMetadata = "routerMetadata",
+	Elicitation = "elicitation",
 }
 
 // Status
@@ -156,4 +163,39 @@ export interface MessageRouterMetadataUpdate {
 	route: string;
 	model: string;
 	provider?: InferenceProvider;
+}
+
+// Elicitation: an MCP server asking the user for input in the middle of a tool call.
+export enum MessageElicitationUpdateType {
+	Request = "request",
+	Resolved = "resolved",
+}
+
+export type MessageElicitationUpdate =
+	MessageElicitationRequestUpdate | MessageElicitationResolvedUpdate;
+
+export interface MessageElicitationRequestUpdate {
+	type: MessageUpdateType.Elicitation;
+	subtype: MessageElicitationUpdateType.Request;
+	request: ElicitationRequestPayload;
+	/** Epoch ms. Replayed history uses it to render a stale form as expired without asking the server. */
+	expiresAt: number;
+	/**
+	 * The tool call that triggered it, when that is knowable. MCP gives a server-initiated
+	 * request no link back to the call it belongs to, and pooled clients run calls
+	 * concurrently, so this is set only when exactly one call was in flight.
+	 */
+	toolUuid?: string;
+}
+
+/**
+ * Terminal state for one elicitation. Always emitted, including when nobody answered, so
+ * a reloaded transcript never shows a form that is still waiting for input.
+ */
+export interface MessageElicitationResolvedUpdate {
+	type: MessageUpdateType.Elicitation;
+	subtype: MessageElicitationUpdateType.Resolved;
+	elicitationId: string;
+	action: ElicitationAction;
+	resolution: ElicitationResolution;
 }

--- a/src/lib/types/MessageUpdate.ts
+++ b/src/lib/types/MessageUpdate.ts
@@ -165,7 +165,6 @@ export interface MessageRouterMetadataUpdate {
 	provider?: InferenceProvider;
 }
 
-// Elicitation: an MCP server asking the user for input in the middle of a tool call.
 export enum MessageElicitationUpdateType {
 	Request = "request",
 	Resolved = "resolved",
@@ -178,20 +177,13 @@ export interface MessageElicitationRequestUpdate {
 	type: MessageUpdateType.Elicitation;
 	subtype: MessageElicitationUpdateType.Request;
 	request: ElicitationRequestPayload;
-	/** Epoch ms. Replayed history uses it to render a stale form as expired without asking the server. */
+	/** Epoch ms, so replayed history can render a stale form as expired on its own. */
 	expiresAt: number;
-	/**
-	 * The tool call that triggered it, when that is knowable. MCP gives a server-initiated
-	 * request no link back to the call it belongs to, and pooled clients run calls
-	 * concurrently, so this is set only when exactly one call was in flight.
-	 */
+	/** Only set when exactly one call was in flight; MCP does not link the two. */
 	toolUuid?: string;
 }
 
-/**
- * Terminal state for one elicitation. Always emitted, including when nobody answered, so
- * a reloaded transcript never shows a form that is still waiting for input.
- */
+/** Always emitted, even when nobody answered, so replay never shows a form still waiting. */
 export interface MessageElicitationResolvedUpdate {
 	type: MessageUpdateType.Elicitation;
 	subtype: MessageElicitationUpdateType.Resolved;

--- a/src/lib/types/MessageUpdate.ts
+++ b/src/lib/types/MessageUpdate.ts
@@ -4,6 +4,7 @@ import type {
 	ElicitationAction,
 	ElicitationRequestPayload,
 	ElicitationResolution,
+	ElicitationValue,
 } from "$lib/types/McpElicitation";
 
 export type MessageUpdate =
@@ -193,4 +194,6 @@ export interface MessageElicitationResolvedUpdate {
 	elicitationId: string;
 	action: ElicitationAction;
 	resolution: ElicitationResolution;
+	/** What was submitted, so a reloaded transcript can still show the answers. */
+	content?: Record<string, ElicitationValue>;
 }

--- a/src/lib/types/MessageUpdate.ts
+++ b/src/lib/types/MessageUpdate.ts
@@ -177,8 +177,11 @@ export interface MessageElicitationRequestUpdate {
 	type: MessageUpdateType.Elicitation;
 	subtype: MessageElicitationUpdateType.Request;
 	request: ElicitationRequestPayload;
-	/** Epoch ms, so replayed history can render a stale form as expired on its own. */
-	expiresAt: number;
+	/**
+	 * Epoch ms. Only a 2025-era prompt has one — it blocks a live request. A 2026-era
+	 * prompt is answered out of band and never expires, so the UI shows no countdown.
+	 */
+	expiresAt?: number;
 	/** Only set when exactly one call was in flight; MCP does not link the two. */
 	toolUuid?: string;
 }

--- a/src/lib/utils/elicitationDate.spec.ts
+++ b/src/lib/utils/elicitationDate.spec.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { forDateInput } from "./elicitationDate";
+
+const original = process.env.TZ;
+afterEach(() => {
+	process.env.TZ = original;
+});
+
+// West of UTC is the case that matters: a date-only string parses as UTC midnight, so a
+// naive local round-trip lands on the previous day there and nowhere else.
+const ZONES = ["UTC", "Europe/London", "America/Los_Angeles", "Pacific/Kiritimati"];
+
+describe("a date-only default", () => {
+	for (const zone of ZONES) {
+		it(`keeps its own day in ${zone}`, () => {
+			process.env.TZ = zone;
+			expect(forDateInput("2026-09-01", "date")).toBe("2026-09-01");
+			expect(forDateInput("2026-01-15", "date")).toBe("2026-01-15");
+		});
+	}
+});
+
+describe("an RFC 3339 default", () => {
+	it("is narrowed to what a date input accepts", () => {
+		process.env.TZ = "UTC";
+		expect(forDateInput("2026-09-01T09:30:00Z", "date")).toBe("2026-09-01");
+	});
+
+	it("is narrowed to local wall-clock time for a datetime-local input", () => {
+		process.env.TZ = "UTC";
+		expect(forDateInput("2026-09-01T09:30:00Z", "date-time")).toBe("2026-09-01T09:30");
+		process.env.TZ = "America/Los_Angeles";
+		expect(forDateInput("2026-09-01T09:30:00Z", "date-time")).toBe("2026-09-01T02:30");
+	});
+
+	it("keeps an offset other than Z", () => {
+		process.env.TZ = "UTC";
+		expect(forDateInput("2026-09-01T09:30:00+02:00", "date-time")).toBe("2026-09-01T07:30");
+	});
+});
+
+describe("a value no date control can show", () => {
+	it("becomes empty rather than garbage in a datetime-local input", () => {
+		expect(forDateInput("whenever", "date-time")).toBe("");
+	});
+});

--- a/src/lib/utils/elicitationDate.ts
+++ b/src/lib/utils/elicitationDate.ts
@@ -1,0 +1,16 @@
+/**
+ * `date` and `datetime-local` inputs only accept `YYYY-MM-DD[THH:mm]`, so an RFC 3339
+ * default — which is what the schema asks servers to send — renders as blank unless it is
+ * narrowed to the shape the control understands.
+ */
+export function forDateInput(value: string, format: "date" | "date-time"): string {
+	// A date-only string parses as UTC midnight, so reading it back out in local time would
+	// show the day before to everyone west of it.
+	if (format === "date" && /^\d{4}-\d{2}-\d{2}$/.test(value)) return value;
+	const parsed = new Date(value);
+	if (Number.isNaN(parsed.getTime())) return format === "date" ? value.slice(0, 10) : "";
+	const pad = (n: number) => String(n).padStart(2, "0");
+	const day = `${parsed.getFullYear()}-${pad(parsed.getMonth() + 1)}-${pad(parsed.getDate())}`;
+	if (format === "date") return day;
+	return `${day}T${pad(parsed.getHours())}:${pad(parsed.getMinutes())}`;
+}

--- a/src/lib/utils/messageUpdates.ts
+++ b/src/lib/utils/messageUpdates.ts
@@ -23,6 +23,8 @@ type MessageUpdateRequestOptions = {
 	messageId?: string;
 	isRetry: boolean;
 	isContinue?: boolean;
+	/** Continue the tool call a durable elicitation parked, before generating. */
+	resumeElicitationId?: string;
 	// Client-chosen id for this generation run, echoed back by stop-generating
 	// so the server can match a stop point to the run it belongs to
 	generationId?: string;
@@ -64,6 +66,7 @@ export async function fetchMessageUpdates(
 		inputs: opts.inputs,
 		id: opts.messageId,
 		is_retry: opts.isRetry,
+		...(opts.resumeElicitationId ? { resumeElicitationId: opts.resumeElicitationId } : {}),
 		is_continue: Boolean(opts.isContinue),
 		generationId: opts.generationId,
 		// Will be ignored server-side if unsupported

--- a/src/lib/utils/messageUpdates.ts
+++ b/src/lib/utils/messageUpdates.ts
@@ -6,9 +6,13 @@ import {
 	type MessageToolResultUpdate,
 	type MessageToolErrorUpdate,
 	type MessageToolProgressUpdate,
+	type MessageElicitationUpdate,
+	type MessageElicitationRequestUpdate,
+	type MessageElicitationResolvedUpdate,
 	MessageUpdateType,
 	MessageUpdateStatus,
 	MessageToolUpdateType,
+	MessageElicitationUpdateType,
 } from "$lib/types/MessageUpdate";
 import type { StreamingMode } from "$lib/types/Settings";
 import type { KeyValuePair } from "$lib/types/Tool";
@@ -373,6 +377,20 @@ export const isMessageToolProgressUpdate = (
 	update: MessageUpdate
 ): update is MessageToolProgressUpdate =>
 	isMessageToolUpdate(update) && update.subtype === MessageToolUpdateType.Progress;
+
+export const isMessageElicitationUpdate = (
+	update: MessageUpdate
+): update is MessageElicitationUpdate => update.type === MessageUpdateType.Elicitation;
+
+export const isMessageElicitationRequestUpdate = (
+	update: MessageUpdate
+): update is MessageElicitationRequestUpdate =>
+	isMessageElicitationUpdate(update) && update.subtype === MessageElicitationUpdateType.Request;
+
+export const isMessageElicitationResolvedUpdate = (
+	update: MessageUpdate
+): update is MessageElicitationResolvedUpdate =>
+	isMessageElicitationUpdate(update) && update.subtype === MessageElicitationUpdateType.Resolved;
 
 const defaultSleep = (ms: number): Promise<void> =>
 	new Promise((resolve) => setTimeout(resolve, ms));

--- a/src/routes/conversation/[id]/+page.svelte
+++ b/src/routes/conversation/[id]/+page.svelte
@@ -129,10 +129,12 @@
 
 	// this function is used to send new message to the backends
 	$effect(() => {
-		const id = $elicitationToResume;
-		if (!id || $loading) return;
+		const pending = $elicitationToResume;
+		// Left alone when it belongs elsewhere: the conversation it came from picks it up
+		// when it is next open, rather than this one resuming a stranger's tool call.
+		if (!pending || pending.conversationId !== convId || $loading) return;
 		elicitationToResume.set(null);
-		void writeMessage({ resumeElicitationId: id });
+		void writeMessage({ resumeElicitationId: pending.elicitationId });
 	});
 
 	async function writeMessage({

--- a/src/routes/conversation/[id]/+page.svelte
+++ b/src/routes/conversation/[id]/+page.svelte
@@ -20,6 +20,7 @@
 		resolveStreamingMode,
 		applyStreamingMode,
 	} from "$lib/utils/messageUpdates";
+	import { elicitationToResume } from "$lib/stores/elicitationResume";
 	import { consumeMessageUpdates } from "$lib/utils/consumeMessageUpdates";
 	import { v4 } from "uuid";
 	import { useSettingsStore } from "$lib/stores/settings.js";
@@ -127,14 +128,23 @@
 	}
 
 	// this function is used to send new message to the backends
+	$effect(() => {
+		const id = $elicitationToResume;
+		if (!id || $loading) return;
+		elicitationToResume.set(null);
+		void writeMessage({ resumeElicitationId: id });
+	});
+
 	async function writeMessage({
 		prompt,
 		messageId = messagesPath.at(-1)?.id ?? undefined,
 		isRetry = false,
+		resumeElicitationId,
 	}: {
 		prompt?: string;
 		messageId?: ReturnType<typeof v4>;
 		isRetry?: boolean;
+		resumeElicitationId?: string;
 	}): Promise<void> {
 		try {
 			stopRequestedFor = null;
@@ -273,6 +283,7 @@
 					inputs: prompt,
 					messageId,
 					isRetry,
+					...(resumeElicitationId ? { resumeElicitationId } : {}),
 					generationId: activeGenerationId,
 					files: isRetry ? userMessage?.files : base64Files,
 					selectedMcpServerNames: $enabledServers.map((s) => s.name),

--- a/src/routes/conversation/[id]/+page.svelte
+++ b/src/routes/conversation/[id]/+page.svelte
@@ -171,7 +171,11 @@
 			let messageToWriteToId: Message["id"] | undefined = undefined;
 			// used for building the prompt, subtree of the conversation that goes from the latest message to the root
 
-			if (isRetry && messageId) {
+			if (resumeElicitationId && messageId) {
+				// Continue the parked assistant message in place — mirrors the server, which
+				// writes back into it rather than starting a turn.
+				messageToWriteToId = messageId;
+			} else if (isRetry && messageId) {
 				// two cases, if we're retrying a user message with a newPrompt set,
 				// it means we're editing a user message
 				// if we're retrying on an assistant message, newPrompt cannot be set

--- a/src/routes/conversation/[id]/+server.ts
+++ b/src/routes/conversation/[id]/+server.ts
@@ -10,6 +10,7 @@ import { z } from "zod";
 import {
 	MessageUpdateStatus,
 	MessageUpdateType,
+	MessageElicitationUpdateType,
 	MessageReasoningUpdateType,
 	type MessageUpdate,
 	type MessageStreamUpdate,
@@ -495,6 +496,13 @@ export async function POST({ request, locals, params, getClientAddress }) {
 				}
 
 				if (
+					event.type === MessageUpdateType.Elicitation &&
+					event.subtype === MessageElicitationUpdateType.Request
+				) {
+					showedPrompt = true;
+				}
+
+				if (
 					event.type === MessageUpdateType.Status &&
 					event.status === MessageUpdateStatus.Finished
 				) {
@@ -659,6 +667,8 @@ export async function POST({ request, locals, params, getClientAddress }) {
 			}
 
 			let hasError = false;
+			// A run that ends showing a prompt produced no answer on purpose.
+			let showedPrompt = false;
 			const initialMessageContent = messageToWriteTo.content;
 
 			// Emit the streamed-so-far text as an interrupted final answer. The
@@ -794,7 +804,12 @@ export async function POST({ request, locals, params, getClientAddress }) {
 				}
 			} finally {
 				// check if no output was generated
-				if (!hasError && !abortedByUser && messageToWriteTo.content === initialMessageContent) {
+				if (
+					!hasError &&
+					!abortedByUser &&
+					!showedPrompt &&
+					messageToWriteTo.content === initialMessageContent
+				) {
 					hasError = true;
 					logger.warn(
 						{

--- a/src/routes/conversation/[id]/+server.ts
+++ b/src/routes/conversation/[id]/+server.ts
@@ -297,7 +297,17 @@ export async function POST({ request, locals, params, getClientAddress }) {
 	// used for building the prompt, subtree of the conversation that goes from the latest message to the root
 	let messagesForPrompt: Message[] = [];
 
-	if (isRetry && messageId) {
+	if (resumeElicitationId && messageId) {
+		// Continue the assistant message the prompt parked, in place: its tool call and the
+		// answer belong to that turn, and a new one would strand them behind an empty user
+		// message.
+		const parked = conv.messages.find((message) => message.id === messageId);
+		if (!parked || parked.from !== "assistant") {
+			error(404, "No parked message to resume");
+		}
+		messageToWriteToId = parked.id;
+		messagesForPrompt = buildSubtree(conv, parked.id);
+	} else if (isRetry && messageId) {
 		// two cases, if we're retrying a user message with a newPrompt set,
 		// it means we're editing a user message
 		// if we're retrying on an assistant message, newPrompt cannot be set
@@ -691,12 +701,11 @@ export async function POST({ request, locals, params, getClientAddress }) {
 							?.mcp?.selectedServers,
 						signal: ctrl.signal,
 					});
-					if (!outcome.resumed) {
-						logger.warn(
-							{ conversationId: id, reason: outcome.reason },
-							"[mcp] could not resume a parked tool call"
-						);
-					}
+					logger.info(
+						{ conversationId: id, resumed: outcome.resumed, reason: outcome.reason },
+						"[mcp] resuming a parked tool call"
+					);
+					if (outcome.update) await update(outcome.update);
 				}
 
 				const ctx: TextGenerationContext = {

--- a/src/routes/conversation/[id]/+server.ts
+++ b/src/routes/conversation/[id]/+server.ts
@@ -692,20 +692,28 @@ export async function POST({ request, locals, params, getClientAddress }) {
 				// Add billing organization to locals for the endpoint to use
 				locals.billingOrganization = userSettings?.billingOrganization;
 
+				let parkedAgain = false;
 				if (resumeElicitationId) {
 					const { resumeParkedToolCall } = await import("$lib/server/mcp/resumeElicitation");
 					const outcome = await resumeParkedToolCall({
 						conversationId: convId,
 						elicitationId: resumeElicitationId,
+						generationId: effectiveGenerationId,
 						extraServers: (locals as unknown as { mcp?: { selectedServers?: McpServerConfig[] } })
 							?.mcp?.selectedServers,
 						signal: ctrl.signal,
 					});
 					logger.info(
-						{ conversationId: id, resumed: outcome.resumed, reason: outcome.reason },
+						{
+							conversationId: id,
+							resumed: outcome.resumed,
+							parkedAgain: outcome.parkedAgain,
+							reason: outcome.reason,
+						},
 						"[mcp] resuming a parked tool call"
 					);
-					if (outcome.update) await update(outcome.update);
+					for (const event of outcome.updates) await update(event);
+					parkedAgain = outcome.parkedAgain === true;
 				}
 
 				const ctx: TextGenerationContext = {
@@ -743,8 +751,11 @@ export async function POST({ request, locals, params, getClientAddress }) {
 					generationId: effectiveGenerationId,
 					messageId: messageToWriteTo.id,
 				};
-				// run the text generation and send updates to the client
-				for await (const event of textGeneration(ctx)) await update(event);
+				// run the text generation and send updates to the client. Skipped when the
+				// resumed call asked something else: the model has no round to answer yet.
+				if (!parkedAgain) {
+					for await (const event of textGeneration(ctx)) await update(event);
+				}
 				if (ctrl.signal.aborted) {
 					abortedByUser = true;
 				}

--- a/src/routes/conversation/[id]/+server.ts
+++ b/src/routes/conversation/[id]/+server.ts
@@ -23,6 +23,7 @@ import { addSibling } from "$lib/utils/tree/addSibling.js";
 import { usageLimits } from "$lib/server/usageLimits";
 import { textGeneration } from "$lib/server/textGeneration";
 import type { TextGenerationContext } from "$lib/server/textGeneration/types";
+import type { McpServerConfig } from "$lib/server/mcp/httpClient";
 import { logger } from "$lib/server/logger.js";
 import { AbortRegistry } from "$lib/server/abortRegistry";
 import { createGenerationWriter, type GenerationWriter } from "$lib/server/generation/writer";
@@ -179,6 +180,7 @@ export async function POST({ request, locals, params, getClientAddress }) {
 		inputs: newPrompt,
 		id: messageId,
 		is_retry: isRetry,
+		resumeElicitationId,
 		generationId,
 		selectedMcpServerNames,
 		selectedMcpServers,
@@ -196,6 +198,8 @@ export async function POST({ request, locals, params, getClientAddress }) {
 					.transform((s) => s.replace(/\r\n/g, "\n"))
 			),
 			is_retry: z.optional(z.boolean()),
+			/** Continue the tool call a durable elicitation parked, before generating. */
+			resumeElicitationId: z.optional(z.string().uuid()),
 			selectedMcpServerNames: z.optional(z.array(z.string())),
 			selectedMcpServers: z
 				.optional(
@@ -678,6 +682,23 @@ export async function POST({ request, locals, params, getClientAddress }) {
 				// Add billing organization to locals for the endpoint to use
 				locals.billingOrganization = userSettings?.billingOrganization;
 
+				if (resumeElicitationId) {
+					const { resumeParkedToolCall } = await import("$lib/server/mcp/resumeElicitation");
+					const outcome = await resumeParkedToolCall({
+						conversationId: convId,
+						elicitationId: resumeElicitationId,
+						extraServers: (locals as unknown as { mcp?: { selectedServers?: McpServerConfig[] } })
+							?.mcp?.selectedServers,
+						signal: ctrl.signal,
+					});
+					if (!outcome.resumed) {
+						logger.warn(
+							{ conversationId: id, reason: outcome.reason },
+							"[mcp] could not resume a parked tool call"
+						);
+					}
+				}
+
 				const ctx: TextGenerationContext = {
 					model,
 					endpoint: await model.getEndpoint(),
@@ -711,6 +732,7 @@ export async function POST({ request, locals, params, getClientAddress }) {
 					locals,
 					abortController: ctrl,
 					generationId: effectiveGenerationId,
+					messageId: messageToWriteTo.id,
 				};
 				// run the text generation and send updates to the client
 				for await (const event of textGeneration(ctx)) await update(event);

--- a/src/routes/conversation/[id]/+server.ts
+++ b/src/routes/conversation/[id]/+server.ts
@@ -710,6 +710,7 @@ export async function POST({ request, locals, params, getClientAddress }) {
 					artifactsOverride: userSettings?.artifactsOverrides?.[model.id],
 					locals,
 					abortController: ctrl,
+					generationId: effectiveGenerationId,
 				};
 				// run the text generation and send updates to the client
 				for await (const event of textGeneration(ctx)) await update(event);

--- a/src/routes/conversation/[id]/elicitation/+server.ts
+++ b/src/routes/conversation/[id]/elicitation/+server.ts
@@ -19,7 +19,8 @@ const bodySchema = z.object({
 export const POST: RequestHandler = async ({ params, locals, request }) => {
 	if (!locals.user && !locals.sessionId) error(401, "Unauthorized");
 
-	const conversationId = new ObjectId(z.string().parse(params.id));
+	if (!ObjectId.isValid(params.id)) error(404, "Conversation not found");
+	const conversationId = new ObjectId(params.id);
 
 	const conversation = await collections.conversations.findOne(
 		{ _id: conversationId, ...authCondition(locals) },

--- a/src/routes/conversation/[id]/elicitation/+server.ts
+++ b/src/routes/conversation/[id]/elicitation/+server.ts
@@ -40,5 +40,6 @@ export const POST: RequestHandler = async ({ params, locals, request }) => {
 
 	if (!result.ok) error(result.status, result.error);
 
-	return json({ ok: true });
+	// A parked 2026-era call resumes on a fresh run; a blocking one is already unblocked.
+	return json({ ok: true, resume: result.resume });
 };

--- a/src/routes/conversation/[id]/elicitation/+server.ts
+++ b/src/routes/conversation/[id]/elicitation/+server.ts
@@ -9,23 +9,13 @@ import { z } from "zod";
 const bodySchema = z.object({
 	elicitationId: z.string().uuid(),
 	action: z.enum(["accept", "decline", "cancel"]),
-	/**
-	 * Shape-checked here only far enough to be JSON of the right primitive kinds; the
-	 * real check is against the schema the server actually asked for, which lives on the
-	 * stored request rather than in anything the browser sends.
-	 */
+	/** Only shape-checked here; the real check is against the stored requested schema. */
 	content: z
 		.record(z.string(), z.union([z.string(), z.number(), z.boolean(), z.array(z.string())]))
 		.optional(),
 });
 
-/**
- * Deliver a user's answer to an MCP server waiting mid tool call.
- *
- * Deliberately not part of the generation stream: the run holding the tool call may be on
- * another pod, so the answer is written to the conversation's pending elicitation and the
- * waiting pod picks it up from there.
- */
+/** Separate from the generation stream: the run holding the tool call may be on another pod. */
 export const POST: RequestHandler = async ({ params, locals, request }) => {
 	if (!locals.user && !locals.sessionId) error(401, "Unauthorized");
 

--- a/src/routes/conversation/[id]/elicitation/+server.ts
+++ b/src/routes/conversation/[id]/elicitation/+server.ts
@@ -1,0 +1,53 @@
+import type { RequestHandler } from "./$types";
+import { authCondition } from "$lib/server/auth";
+import { collections } from "$lib/server/database";
+import { submitElicitationAnswer } from "$lib/server/mcp/elicitation";
+import { error, json } from "@sveltejs/kit";
+import { ObjectId } from "mongodb";
+import { z } from "zod";
+
+const bodySchema = z.object({
+	elicitationId: z.string().uuid(),
+	action: z.enum(["accept", "decline", "cancel"]),
+	/**
+	 * Shape-checked here only far enough to be JSON of the right primitive kinds; the
+	 * real check is against the schema the server actually asked for, which lives on the
+	 * stored request rather than in anything the browser sends.
+	 */
+	content: z
+		.record(z.string(), z.union([z.string(), z.number(), z.boolean(), z.array(z.string())]))
+		.optional(),
+});
+
+/**
+ * Deliver a user's answer to an MCP server waiting mid tool call.
+ *
+ * Deliberately not part of the generation stream: the run holding the tool call may be on
+ * another pod, so the answer is written to the conversation's pending elicitation and the
+ * waiting pod picks it up from there.
+ */
+export const POST: RequestHandler = async ({ params, locals, request }) => {
+	if (!locals.user && !locals.sessionId) error(401, "Unauthorized");
+
+	const conversationId = new ObjectId(z.string().parse(params.id));
+
+	const conversation = await collections.conversations.findOne(
+		{ _id: conversationId, ...authCondition(locals) },
+		{ projection: { _id: 1 } }
+	);
+	if (!conversation) error(404, "Conversation not found");
+
+	const parsed = bodySchema.safeParse(await request.json().catch(() => null));
+	if (!parsed.success) error(400, "Invalid elicitation response");
+
+	const result = await submitElicitationAnswer({
+		elicitationId: parsed.data.elicitationId,
+		conversationId,
+		action: parsed.data.action,
+		content: parsed.data.content,
+	});
+
+	if (!result.ok) error(result.status, result.error);
+
+	return json({ ok: true });
+};


### PR DESCRIPTION
Lets an MCP server interrupt a tool call to ask the user something — a confirmation, details it's missing, or a link to visit. The request renders as a form in the conversation and the answer goes back to the server, which then finishes the call. Form and URL mode both supported.

Built on the multi-round-trip request pattern (SEP-2322) that arrived with the TS SDK v2 bump, with the 2025-era push style kept working for servers that haven't moved.

## Two eras, one handler

**2026-07-28 — nothing stays live.** The server answers `tools/call` with `input_required` instead of sending a request, so the call is already over by the time the prompt appears. The prompt, the tool, its arguments and the server's opaque `requestState` go into Mongo; when the answer arrives the call is re-issued with `inputResponses` + `requestState`. Neither side holds state in between, so a prompt survives a reload, a redeploy, and the connection being closed and reopened — and it can be answered on a different pod than the one that raised it. A tool may ask more than once (`double_check` does); each round parks the same way rather than handing the model a round that never finished.

**2025-era — the call blocks.** The server sends `elicitation/create` down the connection and waits, so the prompt lives exactly as long as that request. The UI shows a countdown here and none on the modern path, where there is nothing left to expire.

The SDK normalizes both into the same request shape, so there is one `elicitation/create` handler rather than a path per era.

## Notable bits

**Attribution and isolation.** MCP gives a server-initiated request no link back to the `tools/call` that provoked it — there is no correlation id on the client handler in either era — so the only clue is which calls are in flight on that connection. `clientPool` shares one client per URL + headers, which makes that clue ambiguous as soon as two conversations are mid-call, and an unattributable prompt is declined rather than shown to the wrong person. To stop that ambiguity arising at all, a call that can be interrupted for input gets a **per-conversation connection when the server is legacy**; modern servers push nothing, so they keep one shared connection each. Alongside that: every `mcpElicitations` query is scoped by `conversationId`, the client-side resume signal carries the conversation it belongs to, and evicting a client that looked broken to one caller no longer closes it under another's in-flight call.

**Answers go through Mongo, not the stream**, since the pod serving the user's POST need not be the pod holding the tool call — the same split `abortedGenerations` already uses. Side benefit: reloading mid-prompt re-renders a form that still works.

**The call deadline moved out of the SDK.** `Protocol.request` arms a wall-clock timer that only a server-sent progress notification can reset, so a human filling in a form would expire the call waiting on them. It's now enforced via the abort signal and paused while a prompt is open, which puts `MCP_TOOL_TIMEOUT_MS` back to meaning "time the server may go silent".

**Server-authored input is untrusted throughout.** The six spec spellings of a select box normalize to one field kind, field/option/text counts are capped, control characters are stripped from labels, non-http(s) URLs are refused, and the submitted answer is re-validated server-side against the stored schema.

**Answered prompts collapse.** A settled prompt becomes an expandable row — `Answered` / `Declined` / `Expired unanswered` and the server name — that opens to show the questions and what was sent, instead of leaving a filled-in form sitting in the transcript. It reads the same on reload, since the submitted values are persisted on the resolved update.

`extra.signal` is honoured, so a legacy server that gives up on its own request (60s by SDK default) closes the prompt instead of leaving a form that can't be answered.

## Config

- `MCP_ELICITATION_TIMEOUT_MS` — how long a prompt stays answerable, default 1 hour. Independent of the tool timeout. On a modern connection this is the *only* bound, since nothing else is waiting; on a legacy one the server's own timeout usually gives up first.
- `MCP_DISABLE_ELICITATION=true` — kill switch, stops advertising the capability entirely.

## Manual testing

`scripts/mock-elicitation-mcp.mjs` serves a 2026-era server via `createMcpHandler`, with one tool per case worth seeing.

1. Set `MCP_ALLOW_INSECURE_URLS=true` in `.env.local`, or the loopback URL is rejected
2. `node scripts/mock-elicitation-mcp.mjs` (port 8792)
3. Add `http://127.0.0.1:8792/mcp` as a user server, enable it, pick a tools-capable model
4. Ask for each tool by name:

| Tool | Expected |
| --- | --- |
| `book_meeting` | Form covering every field kind — text, email, date, number, select, multi-select, checkbox |
| `double_check` | Two prompts in one call, the second appearing after the first is answered (type the word it asks for — a mismatch is meant to fail) |
| `impatient_confirm` | The pre-MRTR style. Fails fast here, since a modern server cannot raise an unsolicited request; point a 2025-era server at it to exercise the "server stopped waiting" path |
| `sign_in` | URL mode — a link, not a form |

Also worth trying: reload the page while a prompt is open (comes back answerable), answer one from a second tab, and stop the response while one is open (closes as cancelled).

## Notes

- 62 tests across schema normalization, answer validation, the pausable deadline, resume, routing and pool isolation. Full suite green — 700 node, 100 browser.
- Declaring the capability changes behaviour for existing deployments — servers that previously got method-not-found will start raising prompts. Defaulted on, since the capability *is* the feature; `MCP_DISABLE_ELICITATION` is the lever to stage it.
- URL mode responds `accept` once the user confirms they've visited the link. The out-of-band `notifications/elicitation/complete` path isn't wired up, so a server relying on it to auto-close the prompt will see it stay open until confirmed or expired.
- Only one input request per round is accepted. The spec permits several, but no server we have met asks for more, and half an answered round is not resumable.
