### PR TITLE
Render the plan as a dedicated card in chat

### DIFF
--- a/src/lib/components/chat/ChatMessage.svelte
+++ b/src/lib/components/chat/ChatMessage.svelte
@@ -24,15 +24,18 @@
 	import ToolCallsSummary from "./ToolCallsSummary.svelte";
 	import ArtifactCard from "./ArtifactCard.svelte";
 	import ElicitationForm from "./ElicitationForm.svelte";
+	import PlanCard from "./PlanCard.svelte";
 	import {
 		isMessageToolUpdate,
 		isMessageElicitationRequestUpdate,
 		isMessageElicitationResolvedUpdate,
+		isMessagePlanUpdate,
 	} from "$lib/utils/messageUpdates";
 	import {
 		MessageUpdateType,
 		type MessageToolUpdate,
 		type MessageElicitationResolvedUpdate,
+		type MessagePlanUpdate,
 	} from "$lib/types/MessageUpdate";
 	import type { ElicitationRequestPayload } from "$lib/types/McpElicitation";
 	import { page } from "$app/state";
@@ -163,7 +166,8 @@
 		| { type: "think"; content: string; closed: boolean }
 		| { type: "tool"; uuid: string; updates: MessageToolUpdate[] }
 		| { type: "artifact"; op: ArtifactOperation; opIndex: number }
-		| ElicitationBlock;
+		| ElicitationBlock
+		| { type: "plan"; update: MessagePlanUpdate };
 
 	type ToolBlock = Extract<Block, { type: "tool" }>;
 	type ProcessBlock = Extract<Block, { type: "think" } | { type: "tool" }>;
@@ -172,7 +176,8 @@
 		| { kind: "text"; content: string }
 		| { kind: "group"; blocks: ProcessBlock[]; toolCount: number }
 		| { kind: "artifact"; op: ArtifactOperation; opIndex: number }
-		| ({ kind: "elicitation" } & Omit<ElicitationBlock, "type">);
+		| ({ kind: "elicitation" } & Omit<ElicitationBlock, "type">)
+		| { kind: "plan"; update: MessagePlanUpdate };
 
 	// Expand any text block containing <think>…</think> into dedicated think blocks
 	// so reasoning can be grouped/collapsed separately from the answer text.
@@ -297,6 +302,16 @@
 						b.type === "elicitation" && b.request.elicitationId === update.elicitationId
 				);
 				if (target) target.resolved = update;
+			} else if (isMessagePlanUpdate(update)) {
+				// One live card per message: a later update supersedes the earlier card and
+				// takes its stream position, and the generic tool card for the same call
+				// gives way to the dedicated one (a failed call emits no Plan update, so
+				// its error card survives).
+				const toolIdx = res.findIndex((b) => b.type === "tool" && b.uuid === update.uuid);
+				if (toolIdx !== -1) res.splice(toolIdx, 1);
+				const planIdx = res.findIndex((b) => b.type === "plan");
+				if (planIdx !== -1) res.splice(planIdx, 1);
+				res.push({ type: "plan", update });
 			} else if (update.type === MessageUpdateType.FinalAnswer) {
 				sawFinalAnswer = true;
 				const finalText = update.text ?? "";
@@ -368,6 +383,10 @@
 					expiresAt: block.expiresAt,
 					resolved: block.resolved,
 				});
