### PR TITLE
fix: don't use truncated reasoning as the chat title

### DIFF
--- a/src/lib/server/textGeneration/title.spec.ts
+++ b/src/lib/server/textGeneration/title.spec.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ObjectId } from "mongodb";
+import { MessageUpdateType } from "$lib/types/MessageUpdate";
+import type { Conversation } from "$lib/types/Conversation";
+
+const mocks = vi.hoisted(() => ({
+	generateFromDefaultEndpoint: vi.fn(),
+	config: { LLM_SUMMARIZATION: "true", TASK_MODEL: "" } as Record<string, string>,
+}));
+
+vi.mock("$lib/server/config", () => ({ config: mocks.config }));
+vi.mock("$lib/server/logger", () => ({ logger: { error: vi.fn(), info: vi.fn() } }));
+vi.mock("$lib/server/generateFromDefaultEndpoint", () => ({
+	generateFromDefaultEndpoint: mocks.generateFromDefaultEndpoint,
+}));
+
+const { generateTitleForConversation } = await import("./title");
+
+/** Endpoint stub: yields nothing, returns `text` as the generated title. */
+function endpointReturning(text: string) {
+	// eslint-disable-next-line require-yield
+	return async function* () {
+		return text;
+	};
+}
+
+function newConversation(content: string): Conversation {
+	return {
+		_id: new ObjectId(),
+		title: "New Chat",
+		model: "test-model",
+		messages: [{ id: "1" as Conversation["messages"][number]["id"], from: "user", content }],
+	} as unknown as Conversation;
+}
+
+async function titleFor(generated: string, userMessage = "how do I reverse a string in Python?") {
+	mocks.generateFromDefaultEndpoint.mockImplementation(endpointReturning(generated));
+	const updates = [];
+	for await (const u of generateTitleForConversation(newConversation(userMessage), undefined)) {
+		updates.push(u);
+	}
+	const titleUpdate = updates.find((u) => u.type === MessageUpdateType.Title);
+	return titleUpdate && "title" in titleUpdate ? titleUpdate.title : undefined;
+}
+
+describe("generateTitleForConversation", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mocks.config.LLM_SUMMARIZATION = "true";
+	});
+
+	it("uses the model's title when it returns plain text", async () => {
+		expect(await titleFor("Python string reversal")).toBe("Python string reversal");
+	});
+
+	it("drops a complete reasoning block and keeps the title after it", async () => {
+		expect(await titleFor("<think>The user wants Python help.</think>Python string reversal")).toBe(
+			"Python string reversal"
+		);
+	});
+
+	it("does not use truncated reasoning as the title when the budget is spent thinking", async () => {
+		// max_tokens is 24, so a reasoning model can burn the whole budget before
+		// emitting any title, leaving an unterminated <think> block and no content.
+		const title = await titleFor("<think>We need to produce a title. The user is asking");
+		expect(title).not.toContain("We need to produce a title");
+		expect(title).toBe("how do I reverse a");
+	});
+});

--- a/src/lib/server/textGeneration/title.ts
+++ b/src/lib/server/textGeneration/title.ts
@@ -4,6 +4,7 @@ import { logger } from "$lib/server/logger";
 import { MessageUpdateType, type MessageUpdate } from "$lib/types/MessageUpdate";
 import type { Conversation } from "$lib/types/Conversation";
 import { getReturnFromGenerator } from "$lib/utils/getReturnFromGenerator";
+import { stripThink } from "$lib/utils/stripThink";
 
 export async function* generateTitleForConversation(
 	conv: Conversation,
@@ -69,7 +70,11 @@ Return only the title text.`,
 	)
 		.then((summary) => {
 			const firstFive = prompt.split(/\s+/g).slice(0, 5).join(" ");
-			const trimmed = String(summary ?? "").trim();
+			// Reasoning models can spend the whole `max_tokens` budget thinking, which
+			// leaves an unterminated `<think>` block and no title after it. Strip the
+			// trace so that truncated reasoning falls back to the first five words
+			// instead of being shown to the user as their chat title.
+			const trimmed = stripThink(String(summary ?? ""));
 			// Fallback: if empty, return first five words only (no emoji)
 			return trimmed || firstFive;
 		})
@@ -80,4 +85,4 @@ Return only the title text.`,
 		});
 }
 
-// No post-processing: rely solely on prompt instructions above
+// Beyond stripping reasoning traces, no post-processing: rely on prompt instructions above

