### PR TITLE
Add ML Assistant mode behind a build flag

### DIFF
--- a/.env
+++ b/.env
@@ -203,6 +203,9 @@ ENABLE_CONFIG_MANAGER=true
 # They need to be passed when building the docker image
 # See https://github.com/huggingface/chat-ui/main/.github/workflows/deploy-prod.yml#L44-L47
 APP_BASE="" # base path of the app, e.g. /chat, left blank as default
+# Compiles in ML Assistant mode: the composer header strip with the preset switch
+# and, once a task is running, its plan progress. Off unless set to "true".
+ML_ASSISTANT_MODE=
 ### Body size limit for SvelteKit https://svelte.dev/docs/kit/adapter-node#Environment-variables-BODY_SIZE_LIMIT
 BODY_SIZE_LIMIT=15728640
 PUBLIC_COMMIT_SHA=

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,7 @@ COPY --link --chown=1000 package-lock.json package.json ./
 
 ARG APP_BASE=
 ARG PUBLIC_APP_COLOR=
+ARG ML_ASSISTANT_MODE=
 ENV BODY_SIZE_LIMIT=15728640
 
 RUN --mount=type=cache,target=/app/.npm \

--- a/docs/source/configuration/overview.md
+++ b/docs/source/configuration/overview.md
@@ -72,6 +72,18 @@ ENABLE_DATA_EXPORT=true         # Allow users to export their data
 ALLOW_IFRAME=false              # Disallow embedding in iframes (set to true to allow)
 ```
 
+## Build Flags
+
+Some features are fixed when the app is built rather than read at runtime, so a
+build either ships them or has no way to turn them on:
+
+```ini
+ML_ASSISTANT_MODE=true          # Compile in ML Assistant mode (composer header strip)
+```
+
+Pass it to `npm run build`, or as a `--build-arg` to `docker build`. Setting it on
+an already-built instance has no effect.
+
 ## User Authentication
 
 Use OpenID Connect for authentication:

--- a/src/ambient.d.ts
+++ b/src/ambient.d.ts
@@ -5,3 +5,10 @@ declare module "*.ttf" {
 
 // Legacy helpers removed: web search support is deprecated, so we intentionally
 // avoid leaking those shapes into the global ambient types.
+
+/**
+ * Build flag for ML Assistant mode, inlined by Vite's `define` (see vite.config.ts).
+ * Set `ML_ASSISTANT_MODE=true` in the build environment to compile the feature in;
+ * with it off the constant folds to `false` and every gate on it is dead code.
+ */
+declare const __ML_ASSISTANT_MODE__: boolean;

--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type { Message, MessageFile } from "$lib/types/Message";
-	import { onDestroy, onMount, untrack } from "svelte";
+	import { onDestroy, untrack } from "svelte";
 
 	import ArtifactPanel from "./ArtifactPanel.svelte";
 	import { collectArtifacts } from "$lib/utils/artifacts";
@@ -60,7 +60,6 @@
 		ML_ASSISTANT_PLACEHOLDER,
 		mlAssistantExamples,
 	} from "$lib/constants/mlAssistant";
-	import type { ReasoningEffort } from "$lib/types/Settings";
 
 	import { fly } from "svelte/transition";
 	import { cubicInOut } from "svelte/easing";
@@ -454,58 +453,12 @@
 		if (!ML_ASSISTANT_MODE) return;
 		const conversationId = page.params?.id;
 		const startedInMlMode = Boolean((page.data as { mlAssistant?: boolean }).mlAssistant);
-		untrack(() => {
-			if (mlAssistant.syncConversation(conversationId, startedInMlMode)) releaseMlEffort();
-		});
+		untrack(() => mlAssistant.syncConversation(conversationId, startedInMlMode));
 	});
-
-	onMount(() => {
-		// A reload drops the mode but not the effort override it was holding, so this
-		// load is the one that has to hand the setting back. Guarded on the mode being
-		// off: this also runs when navigating into the conversation a mode-on send just
-		// created, and that hold is still live.
-		if (!ML_ASSISTANT_MODE || mlAssistant.enabled) return;
-		mlAssistant.restoreEffortHold();
-		releaseMlEffort();
-	});
-
-	// The preset runs at high effort. Effort is read from the user's saved settings
-	// when the request is built, so the mode has to write the override rather than
-	// only display it; the previous value goes back when the mode is switched off.
-	function holdMlEffort() {
-		if (mlAssistant.effortHold) return;
-		const overrides = { ...($settings.reasoningEffortOverrides ?? {}) };
-		mlAssistant.effortHold = {
-			modelId: currentModel.id,
-			previous: overrides[currentModel.id],
-		};
-		overrides[currentModel.id] = ML_ASSISTANT_EFFORT;
-		settings.instantSet({ reasoningEffortOverrides: overrides });
-	}
-
-	function releaseMlEffort() {
-		const hold = mlAssistant.effortHold;
-		if (!hold) return;
-		mlAssistant.effortHold = null;
-		const overrides: Record<string, ReasoningEffort> = {
-			...($settings.reasoningEffortOverrides ?? {}),
-		};
-		if (hold.previous === undefined) {
-			delete overrides[hold.modelId];
-		} else {
-			overrides[hold.modelId] = hold.previous;
-		}
-		settings.instantSet({ reasoningEffortOverrides: overrides });
-	}
 
 	function toggleMlMode(next: boolean) {
 		if (requireAuthUser()) return;
 		mlAssistant.toggle(next);
-		if (mlAssistant.enabled) {
-			holdMlEffort();
-		} else {
-			releaseMlEffort();
-		}
 	}
 
 	let activeRouterExamplePrompt = $state<string | null>(null);
@@ -1124,7 +1077,10 @@
 					{/if}
 					{#if $settings.reasoningOverrides?.[currentModel.id] ?? currentModel.supportsReasoning}
 						<div class="ml-auto">
-							<ThinkingEffortChip modelId={currentModel.id} />
+							<ThinkingEffortChip
+								modelId={currentModel.id}
+								presetEffort={mlModeOn ? ML_ASSISTANT_EFFORT : undefined}
+							/>
 						</div>
 					{/if}
 				</div>

--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type { Message, MessageFile } from "$lib/types/Message";
-	import { onDestroy, untrack } from "svelte";
+	import { onDestroy, onMount, untrack } from "svelte";
 
 	import ArtifactPanel from "./ArtifactPanel.svelte";
 	import { collectArtifacts } from "$lib/utils/artifacts";
@@ -52,6 +52,15 @@
 	import { mimeMatchesAllowlist } from "$lib/utils/mimeMatch";
 	import LucideHammer from "~icons/lucide/hammer";
 	import LucideSparkles from "~icons/lucide/sparkles";
+	import MlAssistantStrip from "./MlAssistantStrip.svelte";
+	import { ML_ASSISTANT_MODE } from "$lib/utils/mlAssistantFlag";
+	import { mlAssistant } from "$lib/stores/mlAssistant.svelte";
+	import {
+		ML_ASSISTANT_EFFORT,
+		ML_ASSISTANT_PLACEHOLDER,
+		mlAssistantExamples,
+	} from "$lib/constants/mlAssistant";
+	import type { ReasoningEffort } from "$lib/types/Settings";
 
 	import { fly } from "svelte/transition";
 	import { cubicInOut } from "svelte/easing";
@@ -160,6 +169,9 @@
 		if (requireAuthUser() || loading || !draft) return;
 		tap();
 		chatScroll.armSend();
+		// Latches the mode onto the conversation, so the strip stays and swaps its
+		// tool note for the plan progress row. No-op when the mode is off.
+		mlAssistant.startTask();
 		onmessage?.(draft);
 		draft = "";
 	};
@@ -430,10 +442,77 @@
 	let isFileUploadEnabled = $derived(activeMimeTypes.length > 0);
 	let focused = $state(false);
 
+	// --- ML Assistant mode (build flag, see $lib/utils/mlAssistantFlag) --------
+
+	let mlModeOn = $derived(ML_ASSISTANT_MODE && mlAssistant.enabled);
+	let mlTaskRunning = $derived(ML_ASSISTANT_MODE && mlAssistant.taskStarted);
+	// Sending with the mode off collapses the strip away for good; sending with it
+	// on keeps the strip, which is where the plan progress lives.
+	let mlStripVisible = $derived(ML_ASSISTANT_MODE && (mlTaskRunning || messages.length === 0));
+
+	$effect(() => {
+		if (!ML_ASSISTANT_MODE) return;
+		const conversationId = page.params?.id;
+		const startedInMlMode = Boolean((page.data as { mlAssistant?: boolean }).mlAssistant);
+		untrack(() => {
+			if (mlAssistant.syncConversation(conversationId, startedInMlMode)) releaseMlEffort();
+		});
+	});
+
+	onMount(() => {
+		// A reload drops the mode but not the effort override it was holding, so this
+		// load is the one that has to hand the setting back. Guarded on the mode being
+		// off: this also runs when navigating into the conversation a mode-on send just
+		// created, and that hold is still live.
+		if (!ML_ASSISTANT_MODE || mlAssistant.enabled) return;
+		mlAssistant.restoreEffortHold();
+		releaseMlEffort();
+	});
+
+	// The preset runs at high effort. Effort is read from the user's saved settings
+	// when the request is built, so the mode has to write the override rather than
+	// only display it; the previous value goes back when the mode is switched off.
+	function holdMlEffort() {
+		if (mlAssistant.effortHold) return;
+		const overrides = { ...($settings.reasoningEffortOverrides ?? {}) };
+		mlAssistant.effortHold = {
+			modelId: currentModel.id,
+			previous: overrides[currentModel.id],
+		};
+		overrides[currentModel.id] = ML_ASSISTANT_EFFORT;
+		settings.instantSet({ reasoningEffortOverrides: overrides });
+	}
+
+	function releaseMlEffort() {
+		const hold = mlAssistant.effortHold;
+		if (!hold) return;
+		mlAssistant.effortHold = null;
+		const overrides: Record<string, ReasoningEffort> = {
+			...($settings.reasoningEffortOverrides ?? {}),
+		};
+		if (hold.previous === undefined) {
+			delete overrides[hold.modelId];
+		} else {
+			overrides[hold.modelId] = hold.previous;
+		}
+		settings.instantSet({ reasoningEffortOverrides: overrides });
+	}
+
+	function toggleMlMode(next: boolean) {
+		if (requireAuthUser()) return;
+		mlAssistant.toggle(next);
+		if (mlAssistant.enabled) {
+			holdMlEffort();
+		} else {
+			releaseMlEffort();
+		}
+	}
+
 	let activeRouterExamplePrompt = $state<string | null>(null);
-	// Use MCP examples when all base servers are enabled, otherwise use router examples
+	// ML Assistant mode brings its own chip set; otherwise use MCP examples when all
+	// base servers are enabled, and router examples when they are not.
 	let activeExamples = $derived<RouterExample[]>(
-		$allBaseServersEnabled ? mcpExamples : routerExamples
+		mlModeOn ? mlAssistantExamples : $allBaseServersEnabled ? mcpExamples : routerExamples
 	);
 	let routerFollowUps = $derived<RouterFollowUp[]>(
 		activeRouterExamplePrompt
@@ -757,13 +836,18 @@
 			max-sm:py-0 sm:px-[calc(1.25rem+var(--scrollbar-gutter,0px))]
 			md:pb-4 xl:max-w-4xl dark:border-gray-800 dark:from-gray-900 dark:via-gray-900 dark:to-gray-900/0"
 		>
-			{#if !draft.length && !messages.length && !sources.length && !loading && (currentModel.isRouter || (modelSupportsTools && $allBaseServersEnabled)) && activeExamples.length && !hideRouterExamples && !lastIsError && $mcpServersLoaded}
+			{#if !draft.length && !messages.length && !sources.length && !loading && (mlModeOn || currentModel.isRouter || (modelSupportsTools && $allBaseServersEnabled)) && activeExamples.length && !hideRouterExamples && !lastIsError && $mcpServersLoaded}
 				<div
 					class="mb-3 no-scrollbar flex w-full justify-start gap-2 overflow-x-auto whitespace-nowrap text-gray-400 select-none dark:text-gray-500"
 				>
 					{#each activeExamples as ex}
 						<button
-							class="flex items-center gap-1 rounded-lg bg-gray-100/90 px-2 py-0.5 text-center text-sm backdrop-blur-sm hover:text-gray-500 dark:bg-gray-700/50 dark:hover:text-gray-400"
+							class={[
+								"flex items-center gap-1 rounded-lg px-2 py-0.5 text-center text-sm backdrop-blur-sm",
+								mlModeOn
+									? "bg-[#eef2ff] text-[#3450cc] dark:bg-[#1b2140] dark:text-[#93a4f0]"
+									: "bg-gray-100/90 hover:text-gray-500 dark:bg-gray-700/50 dark:hover:text-gray-400",
+							]}
 							onclick={() => startExample(ex)}
 						>
 							{ex.title}
@@ -832,85 +916,110 @@
 						handleSubmit();
 					}}
 					class={{
-						"relative flex w-full max-w-4xl flex-1 items-center rounded-xl border bg-gray-100 dark:border-gray-700 dark:bg-gray-800": true,
+						"relative flex w-full max-w-4xl flex-1 flex-col rounded-xl border bg-gray-100 dark:bg-gray-800": true,
+						"transition-[border-color] duration-[350ms] ease-[ease]": ML_ASSISTANT_MODE,
+						"border-[#dfe4fb] dark:border-[#2b3357]": mlModeOn && mlStripVisible,
+						"dark:border-gray-700": !(mlModeOn && mlStripVisible),
 						"opacity-30": isReadOnly,
 						"max-sm:mb-4": focused && isVirtualKeyboard(),
 					}}
 				>
-					{#if isRecording || isTranscribing}
-						<VoiceRecorder
-							{isTranscribing}
-							{isTouchDevice}
-							oncancel={() => {
-								isRecording = false;
-							}}
-							onconfirm={handleRecordingConfirm}
-							onsend={handleRecordingSend}
-							onerror={handleRecordingError}
+					{#if ML_ASSISTANT_MODE}
+						<MlAssistantStrip
+							visible={mlStripVisible}
+							enabled={mlAssistant.enabled}
+							taskRunning={mlTaskRunning}
+							steps={mlAssistant.steps}
+							statusLabel={mlAssistant.statusLabel}
+							complete={mlAssistant.complete}
+							ontoggle={toggleMlMode}
 						/>
-					{:else if onDrag && isFileUploadEnabled}
-						<FileDropzone bind:files bind:onDrag mimeTypes={activeMimeTypes} />
-					{:else}
-						<div
-							class="flex w-full flex-1 rounded-xl border-none bg-transparent"
-							class:paste-glow={pastedLongContent}
-						>
-							{#if lastIsError}
-								<ChatInput value="Sorry, something went wrong. Please try again." disabled={true} />
-							{:else}
-								<ChatInput
-									placeholder={isReadOnly ? "This conversation is read-only." : "Ask anything"}
-									{loading}
-									bind:value={draft}
-									bind:files
-									mimeTypes={activeMimeTypes}
-									onsubmit={handleSubmit}
-									{onPaste}
-									disabled={isReadOnly || lastIsError}
-									{modelIsMultimodal}
-									{modelSupportsTools}
-									bind:focused
-								/>
-							{/if}
+					{/if}
+					<!-- The composer box is a column so the ML Assistant strip can stack on
+					     top; this row is the composer proper and keeps its own layout. -->
+					<div class="flex w-full items-center">
+						{#if isRecording || isTranscribing}
+							<VoiceRecorder
+								{isTranscribing}
+								{isTouchDevice}
+								oncancel={() => {
+									isRecording = false;
+								}}
+								onconfirm={handleRecordingConfirm}
+								onsend={handleRecordingSend}
+								onerror={handleRecordingError}
+							/>
+						{:else if onDrag && isFileUploadEnabled}
+							<FileDropzone bind:files bind:onDrag mimeTypes={activeMimeTypes} />
+						{:else}
+							<div
+								class="flex w-full flex-1 rounded-xl border-none bg-transparent"
+								class:paste-glow={pastedLongContent}
+							>
+								{#if lastIsError}
+									<ChatInput
+										value="Sorry, something went wrong. Please try again."
+										disabled={true}
+									/>
+								{:else}
+									<ChatInput
+										placeholder={isReadOnly
+											? "This conversation is read-only."
+											: mlModeOn
+												? ML_ASSISTANT_PLACEHOLDER
+												: "Ask anything"}
+										{loading}
+										bind:value={draft}
+										bind:files
+										mimeTypes={activeMimeTypes}
+										onsubmit={handleSubmit}
+										{onPaste}
+										disabled={isReadOnly || lastIsError}
+										{modelIsMultimodal}
+										{modelSupportsTools}
+										bind:focused
+									/>
+								{/if}
 
-							{#if loading}
-								<StopGeneratingBtn
-									onClick={() => {
-										hapticError();
-										onstop?.();
-									}}
-									showBorder={true}
-									classNames="absolute bottom-2 right-2 size-8 sm:size-7 self-end rounded-full border bg-white text-black shadow-sm transition-none dark:border-transparent dark:bg-gray-600 dark:text-white"
-								/>
-							{:else}
-								{#if transcriptionEnabled}
-									<button
-										type="button"
-										class="absolute right-10 bottom-2 mr-1.5 btn size-8 self-end rounded-full border bg-white/50 text-gray-500 transition-none hover:bg-gray-50 hover:text-gray-700 sm:right-9 sm:size-7 dark:border-transparent dark:bg-gray-600/50 dark:text-gray-300 dark:hover:bg-gray-500 dark:hover:text-white"
-										disabled={isReadOnly}
-										onclick={() => {
-											isRecording = true;
+								{#if loading}
+									<StopGeneratingBtn
+										onClick={() => {
+											hapticError();
+											onstop?.();
 										}}
-										aria-label="Start voice recording"
+										showBorder={true}
+										classNames="absolute bottom-2 right-2 size-8 sm:size-7 self-end rounded-full border bg-white text-black shadow-sm transition-none dark:border-transparent dark:bg-gray-600 dark:text-white"
+									/>
+								{:else}
+									{#if transcriptionEnabled}
+										<button
+											type="button"
+											class="absolute right-10 bottom-2 mr-1.5 btn size-8 self-end rounded-full border bg-white/50 text-gray-500 transition-none hover:bg-gray-50 hover:text-gray-700 sm:right-9 sm:size-7 dark:border-transparent dark:bg-gray-600/50 dark:text-gray-300 dark:hover:bg-gray-500 dark:hover:text-white"
+											disabled={isReadOnly}
+											onclick={() => {
+												isRecording = true;
+											}}
+											aria-label="Start voice recording"
+										>
+											<IconMic class="size-4" />
+										</button>
+									{/if}
+									<button
+										class="absolute right-2 bottom-2 btn size-8 self-end rounded-full border bg-white text-black shadow transition-none enabled:hover:bg-white enabled:hover:shadow-inner sm:size-7 dark:border-transparent dark:bg-gray-600 dark:text-white dark:hover:enabled:bg-black {!draft ||
+										isReadOnly
+											? ''
+											: 'bg-black! text-white! dark:bg-white! dark:text-black!'}"
+										disabled={!draft || isReadOnly}
+										type="submit"
+										aria-label="Send message"
+										name="submit"
 									>
-										<IconMic class="size-4" />
+										<IconArrowUp />
 									</button>
 								{/if}
-								<button
-									class="absolute right-2 bottom-2 btn size-8 self-end rounded-full border bg-white text-black shadow transition-none enabled:hover:bg-white enabled:hover:shadow-inner sm:size-7 dark:border-transparent dark:bg-gray-600 dark:text-white dark:hover:enabled:bg-black {!draft ||
-									isReadOnly
-										? ''
-										: 'bg-black! text-white! dark:bg-white! dark:text-black!'}"
-									disabled={!draft || isReadOnly}
-									type="submit"
-									aria-label="Send message"
-									name="submit"
-								>
-									<IconArrowUp />
-								</button>
-							{/if}
-						</div>
-					{/if}
+							</div>
+						{/if}
+					</div>
 				</form>
 				<div
 					class={{

--- a/src/lib/components/chat/MlAssistantPlanProgress.svelte
+++ b/src/lib/components/chat/MlAssistantPlanProgress.svelte
@@ -1,0 +1,181 @@
+<script lang="ts">
+	import { Tooltip } from "bits-ui";
+	import type { MlPlanStep } from "$lib/types/MlAssistant";
+
+	interface Props {
+		steps: MlPlanStep[];
+		/** Status label for the running step, or "Done" once the plan finishes. */
+		statusLabel: string;
+		complete: boolean;
+	}
+
+	let { steps, statusLabel, complete }: Props = $props();
+
+	// Tap opens the tooltip on touch, where hover never fires. One index rather
+	// than one flag per dot so opening a second dot closes the first.
+	let openStep = $state(-1);
+
+	function accessibleName(step: MlPlanStep) {
+		return `${step.label} — ${step.status}`;
+	}
+</script>
+
+<div class="flex items-center gap-3">
+	<Tooltip.Provider delayDuration={80} disableHoverableContent>
+		<div class="flex items-center gap-[5px]">
+			{#each steps as step, index (index)}
+				<Tooltip.Root
+					open={openStep === index}
+					onOpenChange={(open) => (openStep = open ? index : -1)}
+					disableCloseOnTriggerClick
+				>
+					<Tooltip.Trigger
+						class="ml-dot-hit"
+						aria-label={accessibleName(step)}
+						onclick={() => (openStep = openStep === index ? -1 : index)}
+					>
+						<span class="ml-dot" data-status={step.status}>{index + 1}</span>
+					</Tooltip.Trigger>
+					<Tooltip.Portal>
+						<Tooltip.Content class="ml-dot-tooltip" side="top" sideOffset={10}>
+							<span class="font-semibold">{step.label}</span>
+							<span> — </span>
+							<span class="opacity-65">{step.description}</span>
+						</Tooltip.Content>
+					</Tooltip.Portal>
+				</Tooltip.Root>
+			{/each}
+		</div>
+	</Tooltip.Provider>
+
+	<span
+		class={[
+			"text-[13.5px] leading-none font-medium whitespace-nowrap",
+			complete ? "text-[#16a34a] dark:text-[#4ade80]" : "text-[#2244cc] dark:text-[#93a4f0]",
+		]}
+		aria-live="polite"
+		aria-atomic="true"
+	>
+		{statusLabel}
+	</span>
+</div>
+
+<style>
+	/* 27x44 hit target that leaves the 22px dot's footprint untouched, so the row
+	   still lays out on the designed 5px gap. */
+	:global(.ml-dot-hit) {
+		display: grid;
+		place-items: center;
+		width: 27px;
+		height: 44px;
+		margin: -11px -2.5px;
+		padding: 0;
+		border: 0;
+		background: transparent;
+	}
+
+	:global(.ml-dot-hit:focus-visible) {
+		outline: 2px solid #2244cc;
+		outline-offset: -8px;
+		border-radius: 8px;
+	}
+
+	.ml-dot {
+		display: grid;
+		place-items: center;
+		box-sizing: border-box;
+		width: 22px;
+		height: 22px;
+		border-radius: 50%;
+		font-family: var(--font-mono, ui-monospace, monospace);
+		font-size: 11px;
+		font-weight: 500;
+		line-height: 1;
+		transition:
+			background 0.3s,
+			border-color 0.3s,
+			color 0.3s;
+	}
+
+	.ml-dot[data-status="pending"] {
+		background: #fff;
+		border: 1px solid #dcdce2;
+		color: #b0b0b8;
+	}
+
+	.ml-dot[data-status="running"] {
+		background: #2244cc;
+		border: 1px solid #2244cc;
+		color: #fff;
+		animation: mlpulse 1.5s ease-in-out infinite;
+	}
+
+	.ml-dot[data-status="done"] {
+		background: #16a34a;
+		border: 1px solid #16a34a;
+		color: #fff;
+	}
+
+	.ml-dot[data-status="skipped"] {
+		background: #eeeef1;
+		border: 1px solid #eeeef1;
+		color: #b4b4bc;
+		opacity: 0.65;
+	}
+
+	:global(.dark) .ml-dot[data-status="pending"] {
+		background: transparent;
+		border-color: #3a3a42;
+		color: #7a7a84;
+	}
+
+	:global(.dark) .ml-dot[data-status="skipped"] {
+		background: #26262c;
+		border-color: #26262c;
+		color: #6f6f79;
+	}
+
+	@keyframes mlpulse {
+		0%,
+		100% {
+			box-shadow: 0 0 0 0 rgba(34, 68, 204, 0.45);
+		}
+		50% {
+			box-shadow: 0 0 0 5px rgba(34, 68, 204, 0);
+		}
+	}
+
+	:global(.ml-dot-tooltip) {
+		z-index: 50;
+		background: #1a1a1f;
+		color: #fff;
+		padding: 7px 10px;
+		border-radius: 7px;
+		font-size: 12px;
+		font-weight: 400;
+		line-height: 1.35;
+		white-space: nowrap;
+		box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18);
+		animation: mlfade 0.12s ease-out;
+	}
+
+	@keyframes mlfade {
+		from {
+			opacity: 0;
+			transform: translateY(4px);
+		}
+		to {
+			opacity: 1;
+			transform: none;
+		}
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.ml-dot[data-status="running"] {
+			animation: none;
+		}
+		:global(.ml-dot-tooltip) {
+			animation: none;
+		}
+	}
+</style>

--- a/src/lib/components/chat/MlAssistantStrip.svelte
+++ b/src/lib/components/chat/MlAssistantStrip.svelte
@@ -1,0 +1,209 @@
+<script lang="ts">
+	import { Switch } from "bits-ui";
+	import MlAssistantPlanProgress from "./MlAssistantPlanProgress.svelte";
+	import { ML_ASSISTANT_NOTE_OFF, ML_ASSISTANT_TOOLS } from "$lib/constants/mlAssistant";
+	import type { MlPlanStep } from "$lib/types/MlAssistant";
+
+	interface Props {
+		/** Collapses the strip out of the composer when false, rather than unmounting it. */
+		visible: boolean;
+		enabled: boolean;
+		/** Locks the switch and swaps the tool note for the plan progress row. */
+		taskRunning: boolean;
+		steps: MlPlanStep[];
+		statusLabel: string;
+		complete: boolean;
+		ontoggle: (enabled: boolean) => void;
+		/**
+		 * Opens the preset's tool and prompt configuration. That panel doesn't exist
+		 * yet, so the link renders as designed but does nothing until one is passed.
+		 */
+		onconfigure?: () => void;
+	}
+
+	let {
+		visible,
+		enabled,
+		taskRunning,
+		steps,
+		statusLabel,
+		complete,
+		ontoggle,
+		onconfigure,
+	}: Props = $props();
+</script>
+
+<div class="ml-strip-collapse" class:is-open={visible} inert={!visible}>
+	<div
+		class={[
+			"ml-strip flex items-center gap-[9px] border-b px-4 py-[9px] text-[13.5px]",
+			enabled
+				? "border-[#e2e7fb] bg-[#f0f3ff] text-[#2244cc] dark:border-[#2b3357] dark:bg-[#151a2e] dark:text-[#93a4f0]"
+				: "border-[#ececee] bg-transparent text-[#9a9aa0] dark:border-gray-700 dark:text-gray-500",
+		]}
+	>
+		<!-- Once the task is running the mode can no longer be switched off, so the
+		     control collapses out of the row and everything after it slides left.
+		     The negative margin absorbs the flex gap. -->
+		<span class="ml-switch-slot" class:is-collapsed={taskRunning} inert={taskRunning}>
+			<Switch.Root
+				class="ml-switch"
+				checked={enabled}
+				disabled={taskRunning}
+				onCheckedChange={ontoggle}
+				aria-label="ML Assistant mode"
+			>
+				<span class="ml-switch-track" class:is-on={enabled}>
+					<Switch.Thumb class="ml-switch-knob" />
+				</span>
+			</Switch.Root>
+		</span>
+
+		<!-- The switch is gone once a task is running, so the title has to be what
+		     tells a screen reader the mode is on. -->
+		<span class="flex-none" class:font-semibold={enabled}>
+			ML Assistant{#if taskRunning}<span class="sr-only">, mode on</span>{/if}
+		</span>
+
+		<!-- The plan replaces the tool note, but only once there is a plan to show:
+		     a run that has not reported its steps yet would otherwise leave a gap. -->
+		{#if taskRunning && steps.length}
+			<MlAssistantPlanProgress {steps} {statusLabel} {complete} />
+		{:else if enabled}
+			<span class="truncate font-mono text-xs text-[#7f8cd8]">
+				{ML_ASSISTANT_TOOLS.join(" · ")}
+			</span>
+		{:else}
+			<span class="truncate text-[#c2c2c8] dark:text-gray-600">{ML_ASSISTANT_NOTE_OFF}</span>
+		{/if}
+
+		<span class="ml-auto"></span>
+
+		{#if enabled && !taskRunning}
+			<button
+				type="button"
+				class="flex-none cursor-pointer text-[13.5px] text-[#7f8cd8] hover:underline"
+				onclick={onconfigure}
+			>
+				Configure
+			</button>
+		{/if}
+	</div>
+</div>
+
+<style>
+	.ml-strip-collapse {
+		max-height: 0;
+		opacity: 0;
+		/* Also clips the tint to the composer's top corners, so the composer box
+		   itself does not need overflow:hidden (which would cut off the paste
+		   glow). The radius is the composer's rounded-xl minus its 1px border. */
+		overflow: hidden;
+		border-top-left-radius: calc(0.75rem - 1px);
+		border-top-right-radius: calc(0.75rem - 1px);
+		transition:
+			max-height 0.45s cubic-bezier(0.4, 0, 0.2, 1),
+			opacity 0.3s ease;
+	}
+
+	.ml-strip-collapse.is-open {
+		max-height: 56px;
+		opacity: 1;
+	}
+
+	.ml-strip {
+		transition:
+			background 0.35s ease,
+			border-color 0.35s ease;
+	}
+
+	/* The slot owns the switch's footprint in the row; the button is absolutely
+	   positioned over it at 44x44 so the hit target never affects layout. */
+	.ml-switch-slot {
+		position: relative;
+		display: block;
+		flex: none;
+		width: 26px;
+		height: 15px;
+		transition:
+			width 0.4s cubic-bezier(0.4, 0, 0.2, 1),
+			margin-right 0.4s cubic-bezier(0.4, 0, 0.2, 1),
+			opacity 0.25s ease;
+	}
+
+	.ml-switch-slot.is-collapsed {
+		width: 0;
+		margin-right: -9px;
+		opacity: 0;
+		/* Clips the track as it vanishes. Only set while collapsing, so the 44x44
+		   hit target is not cut down in the state where it is actually used. */
+		overflow: hidden;
+	}
+
+	:global(.ml-switch) {
+		position: absolute;
+		top: -14.5px;
+		right: -9px;
+		bottom: -14.5px;
+		left: -9px;
+		display: block;
+		padding: 0;
+		border: 0;
+		background: transparent;
+	}
+
+	.ml-switch-track {
+		position: absolute;
+		top: 14.5px;
+		left: 9px;
+		width: 26px;
+		height: 15px;
+		border-radius: 999px;
+		overflow: hidden;
+		background: #d8d8dd;
+		transition: background 0.3s ease;
+	}
+
+	.ml-switch-track.is-on {
+		background: #2244cc;
+	}
+
+	:global(.dark) .ml-switch-track {
+		background: #3a3a42;
+	}
+
+	:global(.dark) .ml-switch-track.is-on {
+		background: #3b5ce0;
+	}
+
+	:global(.ml-switch:focus-visible) .ml-switch-track {
+		outline: 2px solid #2244cc;
+		outline-offset: 2px;
+	}
+
+	:global(.ml-switch-knob) {
+		position: absolute;
+		top: 2px;
+		left: 2px;
+		display: block;
+		width: 11px;
+		height: 11px;
+		border-radius: 50%;
+		background: #fff;
+		transition: left 0.28s cubic-bezier(0.4, 0, 0.2, 1);
+	}
+
+	:global(.ml-switch-knob[data-state="checked"]) {
+		left: 13px;
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.ml-strip-collapse,
+		.ml-strip,
+		.ml-switch-slot,
+		.ml-switch-track,
+		:global(.ml-switch-knob) {
+			transition: none;
+		}
+	}
+</style>

--- a/src/lib/components/chat/MlAssistantStrip.svelte.test.ts
+++ b/src/lib/components/chat/MlAssistantStrip.svelte.test.ts
@@ -1,0 +1,281 @@
+import MlAssistantStrip from "./MlAssistantStrip.svelte";
+import { render } from "vitest-browser-svelte";
+import { describe, expect, it, vi } from "vitest";
+import type { MlPlanStep } from "$lib/types/MlAssistant";
+
+/**
+ * The design handoff pins exact colours, sizes and timings, so these assert
+ * computed style rather than class names.
+ */
+
+const ACCENT = "rgb(34, 68, 204)";
+const SUCCESS = "rgb(22, 163, 74)";
+
+const step = (
+	label: string,
+	status: MlPlanStep["status"],
+	statusLabel = `${label}ing`
+): MlPlanStep => ({ label, statusLabel, description: `${label} description`, status });
+
+const PLAN: MlPlanStep[] = [
+	step("Research", "done", "Researching"),
+	step("Baseline eval", "skipped", "Skipped"),
+	step("Training", "running", "Training"),
+	step("Deploy", "pending", "Deploying"),
+];
+
+function mount(props: Partial<Parameters<typeof render<typeof MlAssistantStrip>>[1]> = {}) {
+	return render(MlAssistantStrip, {
+		visible: true,
+		enabled: false,
+		taskRunning: false,
+		steps: [],
+		statusLabel: "",
+		complete: false,
+		ontoggle: () => {},
+		...props,
+	});
+}
+
+const find = (root: ParentNode, selector: string): HTMLElement => {
+	const el = root.querySelector<HTMLElement>(selector);
+	if (!el) throw new Error(`no element matching ${selector}`);
+	return el;
+};
+const style = (el: Element) => getComputedStyle(el);
+const box = (el: Element) => {
+	const r = el.getBoundingClientRect();
+	return { width: Math.round(r.width), height: Math.round(r.height) };
+};
+
+describe("MlAssistantStrip", () => {
+	it("renders the off state with the tool note and no Configure link", () => {
+		const { container } = mount();
+		const strip = find(container, ".ml-strip");
+
+		expect(strip.textContent).toContain("ML Assistant");
+		expect(strip.textContent).toContain(
+			"— tools and prompts for papers, finetuning, demos and datasets"
+		);
+		expect(container.textContent).not.toContain("Configure");
+		expect(style(strip).backgroundColor).toBe("rgba(0, 0, 0, 0)");
+		expect(style(strip).borderBottomColor).toBe("rgb(236, 236, 238)");
+	});
+
+	it("renders the on state with the preset tool list, Configure link and accent tint", () => {
+		const { container } = mount({ enabled: true });
+		const strip = find(container, ".ml-strip");
+
+		expect(strip.textContent).toContain("papers · training · spaces · datasets · eval · hub");
+		expect(container.textContent).toContain("Configure");
+		expect(style(strip).backgroundColor).toBe("rgb(240, 243, 255)");
+		expect(style(strip).borderBottomColor).toBe("rgb(226, 231, 251)");
+		expect(style(strip).color).toBe(ACCENT);
+	});
+
+	it("lays the strip out on the specified spacing", () => {
+		const { container } = mount({ enabled: true });
+		const strip = style(find(container, ".ml-strip"));
+
+		expect(strip.padding).toBe("9px 16px");
+		expect(strip.gap).toBe("9px");
+		expect(strip.fontSize).toBe("13.5px");
+	});
+
+	it("truncates the tool note rather than pushing Configure off a narrow composer", () => {
+		const { container } = mount({ enabled: true });
+		container.style.width = "375px";
+		const note = find(container, ".ml-strip span.truncate");
+		const configure = find(container, "button:not(.ml-switch)");
+
+		expect(style(note).textOverflow).toBe("ellipsis");
+		expect(note.scrollWidth).toBeGreaterThan(note.clientWidth);
+		expect(configure.getBoundingClientRect().right).toBeLessThanOrEqual(
+			Math.ceil(find(container, ".ml-strip").getBoundingClientRect().right)
+		);
+	});
+
+	it("exposes the mode as a labelled switch", async () => {
+		const ontoggle = vi.fn();
+		const { container } = mount({ enabled: false, ontoggle });
+		const control = container.querySelector(".ml-switch") as HTMLElement;
+
+		expect(control.getAttribute("role")).toBe("switch");
+		expect(control.getAttribute("aria-checked")).toBe("false");
+		expect(control.getAttribute("aria-label")).toBe("ML Assistant mode");
+		// Visual size is 26x15, but the control itself has to stay tappable.
+		expect(box(control)).toEqual({ width: 44, height: 44 });
+
+		control.click();
+		expect(ontoggle).toHaveBeenCalledWith(true);
+	});
+
+	it("moves the knob across the track when the mode is on", () => {
+		const off = mount().container;
+		expect(box(find(off, ".ml-switch-track"))).toEqual({ width: 26, height: 15 });
+		expect(box(find(off, ".ml-switch-knob"))).toEqual({ width: 11, height: 11 });
+		expect(style(find(off, ".ml-switch-knob")).left).toBe("2px");
+		expect(style(find(off, ".ml-switch-track")).backgroundColor).toBe("rgb(216, 216, 221)");
+
+		const on = mount({ enabled: true }).container;
+		expect(style(find(on, ".ml-switch-knob")).left).toBe("13px");
+		expect(style(find(on, ".ml-switch-track")).backgroundColor).toBe(ACCENT);
+	});
+
+	it("collapses out of the composer when hidden", () => {
+		const shown = style(find(mount().container, ".ml-strip-collapse"));
+		expect(shown.maxHeight).toBe("56px");
+		expect(shown.opacity).toBe("1");
+
+		const hidden = style(find(mount({ visible: false }).container, ".ml-strip-collapse"));
+		expect(hidden.maxHeight).toBe("0px");
+		expect(hidden.opacity).toBe("0");
+	});
+
+	it("collapses the switch and drops Configure once a task is running", () => {
+		const { container } = mount({
+			enabled: true,
+			taskRunning: true,
+			steps: PLAN,
+			statusLabel: "Training",
+		});
+		const slot = style(find(container, ".ml-switch-slot"));
+
+		// Zero width plus a negative margin that eats the flex gap, so the title
+		// slides all the way left.
+		expect(slot.width).toBe("0px");
+		expect(slot.marginRight).toBe("-9px");
+		expect(slot.opacity).toBe("0");
+		expect(container.textContent).not.toContain("Configure");
+		expect(container.textContent).not.toContain("papers · training");
+	});
+
+	it("keeps the tool note until the run reports a plan", () => {
+		const { container } = mount({ enabled: true, taskRunning: true, steps: [] });
+
+		expect(container.textContent).toContain("papers · training · spaces · datasets · eval · hub");
+		expect(container.querySelector(".ml-dot")).toBeNull();
+	});
+
+	it("renders one dot per plan step, styled by status", () => {
+		const { container } = mount({
+			enabled: true,
+			taskRunning: true,
+			steps: PLAN,
+			statusLabel: "Training",
+		});
+		const dots = [...container.querySelectorAll(".ml-dot")];
+		expect(dots.map((d) => d.textContent)).toEqual(["1", "2", "3", "4"]);
+		expect(box(dots[0])).toEqual({ width: 22, height: 22 });
+
+		const [done, skipped, running, pending] = dots.map(style);
+		expect(done.backgroundColor).toBe(SUCCESS);
+		expect(skipped.backgroundColor).toBe("rgb(238, 238, 241)");
+		expect(skipped.opacity).toBe("0.65");
+		expect(running.backgroundColor).toBe(ACCENT);
+		expect(running.animationName).toContain("mlpulse");
+		expect(pending.backgroundColor).toBe("rgb(255, 255, 255)");
+		expect(pending.borderTopColor).toBe("rgb(220, 220, 226)");
+	});
+
+	it("keeps the dots tappable without disturbing the row's 5px rhythm", () => {
+		const { container } = mount({
+			enabled: true,
+			taskRunning: true,
+			steps: PLAN,
+			statusLabel: "Training",
+		});
+		const hits = [...container.querySelectorAll(".ml-dot-hit")];
+		expect(box(hits[0])).toEqual({ width: 27, height: 44 });
+
+		const dots = [...container.querySelectorAll(".ml-dot")];
+		const gap = dots[1].getBoundingClientRect().left - dots[0].getBoundingClientRect().right;
+		expect(Math.round(gap)).toBe(5);
+	});
+
+	it("names each dot by its step and status", () => {
+		const { container } = mount({
+			enabled: true,
+			taskRunning: true,
+			steps: PLAN,
+			statusLabel: "Training",
+		});
+
+		expect(
+			[...container.querySelectorAll(".ml-dot-hit")].map((b) => b.getAttribute("aria-label"))
+		).toEqual([
+			"Research — done",
+			"Baseline eval — skipped",
+			"Training — running",
+			"Deploy — pending",
+		]);
+	});
+
+	it("announces the running step, and turns the label green when the plan is done", () => {
+		const running = find(
+			mount({ enabled: true, taskRunning: true, steps: PLAN, statusLabel: "Training" }).container,
+			'[aria-live="polite"]'
+		);
+		expect(running.textContent?.trim()).toBe("Training");
+		expect(style(running).color).toBe(ACCENT);
+
+		const done = find(
+			mount({
+				enabled: true,
+				taskRunning: true,
+				steps: PLAN.map((s) => ({ ...s, status: "done" as const })),
+				statusLabel: "Done",
+				complete: true,
+			}).container,
+			'[aria-live="polite"]'
+		);
+		expect(done.textContent?.trim()).toBe("Done");
+		expect(style(done).color).toBe(SUCCESS);
+	});
+
+	it("keeps the mode announced after the switch collapses", () => {
+		const { container } = mount({
+			enabled: true,
+			taskRunning: true,
+			steps: PLAN,
+			statusLabel: "Training",
+		});
+
+		expect(container.textContent).toContain("ML Assistant, mode on");
+	});
+
+	it("reaches a step's description by keyboard focus, not hover alone", async () => {
+		const { container } = mount({
+			enabled: true,
+			taskRunning: true,
+			steps: PLAN,
+			statusLabel: "Training",
+		});
+		(container.querySelector(".ml-dot-hit") as HTMLElement).focus();
+
+		await vi.waitFor(() => {
+			expect(find(document, ".ml-dot-tooltip").textContent).toContain("Research description");
+		});
+	});
+
+	it("shows a step's description on hover, escaping the composer's overflow", async () => {
+		const { container } = mount({
+			enabled: true,
+			taskRunning: true,
+			steps: PLAN,
+			statusLabel: "Training",
+		});
+		const trigger = find(container, ".ml-dot-hit");
+		trigger.dispatchEvent(new PointerEvent("pointerenter", { bubbles: true }));
+		trigger.dispatchEvent(new PointerEvent("pointermove", { bubbles: true }));
+
+		await vi.waitFor(() => {
+			const tip = find(document, ".ml-dot-tooltip");
+			expect(tip.textContent).toContain("Research");
+			expect(tip.textContent).toContain("Research description");
+			// Portalled out of the strip, which is clipped by the composer box.
+			expect(find(container, ".ml-strip").contains(tip)).toBe(false);
+			expect(style(tip).backgroundColor).toBe("rgb(26, 26, 31)");
+		});
+	});
+});

--- a/src/lib/components/chat/ThinkingEffortChip.svelte
+++ b/src/lib/components/chat/ThinkingEffortChip.svelte
@@ -7,13 +7,19 @@
 
 	interface Props {
 		modelId: string;
+		/**
+		 * Effort a preset pins for this conversation, overriding the user's setting.
+		 * Shown instead of their value and not editable, because the request really
+		 * does go out at this effort — the preset applies it server-side.
+		 */
+		presetEffort?: ReasoningEffort;
 	}
 
-	let { modelId }: Props = $props();
+	let { modelId, presetEffort }: Props = $props();
 
 	const settings = useSettingsStore();
 
-	let current = $derived($settings.reasoningEffortOverrides?.[modelId]);
+	let current = $derived(presetEffort ?? $settings.reasoningEffortOverrides?.[modelId]);
 	let label = $derived(current ? capitalize(current) : "Default");
 
 	function capitalize(s: string) {
@@ -40,33 +46,37 @@
 	];
 </script>
 
-<DropdownMenu.Root>
-	<DropdownMenu.Trigger
-		class="inline-flex items-center gap-1 hover:underline"
-		aria-label="Select thinking effort"
-		title="Thinking effort"
-	>
-		Effort: {label}
-		<CarbonCaretDown class="-ml-0.5 text-xxs" />
-	</DropdownMenu.Trigger>
-	<DropdownMenu.Portal>
-		<DropdownMenu.Content
-			class="z-50 min-w-40 rounded-xl border border-gray-200 bg-white/95 p-1 text-gray-800 shadow-lg backdrop-blur-sm dark:border-gray-700/60 dark:bg-gray-800/95 dark:text-gray-100"
-			side="top"
-			align="end"
-			sideOffset={6}
+{#if presetEffort}
+	<span title="Set by ML Assistant mode">Effort: {label}</span>
+{:else}
+	<DropdownMenu.Root>
+		<DropdownMenu.Trigger
+			class="inline-flex items-center gap-1 hover:underline"
+			aria-label="Select thinking effort"
+			title="Thinking effort"
 		>
-			{#each OPTIONS as opt (opt.label)}
-				<DropdownMenu.Item
-					class="flex h-8 cursor-pointer items-center justify-between gap-2 rounded-md px-2 text-sm select-none focus-visible:outline-hidden data-highlighted:bg-gray-100 dark:data-highlighted:bg-white/10"
-					onSelect={() => setEffort(opt.value)}
-				>
-					<span>{opt.label}</span>
-					{#if current === opt.value}
-						<LucideCheck class="size-4 text-gray-500" />
-					{/if}
-				</DropdownMenu.Item>
-			{/each}
-		</DropdownMenu.Content>
-	</DropdownMenu.Portal>
-</DropdownMenu.Root>
+			Effort: {label}
+			<CarbonCaretDown class="-ml-0.5 text-xxs" />
+		</DropdownMenu.Trigger>
+		<DropdownMenu.Portal>
+			<DropdownMenu.Content
+				class="z-50 min-w-40 rounded-xl border border-gray-200 bg-white/95 p-1 text-gray-800 shadow-lg backdrop-blur-sm dark:border-gray-700/60 dark:bg-gray-800/95 dark:text-gray-100"
+				side="top"
+				align="end"
+				sideOffset={6}
+			>
+				{#each OPTIONS as opt (opt.label)}
+					<DropdownMenu.Item
+						class="flex h-8 cursor-pointer items-center justify-between gap-2 rounded-md px-2 text-sm select-none focus-visible:outline-hidden data-highlighted:bg-gray-100 dark:data-highlighted:bg-white/10"
+						onSelect={() => setEffort(opt.value)}
+					>
+						<span>{opt.label}</span>
+						{#if current === opt.value}
+							<LucideCheck class="size-4 text-gray-500" />
+						{/if}
+					</DropdownMenu.Item>
+				{/each}
+			</DropdownMenu.Content>
+		</DropdownMenu.Portal>
+	</DropdownMenu.Root>
+{/if}

--- a/src/lib/constants/mlAssistant.ts
+++ b/src/lib/constants/mlAssistant.ts
@@ -1,0 +1,43 @@
+import type { RouterExample } from "./routerExamples";
+
+/**
+ * Copy and preset data for ML Assistant mode. The tool list mirrors what the
+ * preset loads; once the backend serves the preset it should replace this.
+ */
+
+/** Tool ids shown in the strip while the mode is on and no task is running. */
+export const ML_ASSISTANT_TOOLS = ["papers", "training", "spaces", "datasets", "eval", "hub"];
+
+/** Strip note shown while the mode is off. */
+export const ML_ASSISTANT_NOTE_OFF =
+	"— tools and prompts for papers, finetuning, demos and datasets";
+
+/** Composer placeholder while the mode is on. */
+export const ML_ASSISTANT_PLACEHOLDER = "Describe the ML task — paper URL, model id, or dataset";
+
+/** Reasoning effort the preset runs at. */
+export const ML_ASSISTANT_EFFORT = "high" as const;
+
+/** Suggestion chips that replace the default set while the mode is on. */
+export const mlAssistantExamples: RouterExample[] = [
+	{
+		title: "Reproduce a paper",
+		prompt: "Reproduce the results of this paper and report where they diverge:",
+	},
+	{
+		title: "Finetune a model",
+		prompt: "Finetune a small open model on this dataset and evaluate the checkpoint.",
+	},
+	{
+		title: "Build a demo",
+		prompt: "Build a Gradio demo Space for this model.",
+	},
+	{
+		title: "Generate a dataset",
+		prompt: "Generate a synthetic dataset for this task and push it to the Hub.",
+	},
+	{
+		title: "Run an eval",
+		prompt: "Run an evaluation of this model against a held-out split and score it.",
+	},
+];

--- a/src/lib/server/mlAssistant.spec.ts
+++ b/src/lib/server/mlAssistant.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import {
+	ML_ASSISTANT_MCP_SERVERS,
+	ML_ASSISTANT_PREPROMPT,
+	isMlAssistantConversation,
+	withMlAssistantServers,
+} from "./mlAssistant";
+import { ML_ASSISTANT_MODE } from "$lib/utils/mlAssistantFlag";
+
+describe("ML Assistant preset", () => {
+	it("marks a conversation only when the build ships the mode", () => {
+		// The database can carry the flag from a build that had the feature on.
+		expect(isMlAssistantConversation({ mlAssistant: true })).toBe(ML_ASSISTANT_MODE);
+		expect(isMlAssistantConversation({ mlAssistant: false })).toBe(false);
+		expect(isMlAssistantConversation({})).toBe(false);
+	});
+
+	it("keeps the user's servers and adds the preset's", () => {
+		const merged = withMlAssistantServers([
+			{ name: "Web Search (Exa)", url: "https://mcp.exa.ai/mcp" },
+		]);
+
+		expect(merged.map((s) => s.name)).toContain("Web Search (Exa)");
+		for (const preset of ML_ASSISTANT_MCP_SERVERS) {
+			expect(merged.find((s) => s.name === preset.name)?.url).toBe(preset.url);
+		}
+	});
+
+	it("does not let a same-named user server shadow a preset one", () => {
+		const preset = ML_ASSISTANT_MCP_SERVERS[0];
+		const merged = withMlAssistantServers([{ name: preset.name, url: "https://evil.example/mcp" }]);
+
+		expect(merged.filter((s) => s.name === preset.name)).toHaveLength(1);
+		expect(merged.find((s) => s.name === preset.name)?.url).toBe(preset.url);
+	});
+
+	it("adds the preset even when nothing was selected", () => {
+		expect(withMlAssistantServers([]).map((s) => s.name)).toEqual(
+			ML_ASSISTANT_MCP_SERVERS.map((s) => s.name)
+		);
+	});
+
+	it("ships a prompt that does not depend on the model", () => {
+		expect(ML_ASSISTANT_PREPROMPT.trim().length).toBeGreaterThan(0);
+		expect(ML_ASSISTANT_PREPROMPT).not.toMatch(/\{\{|\$\{/);
+	});
+});

--- a/src/lib/server/mlAssistant.spec.ts
+++ b/src/lib/server/mlAssistant.spec.ts
@@ -34,6 +34,27 @@ describe("ML Assistant preset", () => {
 		expect(merged.find((s) => s.name === preset.name)?.url).toBe(preset.url);
 	});
 
+	it("puts the preset's servers first", () => {
+		const merged = withMlAssistantServers([
+			{ name: "Web Search (Exa)", url: "https://mcp.exa.ai/mcp" },
+		]);
+
+		expect(merged.slice(0, ML_ASSISTANT_MCP_SERVERS.length).map((s) => s.name)).toEqual(
+			ML_ASSISTANT_MCP_SERVERS.map((s) => s.name)
+		);
+	});
+
+	it("keeps a same-named preset server in the preset's position, not the user's", () => {
+		const preset = ML_ASSISTANT_MCP_SERVERS[0];
+		const merged = withMlAssistantServers([
+			{ name: "First", url: "https://first.example/mcp" },
+			{ name: preset.name, url: "https://shadow.example/mcp" },
+		]);
+
+		expect(merged[0].name).toBe(preset.name);
+		expect(merged[0].url).toBe(preset.url);
+	});
+
 	it("adds the preset even when nothing was selected", () => {
 		expect(withMlAssistantServers([]).map((s) => s.name)).toEqual(
 			ML_ASSISTANT_MCP_SERVERS.map((s) => s.name)

--- a/src/lib/server/mlAssistant.ts
+++ b/src/lib/server/mlAssistant.ts
@@ -47,8 +47,14 @@ export function isMlAssistantConversation(conv: Pick<Conversation, "mlAssistant"
  * first. Deduplicated by name with the preset winning.
  */
 export function withMlAssistantServers(servers: McpServerConfig[]): McpServerConfig[] {
-	const byName = new Map<string, McpServerConfig>();
-	for (const server of servers) byName.set(server.name, server);
-	for (const server of ML_ASSISTANT_MCP_SERVERS) byName.set(server.name, server);
+	// Seeded with the preset rather than overwriting later: Map#set keeps an
+	// existing key's position, so merging the other way round would leave a
+	// preset server wherever the user's same-named entry happened to sit.
+	const byName = new Map<string, McpServerConfig>(
+		ML_ASSISTANT_MCP_SERVERS.map((server) => [server.name, server])
+	);
+	for (const server of servers) {
+		if (!byName.has(server.name)) byName.set(server.name, server);
+	}
 	return [...byName.values()];
 }

--- a/src/lib/server/mlAssistant.ts
+++ b/src/lib/server/mlAssistant.ts
@@ -1,0 +1,54 @@
+import type { Conversation } from "$lib/types/Conversation";
+import type { McpServerConfig } from "./mcp/httpClient";
+import { ML_ASSISTANT_MODE } from "$lib/utils/mlAssistantFlag";
+
+/**
+ * The ML Assistant preset: the prompt, tools and capabilities a conversation gets
+ * when it was started in the mode.
+ *
+ * Everything here is fixed. The prompt deliberately replaces the user's per-model
+ * custom prompt rather than composing with it — the preset is a mode, not a
+ * suggestion — and the servers below are unioned into whatever the user has
+ * selected, so extra servers still work but the preset's cannot be turned off.
+ *
+ * Resolved per generation rather than frozen onto the conversation at creation,
+ * so editing the preset reaches conversations that already exist.
+ */
+
+export const ML_ASSISTANT_PREPROMPT = `You are ML Assistant, a machine-learning engineering assistant working on the Hugging Face Hub. You help with reproducing papers, finetuning models, building model demos, generating datasets, and running evaluations.
+
+Work like an engineer, not a search engine:
+
+- Ground every claim about a model, dataset, paper or Space in the Hub tools rather than in recall. Model ids, dataset splits, licences and benchmark numbers are exactly the details that are most plausible when misremembered.
+- Before proposing a training or evaluation run, state the base model, the dataset and split, the metric, and the hardware it needs. If the user has not given you one of those, ask instead of assuming.
+- Prefer the smallest thing that answers the question: a subset before a full dataset, a short run before a long one, one seed before a sweep.
+- Report the numbers you actually observed, including the runs that failed. Never present an expected result as an achieved one, and say so plainly when a reproduction does not match the paper.
+- Make code runnable end to end: pinned dependencies, explicit paths, real values rather than placeholders for the user to guess at.`;
+
+/**
+ * MCP servers always available in the mode. Merged over the user's selection by
+ * name, so a same-named entry of theirs cannot shadow one of these.
+ */
+export const ML_ASSISTANT_MCP_SERVERS: McpServerConfig[] = [
+	{ name: "Hugging Face", url: "https://hf.co/mcp" },
+];
+
+/**
+ * Whether this conversation runs under the preset. Gated on the build flag too,
+ * so a build that doesn't ship the mode ignores the field even if the database
+ * carries it from a build that did.
+ */
+export function isMlAssistantConversation(conv: Pick<Conversation, "mlAssistant">): boolean {
+	return ML_ASSISTANT_MODE && conv.mlAssistant === true;
+}
+
+/**
+ * The preset's servers plus the ones already resolved for this request, preset
+ * first. Deduplicated by name with the preset winning.
+ */
+export function withMlAssistantServers(servers: McpServerConfig[]): McpServerConfig[] {
+	const byName = new Map<string, McpServerConfig>();
+	for (const server of servers) byName.set(server.name, server);
+	for (const server of ML_ASSISTANT_MCP_SERVERS) byName.set(server.name, server);
+	return [...byName.values()];
+}

--- a/src/lib/server/textGeneration/index.ts
+++ b/src/lib/server/textGeneration/index.ts
@@ -1,7 +1,6 @@
 import { preprocessMessages } from "../endpoints/preprocessMessages";
 
 import { generateTitleForConversation } from "./title";
-import { injectArtifactsPrompt } from "./artifacts";
 import {
 	type MessageUpdate,
 	MessageUpdateType,
@@ -11,6 +10,8 @@ import { generate } from "./generate";
 import { runMcpFlow } from "./mcp/runMcpFlow";
 import { mergeAsyncGenerators } from "$lib/utils/mergeAsyncGenerators";
 import type { TextGenerationContext } from "./types";
+import { isMlAssistantConversation } from "$lib/server/mlAssistant";
+import { resolvePreprompt } from "./preprompt";
 
 /** Updates that mean the user has already been shown something for this turn. */
 function isVisibleWork(update: MessageUpdate): boolean {
@@ -56,12 +57,18 @@ async function* textGenerationWithoutTitle(
 	const { conv, messages } = ctx;
 	const convId = conv._id;
 
-	// Artifacts are opt-in per model (supportsArtifacts in the MODELS overrides),
-	// with a per-model user override from the model settings page
-	const preprompt =
-		(ctx.artifactsOverride ?? ctx.model.supportsArtifacts)
-			? injectArtifactsPrompt(conv.preprompt)
-			: conv.preprompt;
+	// ML Assistant conversations run the preset instead of the user's per-model
+	// custom prompt, and get its capabilities regardless of what the model
+	// advertises: the preset is a mode, not a set of defaults to fall back from.
+	// Outside it nothing changes — artifacts stay opt-in per model.
+	const mlAssistant = isMlAssistantConversation(conv);
+
+	const preprompt = resolvePreprompt({
+		conversationPreprompt: conv.preprompt,
+		mlAssistant,
+		artifactsOverride: ctx.artifactsOverride,
+		supportsArtifacts: ctx.model.supportsArtifacts,
+	});
 
 	const processedMessages = await preprocessMessages(messages, convId);
 
@@ -75,7 +82,7 @@ async function* textGenerationWithoutTitle(
 			messages: processedMessages,
 			assistant: ctx.assistant,
 			forceMultimodal: ctx.forceMultimodal,
-			forceTools: ctx.forceTools,
+			forceTools: mlAssistant || ctx.forceTools,
 			provider: ctx.provider,
 			reasoningEffort: ctx.reasoningEffort,
 			reasoningOverride: ctx.reasoningOverride,

--- a/src/lib/server/textGeneration/mcp/runMcpFlow.ts
+++ b/src/lib/server/textGeneration/mcp/runMcpFlow.ts
@@ -28,6 +28,7 @@ import { makeImageProcessor } from "$lib/server/endpoints/images";
 import { logger } from "$lib/server/logger";
 import { AbortedGenerations } from "$lib/server/abortedGenerations";
 import { withoutContentLength } from "$lib/server/undiciCompat";
+import { isMlAssistantConversation, withMlAssistantServers } from "$lib/server/mlAssistant";
 
 export type RunMcpFlowContext = Pick<
 	TextGenerationContext,
@@ -156,6 +157,19 @@ export async function* runMcpFlow({
 		}
 	} catch {
 		// ignore selection merge errors and proceed with env servers
+	}
+
+	// The preset's servers go on after the user's selection has been filtered, so
+	// they survive a selection that excludes them. Anything the user picked on top
+	// still comes through — extra servers are configurable, these are not.
+	if (isMlAssistantConversation(conv)) {
+		servers = withMlAssistantServers(servers);
+		try {
+			logger.debug(
+				{ servers: servers.map((s) => s.name) },
+				"[mcp] applied ML Assistant preset servers"
+			);
+		} catch {}
 	}
 
 	// If selection/merge yielded no servers, bail early with clearer log

--- a/src/lib/server/textGeneration/preprompt.spec.ts
+++ b/src/lib/server/textGeneration/preprompt.spec.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import { resolvePreprompt } from "./preprompt";
+import { injectArtifactsPrompt } from "./artifacts";
+import { ML_ASSISTANT_PREPROMPT } from "$lib/server/mlAssistant";
+
+/**
+ * The ML Assistant preset must not change how artifacts resolve for anything
+ * else. `legacy` is the expression this replaced, kept here verbatim so the
+ * non-preset half of the matrix is pinned to the old behaviour.
+ */
+const legacy = (
+	conversationPreprompt: string | undefined,
+	artifactsOverride: boolean | undefined,
+	supportsArtifacts: boolean | undefined
+) =>
+	(artifactsOverride ?? supportsArtifacts)
+		? injectArtifactsPrompt(conversationPreprompt)
+		: conversationPreprompt;
+
+const PREPROMPTS = [undefined, "", "You are a pirate."];
+const OVERRIDES = [undefined, true, false];
+const SUPPORTS = [undefined, true, false];
+
+describe("resolvePreprompt", () => {
+	it("leaves every non-preset case exactly as it was before the preset existed", () => {
+		for (const conversationPreprompt of PREPROMPTS) {
+			for (const artifactsOverride of OVERRIDES) {
+				for (const supportsArtifacts of SUPPORTS) {
+					expect(
+						resolvePreprompt({
+							conversationPreprompt,
+							mlAssistant: false,
+							artifactsOverride,
+							supportsArtifacts,
+						}),
+						`preprompt=${conversationPreprompt} override=${artifactsOverride} supports=${supportsArtifacts}`
+					).toBe(legacy(conversationPreprompt, artifactsOverride, supportsArtifacts));
+				}
+			}
+		}
+	});
+
+	it("still gives artifacts to a model that supports them, with no preset in sight", () => {
+		const resolved = resolvePreprompt({
+			conversationPreprompt: "You are a pirate.",
+			mlAssistant: false,
+			supportsArtifacts: true,
+		});
+
+		expect(resolved).toContain("You are a pirate.");
+		expect(resolved).toBe(injectArtifactsPrompt("You are a pirate."));
+		expect(resolved).not.toContain(ML_ASSISTANT_PREPROMPT);
+	});
+
+	it("still withholds artifacts from a model that does not support them", () => {
+		expect(
+			resolvePreprompt({
+				conversationPreprompt: "You are a pirate.",
+				mlAssistant: false,
+				supportsArtifacts: false,
+			})
+		).toBe("You are a pirate.");
+	});
+
+	it("lets the per-model override win in both directions outside the preset", () => {
+		expect(
+			resolvePreprompt({
+				conversationPreprompt: "base",
+				mlAssistant: false,
+				artifactsOverride: false,
+				supportsArtifacts: true,
+			})
+		).toBe("base");
+
+		expect(
+			resolvePreprompt({
+				conversationPreprompt: "base",
+				mlAssistant: false,
+				artifactsOverride: true,
+				supportsArtifacts: false,
+			})
+		).toBe(injectArtifactsPrompt("base"));
+	});
+
+	it("replaces the conversation prompt with the preset, not per model", () => {
+		const resolved = resolvePreprompt({
+			conversationPreprompt: "You are a pirate.",
+			mlAssistant: true,
+			supportsArtifacts: false,
+		});
+
+		expect(resolved).toContain(ML_ASSISTANT_PREPROMPT);
+		expect(resolved).not.toContain("You are a pirate.");
+	});
+
+	it("force-enables artifacts for the preset even when the model and override say no", () => {
+		expect(
+			resolvePreprompt({
+				conversationPreprompt: undefined,
+				mlAssistant: true,
+				artifactsOverride: false,
+				supportsArtifacts: false,
+			})
+		).toBe(injectArtifactsPrompt(ML_ASSISTANT_PREPROMPT));
+	});
+});

--- a/src/lib/server/textGeneration/preprompt.ts
+++ b/src/lib/server/textGeneration/preprompt.ts
@@ -1,0 +1,32 @@
+import { injectArtifactsPrompt } from "./artifacts";
+import { ML_ASSISTANT_PREPROMPT } from "$lib/server/mlAssistant";
+
+export interface PrepromptInput {
+	/** The conversation's stored system prompt. */
+	conversationPreprompt?: string;
+	/** Whether this conversation runs the ML Assistant preset. */
+	mlAssistant: boolean;
+	/** Per-model user override for artifacts, from the model settings page. */
+	artifactsOverride?: boolean;
+	/** Whether the model advertises artifact support (supportsArtifacts). */
+	supportsArtifacts?: boolean;
+}
+
+/**
+ * The system prompt for one generation.
+ *
+ * Artifacts are unchanged by the preset: outside it they stay opt-in per model
+ * with a per-model user override, exactly as before. The preset force-enables
+ * them on top of that — it is not a gate, and a conversation that would have got
+ * the artifacts prompt still gets it whether or not the mode exists.
+ */
+export function resolvePreprompt({
+	conversationPreprompt,
+	mlAssistant,
+	artifactsOverride,
+	supportsArtifacts,
+}: PrepromptInput): string | undefined {
+	const base = mlAssistant ? ML_ASSISTANT_PREPROMPT : conversationPreprompt;
+	const artifacts = mlAssistant || (artifactsOverride ?? supportsArtifacts);
+	return artifacts ? injectArtifactsPrompt(base) : base;
+}

--- a/src/lib/stores/mlAssistant.spec.ts
+++ b/src/lib/stores/mlAssistant.spec.ts
@@ -12,7 +12,6 @@ const step = (label: string, status: MlPlanStep["status"]): MlPlanStep => ({
 describe("mlAssistant store", () => {
 	beforeEach(() => {
 		mlAssistant.reset();
-		mlAssistant.effortHold = null;
 		mlAssistant.syncConversation(undefined);
 	});
 
@@ -59,10 +58,36 @@ describe("mlAssistant store", () => {
 	it("adopts the conversation a run started from the home composer creates", () => {
 		mlAssistant.toggle(true);
 		mlAssistant.startTask();
+		mlAssistant.setPlan([step("Research", "running")]);
 
-		expect(mlAssistant.syncConversation("new-conversation")).toBe(false);
+		// The created conversation arrives already marked, and keeps its plan.
+		expect(mlAssistant.syncConversation("new-conversation", true)).toBe(false);
 		expect(mlAssistant.enabled).toBe(true);
 		expect(mlAssistant.taskStarted).toBe(true);
+		expect(mlAssistant.steps).toHaveLength(1);
+	});
+
+	it("does not adopt a plain conversation opened while a create is in flight", () => {
+		mlAssistant.toggle(true);
+		mlAssistant.startTask();
+
+		expect(mlAssistant.syncConversation("someone-elses-conversation")).toBe(true);
+		expect(mlAssistant.enabled).toBe(false);
+		expect(mlAssistant.taskStarted).toBe(false);
+	});
+
+	it("unlatches the task when the conversation it was for never got created", () => {
+		mlAssistant.toggle(true);
+		mlAssistant.startTask();
+		mlAssistant.setPlan([step("Research", "running")]);
+
+		mlAssistant.abortTask();
+
+		expect(mlAssistant.taskStarted).toBe(false);
+		expect(mlAssistant.steps).toEqual([]);
+		// The switch is usable again, and the mode stays on so a retry keeps it.
+		expect(mlAssistant.locked).toBe(false);
+		expect(mlAssistant.enabled).toBe(true);
 	});
 
 	it("resets when the conversation changes", () => {
@@ -115,18 +140,6 @@ describe("mlAssistant store", () => {
 
 		expect(mlAssistant.syncConversation("same")).toBe(false);
 		expect(mlAssistant.enabled).toBe(true);
-	});
-
-	it("round-trips the effort hold it is asked to keep", () => {
-		expect(mlAssistant.effortHold).toBeNull();
-
-		mlAssistant.effortHold = { modelId: "org/model", previous: "low" };
-		expect(mlAssistant.effortHold).toEqual({ modelId: "org/model", previous: "low" });
-
-		// Held across a conversation reset: only the composer can put the value
-		// back, so `reset()` must not drop the record of what to put back.
-		mlAssistant.syncConversation("elsewhere");
-		expect(mlAssistant.effortHold).toEqual({ modelId: "org/model", previous: "low" });
 	});
 
 	it("ignores a status update for a step outside the plan", () => {

--- a/src/lib/stores/mlAssistant.spec.ts
+++ b/src/lib/stores/mlAssistant.spec.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { mlAssistant } from "./mlAssistant.svelte";
+import type { MlPlanStep } from "$lib/types/MlAssistant";
+
+const step = (label: string, status: MlPlanStep["status"]): MlPlanStep => ({
+	label,
+	statusLabel: `${label}ing`,
+	description: `${label} description`,
+	status,
+});
+
+describe("mlAssistant store", () => {
+	beforeEach(() => {
+		mlAssistant.reset();
+		mlAssistant.effortHold = null;
+		mlAssistant.syncConversation(undefined);
+	});
+
+	it("toggles freely until a task starts, then locks", () => {
+		mlAssistant.toggle(true);
+		expect(mlAssistant.enabled).toBe(true);
+		expect(mlAssistant.locked).toBe(false);
+
+		mlAssistant.startTask();
+		expect(mlAssistant.taskStarted).toBe(true);
+		expect(mlAssistant.locked).toBe(true);
+
+		mlAssistant.toggle(false);
+		expect(mlAssistant.enabled).toBe(true);
+	});
+
+	it("does not start a task while the mode is off", () => {
+		mlAssistant.startTask();
+		expect(mlAssistant.taskStarted).toBe(false);
+	});
+
+	it("reports the running step's status label, then Done", () => {
+		mlAssistant.setPlan([step("Research", "done"), step("Train", "running")]);
+		expect(mlAssistant.activeStep).toBe(1);
+		expect(mlAssistant.statusLabel).toBe("Training");
+		expect(mlAssistant.complete).toBe(false);
+
+		mlAssistant.setStepStatus(1, "done");
+		expect(mlAssistant.activeStep).toBe(-1);
+		expect(mlAssistant.complete).toBe(true);
+		expect(mlAssistant.statusLabel).toBe("Done");
+	});
+
+	it("counts a plan that ends on a skipped step as complete", () => {
+		mlAssistant.setPlan([step("Research", "done"), step("Baseline", "skipped")]);
+		expect(mlAssistant.complete).toBe(true);
+	});
+
+	it("is not complete with no plan", () => {
+		expect(mlAssistant.complete).toBe(false);
+		expect(mlAssistant.statusLabel).toBe("");
+	});
+
+	it("adopts the conversation a run started from the home composer creates", () => {
+		mlAssistant.toggle(true);
+		mlAssistant.startTask();
+
+		expect(mlAssistant.syncConversation("new-conversation")).toBe(false);
+		expect(mlAssistant.enabled).toBe(true);
+		expect(mlAssistant.taskStarted).toBe(true);
+	});
+
+	it("resets when the conversation changes", () => {
+		mlAssistant.toggle(true);
+		mlAssistant.startTask();
+		mlAssistant.syncConversation("first");
+
+		expect(mlAssistant.syncConversation("second")).toBe(true);
+		expect(mlAssistant.enabled).toBe(false);
+		expect(mlAssistant.taskStarted).toBe(false);
+	});
+
+	it("resets when leaving a conversation for the home composer", () => {
+		mlAssistant.toggle(true);
+		mlAssistant.startTask();
+		mlAssistant.syncConversation("first");
+
+		expect(mlAssistant.syncConversation(undefined)).toBe(true);
+		expect(mlAssistant.enabled).toBe(false);
+	});
+
+	it("comes back locked on when reopening a conversation started in the mode", () => {
+		mlAssistant.syncConversation("plain-conversation");
+		expect(mlAssistant.enabled).toBe(false);
+
+		expect(mlAssistant.syncConversation("ml-conversation", true)).toBe(true);
+		expect(mlAssistant.enabled).toBe(true);
+		expect(mlAssistant.taskStarted).toBe(true);
+		expect(mlAssistant.locked).toBe(true);
+	});
+
+	it("drops the mode again when leaving that conversation for a plain one", () => {
+		mlAssistant.syncConversation("ml-conversation", true);
+
+		expect(mlAssistant.syncConversation("plain-conversation")).toBe(true);
+		expect(mlAssistant.enabled).toBe(false);
+		expect(mlAssistant.taskStarted).toBe(false);
+	});
+
+	it("does not adopt a conversation opened before any task started", () => {
+		mlAssistant.toggle(true);
+
+		expect(mlAssistant.syncConversation("existing")).toBe(true);
+		expect(mlAssistant.enabled).toBe(false);
+	});
+
+	it("is idempotent for the same conversation", () => {
+		mlAssistant.syncConversation("same");
+		mlAssistant.toggle(true);
+
+		expect(mlAssistant.syncConversation("same")).toBe(false);
+		expect(mlAssistant.enabled).toBe(true);
+	});
+
+	it("round-trips the effort hold it is asked to keep", () => {
+		expect(mlAssistant.effortHold).toBeNull();
+
+		mlAssistant.effortHold = { modelId: "org/model", previous: "low" };
+		expect(mlAssistant.effortHold).toEqual({ modelId: "org/model", previous: "low" });
+
+		// Held across a conversation reset: only the composer can put the value
+		// back, so `reset()` must not drop the record of what to put back.
+		mlAssistant.syncConversation("elsewhere");
+		expect(mlAssistant.effortHold).toEqual({ modelId: "org/model", previous: "low" });
+	});
+
+	it("ignores a status update for a step outside the plan", () => {
+		mlAssistant.setPlan([step("Research", "pending")]);
+		mlAssistant.setStepStatus(4, "done");
+		expect(mlAssistant.steps).toHaveLength(1);
+		expect(mlAssistant.steps[0].status).toBe("pending");
+	});
+});

--- a/src/lib/stores/mlAssistant.svelte.ts
+++ b/src/lib/stores/mlAssistant.svelte.ts
@@ -1,14 +1,4 @@
-import { browser } from "$app/environment";
 import type { MlPlanStep, MlPlanStepStatus } from "$lib/types/MlAssistant";
-import type { ReasoningEffort } from "$lib/types/Settings";
-
-/** A reasoning-effort override the preset replaced, and the value to put back. */
-export interface MlEffortHold {
-	modelId: string;
-	previous?: ReasoningEffort;
-}
-
-const EFFORT_HOLD_KEY = "mlAssistantEffortHold";
 
 /**
  * UI state for ML Assistant mode (see `$lib/utils/mlAssistantFlag`).
@@ -27,51 +17,8 @@ class MlAssistantStore {
 	/** The plan as reported by the run. Empty until a plan arrives. */
 	steps = $state<MlPlanStep[]>([]);
 
-	#effortHold = $state<MlEffortHold | null>(null);
-
 	/** Conversation the state above belongs to, so a different one starts clean. */
 	#conversationKey: string | undefined;
-
-	/**
-	 * Reasoning-effort override the preset is holding, with the value to put back.
-	 * Lives here rather than in the composer so it survives the navigation from the
-	 * home composer into the conversation the send creates, and is mirrored into
-	 * sessionStorage so a reload — which drops the mode but not the override — can
-	 * still hand the user their setting back (see `restoreEffortHold`).
-	 */
-	get effortHold() {
-		return this.#effortHold;
-	}
-
-	set effortHold(hold: MlEffortHold | null) {
-		this.#effortHold = hold;
-		if (!browser) return;
-		if (hold) {
-			sessionStorage.setItem(EFFORT_HOLD_KEY, JSON.stringify(hold));
-		} else {
-			sessionStorage.removeItem(EFFORT_HOLD_KEY);
-		}
-	}
-
-	/**
-	 * Picks up a hold left by an earlier page load. The mode is client state and
-	 * does not survive a reload, so whatever it was holding has to be released by
-	 * the next load instead.
-	 */
-	restoreEffortHold(): MlEffortHold | null {
-		if (!browser || this.#effortHold) return this.#effortHold;
-		const raw = sessionStorage.getItem(EFFORT_HOLD_KEY);
-		if (!raw) return null;
-		try {
-			const hold = JSON.parse(raw) as MlEffortHold;
-			if (typeof hold?.modelId === "string") {
-				this.#effortHold = hold;
-			}
-		} catch {
-			sessionStorage.removeItem(EFFORT_HOLD_KEY);
-		}
-		return this.#effortHold;
-	}
 
 	/** The switch stops being interactive once the mode is locked in. */
 	get locked() {
@@ -105,6 +52,16 @@ class MlAssistantStore {
 	startTask() {
 		if (!this.enabled) return;
 		this.taskStarted = true;
+	}
+
+	/**
+	 * Undoes `startTask` when the send it was latched for never produced a
+	 * conversation. Without this a failed create leaves the composer locked in a
+	 * task that does not exist, with no way to switch the mode back off.
+	 */
+	abortTask() {
+		this.taskStarted = false;
+		this.steps = [];
 	}
 
 	/**
@@ -143,7 +100,14 @@ class MlAssistantStore {
 	 */
 	syncConversation(key: string | undefined, isMlConversation = false): boolean {
 		if (this.#conversationKey === key) return false;
-		const adopting = this.#conversationKey === undefined && key !== undefined && this.taskStarted;
+		// Adoption is only for the conversation the run just created, which arrives
+		// already marked. Without that check, opening any conversation while a
+		// create is pending would inherit the mode the server knows nothing about.
+		const adopting =
+			this.#conversationKey === undefined &&
+			key !== undefined &&
+			this.taskStarted &&
+			isMlConversation;
 		this.#conversationKey = key;
 		if (adopting) return false;
 		this.reset();

--- a/src/lib/stores/mlAssistant.svelte.ts
+++ b/src/lib/stores/mlAssistant.svelte.ts
@@ -1,0 +1,159 @@
+import { browser } from "$app/environment";
+import type { MlPlanStep, MlPlanStepStatus } from "$lib/types/MlAssistant";
+import type { ReasoningEffort } from "$lib/types/Settings";
+
+/** A reasoning-effort override the preset replaced, and the value to put back. */
+export interface MlEffortHold {
+	modelId: string;
+	previous?: ReasoningEffort;
+}
+
+const EFFORT_HOLD_KEY = "mlAssistantEffortHold";
+
+/**
+ * UI state for ML Assistant mode (see `$lib/utils/mlAssistantFlag`).
+ *
+ * The mode is a property of the conversation: it can be toggled freely until the
+ * first message goes out, and is locked for the rest of the conversation after
+ * that. Plan steps are pushed in by whatever drives the run — nothing here
+ * invents or advances them, so with no plan source the strip stays on its tool
+ * note and the progress row never appears.
+ */
+class MlAssistantStore {
+	/** Preset toggle. Editable until `taskStarted`. */
+	enabled = $state(false);
+	/** Latched by `startTask()` on the send that begins an ML run. */
+	taskStarted = $state(false);
+	/** The plan as reported by the run. Empty until a plan arrives. */
+	steps = $state<MlPlanStep[]>([]);
+
+	#effortHold = $state<MlEffortHold | null>(null);
+
+	/** Conversation the state above belongs to, so a different one starts clean. */
+	#conversationKey: string | undefined;
+
+	/**
+	 * Reasoning-effort override the preset is holding, with the value to put back.
+	 * Lives here rather than in the composer so it survives the navigation from the
+	 * home composer into the conversation the send creates, and is mirrored into
+	 * sessionStorage so a reload — which drops the mode but not the override — can
+	 * still hand the user their setting back (see `restoreEffortHold`).
+	 */
+	get effortHold() {
+		return this.#effortHold;
+	}
+
+	set effortHold(hold: MlEffortHold | null) {
+		this.#effortHold = hold;
+		if (!browser) return;
+		if (hold) {
+			sessionStorage.setItem(EFFORT_HOLD_KEY, JSON.stringify(hold));
+		} else {
+			sessionStorage.removeItem(EFFORT_HOLD_KEY);
+		}
+	}
+
+	/**
+	 * Picks up a hold left by an earlier page load. The mode is client state and
+	 * does not survive a reload, so whatever it was holding has to be released by
+	 * the next load instead.
+	 */
+	restoreEffortHold(): MlEffortHold | null {
+		if (!browser || this.#effortHold) return this.#effortHold;
+		const raw = sessionStorage.getItem(EFFORT_HOLD_KEY);
+		if (!raw) return null;
+		try {
+			const hold = JSON.parse(raw) as MlEffortHold;
+			if (typeof hold?.modelId === "string") {
+				this.#effortHold = hold;
+			}
+		} catch {
+			sessionStorage.removeItem(EFFORT_HOLD_KEY);
+		}
+		return this.#effortHold;
+	}
+
+	/** The switch stops being interactive once the mode is locked in. */
+	get locked() {
+		return this.taskStarted;
+	}
+
+	/** Index of the running step, `-1` before the first one starts. */
+	get activeStep() {
+		return this.steps.findIndex((step) => step.status === "running");
+	}
+
+	get complete() {
+		return (
+			this.steps.length > 0 &&
+			this.steps.every((step) => step.status === "done" || step.status === "skipped")
+		);
+	}
+
+	/** 1-3 words naming what the plan is doing right now, shown beside the dots. */
+	get statusLabel() {
+		if (this.complete) return "Done";
+		return this.steps.find((step) => step.status === "running")?.statusLabel ?? "";
+	}
+
+	toggle(next = !this.enabled) {
+		if (this.locked) return;
+		this.enabled = next;
+	}
+
+	/** Called on the send that starts an ML task. No-op unless the mode is on. */
+	startTask() {
+		if (!this.enabled) return;
+		this.taskStarted = true;
+	}
+
+	/**
+	 * Seam for the backend: replaces the plan wholesale. Steps arrive with their
+	 * own statuses so a resumed conversation renders mid-plan correctly.
+	 */
+	setPlan(steps: MlPlanStep[]) {
+		this.steps = steps;
+	}
+
+	/** Seam for the backend: advances a single step as its status streams in. */
+	setStepStatus(index: number, status: MlPlanStepStatus) {
+		const step = this.steps[index];
+		if (!step) return;
+		this.steps[index] = { ...step, status };
+	}
+
+	reset() {
+		this.enabled = false;
+		this.taskStarted = false;
+		this.steps = [];
+	}
+
+	/**
+	 * Binds the state to a conversation, dropping it when that conversation
+	 * changes. Idempotent, so it is safe to call from an effect on every render.
+	 *
+	 * A run started from the home composer has no conversation yet, so it adopts
+	 * the first id it lands on instead of resetting — otherwise the send that
+	 * creates the conversation would immediately throw the mode away.
+	 *
+	 * @param isMlConversation whether the conversation being opened was started in
+	 * the mode (persisted on the conversation, so reopening one restores it).
+	 * @returns whether the state was reset, so the caller can release anything
+	 * it was holding on the mode's behalf.
+	 */
+	syncConversation(key: string | undefined, isMlConversation = false): boolean {
+		if (this.#conversationKey === key) return false;
+		const adopting = this.#conversationKey === undefined && key !== undefined && this.taskStarted;
+		this.#conversationKey = key;
+		if (adopting) return false;
+		this.reset();
+		if (isMlConversation) {
+			// Already past its first send, so the mode comes back locked on.
+			this.enabled = true;
+			this.taskStarted = true;
+		}
+		return true;
+	}
+}
+
+export const mlAssistant = new MlAssistantStore();

--- a/src/lib/types/Conversation.ts
+++ b/src/lib/types/Conversation.ts
@@ -26,6 +26,14 @@ export interface Conversation extends Timestamps {
 	userAgent?: string;
 
 	/**
+	 * Set when the conversation was started in ML Assistant mode. The mode is a
+	 * property of the conversation, not of the tab that started it, so reopening
+	 * one brings its composer strip back. Only ever written by builds that ship
+	 * the feature (see `$lib/utils/mlAssistantFlag`).
+	 */
+	mlAssistant?: boolean;
+
+	/**
 	 * Spaces this conversation's artifacts have been deployed to, keyed by the
 	 * stable artifact `identifier`. Lets a re-deploy push a new commit to the same
 	 * Space instead of creating a new one. Only Spaces created through this app's

--- a/src/lib/types/MlAssistant.ts
+++ b/src/lib/types/MlAssistant.ts
@@ -1,0 +1,12 @@
+/** Lifecycle of a single step in an ML Assistant plan. */
+export type MlPlanStepStatus = "pending" | "running" | "done" | "skipped";
+
+export interface MlPlanStep {
+	/** One or two words naming the step, e.g. "Baseline eval". Used as the dot's accessible name. */
+	label: string;
+	/** Present-tense label shown beside the dots while this step runs, e.g. "Evaluating". */
+	statusLabel: string;
+	/** One-line explanation shown in the dot's tooltip. */
+	description: string;
+	status: MlPlanStepStatus;
+}

--- a/src/lib/utils/mlAssistantFlag.ts
+++ b/src/lib/utils/mlAssistantFlag.ts
@@ -1,0 +1,13 @@
+/**
+ * ML Assistant mode is a preset that loads a fixed set of tools and prompts for
+ * machine-learning work, surfaced as a header strip on the composer.
+ *
+ * The flag is a build-time constant (`define` in vite.config.ts), not a runtime
+ * config key: a build either ships the feature or has no way to turn it on, so
+ * the preset can't be reached by flipping an env var on a deployed instance.
+ * (The components still land in the bundle — Svelte's compiled templates aren't
+ * side-effect-free, so the branch folds but the modules don't tree-shake.)
+ *
+ * Enable with `ML_ASSISTANT_MODE=true` in the build environment or `.env.local`.
+ */
+export const ML_ASSISTANT_MODE: boolean = __ML_ASSISTANT_MODE__;

--- a/src/lib/utils/pendingConversation.ts
+++ b/src/lib/utils/pendingConversation.ts
@@ -15,6 +15,7 @@ export interface ConversationData {
 	modelId: string;
 	shared: boolean;
 	deployedSpaces?: Record<string, DeployedSpace>;
+	mlAssistant?: boolean;
 }
 
 // One-shot handoff of the conversation payload embedded in the create

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -77,6 +77,8 @@
 				}
 				error.set(errorMessage);
 				console.error("Error while creating conversation: ", errorMessage);
+				// The composer latched the mode for a conversation that never happened.
+				mlAssistant.abortTask();
 				return;
 			}
 
@@ -115,6 +117,8 @@
 		} catch (err) {
 			error.set((err as Error).message || ERROR_MESSAGES.default);
 			console.error(err);
+			// The composer latched the mode for a conversation that never happened.
+			mlAssistant.abortTask();
 		} finally {
 			$loading = false;
 		}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -19,6 +19,7 @@
 	import { loading } from "$lib/stores/loading.js";
 	import { loadAttachmentsFromUrls } from "$lib/utils/loadAttachmentsFromUrls";
 	import { requireAuthUser } from "$lib/utils/auth";
+	import { mlAssistant } from "$lib/stores/mlAssistant.svelte";
 
 	let { data } = $props();
 
@@ -57,6 +58,9 @@
 						($settings.customPromptsEnabled?.[$settings.activeModel] ?? true)
 							? $settings.customPrompts[$settings.activeModel]
 							: "",
+					// The composer latches the mode before handing the message over, so
+					// the conversation this creates is marked with it from the start.
+					mlAssistant: mlAssistant.taskStarted,
 				}),
 			});
 

--- a/src/routes/api/v2/conversations/[id]/+server.ts
+++ b/src/routes/api/v2/conversations/[id]/+server.ts
@@ -28,6 +28,7 @@ export const GET: RequestHandler = async ({ locals, params, url }) => {
 		modelId: conversation.model,
 		shared: conversation.shared,
 		deployedSpaces: "deployedSpaces" in conversation ? conversation.deployedSpaces : undefined,
+		mlAssistant: "mlAssistant" in conversation ? conversation.mlAssistant : undefined,
 	});
 };
 

--- a/src/routes/conversation/+server.ts
+++ b/src/routes/conversation/+server.ts
@@ -11,6 +11,7 @@ import { authCondition } from "$lib/server/auth";
 import { usageLimits } from "$lib/server/usageLimits";
 import { MetricsServer } from "$lib/server/metrics";
 import superjson from "superjson";
+import { ML_ASSISTANT_MODE } from "$lib/utils/mlAssistantFlag";
 
 export const POST: RequestHandler = async ({ locals, request }) => {
 	const body = await request.text();
@@ -22,6 +23,7 @@ export const POST: RequestHandler = async ({ locals, request }) => {
 			fromShare: z.string().optional(),
 			model: validateModel(models),
 			preprompt: z.string().optional(),
+			mlAssistant: z.boolean().optional(),
 		})
 		.safeParse(JSON.parse(body));
 
@@ -77,8 +79,19 @@ export const POST: RequestHandler = async ({ locals, request }) => {
 		error(400, "Can't start a conversation with an unlisted model");
 	}
 
+	// Only builds that ship ML Assistant mode can start a conversation in it.
+	const isMlAssistant = ML_ASSISTANT_MODE && values.mlAssistant === true;
+
 	// use provided preprompt or model preprompt
 	values.preprompt ??= model?.preprompt ?? "";
+
+	// The ML Assistant preset supplies the whole system prompt at generation time.
+	// Storing nothing here keeps the user's per-model custom prompt out of the
+	// conversation entirely — the endpoint appends a stored system message after
+	// the preprompt, so leaving one would compose the two.
+	if (isMlAssistant) {
+		values.preprompt = "";
+	}
 
 	if (messages && messages.length > 0 && messages[0].from === "system") {
 		messages[0].content = values.preprompt;
@@ -100,6 +113,8 @@ export const POST: RequestHandler = async ({ locals, request }) => {
 		userAgent: request.headers.get("User-Agent") ?? undefined,
 		...(locals.user ? { userId: locals.user._id } : { sessionId: locals.sessionId }),
 		...(values.fromShare ? { meta: { fromShareId: values.fromShare } } : {}),
+		// Only builds that ship ML Assistant mode can mark a conversation with it.
+		...(isMlAssistant ? { mlAssistant: true } : {}),
 	});
 
 	if (MetricsServer.isEnabled()) {
@@ -130,6 +145,7 @@ export const POST: RequestHandler = async ({ locals, request }) => {
 				// only reports shared=true when the viewing URL's fromShare matches.
 				shared: false,
 				deployedSpaces: undefined,
+				mlAssistant: isMlAssistant ? true : undefined,
 			}),
 		}),
 		{ headers: { "Content-Type": "application/json" } }

--- a/src/routes/conversation/[id]/+server.ts
+++ b/src/routes/conversation/[id]/+server.ts
@@ -25,6 +25,8 @@ import { usageLimits } from "$lib/server/usageLimits";
 import { textGeneration } from "$lib/server/textGeneration";
 import type { TextGenerationContext } from "$lib/server/textGeneration/types";
 import type { McpServerConfig } from "$lib/server/mcp/httpClient";
+import { isMlAssistantConversation } from "$lib/server/mlAssistant";
+import { ML_ASSISTANT_EFFORT } from "$lib/constants/mlAssistant";
 import { logger } from "$lib/server/logger.js";
 import { AbortRegistry } from "$lib/server/abortRegistry";
 import { createGenerationWriter, type GenerationWriter } from "$lib/server/generation/writer";
@@ -747,10 +749,14 @@ export async function POST({ request, locals, params, getClientAddress }) {
 							? userSettings?.providerOverrides?.[model.id]
 							: undefined,
 					// Thinking-effort override (only forwarded for reasoning-capable models;
-					// per-user override can force-enable on self-hosted)
+					// per-user override can force-enable on self-hosted). The ML Assistant
+					// preset pins its own effort here rather than writing the user's saved
+					// setting, so the mode never outlives the conversation it belongs to.
 					reasoningEffort:
 						(userSettings?.reasoningOverrides?.[model.id] ?? model.supportsReasoning)
-							? userSettings?.reasoningEffortOverrides?.[model.id]
+							? isMlAssistantConversation(conv)
+								? ML_ASSISTANT_EFFORT
+								: userSettings?.reasoningEffortOverrides?.[model.id]
 							: undefined,
 					reasoningOverride: userSettings?.reasoningOverrides?.[model.id],
 					// Artifacts aren't provider-determined, so the per-model user

--- a/src/routes/models/[...model]/+page.svelte
+++ b/src/routes/models/[...model]/+page.svelte
@@ -8,6 +8,7 @@
 	import ChatWindow from "$lib/components/chat/ChatWindow.svelte";
 	import { findCurrentModel } from "$lib/utils/models";
 	import { useSettingsStore } from "$lib/stores/settings";
+	import { mlAssistant } from "$lib/stores/mlAssistant.svelte";
 	import { useConversationsStore } from "$lib/stores/conversations.svelte";
 	import { ERROR_MESSAGES, error } from "$lib/stores/errors";
 	import { storePendingFiles } from "$lib/utils/pendingFiles";
@@ -48,6 +49,9 @@
 						($settings.customPromptsEnabled?.[modelId] ?? true)
 							? $settings.customPrompts[modelId]
 							: "",
+					// The composer latches the mode before handing the message over, so
+					// the conversation this creates is marked with it from the start.
+					mlAssistant: mlAssistant.taskStarted,
 				}),
 			});
 

--- a/src/routes/models/[...model]/+page.svelte
+++ b/src/routes/models/[...model]/+page.svelte
@@ -58,6 +58,8 @@
 			if (!res.ok) {
 				error.set("Error while creating conversation, try again.");
 				console.error("Error while creating conversation: " + (await res.text()));
+				// The composer latched the mode for a conversation that never happened.
+				mlAssistant.abortTask();
 				return;
 			}
 
@@ -85,6 +87,8 @@
 		} catch (err) {
 			error.set(ERROR_MESSAGES.default);
 			console.error(err);
+			// The composer latched the mode for a conversation that never happened.
+			mlAssistant.abortTask();
 		} finally {
 			loading = false;
 		}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,7 @@ import { defineConfig } from "vitest/config";
 import { config } from "dotenv";
 
 config({ path: "./.env.local" });
+config({ path: "./.env" });
 
 // used to load fonts server side for thumbnail generation
 function loadTTFAsArrayBuffer() {
@@ -21,6 +22,12 @@ function loadTTFAsArrayBuffer() {
 	};
 }
 export default defineConfig({
+	define: {
+		// Build flag for ML Assistant mode, fixed at build time rather than read from
+		// runtime config so a build either ships the feature or cannot turn it on.
+		// Read it via `ML_ASSISTANT_MODE` in $lib/utils/mlAssistantFlag.
+		__ML_ASSISTANT_MODE__: JSON.stringify(process.env.ML_ASSISTANT_MODE === "true"),
+	},
 	plugins: [
 		tailwindcss(),
 		sveltekit(),


### PR DESCRIPTION
Implements the ML Assistant composer design (option `1d`, "header strip"): a thin strip at the top of the composer carrying the mode switch and, once a task is running, a compact readout of the assistant's plan.

Everything is behind `ML_ASSISTANT_MODE`, off by default.

## The build flag

`ML_ASSISTANT_MODE` is inlined by Vite's `define` rather than read from runtime config, so a build either ships the feature or has no way to turn it on — it can't be flipped on a deployed instance. The server half is gated on the same constant, so a flag-off build ignores the conversation field even if the database carries it from a build that had it on.

```bash
ML_ASSISTANT_MODE=true npm run build
```

Also available as a `--build-arg` to `docker build`. Documented in `.env` and the config docs.

One honest caveat: the branch folds to dead code, but Svelte's compiled templates aren't pure-annotated, so the component modules still land in the bundle unreferenced. The flag gates behaviour completely; it doesn't shrink the bundle.

## The mode is a property of the conversation

Persisted as `mlAssistant` on the conversation document. Toggleable until the first send, locked after. Reopening or reloading an ML conversation brings the strip back; a run started from the home composer adopts the conversation its send creates.

## The preset, enforced server-side

| Piece | Where | How |
| --- | --- | --- |
| Fixed prompt | `textGeneration/preprompt.ts` | Preset preprompt replaces `conv.preprompt` — same for every model, ignores per-model custom prompts |
| MCP servers | `runMcpFlow.ts` | Preset servers unioned in **after** the user's name filter, so they can't be deselected; user selections still stack |
| Capabilities | `textGeneration/index.ts` | Artifacts + tool calling force-enabled |

Doing this in the pipeline rather than having the composer send a preset prompt and server list means the preset is as fixed as it claims to be, and "not per model" falls out for free. Resolving per generation rather than freezing at creation means editing the preset reaches conversations that already exist.

There was a trap worth calling out: `endpointOai` *prepends* the preprompt to a stored system message rather than replacing it, so the user's `customPrompts[model]` would have composed onto the end of the preset. Conversations started in the mode now store an empty preprompt, which `stripEmptyInitialSystemMessage` drops.

**Artifacts are not gated by this.** The preset force-enables them on top; outside the mode they stay opt-in per model with the per-model override, exactly as before. `preprompt.spec.ts` keeps the previous expression verbatim as `legacy` and asserts the two agree across all 27 combinations of `conversationPreprompt × artifactsOverride × supportsArtifacts` when the preset is off — if anyone later makes the preset a gate, that test fails.

## Reasoning effort

Turning the mode on sets the model's reasoning effort to high. Effort is read from saved settings when the request is built, so displaying "High" while sending "Default" would have been a lie. The previous value is restored when the mode is switched off, when the conversation changes, and on the next load after a reload (mirrored to `sessionStorage`, since the mode itself doesn't survive one).

## Verification

Strip fidelity is asserted against computed style rather than class names: tints, `9px 16px` / `gap 9px` / `13.5px`, the 26×15 track with the knob at `left: 2px → 13px`, the switch's `width: 0; margin-right: -9px` collapse, 22px dots on a real 5px rhythm inside 27×44 hit targets, and the `#1a1a1f` portalled tooltip.

The preset was checked end to end against a local instance with `MCP_SERVERS` empty, which makes for a clean control — same question both ways:

- **Mode on** → tool defs built, Hub tool called, answered with grounded model id, licence and download count
- **Mode off** → zero MCP activity

So the tools come from the preset alone and aren't reachable from user config.

856 tests pass with the flag both on and off (34 new); lint and typecheck clean; production builds succeed both ways.

## Deliberately not included

- **Plan progress has no data source.** Nothing emits plan events yet, so the row renders only what `setPlan`/`setStepStatus` are given, and the strip keeps its tool note until a plan arrives. The prototype's timer was not shipped.
- **"Configure" is inert.** It renders as designed, but the configuration panel it should open isn't designed yet.
- **The preset's MCP server list is a source constant**, not operator config — a self-hoster building with the flag on gets `hf.co/mcp`. Fine while it's opt-in at build time; a one-line change when it needs to be env-driven.
- **The base composer is untouched.** The handoff specs 16px radius, 40px buttons and a 17px input against the shipped 12px/32px/16px. Restyling the composer for every user isn't what "add ML Assistant behind a flag" means, so only the new element matches the spec exactly.