+			} else if (block.type === "plan") {
+				// Never folded into the collapsible summary: the plan stays visible.
+				flush();
+				units.push({ kind: "plan", update: block.update });
 			} else {
 				flush();
 				units.push({ kind: "text", content: block.content });
@@ -383,7 +402,13 @@
 	let isProcessStreaming = $derived.by(() => {
 		if (!isLast || !loading) return false;
 		const last = blocks.at(-1);
-		return !!last && (last.type === "think" || last.type === "tool" || last.type === "elicitation");
+		return (
+			!!last &&
+			(last.type === "think" ||
+				last.type === "tool" ||
+				last.type === "elicitation" ||
+				last.type === "plan")
+		);
 	});
 
 	$effect(() => {
@@ -455,7 +480,7 @@
 				{#if isProcessStreaming}
 					<!-- Streaming the thinking / tool phase: render every block flat and
 					     inline, exactly like today. Nesting kicks in once the answer starts. -->
-					{#each blocks as block, blockIndex (block.type === "tool" ? `tool-${block.uuid}-${blockIndex}` : `block-${blockIndex}`)}
+					{#each blocks as block, blockIndex (block.type === "tool" ? `tool-${block.uuid}-${blockIndex}` : block.type === "plan" ? `plan-${block.update.version}` : `block-${blockIndex}`)}
 						{#if block.type === "text"}
 							{#if block.content.trim().length > 0}
 								<div class={proseClasses}>
@@ -473,6 +498,10 @@
 									resolved={block.resolved}
 								/>
 							</div>
+						{:else if block.type === "plan"}
+							<div data-exclude-from-copy>
+								<PlanCard update={block.update} />
+							</div>
 						{:else}
 							<div data-exclude-from-copy class="not-last:mb-1 has-[+.prose]:mb-2! [.prose+&]:mt-3">
 								{#if block.type === "think"}
@@ -488,7 +517,7 @@
 					{/each}
 				{:else}
 					<!-- Answer started or generation finished: nest the process blocks. -->
-					{#each renderUnits as unit, unitIndex (`${unit.kind}-${unitIndex}`)}
+					{#each renderUnits as unit, unitIndex (unit.kind === "plan" ? `plan-${unit.update.version}` : `${unit.kind}-${unitIndex}`)}
 						{#if unit.kind === "text"}
 							{#if isLast && loading && unit.content.length === 0}
 								<IconLoading classNames="loading inline ml-2 first:ml-0" />
@@ -507,6 +536,10 @@
 									expiresAt={unit.expiresAt}
 									resolved={unit.resolved}
 								/>
+							</div>
+						{:else if unit.kind === "plan"}
+							<div data-exclude-from-copy>
+								<PlanCard update={unit.update} />
 							</div>
 						{:else if unit.kind === "group"}
 							<div data-exclude-from-copy class="not-last:mb-1 has-[+.prose]:mb-2! [.prose+&]:mt-3">

--- a/src/lib/components/chat/ChatMessage.svelte
+++ b/src/lib/components/chat/ChatMessage.svelte
@@ -24,17 +24,20 @@
 	import ToolCallsSummary from "./ToolCallsSummary.svelte";
 	import ArtifactCard from "./ArtifactCard.svelte";
 	import ElicitationForm from "./ElicitationForm.svelte";
+	import PlanCard from "./PlanCard.svelte";
 	import {
 		isMessageToolUpdate,
 		isMessageToolResultUpdate,
 		isMessageToolErrorUpdate,
 		isMessageElicitationRequestUpdate,
 		isMessageElicitationResolvedUpdate,
+		isMessagePlanUpdate,
 	} from "$lib/utils/messageUpdates";
 	import {
 		MessageUpdateType,
 		type MessageToolUpdate,
 		type MessageElicitationResolvedUpdate,
+		type MessagePlanUpdate,
 	} from "$lib/types/MessageUpdate";
 	import type { ElicitationRequestPayload } from "$lib/types/McpElicitation";
 	import { page } from "$app/state";
@@ -165,7 +168,8 @@
 		| { type: "think"; content: string; closed: boolean }
 		| { type: "tool"; uuid: string; updates: MessageToolUpdate[] }
 		| { type: "artifact"; op: ArtifactOperation; opIndex: number }
-		| ElicitationBlock;
+		| ElicitationBlock
+		| { type: "plan"; update: MessagePlanUpdate };
 
 	type ToolBlock = Extract<Block, { type: "tool" }>;
 	type ProcessBlock = Extract<Block, { type: "think" } | { type: "tool" }>;
@@ -174,7 +178,8 @@
 		| { kind: "text"; content: string }
 		| { kind: "group"; blocks: ProcessBlock[]; toolCount: number }
 		| { kind: "artifact"; op: ArtifactOperation; opIndex: number }
-		| ({ kind: "elicitation" } & Omit<ElicitationBlock, "type">);
+		| ({ kind: "elicitation" } & Omit<ElicitationBlock, "type">)
+		| { kind: "plan"; update: MessagePlanUpdate };
 
 	// Expand any text block containing <think>…</think> into dedicated think blocks
 	// so reasoning can be grouped/collapsed separately from the answer text.
@@ -299,6 +304,16 @@
 						b.type === "elicitation" && b.request.elicitationId === update.elicitationId
 				);
 				if (target) target.resolved = update;
+			} else if (isMessagePlanUpdate(update)) {
+				// One live card per message: a later update supersedes the earlier card and
+				// takes its stream position, and the generic tool card for the same call
+				// gives way to the dedicated one (a failed call emits no Plan update, so
+				// its error card survives).
+				const toolIdx = res.findIndex((b) => b.type === "tool" && b.uuid === update.uuid);
+				if (toolIdx !== -1) res.splice(toolIdx, 1);
+				const planIdx = res.findIndex((b) => b.type === "plan");
+				if (planIdx !== -1) res.splice(planIdx, 1);
+				res.push({ type: "plan", update });
 			} else if (update.type === MessageUpdateType.FinalAnswer) {
 				sawFinalAnswer = true;
 				const finalText = update.text ?? "";
@@ -370,6 +385,10 @@
 					expiresAt: block.expiresAt,
 					resolved: block.resolved,
 				});
+			} else if (block.type === "plan") {
+				// Never folded into the collapsible summary: the plan stays visible.
+				flush();
+				units.push({ kind: "plan", update: block.update });
 			} else {
 				flush();
 				units.push({ kind: "text", content: block.content });
@@ -398,7 +417,13 @@
 	let isProcessStreaming = $derived.by(() => {
 		if (!isLast || !loading) return false;
 		const last = blocks.at(-1);
-		return !!last && (last.type === "think" || last.type === "tool" || last.type === "elicitation");
+		return (
+			!!last &&
+			(last.type === "think" ||
+				last.type === "tool" ||
+				last.type === "elicitation" ||
+				last.type === "plan")
+		);
 	});
 
 	$effect(() => {
@@ -470,7 +495,7 @@
 				{#if isProcessStreaming}
 					<!-- Streaming the thinking / tool phase: render every block flat and
 					     inline, exactly like today. Nesting kicks in once the answer starts. -->
-					{#each blocks as block, blockIndex (block.type === "tool" ? `tool-${block.uuid}-${blockIndex}` : `block-${blockIndex}`)}
+					{#each blocks as block, blockIndex (block.type === "tool" ? `tool-${block.uuid}-${blockIndex}` : block.type === "plan" ? `plan-${block.update.version}` : `block-${blockIndex}`)}
 						{#if block.type === "text"}
 							{#if block.content.trim().length > 0}
 								<div class={proseClasses}>
@@ -487,6 +512,10 @@
 									expiresAt={block.expiresAt}
 									resolved={block.resolved}
 								/>
+							</div>
+						{:else if block.type === "plan"}
+							<div data-exclude-from-copy>
+								<PlanCard update={block.update} />
 							</div>
 						{:else}
 							<div data-exclude-from-copy class="not-last:mb-1 has-[+.prose]:mb-2! [.prose+&]:mt-3">
@@ -506,7 +535,7 @@
 					{/if}
 				{:else}
 					<!-- Answer started or generation finished: nest the process blocks. -->
-					{#each renderUnits as unit, unitIndex (`${unit.kind}-${unitIndex}`)}
+					{#each renderUnits as unit, unitIndex (unit.kind === "plan" ? `plan-${unit.update.version}` : `${unit.kind}-${unitIndex}`)}
 						{#if unit.kind === "text"}
 							{#if isLast && loading && unit.content.length === 0}
 								<IconLoading classNames="loading inline ml-2 first:ml-0" />
@@ -525,6 +554,10 @@
 									expiresAt={unit.expiresAt}
 									resolved={unit.resolved}
 								/>
+							</div>
+						{:else if unit.kind === "plan"}
+							<div data-exclude-from-copy>
+								<PlanCard update={unit.update} />
 							</div>
 						{:else if unit.kind === "group"}
 							<div data-exclude-from-copy class="not-last:mb-1 has-[+.prose]:mb-2! [.prose+&]:mt-3">

--- a/src/lib/components/chat/PlanCard.svelte
+++ b/src/lib/components/chat/PlanCard.svelte
@@ -1,0 +1,88 @@
+<script lang="ts">
+	import type { MessagePlanUpdate } from "$lib/types/MessageUpdate";
+	import type { PlanStepStatus } from "$lib/types/Plan";
+	import CarbonChevronRight from "~icons/carbon/chevron-right";
+	import CarbonCheckmark from "~icons/carbon/checkmark";
+	import CarbonInProgress from "~icons/carbon/in-progress";
+	import CarbonRadioButton from "~icons/carbon/radio-button";
+	import CarbonSubtract from "~icons/carbon/subtract";
+
+	interface Props {
+		update: MessagePlanUpdate;
+	}
+
+	let { update }: Props = $props();
+
+	let isOpen = $state(true);
+
+	let completedCount = $derived(update.steps.filter((s) => s.status === "completed").length);
+
+	const stepTextClasses: Record<PlanStepStatus, string> = {
+		pending: "text-gray-600 dark:text-gray-300",
+		in_progress: "font-medium text-gray-700 dark:text-gray-200",
+		completed: "text-gray-400 dark:text-gray-500",
+		skipped: "text-gray-400 line-through dark:text-gray-500",
+	};
+</script>
+
+<div class="flex max-w-full min-w-0 flex-col items-start">
+	<!-- Header row -->
+	<button
+		type="button"
+		class="group/header flex max-w-full cursor-pointer items-center gap-1.5 text-left whitespace-nowrap select-none focus:outline-hidden"
+		onclick={() => (isOpen = !isOpen)}
+		aria-expanded={isOpen}
+		aria-label={isOpen ? "Collapse plan" : "Expand plan"}
+	>
+		<span
+			class="shrink-0 text-sm font-medium transition-colors group-hover/header:text-gray-600 dark:group-hover/header:text-gray-300 {isOpen
+				? 'text-gray-600 dark:text-gray-300'
+				: 'text-gray-500 dark:text-gray-400'}"
+		>
+			Plan
+		</span>
+		<span
+			class="shrink-0 rounded-sm bg-gray-100 px-1 py-px font-mono text-xs text-gray-500 dark:bg-gray-800 dark:text-gray-400"
+		>
+			{completedCount}/{update.steps.length}
+		</span>
+		{#if update.explanation}
+			<span class="min-w-0 truncate text-xs text-gray-400 dark:text-gray-500">
+				{update.explanation}
+			</span>
+		{/if}
+		<CarbonChevronRight
+			class="size-3.5 shrink-0 transition-all duration-200 group-hover/header:text-gray-600 dark:group-hover/header:text-gray-300 {isOpen
+				? 'rotate-90 text-gray-600 dark:text-gray-300'
+				: 'text-gray-400'}"
+		/>
+	</button>
+
+	<!-- Expandable content -->
+	{#if isOpen}
+		<div class="mt-1.5 w-full min-w-0">
+			<p class="text-xs break-words text-gray-500 dark:text-gray-400">{update.goal}</p>
+			<ol class="mt-1.5 flex w-full list-none flex-col gap-1">
+				{#each update.steps as step, i (i)}
+					<li
+						data-status={step.status}
+						class="flex min-w-0 items-start gap-1.5 text-sm {stepTextClasses[step.status]}"
+					>
+						<span class="mt-1 shrink-0" aria-hidden="true">
+							{#if step.status === "completed"}
+								<CarbonCheckmark class="size-3.5 text-green-600 dark:text-green-500" />
+							{:else if step.status === "in_progress"}
+								<CarbonInProgress class="size-3.5 text-blue-600 dark:text-blue-400" />
+							{:else if step.status === "skipped"}
+								<CarbonSubtract class="size-3.5 text-gray-300 dark:text-gray-600" />
+							{:else}
+								<CarbonRadioButton class="size-3.5 text-gray-300 dark:text-gray-600" />
+							{/if}
+						</span>
+						<span class="min-w-0 break-words">{step.step}</span>
+					</li>
+				{/each}
+			</ol>
+		</div>
+	{/if}
+</div>

--- a/src/lib/components/chat/PlanCard.svelte.test.ts
+++ b/src/lib/components/chat/PlanCard.svelte.test.ts
@@ -1,0 +1,94 @@
+import PlanCard from "./PlanCard.svelte";
+import { render } from "vitest-browser-svelte";
+import { describe, expect, it, vi } from "vitest";
+import { MessageUpdateType, type MessagePlanUpdate } from "$lib/types/MessageUpdate";
+import type { PlanStep } from "$lib/types/Plan";
+
+const steps: PlanStep[] = [
+	{ step: "Read the existing types", status: "completed" },
+	{ step: "Write the component", status: "completed" },
+	{ step: "Integrate into ChatMessage", status: "in_progress" },
+	{ step: "Manual QA pass", status: "skipped" },
+	{ step: "Write the browser tests", status: "pending" },
+];
+
+const plan = (over: Partial<MessagePlanUpdate> = {}): MessagePlanUpdate => ({
+	type: MessageUpdateType.Plan,
+	uuid: "22222222-2222-4222-8222-222222222222",
+	goal: "Ship the plan card end to end",
+	steps,
+	version: 3,
+	...over,
+});
+
+const mount = (update: MessagePlanUpdate = plan()) => render(PlanCard, { update });
+
+const header = (el: HTMLElement) =>
+	[...el.querySelectorAll("button")].find((b) => (b.textContent ?? "").includes("Plan"));
+
+const stepLi = (el: HTMLElement, status: PlanStep["status"]) =>
+	el.querySelector<HTMLLIElement>(`li[data-status="${status}"]`);
+
+describe("the plan card", () => {
+	it("renders the goal, every step, and the progress fraction", () => {
+		const { baseElement } = mount();
+		expect(baseElement.textContent).toContain("Ship the plan card end to end");
+		for (const { step } of steps) {
+			expect(baseElement.textContent).toContain(step);
+		}
+		// 2 of the 5 steps are completed.
+		expect(baseElement.textContent).toContain("2/5");
+	});
+
+	it("tells the step states apart at a glance", () => {
+		const { baseElement } = mount();
+
+		// Skipped reads as crossed out and muted.
+		const skipped = stepLi(baseElement, "skipped");
+		expect(skipped?.classList.contains("line-through")).toBe(true);
+
+		// Completed keeps its text but gains a check icon; nothing crosses it out.
+		const completed = stepLi(baseElement, "completed");
+		expect(completed?.classList.contains("line-through")).toBe(false);
+		expect(completed?.querySelector("svg")).not.toBeNull();
+
+		// The current step is the emphasized one.
+		const current = stepLi(baseElement, "in_progress");
+		expect(current?.classList.contains("font-medium")).toBe(true);
+		expect(stepLi(baseElement, "pending")?.classList.contains("font-medium")).toBe(false);
+
+		// Each state carries its own icon, so no two rows look alike.
+		expect(completed?.querySelector("svg")?.innerHTML).not.toBe(
+			current?.querySelector("svg")?.innerHTML
+		);
+	});
+
+	it("shows the explanation in the header when the update carries one", () => {
+		const { baseElement } = mount(plan({ explanation: "Reordered after the API change" }));
+		expect(baseElement.textContent).toContain("Reordered after the API change");
+	});
+
+	it("shows no explanation note when the update has none", () => {
+		const { baseElement } = mount();
+		expect(baseElement.textContent).not.toContain("Reordered after the API change");
+		// Header holds exactly the label and the fraction.
+		expect((header(baseElement)?.textContent ?? "").replace(/\s+/g, " ").trim()).toBe("Plan 2/5");
+	});
+
+	it("collapses to just the header and expands back", async () => {
+		const { baseElement } = mount();
+		expect(baseElement.querySelector("ol")).not.toBeNull();
+
+		header(baseElement)?.click();
+		await vi.waitFor(() => expect(baseElement.querySelector("ol")).toBeNull());
+
+		// The header survives the collapse.
+		expect(baseElement.textContent).toContain("Plan");
+		expect(baseElement.textContent).toContain("2/5");
+		expect(baseElement.textContent).not.toContain("Ship the plan card end to end");
+
+		header(baseElement)?.click();
+		await vi.waitFor(() => expect(baseElement.querySelector("ol")).not.toBeNull());
+		expect(baseElement.textContent).toContain("Ship the plan card end to end");
+	});
+});


### PR DESCRIPTION
Stacked on #2514 (targets `harness-update-plan`; retarget as the stack merges). Client half of the plan tool — the server half (#2514) ships the `update_plan` builtin and streams `MessageUpdateType.Plan`; until this PR those updates render as a generic tool card.

## What this does

**`PlanCard.svelte`** — a read-only, collapsible card (open by default) for the current plan:
- Header: "Plan" label, a completed/total progress fraction, and the model's one-line `explanation` (the per-update changelog) when present, truncated to one line.
- Body: the consolidated goal as a muted paragraph, then the steps with per-status rendering — completed (check, muted), in_progress (emphasized — the "current" step), pending (neutral, empty circle), skipped (struck-through, muted).
- Long steps wrap; the card never forces horizontal scroll; full dark-mode variants; visual language matches `ToolUpdate`/`ToolCallsSummary`.

**`ChatMessage.svelte` integration:**
- Plan updates become a first-class block that is **never folded** into the collapsed "Called N tools" summary — same rule as elicitation: state the user tracks stays visible.
- **One live card per message**: successive `update_plan` calls coalesce; the latest update supersedes the earlier card and takes its stream position, so the plan doesn't stack a card per revision.
- The **generic tool card for a successful plan call is suppressed** (matched by the shared uuid), so the call renders once, as the dedicated card. A **failed** call emits no Plan update, so its error card survives untouched — and the "Called N tools" count stays correct for free since suppressed calls leave the group.
- A trailing plan block keeps the flat streaming layout (like think/tool/elicitation), so the card renders live while the model continues working.
- Works identically on replay from persisted updates and in the shared-conversation view, since both render from `Message.updates`.

## Tests
`PlanCard.svelte.test.ts` — 5 browser-workspace tests: goal/steps/fraction rendering, status distinction (skipped line-through, completed check, in_progress emphasis), explanation present/absent, collapse/expand. Full suite green; `npm run check` and lint clean; svelte autofixer reports zero issues on the new code.