--- a/src/lib/server/textGeneration/utils/prepareFiles.ts
+++ b/src/lib/server/textGeneration/utils/prepareFiles.ts
@@ -2,6 +2,7 @@ import type { MessageFile } from "$lib/types/Message";
 import type { EndpointMessage } from "$lib/server/endpoints/endpoints";
 import type { OpenAI } from "openai";
 import { TEXT_MIME_ALLOWLIST } from "$lib/constants/mime";
+import { stripThink } from "$lib/utils/stripThink";
 import type { makeImageProcessor } from "$lib/server/endpoints/images";
 import {
 	MessageToolUpdateType,
@@ -171,14 +172,6 @@ function splitReasoning(
 	});
 	const parts = [storedReasoning ?? "", ...thinkParts].filter((part) => part.trim().length > 0);
 	return { visible: visible.trim(), parts };
-}
-
-/** Strip `<think>` blocks without collecting them; used for the degraded
- * fallback shape so a budget cutoff never leaks raw reasoning as visible
- * content, including to models whose vendor requires historical thoughts
- * to be stripped (e.g. Gemma) regardless of the replay budget. */
-function stripThink(content: string): string {
-	return content.replace(/<think>[\s\S]*?(?:<\/think>|$)/g, "").trim();
 }
 
 /**

--- a/src/lib/utils/stripThink.spec.ts
+++ b/src/lib/utils/stripThink.spec.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { stripThink } from "./stripThink";
+
+describe("stripThink", () => {
+	it("leaves text without reasoning untouched", () => {
+		expect(stripThink("Python string reversal")).toBe("Python string reversal");
+	});
+
+	it("removes a complete block and its contents", () => {
+		expect(stripThink("<think>deliberating</think>Python string reversal")).toBe(
+			"Python string reversal"
+		);
+	});
+
+	it("removes an unterminated block left by a budget cutoff", () => {
+		expect(stripThink("<think>We need to produce a title. The user is")).toBe("");
+	});
+
+	it("removes every block when several are present", () => {
+		expect(stripThink("<think>a</think>one<think>b</think>two")).toBe("onetwo");
+	});
+
+	it("keeps text that precedes a block", () => {
+		expect(stripThink("visible<think>hidden</think>")).toBe("visible");
+	});
+});

--- a/src/lib/utils/stripThink.ts
+++ b/src/lib/utils/stripThink.ts
@@ -1,0 +1,10 @@
+/**
+ * Remove `<think>` blocks and their contents from model output.
+ *
+ * The unterminated case matters: when a generation budget runs out mid-trace
+ * the closing tag never arrives, so an anchored `$` alternative is what stops
+ * raw reasoning from leaking out as if it were the answer.
+ */
+export function stripThink(content: string): string {
+	return content.replace(/<think>[\s\S]*?(?:<\/think>|$)/g, "").trim();
+}


### PR DESCRIPTION
Closes #2512

Chat titles were coming out as the model's reasoning — "We need to produce a title...." — instead of a title.

Title generation runs with `max_tokens: 24`. A reasoning model can spend that entire budget thinking, so the generation ends mid-trace: an unterminated `<think>` block with no title after it. `generateTitle` had no post-processing (the file said so explicitly), so that trace was used as the title verbatim. The cleanup further down in `applyConversationSettings` and the shared-conversation path only strips the `<think>`/`</think>` tags, not what's inside them, which is why the reasoning text itself ended up on screen.

This strips reasoning blocks from the summary before using it, so a budget spent thinking falls back to the existing first-five-words behaviour rather than showing the trace. Titles that do come back normally are unaffected.

`stripThink` already existed as a private helper in `prepareFiles.ts`, with a comment about exactly this failure mode ("so a budget cutoff never leaks raw reasoning as visible content"). Rather than add a fourth copy of the regex, I moved it to `$lib/utils/stripThink` and had both callers use it — that move is behaviour-preserving, the implementation is unchanged.

### Checks

`npm test` (716 tests), `npm run check` and `npm run lint` all pass. Added `title.spec.ts` covering the plain, complete-block and truncated-block cases, plus a small spec for the shared helper. The two reasoning tests fail on `main` and pass here.

### Note

I left the tag-only cleanups in `applyConversationSettings` and the shared-conversation path alone: they also apply to user-supplied titles, where deleting a `<think>...</think>` span outright would discard what someone typed. Fixing the source seemed like the right scope. Happy to widen it if you'd rather.
