### PR TITLE
Feed the ML Assistant plan strip from update_plan

### DIFF
--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -58,6 +58,8 @@
 	import MlAssistantStrip from "./MlAssistantStrip.svelte";
 	import { ML_ASSISTANT_MODE } from "$lib/utils/mlAssistantFlag";
 	import { mlAssistant } from "$lib/stores/mlAssistant.svelte";
+	import { planStepsToMlSteps } from "$lib/utils/planProgress";
+	import type { PlanState } from "$lib/types/Plan";
 	import {
 		ML_ASSISTANT_EFFORT,
 		ML_ASSISTANT_PLACEHOLDER,
@@ -460,8 +462,18 @@
 	$effect(() => {
 		if (!ML_ASSISTANT_MODE) return;
 		const conversationId = page.params?.id;
-		const startedInMlMode = Boolean((page.data as { mlAssistant?: boolean }).mlAssistant);
-		untrack(() => mlAssistant.syncConversation(conversationId, startedInMlMode));
+		const { mlAssistant: startedInMlMode, plan } = page.data as {
+			mlAssistant?: boolean;
+			plan?: PlanState;
+		};
+		untrack(() => {
+			const reset = mlAssistant.syncConversation(conversationId, Boolean(startedInMlMode));
+			// A reopened mode conversation renders mid-plan from the stored snapshot;
+			// a reset without one keeps the strip on its tool note.
+			if (reset && startedInMlMode && plan?.steps.length) {
+				mlAssistant.setPlan(planStepsToMlSteps(plan.steps));
+			}
+		});
 	});
 
 	function toggleMlMode(next: boolean) {

--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -818,7 +818,7 @@
 							class={[
 								"flex items-center gap-1 rounded-lg px-2 py-0.5 text-center text-sm backdrop-blur-sm",
 								mlModeOn
-									? "bg-[#eef2ff] text-[#3450cc] dark:bg-[#1b2140] dark:text-[#93a4f0]"
+									? "bg-[#fff1e4] text-[#c2410c] dark:bg-[#3a2410] dark:text-[#fdba74]"
 									: "bg-gray-100/90 hover:text-gray-500 dark:bg-gray-700/50 dark:hover:text-gray-400",
 							]}
 							onclick={() => startExample(ex)}
@@ -894,7 +894,7 @@
 					class={{
 						"relative flex w-full max-w-4xl flex-1 flex-col rounded-xl border bg-gray-100 dark:bg-gray-800": true,
 						"transition-[border-color] duration-[350ms] ease-[ease]": ML_ASSISTANT_MODE,
-						"border-[#dfe4fb] dark:border-[#2b3357]": mlModeOn && mlStripVisible,
+						"border-[#f7ddc2] dark:border-[#54371c]": mlModeOn && mlStripVisible,
 						"dark:border-gray-700": !(mlModeOn && mlStripVisible),
 						"opacity-30": isReadOnly,
 						"max-sm:mb-4": focused && isVirtualKeyboard(),

--- a/src/lib/components/chat/MlAssistantPlanProgress.svelte
+++ b/src/lib/components/chat/MlAssistantPlanProgress.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { Tooltip } from "bits-ui";
 	import LucideCheck from "~icons/lucide/check";
+	import LucideSlash from "~icons/lucide/slash";
 	import type { MlPlanStep } from "$lib/types/MlAssistant";
 
 	interface Props {
@@ -16,6 +17,9 @@
 	// than one flag per dot so opening a second dot closes the first.
 	let openStep = $state(-1);
 
+	// None of the dot glyphs clear 4.5:1 by design (they are decorative), so this
+	// label is the accessible carrier of each step's name and status — the visible
+	// numeral/icon never makes it redundant.
 	function accessibleName(step: MlPlanStep) {
 		return `${step.label} — ${step.status}`;
 	}
@@ -37,7 +41,9 @@
 					>
 						<span class="ml-dot" data-status={step.status}>
 							{#if step.status === "done"}
-								<LucideCheck class="ml-dot-check" aria-hidden="true" />
+								<LucideCheck class="ml-dot-icon" aria-hidden="true" />
+							{:else if step.status === "skipped"}
+								<LucideSlash class="ml-dot-icon ml-dot-slash" aria-hidden="true" />
 							{:else}
 								{index + 1}
 							{/if}
@@ -146,11 +152,22 @@
 		color: #fff;
 	}
 
-	/* Thickened past lucide's default 2 so the tick stays legible at dot size. */
-	:global(.ml-dot-check) {
+	/* Thickened past lucide's default 2 so the strokes stay legible at dot size. */
+	:global(.ml-dot-icon) {
 		width: 13px;
 		height: 13px;
 		stroke-width: 3.5;
+	}
+
+	/* The slash spans lucide's full viewBox diagonal, so it runs smaller and
+	   thicker than the check to sit at the same visual weight. */
+	:global(.ml-dot-slash) {
+		width: 10px;
+		height: 10px;
+		stroke-width: 6;
+		/* A stroke this wide overshoots the path's endpoints; without this the
+		   rounded caps clip against the viewBox. */
+		overflow: visible;
 	}
 
 	/* Washed out via pre-blended solids, not element opacity — a translucent dot
@@ -159,7 +176,7 @@
 	.ml-dot[data-status="skipped"] {
 		background: #eff0f6;
 		border: 1px solid #d7d9e2;
-		color: #8f8f9a;
+		color: #9b9ca6;
 	}
 
 	/* Solid (the strip's own band color) so the connector line cannot show
@@ -173,7 +190,7 @@
 	:global(.dark) .ml-dot[data-status="skipped"] {
 		background: #20222d;
 		border-color: #383e54;
-		color: #7e8290;
+		color: #767a88;
 	}
 
 	@keyframes mlpulse {

--- a/src/lib/components/chat/MlAssistantPlanProgress.svelte
+++ b/src/lib/components/chat/MlAssistantPlanProgress.svelte
@@ -64,7 +64,7 @@
 	<span
 		class={[
 			"text-[13.5px] leading-none font-medium whitespace-nowrap",
-			complete ? "text-[#16a34a] dark:text-[#4ade80]" : "text-[#2244cc] dark:text-[#93a4f0]",
+			complete ? "text-[#16a34a] dark:text-[#4ade80]" : "text-[#c2410c] dark:text-[#fdba74]",
 		]}
 		aria-live="polite"
 		aria-atomic="true"
@@ -88,7 +88,7 @@
 	}
 
 	:global(.ml-dot-hit:focus-visible) {
-		outline: 2px solid #2244cc;
+		outline: 2px solid #ea580c;
 		outline-offset: -8px;
 		border-radius: 8px;
 	}
@@ -107,12 +107,12 @@
 		height: 1.5px;
 		transform: translateY(-50%);
 		border-radius: 1px;
-		background: #aebcec;
+		background: #f2cda4;
 		pointer-events: none;
 	}
 
 	:global(.dark) .ml-dot-row::before {
-		background: #46538a;
+		background: #7a4f24;
 	}
 
 	.ml-dot {
@@ -140,8 +140,8 @@
 	}
 
 	.ml-dot[data-status="running"] {
-		background: #2244cc;
-		border: 1px solid #2244cc;
+		background: #ea580c;
+		border: 1px solid #ea580c;
 		color: #fff;
 		animation: mlpulse 1.5s ease-in-out infinite;
 	}
@@ -182,32 +182,32 @@
 	   would let the connector line show through. Border and text stay a notch
 	   above the band so a skipped dot reads muted, not missing. */
 	.ml-dot[data-status="skipped"] {
-		background: #eff0f6;
-		border: 1px solid #d7d9e2;
+		background: #f4f0ef;
+		border: 1px solid #d9d5d1;
 		color: #aeafbb;
 	}
 
 	/* Solid (the strip's own band color) so the connector line cannot show
 	   through, staying in step if the band is ever retinted. */
 	:global(.dark) .ml-dot[data-status="pending"] {
-		background: var(--ml-strip-band, #151a2e);
+		background: var(--ml-strip-band, #2b1c0e);
 		border-color: #3a3a42;
 		color: #7a7a84;
 	}
 
 	:global(.dark) .ml-dot[data-status="skipped"] {
-		background: #20222d;
-		border-color: #383e54;
+		background: #282222;
+		border-color: #46403a;
 		color: #6a6e7d;
 	}
 
 	@keyframes mlpulse {
 		0%,
 		100% {
-			box-shadow: 0 0 0 0 rgba(34, 68, 204, 0.45);
+			box-shadow: 0 0 0 0 rgba(234, 88, 12, 0.45);
 		}
 		50% {
-			box-shadow: 0 0 0 5px rgba(34, 68, 204, 0);
+			box-shadow: 0 0 0 5px rgba(234, 88, 12, 0);
 		}
 	}
 

--- a/src/lib/components/chat/MlAssistantPlanProgress.svelte
+++ b/src/lib/components/chat/MlAssistantPlanProgress.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { Tooltip } from "bits-ui";
+	import LucideCheck from "~icons/lucide/check";
 	import type { MlPlanStep } from "$lib/types/MlAssistant";
 
 	interface Props {
@@ -34,7 +35,13 @@
 						aria-label={accessibleName(step)}
 						onclick={() => (openStep = openStep === index ? -1 : index)}
 					>
-						<span class="ml-dot" data-status={step.status}>{index + 1}</span>
+						<span class="ml-dot" data-status={step.status}>
+							{#if step.status === "done"}
+								<LucideCheck class="ml-dot-check" aria-hidden="true" />
+							{:else}
+								{index + 1}
+							{/if}
+						</span>
 					</Tooltip.Trigger>
 					<Tooltip.Portal>
 						<Tooltip.Content class="ml-dot-tooltip" side="top" sideOffset={10}>
@@ -137,6 +144,13 @@
 		background: #16a34a;
 		border: 1px solid #16a34a;
 		color: #fff;
+	}
+
+	/* Thickened past lucide's default 2 so the tick stays legible at dot size. */
+	:global(.ml-dot-check) {
+		width: 13px;
+		height: 13px;
+		stroke-width: 3.5;
 	}
 
 	.ml-dot[data-status="skipped"] {

--- a/src/lib/components/chat/MlAssistantPlanProgress.svelte
+++ b/src/lib/components/chat/MlAssistantPlanProgress.svelte
@@ -22,7 +22,7 @@
 
 <div class="flex items-center gap-3">
 	<Tooltip.Provider delayDuration={80} disableHoverableContent>
-		<div class="flex items-center gap-[5px]">
+		<div class="ml-dot-row flex items-center gap-[10px]">
 			{#each steps as step, index (index)}
 				<Tooltip.Root
 					open={openStep === index}
@@ -62,7 +62,7 @@
 
 <style>
 	/* 27x44 hit target that leaves the 22px dot's footprint untouched, so the row
-	   still lays out on the designed 5px gap. */
+	   still lays out on the designed 10px gap. */
 	:global(.ml-dot-hit) {
 		display: grid;
 		place-items: center;
@@ -80,7 +80,30 @@
 		border-radius: 8px;
 	}
 
+	/* Stepper connector behind the dots, ending under the outer dots' centers. */
+	.ml-dot-row {
+		position: relative;
+	}
+
+	.ml-dot-row::before {
+		content: "";
+		position: absolute;
+		top: 50%;
+		left: 11px;
+		right: 11px;
+		height: 1.5px;
+		transform: translateY(-50%);
+		border-radius: 1px;
+		background: #aebcec;
+		pointer-events: none;
+	}
+
+	:global(.dark) .ml-dot-row::before {
+		background: #46538a;
+	}
+
 	.ml-dot {
+		position: relative;
 		display: grid;
 		place-items: center;
 		box-sizing: border-box;
@@ -123,8 +146,9 @@
 		opacity: 0.65;
 	}
 
+	/* Solid (strip band color) so the connector line cannot show through. */
 	:global(.dark) .ml-dot[data-status="pending"] {
-		background: transparent;
+		background: #151a2e;
 		border-color: #3a3a42;
 		color: #7a7a84;
 	}

--- a/src/lib/components/chat/MlAssistantPlanProgress.svelte
+++ b/src/lib/components/chat/MlAssistantPlanProgress.svelte
@@ -184,7 +184,7 @@
 	.ml-dot[data-status="skipped"] {
 		background: #eff0f6;
 		border: 1px solid #d7d9e2;
-		color: #9b9ca6;
+		color: #aeafbb;
 	}
 
 	/* Solid (the strip's own band color) so the connector line cannot show
@@ -198,7 +198,7 @@
 	:global(.dark) .ml-dot[data-status="skipped"] {
 		background: #20222d;
 		border-color: #383e54;
-		color: #767a88;
+		color: #6a6e7d;
 	}
 
 	@keyframes mlpulse {

--- a/src/lib/components/chat/MlAssistantPlanProgress.svelte
+++ b/src/lib/components/chat/MlAssistantPlanProgress.svelte
@@ -152,10 +152,15 @@
 		color: #fff;
 	}
 
-	/* Thickened past lucide's default 2 so the strokes stay legible at dot size. */
 	:global(.ml-dot-icon) {
 		width: 13px;
 		height: 13px;
+	}
+
+	/* On the path, not the svg: the icon inlines stroke-width="2" as a
+	   presentation attribute per path, which beats anything inherited from the
+	   root. Thickened well past 2 so the strokes stay legible at dot size. */
+	:global(.ml-dot-icon path) {
 		stroke-width: 3.5;
 	}
 
@@ -164,10 +169,13 @@
 	:global(.ml-dot-slash) {
 		width: 10px;
 		height: 10px;
-		stroke-width: 6;
-		/* A stroke this wide overshoots the path's endpoints; without this the
+		/* The wide stroke overshoots the path's endpoints; without this the
 		   rounded caps clip against the viewBox. */
 		overflow: visible;
+	}
+
+	:global(.ml-dot-slash path) {
+		stroke-width: 6;
 	}
 
 	/* Washed out via pre-blended solids, not element opacity — a translucent dot

--- a/src/lib/components/chat/MlAssistantPlanProgress.svelte
+++ b/src/lib/components/chat/MlAssistantPlanProgress.svelte
@@ -153,24 +153,27 @@
 		stroke-width: 3.5;
 	}
 
+	/* Washed out via pre-blended solids, not element opacity — a translucent dot
+	   would let the connector line show through. Border and text stay a notch
+	   above the band so a skipped dot reads muted, not missing. */
 	.ml-dot[data-status="skipped"] {
-		background: #eeeef1;
-		border: 1px solid #eeeef1;
-		color: #b4b4bc;
-		opacity: 0.65;
+		background: #eff0f6;
+		border: 1px solid #d7d9e2;
+		color: #8f8f9a;
 	}
 
-	/* Solid (strip band color) so the connector line cannot show through. */
+	/* Solid (the strip's own band color) so the connector line cannot show
+	   through, staying in step if the band is ever retinted. */
 	:global(.dark) .ml-dot[data-status="pending"] {
-		background: #151a2e;
+		background: var(--ml-strip-band, #151a2e);
 		border-color: #3a3a42;
 		color: #7a7a84;
 	}
 
 	:global(.dark) .ml-dot[data-status="skipped"] {
-		background: #26262c;
-		border-color: #26262c;
-		color: #6f6f79;
+		background: #20222d;
+		border-color: #383e54;
+		color: #7e8290;
 	}
 
 	@keyframes mlpulse {

--- a/src/lib/components/chat/MlAssistantStrip.svelte
+++ b/src/lib/components/chat/MlAssistantStrip.svelte
@@ -38,7 +38,7 @@
 		class={[
 			"ml-strip flex items-center gap-[9px] border-b px-4 py-[9px] text-[13.5px]",
 			enabled
-				? "border-[#e2e7fb] bg-[#f0f3ff] text-[#2244cc] dark:border-[#2b3357] dark:bg-[#151a2e] dark:text-[#93a4f0]"
+				? "border-[#e2e7fb] bg-[var(--ml-strip-band)] text-[#2244cc] [--ml-strip-band:#f0f3ff] dark:border-[#2b3357] dark:text-[#93a4f0] dark:[--ml-strip-band:#151a2e]"
 				: "border-[#ececee] bg-transparent text-[#9a9aa0] dark:border-gray-700 dark:text-gray-500",
 		]}
 	>

--- a/src/lib/components/chat/MlAssistantStrip.svelte
+++ b/src/lib/components/chat/MlAssistantStrip.svelte
@@ -68,7 +68,9 @@
 		<!-- The plan replaces the tool note, but only once there is a plan to show:
 		     a run that has not reported its steps yet would otherwise leave a gap. -->
 		{#if taskRunning && steps.length}
-			<MlAssistantPlanProgress {steps} {statusLabel} {complete} />
+			<span class="ml-2 flex min-w-0 items-center">
+				<MlAssistantPlanProgress {steps} {statusLabel} {complete} />
+			</span>
 		{:else if enabled}
 			<span class="truncate font-mono text-xs text-[#7f8cd8]">
 				{ML_ASSISTANT_TOOLS.join(" · ")}

--- a/src/lib/components/chat/MlAssistantStrip.svelte
+++ b/src/lib/components/chat/MlAssistantStrip.svelte
@@ -37,6 +37,8 @@
 	<div
 		class={[
 			"ml-strip flex items-center gap-[9px] border-b px-4 py-[9px] text-[13.5px]",
+			// Label text must clear 4.5:1 on the band: #c2410c on #fff4ea is 4.78:1 with
+			// little headroom — retint band and text together, not separately.
 			enabled
 				? "border-[#fbe4cc] bg-[var(--ml-strip-band)] text-[#c2410c] [--ml-strip-band:#fff4ea] dark:border-[#54371c] dark:text-[#fdba74] dark:[--ml-strip-band:#2b1c0e]"
 				: "border-[#ececee] bg-transparent text-[#9a9aa0] dark:border-gray-700 dark:text-gray-500",

--- a/src/lib/components/chat/MlAssistantStrip.svelte
+++ b/src/lib/components/chat/MlAssistantStrip.svelte
@@ -38,7 +38,7 @@
 		class={[
 			"ml-strip flex items-center gap-[9px] border-b px-4 py-[9px] text-[13.5px]",
 			enabled
-				? "border-[#e2e7fb] bg-[var(--ml-strip-band)] text-[#2244cc] [--ml-strip-band:#f0f3ff] dark:border-[#2b3357] dark:text-[#93a4f0] dark:[--ml-strip-band:#151a2e]"
+				? "border-[#fbe4cc] bg-[var(--ml-strip-band)] text-[#c2410c] [--ml-strip-band:#fff4ea] dark:border-[#54371c] dark:text-[#fdba74] dark:[--ml-strip-band:#2b1c0e]"
 				: "border-[#ececee] bg-transparent text-[#9a9aa0] dark:border-gray-700 dark:text-gray-500",
 		]}
 	>
@@ -51,7 +51,7 @@
 				checked={enabled}
 				disabled={taskRunning}
 				onCheckedChange={ontoggle}
-				aria-label="ML Assistant mode"
+				aria-label="ML Intern mode"
 			>
 				<span class="ml-switch-track" class:is-on={enabled}>
 					<Switch.Thumb class="ml-switch-knob" />
@@ -62,7 +62,7 @@
 		<!-- The switch is gone once a task is running, so the title has to be what
 		     tells a screen reader the mode is on. -->
 		<span class="flex-none" class:font-semibold={enabled}>
-			ML Assistant{#if taskRunning}<span class="sr-only">, mode on</span>{/if}
+			ML Intern{#if taskRunning}<span class="sr-only">, mode on</span>{/if}
 		</span>
 
 		<!-- The plan replaces the tool note, but only once there is a plan to show:
@@ -167,7 +167,7 @@
 	}
 
 	.ml-switch-track.is-on {
-		background: #2244cc;
+		background: #ea580c;
 	}
 
 	:global(.dark) .ml-switch-track {
@@ -179,7 +179,7 @@
 	}
 
 	:global(.ml-switch:focus-visible) .ml-switch-track {
-		outline: 2px solid #2244cc;
+		outline: 2px solid #ea580c;
 		outline-offset: 2px;
 	}
 

--- a/src/lib/components/chat/MlAssistantStrip.svelte.test.ts
+++ b/src/lib/components/chat/MlAssistantStrip.svelte.test.ts
@@ -165,10 +165,12 @@ describe("MlAssistantStrip", () => {
 			statusLabel: "Training",
 		});
 		const dots = [...container.querySelectorAll(".ml-dot")];
-		// A completed step trades its number for a tick.
-		expect(dots.map((d) => d.textContent?.trim())).toEqual(["", "2", "3", "4"]);
+		// Settled steps trade their number for an icon: a tick when done, a slash
+		// when skipped. Unsettled steps keep their number.
+		expect(dots.map((d) => d.textContent?.trim())).toEqual(["", "", "3", "4"]);
 		expect(dots[0].querySelector("svg")).not.toBeNull();
-		expect(dots[1].querySelector("svg")).toBeNull();
+		expect(dots[1].querySelector("svg")).not.toBeNull();
+		expect(dots[2].querySelector("svg")).toBeNull();
 		expect(box(dots[0])).toEqual({ width: 22, height: 22 });
 
 		const [done, skipped, running, pending] = dots.map(style);

--- a/src/lib/components/chat/MlAssistantStrip.svelte.test.ts
+++ b/src/lib/components/chat/MlAssistantStrip.svelte.test.ts
@@ -8,7 +8,10 @@ import type { MlPlanStep } from "$lib/types/MlAssistant";
  * computed style rather than class names.
  */
 
-const ACCENT = "rgb(34, 68, 204)";
+// The mode's fills (switch track, running dot) and its text run two different
+// oranges: vibrant for surfaces, darker for legible text on the pale band.
+const ACCENT = "rgb(234, 88, 12)";
+const ACCENT_TEXT = "rgb(194, 65, 12)";
 const SUCCESS = "rgb(22, 163, 74)";
 
 const step = (
@@ -53,7 +56,7 @@ describe("MlAssistantStrip", () => {
 		const { container } = mount();
 		const strip = find(container, ".ml-strip");
 
-		expect(strip.textContent).toContain("ML Assistant");
+		expect(strip.textContent).toContain("ML Intern");
 		expect(strip.textContent).toContain(
 			"— tools and prompts for papers, finetuning, demos and datasets"
 		);
@@ -68,9 +71,9 @@ describe("MlAssistantStrip", () => {
 
 		expect(strip.textContent).toContain("papers · training · spaces · datasets · eval · hub");
 		expect(container.textContent).toContain("Configure");
-		expect(style(strip).backgroundColor).toBe("rgb(240, 243, 255)");
-		expect(style(strip).borderBottomColor).toBe("rgb(226, 231, 251)");
-		expect(style(strip).color).toBe(ACCENT);
+		expect(style(strip).backgroundColor).toBe("rgb(255, 244, 234)");
+		expect(style(strip).borderBottomColor).toBe("rgb(251, 228, 204)");
+		expect(style(strip).color).toBe(ACCENT_TEXT);
 	});
 
 	it("lays the strip out on the specified spacing", () => {
@@ -102,7 +105,7 @@ describe("MlAssistantStrip", () => {
 
 		expect(control.getAttribute("role")).toBe("switch");
 		expect(control.getAttribute("aria-checked")).toBe("false");
-		expect(control.getAttribute("aria-label")).toBe("ML Assistant mode");
+		expect(control.getAttribute("aria-label")).toBe("ML Intern mode");
 		// Visual size is 26x15, but the control itself has to stay tappable.
 		expect(box(control)).toEqual({ width: 44, height: 44 });
 
@@ -177,7 +180,7 @@ describe("MlAssistantStrip", () => {
 		expect(done.backgroundColor).toBe(SUCCESS);
 		// Washed out via pre-blended solids, not element opacity, so the connector
 		// line cannot show through a translucent dot.
-		expect(skipped.backgroundColor).toBe("rgb(239, 240, 246)");
+		expect(skipped.backgroundColor).toBe("rgb(244, 240, 239)");
 		expect(skipped.opacity).toBe("1");
 		expect(running.backgroundColor).toBe(ACCENT);
 		expect(running.animationName).toContain("mlpulse");
@@ -224,7 +227,7 @@ describe("MlAssistantStrip", () => {
 			'[aria-live="polite"]'
 		);
 		expect(running.textContent?.trim()).toBe("Training");
-		expect(style(running).color).toBe(ACCENT);
+		expect(style(running).color).toBe(ACCENT_TEXT);
 
 		const done = find(
 			mount({
@@ -248,7 +251,7 @@ describe("MlAssistantStrip", () => {
 			statusLabel: "Training",
 		});
 
-		expect(container.textContent).toContain("ML Assistant, mode on");
+		expect(container.textContent).toContain("ML Intern, mode on");
 	});
 
 	it("reaches a step's description by keyboard focus, not hover alone", async () => {

--- a/src/lib/components/chat/MlAssistantStrip.svelte.test.ts
+++ b/src/lib/components/chat/MlAssistantStrip.svelte.test.ts
@@ -165,7 +165,10 @@ describe("MlAssistantStrip", () => {
 			statusLabel: "Training",
 		});
 		const dots = [...container.querySelectorAll(".ml-dot")];
-		expect(dots.map((d) => d.textContent)).toEqual(["1", "2", "3", "4"]);
+		// A completed step trades its number for a tick.
+		expect(dots.map((d) => d.textContent?.trim())).toEqual(["", "2", "3", "4"]);
+		expect(dots[0].querySelector("svg")).not.toBeNull();
+		expect(dots[1].querySelector("svg")).toBeNull();
 		expect(box(dots[0])).toEqual({ width: 22, height: 22 });
 
 		const [done, skipped, running, pending] = dots.map(style);
@@ -178,7 +181,7 @@ describe("MlAssistantStrip", () => {
 		expect(pending.borderTopColor).toBe("rgb(220, 220, 226)");
 	});
 
-	it("keeps the dots tappable without disturbing the row's 5px rhythm", () => {
+	it("keeps the dots tappable without disturbing the row's 10px rhythm", () => {
 		const { container } = mount({
 			enabled: true,
 			taskRunning: true,
@@ -190,7 +193,7 @@ describe("MlAssistantStrip", () => {
 
 		const dots = [...container.querySelectorAll(".ml-dot")];
 		const gap = dots[1].getBoundingClientRect().left - dots[0].getBoundingClientRect().right;
-		expect(Math.round(gap)).toBe(5);
+		expect(Math.round(gap)).toBe(10);
 	});
 
 	it("names each dot by its step and status", () => {

--- a/src/lib/components/chat/MlAssistantStrip.svelte.test.ts
+++ b/src/lib/components/chat/MlAssistantStrip.svelte.test.ts
@@ -173,8 +173,10 @@ describe("MlAssistantStrip", () => {
 
 		const [done, skipped, running, pending] = dots.map(style);
 		expect(done.backgroundColor).toBe(SUCCESS);
-		expect(skipped.backgroundColor).toBe("rgb(238, 238, 241)");
-		expect(skipped.opacity).toBe("0.65");
+		// Washed out via pre-blended solids, not element opacity, so the connector
+		// line cannot show through a translucent dot.
+		expect(skipped.backgroundColor).toBe("rgb(239, 240, 246)");
+		expect(skipped.opacity).toBe("1");
 		expect(running.backgroundColor).toBe(ACCENT);
 		expect(running.animationName).toContain("mlpulse");
 		expect(pending.backgroundColor).toBe("rgb(255, 255, 255)");

--- a/src/lib/components/chat/PlanCard.svelte
+++ b/src/lib/components/chat/PlanCard.svelte
@@ -72,7 +72,7 @@
 							{#if step.status === "completed"}
 								<CarbonCheckmark class="size-3.5 text-green-600 dark:text-green-500" />
 							{:else if step.status === "in_progress"}
-								<CarbonInProgress class="size-3.5 text-blue-600 dark:text-blue-400" />
+								<CarbonInProgress class="size-3.5 text-orange-600 dark:text-orange-400" />
 							{:else if step.status === "skipped"}
 								<CarbonSubtract class="size-3.5 text-gray-300 dark:text-gray-600" />
 							{:else}

--- a/src/lib/components/chat/ThinkingEffortChip.svelte
+++ b/src/lib/components/chat/ThinkingEffortChip.svelte
@@ -47,7 +47,7 @@
 </script>
 
 {#if presetEffort}
-	<span title="Set by ML Assistant mode">Effort: {label}</span>
+	<span title="Set by ML Intern mode">Effort: {label}</span>
 {:else}
 	<DropdownMenu.Root>
 		<DropdownMenu.Trigger

--- a/src/lib/server/textGeneration/builtinTools/planTool.spec.ts
+++ b/src/lib/server/textGeneration/builtinTools/planTool.spec.ts
@@ -81,6 +81,25 @@ describe("parsePlanArgs", () => {
 		expect(parsed.ok).toBe(true);
 		if (parsed.ok) expect(parsed.steps[0].step.length).toBeLessThanOrEqual(200);
 	});
+
+	it("keeps a step label, truncated, and drops a blank one", () => {
+		const parsed = parsePlanArgs({
+			goal: "g",
+			steps: [
+				{ step: "run the baseline", label: "Baseline eval", status: "pending" },
+				{ step: "train", label: "y".repeat(60), status: "pending" },
+				{ step: "compare", label: "   ", status: "pending" },
+				{ step: "report", status: "pending" },
+			],
+		});
+		expect(parsed.ok).toBe(true);
+		if (parsed.ok) {
+			expect(parsed.steps[0].label).toBe("Baseline eval");
+			expect(parsed.steps[1].label?.length).toBeLessThanOrEqual(24);
+			expect(parsed.steps[2].label).toBeUndefined();
+			expect(parsed.steps[3].label).toBeUndefined();
+		}
+	});
 });
 
 describe("renderPlanBlock", () => {

--- a/src/lib/server/textGeneration/builtinTools/planTool.ts
+++ b/src/lib/server/textGeneration/builtinTools/planTool.ts
@@ -11,6 +11,7 @@ export const PLAN_TOOL_NAME = "update_plan";
 
 const MAX_STEPS = 20;
 const MAX_STEP_CHARS = 200;
+const MAX_STEP_LABEL_CHARS = 24;
 const MAX_GOAL_CHARS = 1500;
 const MAX_EXPLANATION_CHARS = 200;
 
@@ -55,13 +56,19 @@ export const planToolDefinition = {
 						type: "object",
 						properties: {
 							step: { type: "string", description: "The step, short and imperative." },
+							label: {
+								type: "string",
+								description:
+									"One or two words naming the step for the compact progress display, " +
+									"e.g. 'Baseline eval'.",
+							},
 							status: {
 								type: "string",
 								enum: ["pending", "in_progress", "completed", "skipped"],
 								description: "Mark abandoned steps skipped instead of deleting them.",
 							},
 						},
-						required: ["step", "status"],
+						required: ["step", "status", "label"],
 					},
 				},
 			},
@@ -77,6 +84,7 @@ const planArgsSchema = z.object({
 		.array(
 			z.object({
 				step: z.string().trim().min(1, "every step needs text"),
+				label: z.string().trim().optional(),
 				status: z.enum(["pending", "in_progress", "completed", "skipped"]),
 			})
 		)
@@ -111,7 +119,12 @@ export function parsePlanArgs(args: Record<string, unknown>): ParsedPlanArgs {
 			if (sawInProgress) status = "pending";
 			sawInProgress = true;
 		}
-		return { step: truncate(step.step, MAX_STEP_CHARS), status };
+		const label = step.label ? truncate(step.label, MAX_STEP_LABEL_CHARS) : undefined;
+		return {
+			step: truncate(step.step, MAX_STEP_CHARS),
+			status,
+			...(label ? { label } : {}),
+		};
 	});
 
 	const explanation = parsed.data.explanation
@@ -197,7 +210,7 @@ export function createPlanTool(conv: Pick<Conversation, "_id" | "plan">): Builti
 		exemptFromToolRestraint: true,
 		preprompt:
 			`PLANNING: For complex multi-step work — several distinct stages, multiple tool calls, or requirements that evolve over the conversation — call ${PLAN_TOOL_NAME} before starting and keep it current as you go. ` +
-			`Keep 3-7 short, verifiable steps with exactly one in_progress; mark steps completed the moment they finish, and mark abandoned steps skipped instead of deleting them. ` +
+			`Keep 3-7 short, verifiable steps with exactly one in_progress, each with a one-or-two-word label; mark steps completed the moment they finish, and mark abandoned steps skipped instead of deleting them. ` +
 			`Rewrite the goal whenever the user's requirements change so it always folds in every correction so far. ` +
 			`Never use it for simple or single-step requests, and do not repeat the plan in your reply — the interface already shows it.`,
 		async execute(args, ctx) {

--- a/src/lib/types/Plan.ts
+++ b/src/lib/types/Plan.ts
@@ -3,6 +3,12 @@ export type PlanStepStatus = "pending" | "in_progress" | "completed" | "skipped"
 export interface PlanStep {
 	step: string;
 	status: PlanStepStatus;
+	/**
+	 * Model-authored one-or-two-word name for compact progress displays (the ML
+	 * Assistant strip's dots and their accessible names). Absent on plans from
+	 * before the field existed; consumers fall back to cutting `step`.
+	 */
+	label?: string;
 }
 
 /**

--- a/src/lib/utils/consumeMessageUpdates.ts
+++ b/src/lib/utils/consumeMessageUpdates.ts
@@ -1,6 +1,7 @@
 import {
 	MessageUpdateStatus,
 	MessageUpdateType,
+	type MessagePlanUpdate,
 	type MessageStatusUpdate,
 	type MessageUpdate,
 } from "$lib/types/MessageUpdate";
@@ -18,6 +19,8 @@ export interface ConsumeContext {
 	onStreamStart: () => void;
 	onTitle: (title: string) => void;
 	onError: (update: MessageStatusUpdate) => void;
+	/** Fired on every plan snapshot, so mode UI can track progress outside the message. */
+	onPlan?: (update: MessagePlanUpdate) => void;
 }
 
 /**
@@ -151,6 +154,8 @@ export async function consumeMessageUpdates(
 			];
 		} else if (update.type === MessageUpdateType.RouterMetadata) {
 			message.routerMetadata = { route: update.route, model: update.model };
+		} else if (update.type === MessageUpdateType.Plan) {
+			ctx.onPlan?.(update);
 		}
 	}
 

--- a/src/lib/utils/pendingConversation.ts
+++ b/src/lib/utils/pendingConversation.ts
@@ -1,6 +1,7 @@
 import { browser } from "$app/environment";
 import type { Message } from "$lib/types/Message";
 import type { DeployedSpace } from "$lib/types/Conversation";
+import type { PlanState } from "$lib/types/Plan";
 
 // Payload shape of GET /api/v2/conversations/[id] (post superjson-parse),
 // shared by the page load and the create-conversation seed.
@@ -16,6 +17,7 @@ export interface ConversationData {
 	shared: boolean;
 	deployedSpaces?: Record<string, DeployedSpace>;
 	mlAssistant?: boolean;
+	plan?: PlanState;
 }
 
 // One-shot handoff of the conversation payload embedded in the create

--- a/src/lib/utils/planProgress.spec.ts
+++ b/src/lib/utils/planProgress.spec.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { planStepsToMlSteps } from "./planProgress";
+import type { PlanStep } from "$lib/types/Plan";
+
+describe("planStepsToMlSteps", () => {
+	it("maps every plan status onto the strip's lifecycle", () => {
+		const steps: PlanStep[] = [
+			{ step: "Baseline eval", status: "completed" },
+			{ step: "Finetune", status: "in_progress" },
+			{ step: "Compare runs", status: "pending" },
+			{ step: "Sweep seeds", status: "skipped" },
+		];
+		expect(planStepsToMlSteps(steps).map((s) => s.status)).toEqual([
+			"done",
+			"running",
+			"pending",
+			"skipped",
+		]);
+	});
+
+	it("keeps the full step text as the tooltip description", () => {
+		const [mapped] = planStepsToMlSteps([
+			{ step: "Design the social companion: pick platforms and handles", status: "pending" },
+		]);
+		expect(mapped.description).toBe("Design the social companion: pick platforms and handles");
+	});
+
+	it("cuts a short label from long step text and marks the cut", () => {
+		const [mapped] = planStepsToMlSteps([
+			{ step: "Design the social companion: pick platforms and handles", status: "pending" },
+		]);
+		expect(mapped.label.length).toBeLessThanOrEqual(25);
+		expect(mapped.label.endsWith("…")).toBe(true);
+	});
+
+	it("leaves a step that already fits untouched", () => {
+		const [mapped] = planStepsToMlSteps([{ step: "Baseline eval", status: "pending" }]);
+		expect(mapped.label).toBe("Baseline eval");
+		expect(mapped.statusLabel).toBe("Baseline eval");
+	});
+});

--- a/src/lib/utils/planProgress.spec.ts
+++ b/src/lib/utils/planProgress.spec.ts
@@ -38,4 +38,17 @@ describe("planStepsToMlSteps", () => {
 		expect(mapped.label).toBe("Baseline eval");
 		expect(mapped.statusLabel).toBe("Baseline eval");
 	});
+
+	it("prefers the model-authored label over any cut of the step text", () => {
+		const [mapped] = planStepsToMlSteps([
+			{
+				step: "Design the social companion: pick platforms and handles",
+				label: "Social design",
+				status: "in_progress",
+			},
+		]);
+		expect(mapped.label).toBe("Social design");
+		expect(mapped.statusLabel).toBe("Social design");
+		expect(mapped.description).toBe("Design the social companion: pick platforms and handles");
+	});
 });

--- a/src/lib/utils/planProgress.ts
+++ b/src/lib/utils/planProgress.ts
@@ -1,0 +1,33 @@
+import type { PlanStep } from "$lib/types/Plan";
+import type { MlPlanStep, MlPlanStepStatus } from "$lib/types/MlAssistant";
+
+const STATUS_MAP: Record<PlanStep["status"], MlPlanStepStatus> = {
+	pending: "pending",
+	in_progress: "running",
+	completed: "done",
+	skipped: "skipped",
+};
+
+const MAX_LABEL_CHARS = 24;
+const MAX_LABEL_WORDS = 3;
+
+/**
+ * A dot-sized name derived from the step text. The plan schema carries one
+ * string per step, so the strip's short labels are cut from it here; if the
+ * tool ever grows a model-authored label field, it supersedes this.
+ */
+function shortLabel(step: string): string {
+	const words = step.split(/\s+/).slice(0, MAX_LABEL_WORDS).join(" ");
+	const label = words.length > MAX_LABEL_CHARS ? `${words.slice(0, MAX_LABEL_CHARS - 1)}…` : words;
+	return label === step ? label : label.endsWith("…") ? label : `${label}…`;
+}
+
+/** update_plan steps in the shape the ML Assistant progress strip renders. */
+export function planStepsToMlSteps(steps: PlanStep[]): MlPlanStep[] {
+	return steps.map((step) => ({
+		label: shortLabel(step.step),
+		statusLabel: shortLabel(step.step),
+		description: step.step,
+		status: STATUS_MAP[step.status],
+	}));
+}

--- a/src/lib/utils/planProgress.ts
+++ b/src/lib/utils/planProgress.ts
@@ -12,9 +12,8 @@ const MAX_LABEL_CHARS = 24;
 const MAX_LABEL_WORDS = 3;
 
 /**
- * A dot-sized name derived from the step text. The plan schema carries one
- * string per step, so the strip's short labels are cut from it here; if the
- * tool ever grows a model-authored label field, it supersedes this.
+ * Fallback dot name cut from the step text, for plans persisted before the
+ * schema grew its model-authored `label` (or the odd update that omits one).
  */
 function shortLabel(step: string): string {
 	const words = step.split(/\s+/).slice(0, MAX_LABEL_WORDS).join(" ");
@@ -24,10 +23,13 @@ function shortLabel(step: string): string {
 
 /** update_plan steps in the shape the ML Assistant progress strip renders. */
 export function planStepsToMlSteps(steps: PlanStep[]): MlPlanStep[] {
-	return steps.map((step) => ({
-		label: shortLabel(step.step),
-		statusLabel: shortLabel(step.step),
-		description: step.step,
-		status: STATUS_MAP[step.status],
-	}));
+	return steps.map((step) => {
+		const label = step.label ?? shortLabel(step.step);
+		return {
+			label,
+			statusLabel: label,
+			description: step.step,
+			status: STATUS_MAP[step.status],
+		};
+	});
 }

--- a/src/routes/api/v2/conversations/[id]/+server.ts
+++ b/src/routes/api/v2/conversations/[id]/+server.ts
@@ -29,6 +29,7 @@ export const GET: RequestHandler = async ({ locals, params, url }) => {
 		shared: conversation.shared,
 		deployedSpaces: "deployedSpaces" in conversation ? conversation.deployedSpaces : undefined,
 		mlAssistant: "mlAssistant" in conversation ? conversation.mlAssistant : undefined,
+		plan: "plan" in conversation ? conversation.plan : undefined,
 	});
 };
 

--- a/src/routes/conversation/[id]/+page.svelte
+++ b/src/routes/conversation/[id]/+page.svelte
@@ -41,6 +41,9 @@
 	} from "$lib/utils/generationState";
 	import { useAPIClient, handleResponse } from "$lib/APIClient";
 	import SharePreviewTags from "$lib/components/SharePreviewTags.svelte";
+	import { mlAssistant } from "$lib/stores/mlAssistant.svelte";
+	import { ML_ASSISTANT_MODE } from "$lib/utils/mlAssistantFlag";
+	import { planStepsToMlSteps } from "$lib/utils/planProgress";
 
 	let { data } = $props();
 
@@ -334,6 +337,9 @@
 					resuming = false;
 				},
 				onTitle: (title) => convsStore.update(convId, { title }),
+				onPlan: (update) => {
+					if (ML_ASSISTANT_MODE) mlAssistant.setPlan(planStepsToMlSteps(update.steps));
+				},
 				onError: (update) => {
 					if (update.statusCode === 402) {
 						showSubscribeModal = true;
@@ -438,6 +444,9 @@
 					onAbort: () => controller.abort(),
 					onStreamStart: () => {},
 					onTitle: (title) => convsStore.update(runConvId, { title }),
+					onPlan: (update) => {
+						if (ML_ASSISTANT_MODE) mlAssistant.setPlan(planStepsToMlSteps(update.steps));
+					},
 					onError: (update) => {
 						$error = update.message ?? "An error has occurred";
 					},


### PR DESCRIPTION
Stacked on #2516 (targets `harness-update-plan-ui`; retarget as the stack merges). Wires the plan tool into the seam #2520 left for it: the `MlAssistantPlanProgress` dots strip now has a plan source.

## What this does

- **`planStepsToMlSteps`** (`src/lib/utils/planProgress.ts`): maps `PlanStep[]` onto the strip's `MlPlanStep` shape — statuses onto its lifecycle (`in_progress`→`running`, `completed`→`done`), the full step text as the dot's tooltip description, and a short word-boundary cut as the dot label / running status label. The plan schema carries one string per step, so labels are derived; a model-authored label field can supersede this later if dogfooding wants prettier dots.
- **Streaming**: `consumeMessageUpdates` gains an optional `onPlan` callback fired on every `MessageUpdateType.Plan` snapshot — one wiring point shared by the send and reattach paths, so both render identically. The conversation page passes `onPlan` → `mlAssistant.setPlan(...)`, guarded by the `ML_ASSISTANT_MODE` build constant so the branch folds out of flag-off builds.
- **Resume mid-plan**: the conversation payload now carries `plan` (the persisted `Conversation.plan` snapshot), and ChatWindow's existing `syncConversation` effect seeds the strip from it when a mode conversation is (re)opened — only when `syncConversation` actually reset, so live streamed steps are never clobbered and the adopt-after-create path keeps its streamed state. Exactly the wholesale-replacement semantics the store's `setPlan` documents.
- A run that hasn't reported a plan keeps the strip on its tool note (no placeholder emitted), per the strip's designed degradation.

## Tests
`planProgress.spec.ts` covers the status mapping, tooltip fidelity, and label cutting. Full suite green (795); `npm run check` 0 errors; svelte autofixer clean on the touched code.