### PR TITLE
ci: cache playwright browsers and bound the install step

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -48,7 +48,28 @@ jobs:
 
       - run: npm ci
 
-      - run: npx playwright install --with-deps chromium
+      # The browser binaries cache; the system deps cannot. `install-deps` apt-installs
+      # into the ephemeral runner, not into ~/.cache, so it has to run on every job.
+      # The step timeouts are load-bearing. Both halves are network-bound and have
+      # stalled past the whole job budget before, which reads as a bare job timeout
+      # with no clue which step hung.
+      - name: Resolve Playwright version
+        id: playwright-version
+        run: echo "version=$(node -p "require('playwright-core/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}-chromium
+
+      - name: Install Playwright browsers
+        timeout-minutes: 6
+        run: npx playwright install chromium
+
+      - name: Install Playwright system dependencies
+        timeout-minutes: 6
+        run: npx playwright install-deps chromium
 
       - name: "Tests (node)"
         run: npm run test
@@ -58,7 +79,7 @@ jobs:
 
   e2e:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v3
@@ -81,9 +102,27 @@ jobs:
 
       - run: npm ci
 
+      # Same cache/deps split as the test job, see the comment there.
+      - name: Resolve Playwright version
+        id: playwright-version
+        run: echo "version=$(node -p "require('playwright-core/package.json').version")" >> "$GITHUB_OUTPUT"
+
       # WebKit is not optional — the worst regression cluster in this repo is
-      # Safari-specific scroll and layout behaviour.
-      - run: npx playwright install --with-deps chromium webkit
+      # Safari-specific scroll and layout behaviour. It also roughly doubles the
+      # download and triples the apt package list, so the cache matters most here.
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}-chromium-webkit
+
+      - name: Install Playwright browsers
+        timeout-minutes: 8
+        run: npx playwright install chromium webkit
+
+      - name: Install Playwright system dependencies
+        timeout-minutes: 8
+        run: npx playwright install-deps chromium webkit
 
       - name: "Tests (e2e)"
         run: npm run test:e2e

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -48,11 +48,8 @@ jobs:
 
       - run: npm ci
 
-      # The browser binaries cache; the system deps cannot. `install-deps` apt-installs
-      # into the ephemeral runner, not into ~/.cache, so it has to run on every job.
-      # The step timeouts are load-bearing. Both halves are network-bound and have
-      # stalled past the whole job budget before, which reads as a bare job timeout
-      # with no clue which step hung.
+      # Split from `install-deps` on purpose: the browsers cache, the system deps
+      # cannot, since apt installs into the ephemeral runner rather than ~/.cache.
       - name: Resolve Playwright version
         id: playwright-version
         run: echo "version=$(node -p "require('playwright-core/package.json').version")" >> "$GITHUB_OUTPUT"
@@ -67,9 +64,19 @@ jobs:
         timeout-minutes: 6
         run: npx playwright install chromium
 
+      # apt is the half that stalls, and no cache reaches it. Bounding each attempt
+      # turns a hung mirror into a retry on a fresh connection instead of a step that
+      # silently eats the job budget. The e2e job dodges this entirely by running in
+      # the Playwright container; this job keeps apt because chromium-only deps are a
+      # far smaller surface than chromium+webkit.
       - name: Install Playwright system dependencies
-        timeout-minutes: 6
-        run: npx playwright install-deps chromium
+        timeout-minutes: 8
+        run: |
+          for attempt in 1 2 3; do
+            timeout 150 npx playwright install-deps chromium && exit 0
+            echo "install-deps attempt $attempt stalled or failed; retrying"
+          done
+          exit 1
 
       - name: "Tests (node)"
         run: npm run test
@@ -79,7 +86,15 @@ jobs:
 
   e2e:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # Browsers and every system library they need are baked into this image, so this
+    # job runs neither `playwright install` nor apt. That is the whole point: the apt
+    # half of `--with-deps` is the half that stalls (15+ minutes on 837daece, against a
+    # 36-137s baseline), and unlike the browser download it cannot be cached, because it
+    # installs into the runner rather than into ~/.cache. The tag must track
+    # playwright-core in package-lock.json; the check below enforces that.
+    container:
+      image: mcr.microsoft.com/playwright:v1.61.1-noble
+    timeout-minutes: 20
 
     steps:
       - uses: actions/checkout@v3
@@ -92,37 +107,27 @@ jobs:
           cache: "npm"
 
       # The harness starts its own MongoMemoryServer (see startTestDatabase in
-      # tests/fixtures.ts). Same cache key as the unit-test job so they share the
-      # downloaded mongod binary.
+      # tests/fixtures.ts). Keyed apart from the unit-test job rather than shared:
+      # container jobs run with HOME=/github/home, so the two jobs resolve this path to
+      # different absolute locations and must not restore each other's entries.
       - name: Cache mongodb-memory-server binaries
         uses: actions/cache@v4
         with:
           path: ~/.cache/mongodb-binaries
-          key: mongodb-binaries-${{ runner.os }}
+          key: mongodb-binaries-${{ runner.os }}-e2e-container
 
       - run: npm ci
 
-      # Same cache/deps split as the test job, see the comment there.
-      - name: Resolve Playwright version
-        id: playwright-version
-        run: echo "version=$(node -p "require('playwright-core/package.json').version")" >> "$GITHUB_OUTPUT"
-
-      # WebKit is not optional — the worst regression cluster in this repo is
-      # Safari-specific scroll and layout behaviour. It also roughly doubles the
-      # download and triples the apt package list, so the cache matters most here.
-      - name: Cache Playwright browsers
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}-chromium-webkit
-
-      - name: Install Playwright browsers
-        timeout-minutes: 8
-        run: npx playwright install chromium webkit
-
-      - name: Install Playwright system dependencies
-        timeout-minutes: 8
-        run: npx playwright install-deps chromium webkit
+      # The image bakes browsers for exactly one Playwright version. Without this, a
+      # lockfile bump that forgets the tag above fails much later, inside the test run,
+      # as an opaque "Executable doesn't exist at /ms-playwright/...".
+      - name: Check Playwright matches the container image
+        run: |
+          locked=$(node -p "require('playwright-core/package.json').version")
+          if [ "$locked" != "1.61.1" ]; then
+            echo "::error file=.github/workflows/lint-and-test.yml::package-lock.json has playwright-core $locked, but the e2e job runs mcr.microsoft.com/playwright:v1.61.1-noble. Bump the container image tag to match."
+            exit 1
+          fi
 
       - name: "Tests (e2e)"
         run: npm run test:e2e


### PR DESCRIPTION
`npx playwright install --with-deps` was one unbounded step doing two network-bound things at once, with nothing cached. Its baseline is 36-137s, but on a bad day it stalls: the e2e job on 837daece sat in it for 15+ minutes and was killed by the 20 minute job cap before the specs ever started, with no output naming the step that hung.

Cache ~/.cache/ms-playwright keyed on the playwright-core version and browser set, and split the download from `install-deps` so a cache hit skips the download half. Bound both halves with step timeouts, and raise the e2e cap to 30 minutes -- npm ci plus the specs alone are ~10 minutes, which left under ten minutes of headroom for a slow install.