### PR TITLE
Port the ML Intern doctrine into the ML Assistant preset

### DIFF
--- a/.env
+++ b/.env
@@ -171,11 +171,11 @@ MCP_DISABLE_ELICITATION=
 MCP_ELICITATION_TIMEOUT_MS=
 # How often (ms) to sweep for generations whose pod died mid-run and mark them
 # interrupted. Default 60000.
-PARKED_SWEEP_INTERVAL_MS=
+GENERATION_REAP_INTERVAL_MS=
 # How often to look for parked turns whose timer is due. Default 10000. The
 # interval is the floor on how late a wake can be, so it wants to stay well
 # below the shortest wait a tool can ask for.
-GENERATION_REAP_INTERVAL_MS=
+PARKED_SWEEP_INTERVAL_MS=
 # A run with no heartbeat for this long (ms) is presumed dead and finalized.
 # Must stay well above GENERATION_HEARTBEAT_MS or live runs get reaped. Default 90000.
 GENERATION_REAP_AFTER_MS=

--- a/.env
+++ b/.env
@@ -171,6 +171,10 @@ MCP_DISABLE_ELICITATION=
 MCP_ELICITATION_TIMEOUT_MS=
 # How often (ms) to sweep for generations whose pod died mid-run and mark them
 # interrupted. Default 60000.
+PARKED_SWEEP_INTERVAL_MS=
+# How often to look for parked turns whose timer is due. Default 10000. The
+# interval is the floor on how late a wake can be, so it wants to stay well
+# below the shortest wait a tool can ask for.
 GENERATION_REAP_INTERVAL_MS=
 # A run with no heartbeat for this long (ms) is presumed dead and finalized.
 # Must stay well above GENERATION_HEARTBEAT_MS or live runs get reaped. Default 90000.

--- a/src/lib/server/database.ts
+++ b/src/lib/server/database.ts
@@ -11,6 +11,7 @@ import type { SharedConversation } from "$lib/types/SharedConversation";
 import type { AbortedGeneration } from "$lib/types/AbortedGeneration";
 import type { Generation, GenerationEvent } from "$lib/types/Generation";
 import type { McpElicitation } from "$lib/types/McpElicitation";
+import type { ParkedCall } from "$lib/types/ParkedCall";
 import type { Settings } from "$lib/types/Settings";
 import type { User } from "$lib/types/User";
 import type { MessageEvent } from "$lib/types/MessageEvent";
@@ -139,6 +140,7 @@ export class Database {
 		const generations = db.collection<Generation>("generations");
 		const generationEvents = db.collection<GenerationEvent>("generationEvents");
 		const mcpElicitations = db.collection<McpElicitation>("mcpElicitations");
+		const parkedCalls = db.collection<ParkedCall>("parkedCalls");
 		const semaphores = db.collection<Semaphore>("semaphores");
 		const tokenCaches = db.collection<TokenCache>("tokens");
 		const configCollection = db.collection<ConfigKey>("config");
@@ -170,6 +172,7 @@ export class Database {
 			generations,
 			generationEvents,
 			mcpElicitations,
+			parkedCalls,
 			settings,
 			users,
 			sessions,
@@ -198,6 +201,7 @@ export class Database {
 			generations,
 			generationEvents,
 			mcpElicitations,
+			parkedCalls,
 			settings,
 			users,
 			sessions,
@@ -323,6 +327,23 @@ export class Database {
 		generationEvents
 			.createIndex({ createdAt: 1 }, { expireAfterSeconds: 24 * 60 * 60 })
 			.catch((e) => logger.error(e, "Error creating TTL index for generationEvents by createdAt"));
+
+		parkedCalls
+			.createIndex({ parkedCallId: 1 }, { unique: true })
+			.catch((e) => logger.error(e, "Error creating index for parkedCalls by parkedCallId"));
+		// The sweep itself: due rows, oldest first. Compound so a waiting row that is
+		// not yet due costs nothing to skip.
+		parkedCalls
+			.createIndex({ status: 1, resumeAt: 1 })
+			.catch((e) => logger.error(e, "Error creating index for parkedCalls by status and resumeAt"));
+		parkedCalls
+			.createIndex({ conversationId: 1 })
+			.catch((e) => logger.error(e, "Error creating index for parkedCalls by conversationId"));
+		// Rows outlive their usefulness once resumed; a week is long enough to debug a
+		// run and short enough that the collection stays small.
+		parkedCalls
+			.createIndex({ createdAt: 1 }, { expireAfterSeconds: 7 * 24 * 60 * 60 })
+			.catch((e) => logger.error(e, "Error creating TTL index for parkedCalls by createdAt"));
 
 		mcpElicitations
 			.createIndex({ elicitationId: 1 }, { unique: true })

--- a/src/lib/server/generation/applyUpdate.spec.ts
+++ b/src/lib/server/generation/applyUpdate.spec.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from "vitest";
+import { applyUpdateToMessage } from "./applyUpdate";
+import {
+	MessageReasoningUpdateType,
+	MessageToolUpdateType,
+	MessageUpdateStatus,
+	MessageUpdateType,
+	type MessageUpdate,
+} from "$lib/types/MessageUpdate";
+import type { Message } from "$lib/types/Message";
+
+const message = (over: Partial<Message> = {}): Message =>
+	({
+		id: "m1",
+		from: "assistant",
+		content: "",
+		updates: [],
+		createdAt: new Date(0),
+		updatedAt: new Date(0),
+		...over,
+	}) as Message;
+
+const ctx = (m: Message, initialContent = "", isRouterModel = false) => ({
+	message: m,
+	conv: { title: "New Chat" },
+	initialContent,
+	isRouterModel,
+});
+
+const toolCall: MessageUpdate = {
+	type: MessageUpdateType.Tool,
+	subtype: MessageToolUpdateType.Call,
+	uuid: "t1",
+	call: { name: "hf_jobs", parameters: {} },
+};
+
+describe("applyUpdateToMessage", () => {
+	it("drops an empty stream token entirely", () => {
+		// Not merely ignored for content: it must reach neither the updates array
+		// nor, by the caller's contract, the log or the client.
+		const m = message();
+		const applied = applyUpdateToMessage({ type: MessageUpdateType.Stream, token: "" }, ctx(m));
+
+		expect(applied.skipped).toBe(true);
+		expect(m.updates).toHaveLength(0);
+		expect(m.content).toBe("");
+	});
+
+	it("accumulates stream tokens and reasoning separately", () => {
+		const m = message();
+		applyUpdateToMessage({ type: MessageUpdateType.Stream, token: "he" }, ctx(m));
+		applyUpdateToMessage({ type: MessageUpdateType.Stream, token: "llo" }, ctx(m));
+		applyUpdateToMessage(
+			{
+				type: MessageUpdateType.Reasoning,
+				subtype: MessageReasoningUpdateType.Stream,
+				token: "hmm",
+			},
+			ctx(m)
+		);
+
+		expect(m.content).toBe("hello");
+		expect(m.reasoning).toBe("hmm");
+	});
+
+	it("strips think markers from a title and reports the change", () => {
+		const m = message();
+		const c = ctx(m);
+		const applied = applyUpdateToMessage(
+			{ type: MessageUpdateType.Title, title: "<think>Python string reversal</think>" },
+			c
+		);
+
+		expect(applied.titleChanged).toBe(true);
+		expect(c.conv.title).toBe("Python string reversal");
+	});
+
+	it("replaces streamed text with the final answer when no tool ran", () => {
+		const m = message({ content: "partial" });
+		applyUpdateToMessage(
+			{ type: MessageUpdateType.FinalAnswer, text: "the answer", interrupted: false },
+			ctx(m)
+		);
+
+		expect(m.content).toBe("the answer");
+	});
+
+	describe("merging a final answer with pre-tool content", () => {
+		// Providers stream text, call a tool, then answer with something else. The
+		// pre-tool text is the user's, not a draft to be overwritten.
+		it("A: keeps what was streamed when the final text repeats it", () => {
+			const m = message({ content: "a story", updates: [toolCall] });
+			applyUpdateToMessage(
+				{ type: MessageUpdateType.FinalAnswer, text: "story", interrupted: false },
+				ctx(m)
+			);
+
+			expect(m.content).toBe("a story");
+		});
+
+		it("B: uses the final text verbatim when it already contains the prefix", () => {
+			const m = message({ content: "a story", updates: [toolCall] });
+			applyUpdateToMessage(
+				{ type: MessageUpdateType.FinalAnswer, text: "a story and more", interrupted: false },
+				ctx(m)
+			);
+
+			expect(m.content).toBe("a story and more");
+		});
+
+		it("C: joins them with a paragraph break otherwise", () => {
+			const m = message({ content: "a story", updates: [toolCall] });
+			applyUpdateToMessage(
+				{ type: MessageUpdateType.FinalAnswer, text: "a caption", interrupted: false },
+				ctx(m)
+			);
+
+			expect(m.content).toBe("a story\n\na caption");
+		});
+
+		it("does not add a second gap when one is already there", () => {
+			const m = message({ content: "a story\n\n", updates: [toolCall] });
+			applyUpdateToMessage(
+				{ type: MessageUpdateType.FinalAnswer, text: "a caption", interrupted: false },
+				ctx(m)
+			);
+
+			expect(m.content).toBe("a story\n\na caption");
+		});
+	});
+
+	it("leaves content from earlier rounds of the same message alone", () => {
+		// The case a resumed turn depends on: the message already says something,
+		// and this turn's final answer replaces only what this turn produced.
+		const m = message({ content: "earlier work. new bit", updates: [toolCall] });
+		applyUpdateToMessage(
+			{ type: MessageUpdateType.FinalAnswer, text: "conclusion", interrupted: false },
+			ctx(m, "earlier work. ")
+		);
+
+		expect(m.content).toBe("earlier work. new bit\n\nconclusion");
+	});
+
+	it("records the interrupted flag", () => {
+		const m = message();
+		applyUpdateToMessage(
+			{ type: MessageUpdateType.FinalAnswer, text: "cut short", interrupted: true },
+			ctx(m)
+		);
+
+		expect(m.interrupted).toBe(true);
+	});
+
+	it("keeps keepalives out of the updates array", () => {
+		const m = message();
+		applyUpdateToMessage(
+			{ type: MessageUpdateType.Status, status: MessageUpdateStatus.KeepAlive },
+			ctx(m)
+		);
+
+		expect(m.updates).toHaveLength(0);
+	});
+
+	it("merges router metadata for a router model and provider alone otherwise", () => {
+		const router = message();
+		applyUpdateToMessage(
+			{ type: MessageUpdateType.RouterMetadata, route: "omni", model: "big" },
+			ctx(router, "", true)
+		);
+		applyUpdateToMessage(
+			{ type: MessageUpdateType.RouterMetadata, route: "", model: "", provider: "together" },
+			ctx(router, "", true)
+		);
+		expect(router.routerMetadata).toEqual({ route: "omni", model: "big", provider: "together" });
+
+		const plain = message();
+		applyUpdateToMessage(
+			{
+				type: MessageUpdateType.RouterMetadata,
+				route: "ignored",
+				model: "ignored",
+				provider: "hf-inference",
+			},
+			ctx(plain, "", false)
+		);
+		expect(plain.routerMetadata).toEqual({ route: "", model: "", provider: "hf-inference" });
+	});
+});

--- a/src/lib/server/generation/applyUpdate.ts
+++ b/src/lib/server/generation/applyUpdate.ts
@@ -54,27 +54,18 @@ export function applyUpdateToMessage(
 	if (event.type === MessageUpdateType.Stream) {
 		if (event.token === "") return SKIPPED;
 		message.content += event.token;
-	}
-
-	// Append reasoning stream tokens to message.reasoning (server-side)
-	else if (
+	} else if (
 		event.type === MessageUpdateType.Reasoning &&
 		event.subtype === MessageReasoningUpdateType.Stream &&
 		"token" in event
 	) {
 		message.reasoning ??= "";
 		message.reasoning += event.token;
-	}
-
-	// Set the title
-	else if (event.type === MessageUpdateType.Title) {
-		// Always strip <think> markers from titles when saving
+	} else if (event.type === MessageUpdateType.Title) {
+		// A reasoning model will put think markers in a title if nothing removes them.
 		conv.title = event.title.replace(/<\/?think>/gi, "").trim();
 		titleChanged = true;
-	}
-
-	// Set the final text and the interrupted flag
-	else if (event.type === MessageUpdateType.FinalAnswer) {
+	} else if (event.type === MessageUpdateType.FinalAnswer) {
 		message.interrupted = event.interrupted;
 		// Default behavior: replace the streamed text with the provider's final text.
 		// However, when tools (MCP/function calls) were used, providers often stream
@@ -109,18 +100,12 @@ export function applyUpdateToMessage(
 			message.content = initialContent + event.text;
 		}
 		finalAnswerReceived = true;
-	}
-
-	// Add file
-	else if (event.type === MessageUpdateType.File) {
+	} else if (event.type === MessageUpdateType.File) {
 		message.files = [
 			...(message.files ?? []),
 			{ type: "hash", name: event.name, value: event.sha, mime: event.mime },
 		];
-	}
-
-	// Store router metadata (for router models) or provider info (for all models)
-	else if (event.type === MessageUpdateType.RouterMetadata) {
+	} else if (event.type === MessageUpdateType.RouterMetadata) {
 		// Merge metadata updates to preserve existing fields (router may send route/model
 		// first, then provider comes later)
 		if (isRouterModel) {
@@ -129,9 +114,7 @@ export function applyUpdateToMessage(
 				model: event.model || message.routerMetadata?.model || "",
 				provider: event.provider || message.routerMetadata?.provider,
 			};
-		}
-		// Store provider-only metadata for non-router models if available
-		else if (event.provider) {
+		} else if (event.provider) {
 			message.routerMetadata = {
 				route: message.routerMetadata?.route || "",
 				model: message.routerMetadata?.model || "",

--- a/src/lib/server/generation/applyUpdate.ts
+++ b/src/lib/server/generation/applyUpdate.ts
@@ -1,0 +1,154 @@
+import {
+	MessageReasoningUpdateType,
+	MessageUpdateStatus,
+	MessageUpdateType,
+	type MessageUpdate,
+} from "$lib/types/MessageUpdate";
+import type { Conversation } from "$lib/types/Conversation";
+import type { Message } from "$lib/types/Message";
+
+export interface ApplyUpdateContext {
+	/** The assistant message this turn writes into. Mutated in place. */
+	message: Message;
+	/** Mutated in place for title only; persisting it is the caller's job. */
+	conv: Pick<Conversation, "title">;
+	/**
+	 * Content the message already had when the turn began. A resumed turn continues
+	 * a message that is not empty, and the final answer replaces only what this turn
+	 * produced — not what an earlier round of the same message already said.
+	 */
+	initialContent: string;
+	/** Router models record route+model; everything else records provider alone. */
+	isRouterModel: boolean;
+}
+
+export interface AppliedUpdate {
+	/** An empty stream token is not an event: the caller must drop it entirely. */
+	skipped: boolean;
+	/** `conv.title` changed and wants persisting. */
+	titleChanged: boolean;
+	finalAnswerReceived: boolean;
+}
+
+const SKIPPED: AppliedUpdate = { skipped: true, titleChanged: false, finalAnswerReceived: false };
+
+/**
+ * Fold one update into the message a turn is building.
+ *
+ * Extracted from the conversation route so a turn woken by the sweeper persists
+ * the same way a turn driven by an HTTP request does. Two implementations of this
+ * would drift, and drift here means messages that persist subtly wrong — the
+ * pre-tool merge below is exactly the kind of hard-won rule that gets lost.
+ *
+ * Deliberately does no I/O: the title write, the generation writer, metrics, the
+ * wire padding and the SSE enqueue all stay with their callers, because those
+ * differ between an HTTP turn and a swept one.
+ */
+export function applyUpdateToMessage(
+	event: MessageUpdate,
+	{ message, conv, initialContent, isRouterModel }: ApplyUpdateContext
+): AppliedUpdate {
+	let titleChanged = false;
+	let finalAnswerReceived = false;
+
+	if (event.type === MessageUpdateType.Stream) {
+		if (event.token === "") return SKIPPED;
+		message.content += event.token;
+	}
+
+	// Append reasoning stream tokens to message.reasoning (server-side)
+	else if (
+		event.type === MessageUpdateType.Reasoning &&
+		event.subtype === MessageReasoningUpdateType.Stream &&
+		"token" in event
+	) {
+		message.reasoning ??= "";
+		message.reasoning += event.token;
+	}
+
+	// Set the title
+	else if (event.type === MessageUpdateType.Title) {
+		// Always strip <think> markers from titles when saving
+		conv.title = event.title.replace(/<\/?think>/gi, "").trim();
+		titleChanged = true;
+	}
+
+	// Set the final text and the interrupted flag
+	else if (event.type === MessageUpdateType.FinalAnswer) {
+		message.interrupted = event.interrupted;
+		// Default behavior: replace the streamed text with the provider's final text.
+		// However, when tools (MCP/function calls) were used, providers often stream
+		// some content (e.g., a story) before triggering tools, then return a
+		// different follow-up message afterwards (e.g., an image caption). Our
+		// previous logic overwrote the pre-tool content. Preserve it by merging in
+		// the pre-tool stream when tool updates occurred and the final text does
+		// not already include the streamed prefix.
+		const hadTools = (message.updates ?? []).some((u) => u.type === MessageUpdateType.Tool);
+
+		if (hadTools) {
+			const existing = message.content.slice(initialContent.length);
+			if (existing && existing.length > 0) {
+				// A. If we already streamed the same final text, keep as-is.
+				if (event.text && existing.endsWith(event.text)) {
+					message.content = initialContent + existing;
+				}
+				// B. If the final text already includes the streamed prefix, use it verbatim.
+				else if (event.text && event.text.startsWith(existing)) {
+					message.content = initialContent + event.text;
+				}
+				// C. Otherwise, merge with a paragraph break for readability.
+				else {
+					const needsGap = !/\n\n$/.test(existing) && !/^\n/.test(event.text ?? "");
+					message.content =
+						initialContent + existing + (needsGap ? "\n\n" : "") + (event.text ?? "");
+				}
+			} else {
+				message.content = initialContent + (event.text ?? "");
+			}
+		} else {
+			message.content = initialContent + event.text;
+		}
+		finalAnswerReceived = true;
+	}
+
+	// Add file
+	else if (event.type === MessageUpdateType.File) {
+		message.files = [
+			...(message.files ?? []),
+			{ type: "hash", name: event.name, value: event.sha, mime: event.mime },
+		];
+	}
+
+	// Store router metadata (for router models) or provider info (for all models)
+	else if (event.type === MessageUpdateType.RouterMetadata) {
+		// Merge metadata updates to preserve existing fields (router may send route/model
+		// first, then provider comes later)
+		if (isRouterModel) {
+			message.routerMetadata = {
+				route: event.route || message.routerMetadata?.route || "",
+				model: event.model || message.routerMetadata?.model || "",
+				provider: event.provider || message.routerMetadata?.provider,
+			};
+		}
+		// Store provider-only metadata for non-router models if available
+		else if (event.provider) {
+			message.routerMetadata = {
+				route: message.routerMetadata?.route || "",
+				model: message.routerMetadata?.model || "",
+				provider: event.provider,
+			};
+		}
+	}
+
+	// Append updates for audit/replay (streams too, to preserve ordering)
+	if (!(
+		event.type === MessageUpdateType.Status && event.status === MessageUpdateStatus.KeepAlive
+	)) {
+		message.updates ??= [];
+		message.updates.push(event.type === MessageUpdateType.Stream ? { ...event } : event);
+	}
+
+	message.updatedAt = new Date();
+
+	return { skipped: false, titleChanged, finalAnswerReceived };
+}

--- a/src/lib/server/generation/compressUpdates.spec.ts
+++ b/src/lib/server/generation/compressUpdates.spec.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { compressUpdatesForStorage } from "./compressUpdates";
+import {
+	MessageToolUpdateType,
+	MessageUpdateStatus,
+	MessageUpdateType,
+} from "$lib/types/MessageUpdate";
+import type { MessageUpdate } from "$lib/types/MessageUpdate";
+
+const call = (uuid: string): MessageUpdate => ({
+	type: MessageUpdateType.Tool,
+	subtype: MessageToolUpdateType.Call,
+	uuid,
+	call: { name: "hf_jobs", parameters: {} },
+});
+const progress = (uuid: string): MessageUpdate =>
+	({
+		type: MessageUpdateType.Tool,
+		subtype: MessageToolUpdateType.Progress,
+		uuid,
+		progress: 1,
+	}) as unknown as MessageUpdate;
+const result = (uuid: string): MessageUpdate =>
+	({
+		type: MessageUpdateType.Tool,
+		subtype: MessageToolUpdateType.Result,
+		uuid,
+		result: { status: 0, call: { name: "hf_jobs", parameters: {} }, outputs: [] },
+	}) as unknown as MessageUpdate;
+const token = (text: string): MessageUpdate => ({ type: MessageUpdateType.Stream, token: text });
+const keepAlive: MessageUpdate = {
+	type: MessageUpdateType.Status,
+	status: MessageUpdateStatus.KeepAlive,
+};
+
+describe("compressUpdatesForStorage", () => {
+	it("drops progress notifications but keeps the call and its result", () => {
+		// Progress is live-only: 59,487 of one real message's 73,994 updates were
+		// progress ticks, and a stored tick tells a reader nothing the result does
+		// not. Dropping them is what keeps a polling run inside Mongo's 16MB
+		// document limit, past which the conversation can never be written again.
+		const compressed = compressUpdatesForStorage([
+			call("a"),
+			...Array.from({ length: 500 }, () => progress("a")),
+			result("a"),
+		]);
+
+		expect(compressed).toHaveLength(2);
+		expect(compressed?.map((u) => u.type === MessageUpdateType.Tool && u.subtype)).toEqual([
+			MessageToolUpdateType.Call,
+			MessageToolUpdateType.Result,
+		]);
+	});
+
+	it("still drops keepalives and still stores stream tokens as length markers", () => {
+		const compressed = compressUpdatesForStorage([keepAlive, token("hello"), call("a")]);
+
+		expect(compressed).toHaveLength(2);
+		const [stream] = compressed ?? [];
+		expect(stream).toMatchObject({ type: MessageUpdateType.Stream, token: "", len: 5 });
+	});
+
+	it("keeps a normal message untouched apart from that", () => {
+		const updates = [call("a"), result("a"), call("b"), result("b")];
+		expect(compressUpdatesForStorage(updates)).toEqual(updates);
+	});
+
+	it("sheds stream markers before tool history when over the cap", () => {
+		// The text itself lives on the message; a marker only says where a tool
+		// card sat relative to it. The calls and results are the transcript.
+		const updates = [
+			...Array.from({ length: 6000 }, (_, i) => token(`t${i}`)),
+			...Array.from({ length: 100 }, (_, i) => call(`c${i}`)),
+		];
+
+		const compressed = compressUpdatesForStorage(updates) ?? [];
+
+		expect(compressed).toHaveLength(100);
+		expect(compressed.every((u) => u.type === MessageUpdateType.Tool)).toBe(true);
+	});
+
+	it("keeps the most recent tool history when even that is over the cap", () => {
+		const updates = Array.from({ length: 6000 }, (_, i) => call(`c${i}`));
+
+		const compressed = compressUpdatesForStorage(updates) ?? [];
+
+		expect(compressed).toHaveLength(5000);
+		// The tail, not the head: a truncated transcript should end where the run did.
+		expect(compressed.at(-1)).toEqual(call("c5999"));
+	});
+
+	it("handles an absent updates array", () => {
+		expect(compressUpdatesForStorage(undefined)).toEqual([]);
+	});
+});

--- a/src/lib/server/generation/compressUpdates.ts
+++ b/src/lib/server/generation/compressUpdates.ts
@@ -1,0 +1,66 @@
+import { logger } from "$lib/server/logger";
+import {
+	MessageToolUpdateType,
+	MessageUpdateStatus,
+	MessageUpdateType,
+	type MessageStreamUpdate,
+} from "$lib/types/MessageUpdate";
+import type { Message } from "$lib/types/Message";
+
+/**
+ * A conversation is one MongoDB document, and Mongo caps a document at 16MB.
+ * Past that ceiling every write to it fails — not slowly, permanently: the
+ * conversation can never be added to again.
+ *
+ * That ceiling is reachable. One ML Assistant run polling a training job
+ * produced a single assistant message carrying 73,994 updates and 15.1MB, of
+ * which 59,487 were MCP progress notifications. Progress is live-only UI: once
+ * the result is stored, a progress tick tells a reader nothing the result does
+ * not, and it is replayed to the browser on every load forever.
+ *
+ * So progress is dropped here rather than merely rendered cheaply. The cap below
+ * is the backstop for whatever the next unbounded emitter turns out to be.
+ */
+const MAX_PERSISTED_UPDATES = 5_000;
+
+/**
+ * Shape a message's updates for storage: drop keepalives and live-only progress,
+ * and replace each stream token with a length marker (content is stored
+ * separately), preserving ordering without duplicating text. Shared by the full
+ * save and the writer's incremental materialise so both persist the same thing
+ * under materializedSeq.
+ *
+ * Only what is *persisted* changes. Everything still streams to the connected
+ * client as it always did.
+ */
+export function compressUpdatesForStorage(updates: Message["updates"]): Message["updates"] {
+	const kept = (updates ?? [])
+		.filter(
+			(u) =>
+				!(u.type === MessageUpdateType.Status && u.status === MessageUpdateStatus.KeepAlive) &&
+				!(u.type === MessageUpdateType.Tool && u.subtype === MessageToolUpdateType.Progress)
+		)
+		.map((u) => {
+			if (u.type !== MessageUpdateType.Stream) return u;
+			const len = u.len ?? (u.token ?? "").length;
+			return { type: MessageUpdateType.Stream, token: "", len } satisfies MessageStreamUpdate;
+		});
+
+	if (kept.length <= MAX_PERSISTED_UPDATES) return kept;
+
+	// Over the cap, stream markers go first: they carry no text — that lives on
+	// the message — and only preserve where tool cards sit relative to it. The
+	// tool calls and their results ARE the transcript, so they are the last thing
+	// to go, and even then the most recent survive.
+	const withoutStreamMarkers = kept.filter((u) => u.type !== MessageUpdateType.Stream);
+	const capped =
+		withoutStreamMarkers.length <= MAX_PERSISTED_UPDATES
+			? withoutStreamMarkers
+			: withoutStreamMarkers.slice(-MAX_PERSISTED_UPDATES);
+
+	logger.warn(
+		{ before: updates?.length ?? 0, after: capped.length, cap: MAX_PERSISTED_UPDATES },
+		"[generation] message updates exceeded the persistence cap and were truncated"
+	);
+	return capped;
+}

--- a/src/lib/server/generation/parkedSweeper.spec.ts
+++ b/src/lib/server/generation/parkedSweeper.spec.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import { ObjectId } from "mongodb";
+import { collections, ready } from "$lib/server/database";
+import { sweepParkedCalls } from "./parkedSweeper";
+import type { ParkedCall } from "$lib/types/ParkedCall";
+
+const park = (over: Partial<ParkedCall> = {}): ParkedCall => ({
+	_id: new ObjectId(),
+	parkedCallId: new ObjectId().toString(),
+	conversationId: new ObjectId(),
+	messageId: "msg-1",
+	toolCallId: "call-1",
+	toolUuid: "uuid-1",
+	kind: "timer",
+	status: "waiting",
+	// Due unless a test says otherwise.
+	resumeAt: new Date(Date.now() - 1_000),
+	reason: "training job to reach step 1000",
+	attempts: 0,
+	createdAt: new Date(Date.now() - 60_000),
+	updatedAt: new Date(Date.now() - 60_000),
+	...over,
+});
+
+beforeAll(async () => {
+	await ready;
+});
+
+afterEach(async () => {
+	await collections.parkedCalls.deleteMany({});
+});
+
+describe("sweepParkedCalls", () => {
+	it("leaves a row alone until its timer is due", async () => {
+		await collections.parkedCalls.insertOne(park({ resumeAt: new Date(Date.now() + 60_000) }));
+
+		await sweepParkedCalls();
+
+		const row = await collections.parkedCalls.findOne({});
+		expect(row?.status).toBe("waiting");
+		expect(row?.attempts).toBe(0);
+	});
+
+	it("abandons a due row whose conversation is gone, instead of retrying forever", async () => {
+		// The conversation id points at nothing, which is the shape of a deleted chat.
+		await collections.parkedCalls.insertOne(park());
+
+		await sweepParkedCalls();
+
+		const row = await collections.parkedCalls.findOne({});
+		expect(row?.status).toBe("abandoned");
+		expect(row?.abandonedReason).toBe("conversation is gone");
+	});
+
+	it("claims each due row exactly once", async () => {
+		// The claim is what stops two pods waking the same turn: the status is in the
+		// filter, so a racing sweep finds the row already out of `waiting`.
+		await collections.parkedCalls.insertMany([park(), park(), park()]);
+
+		await Promise.all([sweepParkedCalls(), sweepParkedCalls()]);
+
+		const rows = await collections.parkedCalls.find({}).toArray();
+		expect(rows).toHaveLength(3);
+		expect(rows.every((r) => r.status === "abandoned")).toBe(true);
+		// One claim each. A second claim would have incremented past 1.
+		expect(rows.map((r) => r.attempts)).toEqual([1, 1, 1]);
+	});
+
+	it("gives up on a row that keeps failing to resume", async () => {
+		await collections.parkedCalls.insertOne(park({ attempts: 3 }));
+
+		await sweepParkedCalls();
+
+		const row = await collections.parkedCalls.findOne({});
+		expect(row?.status).toBe("abandoned");
+		expect(row?.abandonedReason).toContain("gave up");
+	});
+});

--- a/src/lib/server/generation/parkedSweeper.spec.ts
+++ b/src/lib/server/generation/parkedSweeper.spec.ts
@@ -66,6 +66,34 @@ describe("sweepParkedCalls", () => {
 		expect(rows.map((r) => r.attempts)).toEqual([1, 1, 1]);
 	});
 
+	it("reclaims a claim whose lease expired", async () => {
+		// A resume that dies before its own error handling — or a pod that dies at
+		// any point — leaves the row in `resuming`. Without a lease it sits there
+		// until the TTL removes it, and the attempt ceiling never applies.
+		await collections.parkedCalls.insertOne(
+			park({ status: "resuming", takenAt: new Date(Date.now() - 10 * 60_000), attempts: 1 })
+		);
+
+		await sweepParkedCalls();
+
+		const row = await collections.parkedCalls.findOne({});
+		expect(row?.attempts).toBe(2);
+		expect(row?.status).toBe("abandoned");
+	});
+
+	it("leaves a claim alone while its lease holds", async () => {
+		// Otherwise two sweepers a few seconds apart both resume the same turn.
+		await collections.parkedCalls.insertOne(
+			park({ status: "resuming", takenAt: new Date(), attempts: 1 })
+		);
+
+		await sweepParkedCalls();
+
+		const row = await collections.parkedCalls.findOne({});
+		expect(row?.status).toBe("resuming");
+		expect(row?.attempts).toBe(1);
+	});
+
 	it("gives up on a row that keeps failing to resume", async () => {
 		await collections.parkedCalls.insertOne(park({ attempts: 3 }));
 

--- a/src/lib/server/generation/parkedSweeper.ts
+++ b/src/lib/server/generation/parkedSweeper.ts
@@ -33,12 +33,28 @@ function sweepIntervalMs(): number {
 }
 
 /**
+ * How long a claim holds a row before another sweeper may take it. A resume that
+ * dies between the claim and its own error handling — or a pod that dies at any
+ * point — would otherwise strand the row in `resuming` until the TTL removed it,
+ * and `attempts` would never reach the retry ceiling it exists to enforce.
+ */
+const CLAIM_LEASE_MS = 5 * 60_000;
+
+/**
  * Claim one due row. The filter carries the status, so two pods racing on the
- * same row produce one winner and one miss rather than two resumed turns.
+ * same row produce one winner and one miss rather than two resumed turns. A
+ * claim whose lease has expired is fair game again, which is what makes the
+ * attempt counter meaningful.
  */
 async function claimDueCall(now: Date): Promise<ParkedCall | null> {
 	const claimed = await collections.parkedCalls.findOneAndUpdate(
-		{ status: "waiting", resumeAt: { $lte: now } },
+		{
+			resumeAt: { $lte: now },
+			$or: [
+				{ status: "waiting" },
+				{ status: "resuming", takenAt: { $lt: new Date(now.getTime() - CLAIM_LEASE_MS) } },
+			],
+		},
 		{ $set: { status: "resuming", takenAt: now, updatedAt: now }, $inc: { attempts: 1 } },
 		{ sort: { resumeAt: 1 }, returnDocument: "after" }
 	);
@@ -113,6 +129,15 @@ export async function resumeParkedCall(park: ParkedCall): Promise<void> {
 	const initialContent = message.content;
 	const promptedAt = new Date();
 	const abortController = new AbortController();
+
+	// The browser finds a running turn through the last assistant message's
+	// generationId. A resumed run that leaves the parked turn's id in place is
+	// invisible: its output only appears on a manual refresh.
+	message.generationId = generationId;
+	await collections.conversations.updateOne(
+		{ _id: conv._id, "messages.id": message.id },
+		{ $set: { "messages.$.generationId": generationId, updatedAt: new Date() } }
+	);
 
 	const writer = await createGenerationWriter({
 		generationId,
@@ -206,7 +231,17 @@ export async function resumeParkedCall(park: ParkedCall): Promise<void> {
 		};
 
 		for await (const event of textGeneration(ctx)) apply(event);
-		apply({ type: MessageUpdateType.Status, status: MessageUpdateStatus.Finished });
+		// A resumed turn may park again — on another wait, or on a question. Calling
+		// it finished would tell the client the work is over while a row sits waiting
+		// to wake it.
+		const parkedAgain = await collections.parkedCalls.countDocuments({
+			conversationId: conv._id,
+			messageId: message.id,
+			status: "waiting",
+		});
+		if (parkedAgain === 0) {
+			apply({ type: MessageUpdateType.Status, status: MessageUpdateStatus.Finished });
+		}
 	} catch (err) {
 		hasError = true;
 		logger.error({ err, parkedCallId: park.parkedCallId }, "[parked] resumed turn failed");

--- a/src/lib/server/generation/parkedSweeper.ts
+++ b/src/lib/server/generation/parkedSweeper.ts
@@ -1,0 +1,263 @@
+import { randomUUID } from "crypto";
+import { collections } from "$lib/server/database";
+import { config } from "$lib/server/config";
+import { logger } from "$lib/server/logger";
+import { onExit } from "$lib/server/exitHandler";
+import { models } from "$lib/server/models";
+import { buildSubtree } from "$lib/utils/tree/buildSubtree";
+import { textGeneration } from "$lib/server/textGeneration";
+import { isMlAssistantConversation } from "$lib/server/mlAssistant";
+import { ML_ASSISTANT_EFFORT } from "$lib/constants/mlAssistant";
+import { waitResumeResultText } from "$lib/server/textGeneration/builtinTools/waitTool";
+import { ToolResultStatus } from "$lib/types/Tool";
+import {
+	MessageToolUpdateType,
+	MessageUpdateStatus,
+	MessageUpdateType,
+	type MessageUpdate,
+} from "$lib/types/MessageUpdate";
+import type { ParkedCall } from "$lib/types/ParkedCall";
+import type { TextGenerationContext } from "$lib/server/textGeneration/types";
+import { createGenerationWriter } from "./writer";
+import { applyUpdateToMessage } from "./applyUpdate";
+import { compressUpdatesForStorage } from "./compressUpdates";
+
+const SWEEP_BATCH = 5;
+/** A row this many attempts deep is not going to resume; stop burning turns on it. */
+const MAX_ATTEMPTS = 3;
+
+function sweepIntervalMs(): number {
+	const raw = config.PARKED_SWEEP_INTERVAL_MS;
+	const parsed = raw ? parseInt(raw, 10) : NaN;
+	return !isNaN(parsed) && parsed > 0 ? parsed : 10_000;
+}
+
+/**
+ * Claim one due row. The filter carries the status, so two pods racing on the
+ * same row produce one winner and one miss rather than two resumed turns.
+ */
+async function claimDueCall(now: Date): Promise<ParkedCall | null> {
+	const claimed = await collections.parkedCalls.findOneAndUpdate(
+		{ status: "waiting", resumeAt: { $lte: now } },
+		{ $set: { status: "resuming", takenAt: now, updatedAt: now }, $inc: { attempts: 1 } },
+		{ sort: { resumeAt: 1 }, returnDocument: "after" }
+	);
+	// Driver v5: findOneAndUpdate returns ModifyResult unless told otherwise.
+	return claimed?.value ?? null;
+}
+
+async function abandon(park: ParkedCall, reason: string): Promise<void> {
+	logger.warn({ parkedCallId: park.parkedCallId, reason }, "[parked] abandoning a parked call");
+	await collections.parkedCalls.updateOne(
+		{ _id: park._id },
+		{ $set: { status: "abandoned", abandonedReason: reason, updatedAt: new Date() } }
+	);
+}
+
+/**
+ * Rebuild the identity the parked turn ran as. There is no request to read one
+ * from, so it comes from the row and the stored session — which also means a
+ * resume can only ever act as the user who parked it.
+ *
+ * An expired token is not a reason to drop the turn: the model is told, in the
+ * tool result, so it can say so rather than failing opaquely on the first call.
+ */
+async function rebuildIdentity(park: ParkedCall) {
+	const user = park.userId
+		? ((await collections.users.findOne({ _id: park.userId })) ?? undefined)
+		: undefined;
+
+	const session = park.userId
+		? await collections.sessions.find({ userId: park.userId }).sort({ updatedAt: -1 }).next()
+		: park.sessionId
+			? await collections.sessions.findOne({ sessionId: park.sessionId })
+			: null;
+
+	const token = session?.oauth?.token;
+	const tokenExpired = Boolean(token?.expiresAt && token.expiresAt.getTime() <= Date.now());
+	const settings = await collections.settings.findOne(
+		park.userId ? { userId: park.userId } : { sessionId: park.sessionId ?? "" }
+	);
+
+	return {
+		locals: {
+			user,
+			sessionId: session?.sessionId ?? park.sessionId ?? "",
+			isAdmin: false,
+			...(token?.value && !tokenExpired ? { token: token.value } : {}),
+			...(settings?.billingOrganization
+				? { billingOrganization: settings.billingOrganization }
+				: {}),
+		} as unknown as App.Locals,
+		settings,
+		tokenExpired: tokenExpired || !token?.value,
+	};
+}
+
+/** Wake one parked turn: inject the tool result it parked on, then let it continue. */
+export async function resumeParkedCall(park: ParkedCall): Promise<void> {
+	const conv = await collections.conversations.findOne({ _id: park.conversationId });
+	if (!conv) return abandon(park, "conversation is gone");
+
+	const message = conv.messages.find((m) => m.id === park.messageId);
+	if (!message || message.from !== "assistant") {
+		return abandon(park, "no parked assistant message to resume");
+	}
+
+	const model = models.find((m) => m.id === conv.model);
+	if (!model) return abandon(park, `model ${conv.model} is no longer available`);
+
+	const { locals, settings, tokenExpired } = await rebuildIdentity(park);
+
+	const generationId = randomUUID();
+	const initialContent = message.content;
+	const promptedAt = new Date();
+	const abortController = new AbortController();
+
+	const writer = await createGenerationWriter({
+		generationId,
+		conversationId: conv._id,
+		messageId: message.id,
+		...(park.userId ? { userId: park.userId } : {}),
+		...(locals.sessionId ? { sessionId: locals.sessionId } : {}),
+		snapshot: () => ({
+			content: message.content,
+			reasoning: message.reasoning,
+			files: message.files,
+			routerMetadata: message.routerMetadata,
+			updates: compressUpdatesForStorage(message.updates),
+		}),
+	});
+
+	const apply = (event: MessageUpdate) => {
+		const applied = applyUpdateToMessage(event, {
+			message,
+			conv,
+			initialContent,
+			isRouterModel: Boolean(model.isRouter),
+		});
+		if (applied.skipped) return;
+		writer.push(event);
+	};
+
+	const persist = async () => {
+		message.materializedSeq = writer.currentSeq();
+		await collections.conversations.updateOne(
+			{ _id: conv._id },
+			{
+				$set: {
+					messages: conv.messages.map((m) => ({
+						...m,
+						updates: compressUpdatesForStorage(m.updates),
+					})),
+					title: conv.title,
+					updatedAt: new Date(),
+				},
+			}
+		);
+	};
+
+	let hasError = false;
+	try {
+		// The result the parked call has been missing. Replay pairs it with the call
+		// by uuid, which is what puts it in the model's history for the next round.
+		apply({
+			type: MessageUpdateType.Tool,
+			subtype: MessageToolUpdateType.Result,
+			uuid: park.toolUuid,
+			result: {
+				status: ToolResultStatus.Success,
+				call: { name: "wait", parameters: {} },
+				outputs: [
+					{
+						text:
+							waitResumeResultText(park) +
+							(tokenExpired
+								? " NOTE: the signed-in session expired while you waited, so Hub tools may " +
+									"be unauthenticated. If one fails that way, say so rather than retrying."
+								: ""),
+					},
+				] as unknown as Record<string, unknown>[],
+				display: true,
+			},
+		});
+
+		const ctx: TextGenerationContext = {
+			model,
+			endpoint: await model.getEndpoint(),
+			conv,
+			messages: buildSubtree(conv, message.id),
+			promptedAt,
+			ip: "sweeper",
+			username: locals.user?.username,
+			provider:
+				config.isHuggingChat && !model.isRouter
+					? settings?.providerOverrides?.[model.id]
+					: undefined,
+			reasoningEffort: isMlAssistantConversation(conv)
+				? ML_ASSISTANT_EFFORT
+				: settings?.reasoningEffortOverrides?.[model.id],
+			reasoningOverride: settings?.reasoningOverrides?.[model.id],
+			artifactsOverride: settings?.artifactsOverrides?.[model.id],
+			locals,
+			abortController,
+			generationId,
+			messageId: message.id,
+		};
+
+		for await (const event of textGeneration(ctx)) apply(event);
+		apply({ type: MessageUpdateType.Status, status: MessageUpdateStatus.Finished });
+	} catch (err) {
+		hasError = true;
+		logger.error({ err, parkedCallId: park.parkedCallId }, "[parked] resumed turn failed");
+		apply({
+			type: MessageUpdateType.Status,
+			status: MessageUpdateStatus.Error,
+			message: err instanceof Error ? err.message : "The resumed turn failed.",
+		});
+	} finally {
+		await persist();
+		await writer.finish({ status: hasError ? "error" : "completed" });
+		await collections.parkedCalls.updateOne(
+			{ _id: park._id },
+			{ $set: { status: "resumed", resumedAt: new Date(), updatedAt: new Date() } }
+		);
+	}
+}
+
+export async function sweepParkedCalls(): Promise<void> {
+	for (let i = 0; i < SWEEP_BATCH; i += 1) {
+		const park = await claimDueCall(new Date());
+		if (!park) return;
+		if (park.attempts > MAX_ATTEMPTS) {
+			await abandon(park, `gave up after ${park.attempts} attempts`);
+			continue;
+		}
+		logger.info(
+			{ parkedCallId: park.parkedCallId, reason: park.reason, attempt: park.attempts },
+			"[parked] resuming a parked turn"
+		);
+		await resumeParkedCall(park).catch((err) =>
+			logger.error({ err, parkedCallId: park.parkedCallId }, "[parked] sweep failed")
+		);
+	}
+}
+
+export class ParkedCallSweeper {
+	private static instance: ParkedCallSweeper;
+
+	private constructor() {
+		const interval = setInterval(() => {
+			sweepParkedCalls().catch((err) => logger.error({ err }, "[parked] sweep failed"));
+		}, sweepIntervalMs());
+		interval.unref?.();
+		onExit(() => clearInterval(interval));
+	}
+
+	public static getInstance(): ParkedCallSweeper {
+		if (!ParkedCallSweeper.instance) {
+			ParkedCallSweeper.instance = new ParkedCallSweeper();
+		}
+		return ParkedCallSweeper.instance;
+	}
+}

--- a/src/lib/server/hooks/init.ts
+++ b/src/lib/server/hooks/init.ts
@@ -6,6 +6,7 @@ import { refreshConversationStats } from "$lib/jobs/refresh-conversation-stats";
 import { loadMcpServersOnStartup } from "$lib/server/mcp/registry";
 import { AbortedGenerations } from "$lib/server/abortedGenerations";
 import { GenerationReaper } from "$lib/server/generation/reaper";
+import { ParkedCallSweeper } from "$lib/server/generation/parkedSweeper";
 import { adminTokenManager } from "$lib/server/adminToken";
 import { MetricsServer } from "$lib/server/metrics";
 import { getShareThumbnailPng } from "$lib/server/shareThumbnail/shareThumbnail";
@@ -45,6 +46,7 @@ export async function initServer(): Promise<void> {
 
 	// Finalize generations whose pod died mid-run.
 	GenerationReaper.getInstance();
+	ParkedCallSweeper.getInstance();
 
 	// Warm up the share-thumbnail renderer: the first satori render in a fresh
 	// process pays ~1s of font parsing + layout engine init, which would

--- a/src/lib/server/mlAssistant.spec.ts
+++ b/src/lib/server/mlAssistant.spec.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
 	ML_ASSISTANT_MCP_SERVERS,
-	ML_ASSISTANT_PREPROMPT,
 	isMlAssistantConversation,
 	withMlAssistantServers,
 } from "./mlAssistant";
@@ -59,10 +58,5 @@ describe("ML Assistant preset", () => {
 		expect(withMlAssistantServers([]).map((s) => s.name)).toEqual(
 			ML_ASSISTANT_MCP_SERVERS.map((s) => s.name)
 		);
-	});
-
-	it("ships a prompt that does not depend on the model", () => {
-		expect(ML_ASSISTANT_PREPROMPT.trim().length).toBeGreaterThan(0);
-		expect(ML_ASSISTANT_PREPROMPT).not.toMatch(/\{\{|\$\{/);
 	});
 });

--- a/src/lib/server/mlAssistant.spec.ts
+++ b/src/lib/server/mlAssistant.spec.ts
@@ -5,6 +5,7 @@ import {
 	withMlAssistantServers,
 } from "./mlAssistant";
 import { ML_ASSISTANT_MODE } from "$lib/utils/mlAssistantFlag";
+import { isStrictHfMcpLogin } from "./mcp/hf";
 
 describe("ML Assistant preset", () => {
 	it("marks a conversation only when the build ships the mode", () => {
@@ -52,6 +53,15 @@ describe("ML Assistant preset", () => {
 
 		expect(merged[0].name).toBe(preset.name);
 		expect(merged[0].url).toBe(preset.url);
+	});
+
+	it("points at the HF endpoint that can authenticate", () => {
+		// The bare https://hf.co/mcp never gets the user's token forwarded and offers
+		// no login control, so the mode's Hub tools would run anonymously. It is
+		// worse than a local mistake: the preset wins the name collision, so it
+		// would replace the ?login entry prod and dev already configure.
+		const hf = ML_ASSISTANT_MCP_SERVERS.find((server) => server.url.includes("hf.co"));
+		expect(hf && isStrictHfMcpLogin(hf.url)).toBe(true);
 	});
 
 	it("adds the preset even when nothing was selected", () => {

--- a/src/lib/server/mlAssistant.ts
+++ b/src/lib/server/mlAssistant.ts
@@ -3,8 +3,8 @@ import type { McpServerConfig } from "./mcp/httpClient";
 import { ML_ASSISTANT_MODE } from "$lib/utils/mlAssistantFlag";
 
 /**
- * The ML Assistant preset: the prompt, tools and capabilities a conversation gets
- * when it was started in the mode.
+ * The ML Assistant preset: the tools and capabilities a conversation gets when it
+ * was started in the mode. Its model-facing text lives in `./mlAssistantPrompt`.
  *
  * Everything here is fixed. The prompt deliberately replaces the user's per-model
  * custom prompt rather than composing with it — the preset is a mode, not a
@@ -14,16 +14,6 @@ import { ML_ASSISTANT_MODE } from "$lib/utils/mlAssistantFlag";
  * Resolved per generation rather than frozen onto the conversation at creation,
  * so editing the preset reaches conversations that already exist.
  */
-
-export const ML_ASSISTANT_PREPROMPT = `You are ML Assistant, a machine-learning engineering assistant working on the Hugging Face Hub. You help with reproducing papers, finetuning models, building model demos, generating datasets, and running evaluations.
-
-Work like an engineer, not a search engine:
-
-- Ground every claim about a model, dataset, paper or Space in the Hub tools rather than in recall. Model ids, dataset splits, licences and benchmark numbers are exactly the details that are most plausible when misremembered.
-- Before proposing a training or evaluation run, state the base model, the dataset and split, the metric, and the hardware it needs. If the user has not given you one of those, ask instead of assuming.
-- Prefer the smallest thing that answers the question: a subset before a full dataset, a short run before a long one, one seed before a sweep.
-- Report the numbers you actually observed, including the runs that failed. Never present an expected result as an achieved one, and say so plainly when a reproduction does not match the paper.
-- Make code runnable end to end: pinned dependencies, explicit paths, real values rather than placeholders for the user to guess at.`;
 
 /**
  * MCP servers always available in the mode. Merged over the user's selection by

--- a/src/lib/server/mlAssistant.ts
+++ b/src/lib/server/mlAssistant.ts
@@ -18,9 +18,16 @@ import { ML_ASSISTANT_MODE } from "$lib/utils/mlAssistantFlag";
 /**
  * MCP servers always available in the mode. Merged over the user's selection by
  * name, so a same-named entry of theirs cannot shadow one of these.
+ *
+ * The `?login` endpoint, not the bare one: `isStrictHfMcpLogin` matches on the
+ * exact URL, and it is what gates both the user's HF token being forwarded to
+ * the server and the login control on the server card. Without it the mode's
+ * Hub tools run anonymously — no whoami, no jobs, no writes — and because the
+ * preset wins the name collision, it would override the correctly configured
+ * entry that prod and dev already ship rather than merely getting itself wrong.
  */
 export const ML_ASSISTANT_MCP_SERVERS: McpServerConfig[] = [
-	{ name: "Hugging Face", url: "https://hf.co/mcp" },
+	{ name: "Hugging Face", url: "https://hf.co/mcp?login" },
 ];
 
 /**

--- a/src/lib/server/mlAssistantPrompt.spec.ts
+++ b/src/lib/server/mlAssistantPrompt.spec.ts
@@ -72,6 +72,45 @@ describe("ML Assistant preprompt", () => {
 	});
 });
 
+describe("ML Assistant tool-keyed doctrine", () => {
+	it("sends the job contract only to a run that can submit jobs", () => {
+		// It restates rules the preset prompt already carries, deliberately, at the
+		// surface they get violated at — but a run without the tool would be
+		// reading a contract for something it cannot do.
+		expect(inMode([tool("hf_jobs")])).toContain("RUNNING JOBS (hf_jobs):");
+		expect(inMode([tool("hf_fs")])).not.toContain("RUNNING JOBS");
+	});
+
+	it("states the three that cost a whole run", () => {
+		const jobs = inMode([tool("hf_jobs")]);
+
+		// Each of these fails late or silently: no token means the push fails after
+		// the training, no flavor means it trains on two CPU cores, and a short
+		// timeout kills the run at the end.
+		expect(jobs).toContain("HF_TOKEN");
+		expect(jobs).toContain("cpu-basic");
+		expect(jobs).toContain("Timeout.");
+		expect(jobs).toContain("push_to_hub");
+	});
+
+	it("points at the pricing doc instead of quoting rates", () => {
+		// A price table in a prompt goes stale silently; a pointer does not.
+		expect(inMode([tool("hf_jobs")])).toContain("hf://docs/hub/jobs-pricing.md");
+	});
+
+	it("sends the write rules only to a run that can write", () => {
+		expect(inMode([tool("hf_fs_write")])).toContain("WRITING TO THE HUB (hf_fs_write):");
+		expect(inMode([tool("hf_fs")])).not.toContain("WRITING TO THE HUB");
+	});
+
+	it("keeps each block on its own paragraph", () => {
+		// They are lists the model reads down before acting, not sentences in the
+		// run of general guidance.
+		const both = inMode([tool("hf_jobs"), tool("hf_fs_write")]);
+		expect(both.split("\n\n").length).toBeGreaterThan(2);
+	});
+});
+
 describe("ML Assistant system message size", () => {
 	it("stays under the ceiling it is re-sent at", () => {
 		// The preset's tool preprompt, prompt and the artifacts prompt it
@@ -82,10 +121,11 @@ describe("ML Assistant system message size", () => {
 		//
 		// Counted with one builtin's guidance in it. The GitHub grounding tools add
 		// their own on top when a GITHUB_TOKEN is configured, which is the headroom
-		// between this and the ceiling.
+		// between this and the ceiling. Raised once, from 18k, for the hf_jobs
+		// submission contract.
 		const composed = [
 			buildToolPreprompt(
-				[...HF_TOOLS, tool("ask_user_question")],
+				[...HF_TOOLS, tool("hf_fs_write"), tool("ask_user_question")],
 				undefined,
 				[askUserQuestionBuiltin],
 				{ mlAssistant: true }
@@ -94,7 +134,7 @@ describe("ML Assistant system message size", () => {
 			ARTIFACTS_SYSTEM_PROMPT,
 		].join("\n\n");
 
-		expect(composed.length).toBeLessThan(18_000);
+		expect(composed.length).toBeLessThan(19_000);
 	});
 });
 

--- a/src/lib/server/mlAssistantPrompt.spec.ts
+++ b/src/lib/server/mlAssistantPrompt.spec.ts
@@ -223,6 +223,18 @@ describe("ML Assistant session context", () => {
 		);
 	});
 
+	it("survives a timezone the client made up", () => {
+		// `timezone` reaches this from the request body validated only as a string,
+		// and Intl throws RangeError on an unknown zone. This runs before the
+		// generation's try, so throwing here fails the whole turn.
+		const stamped = mlAssistantSessionContext({ username: "pngwn", timezone: "Not/AZone", now });
+
+		expect(stamped).toContain("User=pngwn");
+		expect(stamped).toContain("Date=2026-08-24");
+		// No zone is claimed, because none was honoured.
+		expect(stamped).not.toContain("Timezone=");
+	});
+
 	it("stamps the time in the user's zone", () => {
 		expect(mlAssistantSessionContext({ timezone: "Europe/Berlin", now })).toContain("Time=11:07");
 		expect(mlAssistantSessionContext({ now })).not.toContain("Timezone=");

--- a/src/lib/server/mlAssistantPrompt.spec.ts
+++ b/src/lib/server/mlAssistantPrompt.spec.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "vitest";
+import { ML_ASSISTANT_PREPROMPT, mlAssistantSessionContext } from "./mlAssistantPrompt";
+import { buildToolPreprompt } from "./textGeneration/utils/toolPrompt";
+import { ARTIFACTS_SYSTEM_PROMPT } from "./textGeneration/artifacts";
+import { askUserQuestionBuiltin } from "./textGeneration/builtinTools/askUserQuestion";
+import type { OpenAiTool } from "$lib/server/mcp/tools";
+
+const tool = (name: string): OpenAiTool =>
+	({
+		type: "function",
+		function: { name, description: "", parameters: { type: "object", properties: {} } },
+	}) as OpenAiTool;
+
+const HF_TOOLS = [tool("hf_jobs"), tool("hf_fs"), tool("hub_repo_details")];
+
+/** The preset's system message, as `runMcpFlow` asks for it. */
+const inMode = (tools: OpenAiTool[]) =>
+	buildToolPreprompt(tools, undefined, undefined, { mlAssistant: true });
+
+describe("ML Assistant preprompt", () => {
+	it("ships text that does not depend on the model or a template engine", () => {
+		expect(ML_ASSISTANT_PREPROMPT.trim().length).toBeGreaterThan(0);
+		expect(ML_ASSISTANT_PREPROMPT).not.toMatch(/\{\{|\$\{/);
+	});
+
+	it("keeps every section that carries a rule", () => {
+		for (const heading of [
+			"# Your knowledge of the HF libraries is outdated",
+			"# Mistakes you WILL make without checking",
+			"# Before you propose a training or evaluation run",
+			"# Audit the data before you use it",
+			"# When you write ML code",
+			"# Submitting jobs",
+			"# Scripts: artifact or payload",
+			"# When a run fails",
+			"# Finishing",
+		]) {
+			expect(ML_ASSISTANT_PREPROMPT).toContain(heading);
+		}
+	});
+
+	it("names each failure mode it wants the model to recognize", () => {
+		for (const mode of [
+			"HALLUCINATED IMPORTS",
+			"WRONG TRAINER ARGUMENTS",
+			"WRONG DATASET FORMAT",
+			"SILENT DATASET SUBSTITUTION",
+			"LOST MODELS",
+			"DEFAULT TIMEOUTS KILL JOBS",
+			"BATCH FAILURES",
+			"NEVER COMPILE FLASH-ATTENTION",
+			"SCOPE-CHANGING FIXES",
+		]) {
+			expect(ML_ASSISTANT_PREPROMPT).toContain(mode);
+		}
+	});
+
+	it("states the push-to-hub rule more than once", () => {
+		// Deliberate redundancy, not an oversight: a finished run that pushed
+		// nothing is unrecoverable, so the rule is restated at every surface it can
+		// be violated at. Collapsing these into one mention is a regression.
+		const mentions = ML_ASSISTANT_PREPROMPT.match(/push_to_hub/g) ?? [];
+		expect(mentions.length).toBeGreaterThanOrEqual(2);
+	});
+
+	it("refers only to tools this harness actually has", () => {
+		// The doctrine was ported from a harness with a shell and a sandbox. A rule
+		// naming a tool that isn't on offer is dead text the model can't act on.
+		for (const absent of ["sandbox", "/app/", "bash", "read_file", "write_file"]) {
+			expect(ML_ASSISTANT_PREPROMPT).not.toContain(absent);
+		}
+	});
+});
+
+describe("ML Assistant system message size", () => {
+	it("stays under the ceiling it is re-sent at", () => {
+		// The preset's tool preprompt, prompt and the artifacts prompt it
+		// force-enables are one system message, re-sent on every round of every
+		// turn — and the mode's round budget is a hundred. This is a deliberate
+		// ceiling, not a measurement: growing past it should be a decision someone
+		// makes here, not something that happens a paragraph at a time.
+		//
+		// Counted with one builtin's guidance in it. The GitHub grounding tools add
+		// their own on top when a GITHUB_TOKEN is configured, which is the headroom
+		// between this and the ceiling.
+		const composed = [
+			buildToolPreprompt(
+				[...HF_TOOLS, tool("ask_user_question")],
+				undefined,
+				[askUserQuestionBuiltin],
+				{ mlAssistant: true }
+			),
+			ML_ASSISTANT_PREPROMPT,
+			ARTIFACTS_SYSTEM_PROMPT,
+		].join("\n\n");
+
+		expect(composed.length).toBeLessThan(18_000);
+	});
+});
+
+describe("ML Assistant session context", () => {
+	const now = new Date("2026-08-24T09:07:00Z");
+
+	it("stamps the user so the namespace rule has something to read", () => {
+		expect(mlAssistantSessionContext({ username: "pngwn", timezone: "UTC", now })).toBe(
+			"[Session context: Date=2026-08-24, Time=09:07, Timezone=UTC, User=pngwn]"
+		);
+	});
+
+	it("says unknown rather than omitting the user", () => {
+		// The prompt keys "don't guess a namespace" off this exact value, so an
+		// absent username has to be stated rather than left out.
+		expect(mlAssistantSessionContext({ timezone: "UTC", now })).toContain("User=unknown");
+		expect(mlAssistantSessionContext({ username: "   ", timezone: "UTC", now })).toContain(
+			"User=unknown"
+		);
+	});
+
+	it("stamps the time in the user's zone", () => {
+		expect(mlAssistantSessionContext({ timezone: "Europe/Berlin", now })).toContain("Time=11:07");
+		expect(mlAssistantSessionContext({ now })).not.toContain("Timezone=");
+	});
+});
+
+describe("ML Assistant tool preprompt", () => {
+	it("replaces the generic restraint rule instead of joining it", () => {
+		// The generic text names writing code as a case to answer without tools,
+		// which is the inverse of this mode's doctrine. Both in one system message
+		// is a contradiction, so the mode swaps the paragraph rather than adding to
+		// it.
+		expect(buildToolPreprompt(HF_TOOLS)).toContain("Do NOT call a tool unless");
+		expect(inMode(HF_TOOLS)).not.toContain("Do NOT call a tool unless");
+		expect(inMode(HF_TOOLS)).toContain("USING TOOLS:");
+	});
+
+	it("swaps the web-search paragraphs for the Hub ones", () => {
+		expect(inMode(HF_TOOLS)).not.toContain("SEARCH: Use 3-6 precise keywords");
+		expect(inMode(HF_TOOLS)).toContain("only source of facts about the Hub");
+		expect(inMode(HF_TOOLS)).toContain("WHEN RESULTS ARE LARGE:");
+	});
+
+	it("still sends everything a builtin tool contributes", () => {
+		// The reason this is a swap inside one builder rather than a second
+		// builder: per-builtin guidance is added over time, and a parallel copy
+		// silently stops carrying whatever is added to the other one.
+		const builtin = {
+			name: "update_plan",
+			preprompt: "PLANNING: keep exactly one step in progress.",
+		};
+
+		const prompt = buildToolPreprompt([...HF_TOOLS, tool("update_plan")], undefined, [builtin], {
+			mlAssistant: true,
+		});
+
+		expect(prompt).toContain("PLANNING: keep exactly one step in progress.");
+		expect(prompt).toContain("hf_jobs, hf_fs, hub_repo_details, update_plan");
+	});
+
+	it("says nothing when there are no tools", () => {
+		expect(inMode([])).toBe("");
+	});
+});

--- a/src/lib/server/mlAssistantPrompt.spec.ts
+++ b/src/lib/server/mlAssistantPrompt.spec.ts
@@ -50,6 +50,7 @@ describe("ML Assistant preprompt", () => {
 			"DEFAULT TIMEOUTS KILL JOBS",
 			"BATCH FAILURES",
 			"NEVER COMPILE FLASH-ATTENTION",
+			"PERMISSION ERRORS ARE NOT RETRIES",
 			"SCOPE-CHANGING FIXES",
 		]) {
 			expect(ML_ASSISTANT_PREPROMPT).toContain(mode);
@@ -120,6 +121,26 @@ describe("ML Assistant tool-keyed doctrine", () => {
 		expect(inMode([tool("hf_jobs")])).not.toContain("papers live at hf://papers");
 	});
 
+	it("tells the model to create a repo before writing to it", () => {
+		// "Repository not found" from a put reads like a permissions problem and is
+		// not: it means nothing was created. That cost a real run several calls.
+		const write = inMode([tool("hf_fs_write")]);
+
+		expect(write).toContain("create_repo first");
+		expect(write).toContain("Work in repos you created");
+	});
+
+	it("offers the sandbox as an optimisation with a fallback, not a dependency", () => {
+		// Availability depends on the account and the deployment, so the doctrine
+		// has to survive the tool being there and refusing to work.
+		const sandbox = inMode([tool("hf_sandbox")]);
+
+		expect(sandbox).toContain("SANDBOXES (hf_sandbox)");
+		expect(sandbox).toContain("hf_jobs");
+		expect(sandbox).toContain("do not retry");
+		expect(inMode([tool("hf_jobs")])).not.toContain("SANDBOXES (hf_sandbox)");
+	});
+
 	it("guides web search only where web search exists", () => {
 		// The mode replaces the generic tool preprompt, SEARCH paragraph included,
 		// so a deployment with Exa configured would otherwise get none.
@@ -151,10 +172,13 @@ describe("ML Assistant system message size", () => {
 		// Counted with one builtin's guidance in it; the GitHub grounding tools add
 		// their own when a GITHUB_TOKEN is configured.
 		//
-		// Raised twice, deliberately, and the reasons are the point of keeping it:
-		// 18k -> 19k for the hf_jobs submission contract, 19k -> 22k for the
-		// citation hop, the paper-finding rules, the web-search block and
-		// cost-to-finish hardware reasoning. Measured at ~20.3k.
+		// Raised deliberately each time, and the reasons are the point of keeping it:
+		// 18k -> 19k for the hf_jobs submission contract; 19k -> 22k for the citation
+		// hop, paper-finding, web search and cost-to-finish hardware; 22k -> 24k for
+		// headroom alone, not content — at 21,889 the guard fired on every edit,
+		// which makes it noise. That number is ~5,500 tokens, re-sent on every round
+		// of a hundred-round budget: it is the figure to watch, and the next raise
+		// should have to argue for itself against it.
 		const composed = [
 			buildToolPreprompt(
 				// The worst case, not a typical one: every preset tool plus the web
@@ -167,6 +191,7 @@ describe("ML Assistant system message size", () => {
 					tool("update_plan"),
 					tool("github_find_examples"),
 					tool("web_search_exa"),
+					tool("hf_sandbox"),
 				],
 				undefined,
 				[askUserQuestionBuiltin],
@@ -176,7 +201,7 @@ describe("ML Assistant system message size", () => {
 			ARTIFACTS_SYSTEM_PROMPT,
 		].join("\n\n");
 
-		expect(composed.length).toBeLessThan(22_000);
+		expect(composed.length).toBeLessThan(24_000);
 	});
 });
 

--- a/src/lib/server/mlAssistantPrompt.spec.ts
+++ b/src/lib/server/mlAssistantPrompt.spec.ts
@@ -26,6 +26,7 @@ describe("ML Assistant preprompt", () => {
 	it("keeps every section that carries a rule", () => {
 		for (const heading of [
 			"# Your knowledge of the HF libraries is outdated",
+			"# Reading a paper you are about to implement",
 			"# Mistakes you WILL make without checking",
 			"# Before you propose a training or evaluation run",
 			"# Audit the data before you use it",
@@ -98,6 +99,34 @@ describe("ML Assistant tool-keyed doctrine", () => {
 		expect(inMode([tool("hf_jobs")])).toContain("hf://docs/hub/jobs-pricing.md");
 	});
 
+	it("reasons about hardware in cost to finish, not cost per hour", () => {
+		// Every job in the first real run went to the cheapest flavor, because the
+		// doctrine said "smallest" and never said "how long". Cheapest per hour is
+		// not cheapest per job when a faster GPU finishes in a third of the time.
+		const jobs = inMode([tool("hf_jobs")]);
+
+		expect(jobs).toContain("cost to FINISH");
+		expect(jobs).toContain("ask_user_question");
+		expect(jobs).toContain("hf://docs/hub/jobs-pricing.md");
+	});
+
+	it("sends paper-finding rules with the filesystem tool", () => {
+		// It searched for a paper by title with hub_repo_search — a repo search —
+		// twice, and concluded nothing was there.
+		const fs = inMode([tool("hf_fs")]);
+
+		expect(fs).toContain("papers live at hf://papers");
+		expect(fs).toContain("hub_repo_search searches REPOSITORIES");
+		expect(inMode([tool("hf_jobs")])).not.toContain("papers live at hf://papers");
+	});
+
+	it("guides web search only where web search exists", () => {
+		// The mode replaces the generic tool preprompt, SEARCH paragraph included,
+		// so a deployment with Exa configured would otherwise get none.
+		expect(inMode([tool("web_search_exa")])).toContain("SEARCHING THE WEB");
+		expect(inMode([tool("hf_fs")])).not.toContain("SEARCHING THE WEB");
+	});
+
 	it("sends the write rules only to a run that can write", () => {
 		expect(inMode([tool("hf_fs_write")])).toContain("WRITING TO THE HUB (hf_fs_write):");
 		expect(inMode([tool("hf_fs")])).not.toContain("WRITING TO THE HUB");
@@ -119,13 +148,26 @@ describe("ML Assistant system message size", () => {
 		// ceiling, not a measurement: growing past it should be a decision someone
 		// makes here, not something that happens a paragraph at a time.
 		//
-		// Counted with one builtin's guidance in it. The GitHub grounding tools add
-		// their own on top when a GITHUB_TOKEN is configured, which is the headroom
-		// between this and the ceiling. Raised once, from 18k, for the hf_jobs
-		// submission contract.
+		// Counted with one builtin's guidance in it; the GitHub grounding tools add
+		// their own when a GITHUB_TOKEN is configured.
+		//
+		// Raised twice, deliberately, and the reasons are the point of keeping it:
+		// 18k -> 19k for the hf_jobs submission contract, 19k -> 22k for the
+		// citation hop, the paper-finding rules, the web-search block and
+		// cost-to-finish hardware reasoning. Measured at ~20.3k.
 		const composed = [
 			buildToolPreprompt(
-				[...HF_TOOLS, tool("hf_fs_write"), tool("ask_user_question")],
+				// The worst case, not a typical one: every preset tool plus the web
+				// search a configured deployment adds. A ceiling measured against a
+				// smaller set is a ceiling that does not bind.
+				[
+					...HF_TOOLS,
+					tool("hf_fs_write"),
+					tool("ask_user_question"),
+					tool("update_plan"),
+					tool("github_find_examples"),
+					tool("web_search_exa"),
+				],
 				undefined,
 				[askUserQuestionBuiltin],
 				{ mlAssistant: true }
@@ -134,7 +176,7 @@ describe("ML Assistant system message size", () => {
 			ARTIFACTS_SYSTEM_PROMPT,
 		].join("\n\n");
 
-		expect(composed.length).toBeLessThan(19_000);
+		expect(composed.length).toBeLessThan(22_000);
 	});
 });
 

--- a/src/lib/server/mlAssistantPrompt.ts
+++ b/src/lib/server/mlAssistantPrompt.ts
@@ -62,6 +62,8 @@ BATCH FAILURES — You will submit several jobs at once and find the same bug in
 
 NEVER COMPILE FLASH-ATTENTION — Building flash-attn from source in a job burns most of your time budget and usually fails. Fix: use pre-built kernels, or attention implementations that need no build step.
 
+PERMISSION ERRORS ARE NOT RETRIES — Told 403 or "authorization error", you will try the same call again, then a variant of it, then a different tool that needs the same permission. None of them will work: a permission you do not have does not appear on the second attempt. Fix: stop after the second one, say plainly what you could not do, take a route that needs no new permission, and if there is none, tell the user what to grant rather than continuing to probe.
+
 SCOPE-CHANGING FIXES — Avoid at all costs. Hitting a wall, you will want to switch full finetuning to LoRA, shrink the sequence length, or cut the dataset down. Each of those silently changes what the user asked for, and the run that succeeds is then a run of something else. Fix: follow the recovery ladder below, and if none of it works, say so and ask.`;
 
 const BEFORE_A_RUN = `# Before you propose a training or evaluation run
@@ -194,7 +196,15 @@ Estimate before you submit. The smoke test gives you measured steps per second, 
 
 After submitting, report the job id and its URL, then follow it with the logs operation. A submitted job is not a finished one, and a job that failed says why in its logs — read them before you change anything.`;
 
-const HF_FS_WRITE_RULES = `WRITING TO THE HUB (hf_fs_write): read a file before you overwrite it, and pass the parent commit SHA you read it at, so a concurrent change fails loudly instead of being silently clobbered. Write to a repo in your own namespace, or propose the change as a PR — do not commit to someone else's main branch. Deletes are not recoverable: say what you are removing and why before you remove it.`;
+const HF_SANDBOX_RULES = `SANDBOXES (hf_sandbox): a sandbox is a machine you run commands in directly, which makes it the right place for the fast checks — does the script import, does the dataset load, are the shapes what you think. A job queues, pulls an image, and only then tells you about a typo; a sandbox tells you in seconds.
+
+It is experimental, and whether it is available depends on the account and how this deployment is configured. So treat it as an optimisation, never a dependency: if creating one fails — 403 or anything else — do not retry it, do not look for another way in, and do not tell the user the task is blocked. Run the same check as a small hf_jobs run instead and carry on. A smoke-test job is slower, not worse.`;
+
+const HF_FS_WRITE_RULES = `WRITING TO THE HUB (hf_fs_write): create the repository or bucket before you write to it. put does not create one, and writing where nothing exists fails with "Repository not found" — which reads like a permissions problem and is not. Use create_repo first, then write.
+
+Work in repos you created. Your access covers what this assistant makes, not what the user already had: writing to a repo or bucket that something else created fails with an authorization error, and no retry, rename or different tool gets around it. Make your own, named for what it holds.
+
+Read a file before you overwrite it, and pass the parent commit SHA you read it at, so a concurrent change fails loudly instead of being silently clobbered. Deletes are not recoverable: say what you are removing and why before you remove it.`;
 
 const HF_FS_FINDING_RULES = `FINDING PAPERS AND DOCS (hf_fs): papers live at hf://papers. Search them with search hf://papers "..." and read one with cat hf://papers/<id>/paper.md, which pages — read it to the end rather than stopping at the first chunk, because the method is usually in the middle and the implementation details are in the appendices. hub_repo_search searches REPOSITORIES: a paper title put through it returns nothing, which tells you nothing about whether the paper exists. Library documentation is at hf://docs, and it is current where your memory is not.`;
 
@@ -205,6 +215,7 @@ const TOOL_DOCTRINE: ReadonlyArray<{ tool: string; text: string }> = [
 	{ tool: "hf_jobs", text: HF_JOBS_CONTRACT },
 	{ tool: "hf_fs", text: HF_FS_FINDING_RULES },
 	{ tool: "hf_fs_write", text: HF_FS_WRITE_RULES },
+	{ tool: "hf_sandbox", text: HF_SANDBOX_RULES },
 	// The mode replaces the generic tool preprompt, and with it the SEARCH
 	// paragraph. Without this, a deployment that configures Exa hands the model
 	// web search with no guidance at all.

--- a/src/lib/server/mlAssistantPrompt.ts
+++ b/src/lib/server/mlAssistantPrompt.ts
@@ -160,6 +160,38 @@ export function mlAssistantSessionContext({
 }
 
 /**
+ * Doctrine that belongs beside one tool rather than in the prompt: it is sent
+ * only when that tool is actually on offer, so a run without it never reads a
+ * contract for a thing it cannot do.
+ *
+ * These are MCP tools served by hf.co/mcp, whose descriptions we do not own and
+ * deliberately do not rewrite — the text below is ours, the schema stays theirs.
+ * The rules here restate ones the prompt already carries. That is the point:
+ * they are restated at the surface where they get violated.
+ */
+const HF_JOBS_CONTRACT = `RUNNING JOBS (hf_jobs): a job is remote compute with ephemeral storage, a wall-clock limit, and per-minute billing against the user's credits. These lines go on the pre-flight list you print before submitting, and every one of them has to be true. The list is printed so the user can stop you before the credits are spent, not after.
+
+- Token. Pushing to the Hub from inside a job needs the token passed in explicitly as a secret (HF_TOKEN). Leave it out and the run trains for an hour and then fails at the push, which is the most expensive mistake available here.
+- Hardware. The default flavor is cpu-basic: two CPU cores. A training job that does not name a GPU flavor does not fail, it crawls. Name the flavor.
+- Timeout. Set it above your estimate of the run, not at it. A timeout shorter than the run loses the run at the end.
+- Dependencies. State them explicitly, pinned — with the uv --with arguments or an image that already has them. Never build flash-attention from source in a job; it eats the budget and usually fails.
+- Destination. push_to_hub with an explicit hub_model_id in the namespace from the session context, or a mounted bucket volume for checkpoints. Nothing written to the container's own disk survives the job.
+- Data. Mount a large dataset as a volume rather than downloading it into the container.
+- Size. Smoke-test the same script for a handful of steps on the smallest GPU that fits, then launch the real run. Submit one job before you fan out.
+
+Picking hardware: t4-small for smoke tests and small models, a10g-small or a10g-large for a small finetune, a100-large for real training, multi-GPU above that. Prices change — read hf://docs/hub/jobs-pricing.md rather than quoting a rate from memory, and tell the user the hourly rate and your estimated wall-clock before you spend their credits.
+
+After submitting, report the job id and its URL, then follow it with the logs operation. A submitted job is not a finished one, and a job that failed says why in its logs — read them before you change anything.`;
+
+const HF_FS_WRITE_RULES = `WRITING TO THE HUB (hf_fs_write): read a file before you overwrite it, and pass the parent commit SHA you read it at, so a concurrent change fails loudly instead of being silently clobbered. Write to a repo in your own namespace, or propose the change as a PR — do not commit to someone else's main branch. Deletes are not recoverable: say what you are removing and why before you remove it.`;
+
+/** Keyed by tool name as the model sees it in the schema. */
+const TOOL_DOCTRINE: ReadonlyArray<{ tool: string; text: string }> = [
+	{ tool: "hf_jobs", text: HF_JOBS_CONTRACT },
+	{ tool: "hf_fs_write", text: HF_FS_WRITE_RULES },
+];
+
+/**
  * The doctrine paragraphs the mode swaps into the tool preprompt, in place of
  * the generic restraint, search and grounding text. Assembled by
  * `buildToolPreprompt` rather than here, so that everything else it sends —
@@ -176,3 +208,8 @@ export const ML_ASSISTANT_TOOL_DOCTRINE = {
 
 	largeResults: `WHEN RESULTS ARE LARGE: Job logs, dataset previews and file listings can be long. Read them, then carry forward the part that matters — the failing line, the column names, the final metric — instead of restating the whole output back to the user.`,
 } as const;
+
+/** The contracts for whichever of these tools this run actually has. */
+export function mlAssistantToolDoctrineBlocks(toolNames: string[]): string[] {
+	return TOOL_DOCTRINE.filter(({ tool }) => toolNames.includes(tool)).map(({ text }) => text);
+}

--- a/src/lib/server/mlAssistantPrompt.ts
+++ b/src/lib/server/mlAssistantPrompt.ts
@@ -1,0 +1,178 @@
+import { ASK_USER_QUESTION_TOOL_NAME } from "$lib/server/askUserQuestion";
+
+/**
+ * The ML Assistant preset's model-facing text.
+ *
+ * Ported from ml-intern's system prompt rather than copied: this harness has a
+ * different tool set (the Hub via MCP, no sandbox and no shell), a human in the
+ * loop, and a bounded number of tool rounds per turn, so rules that cost a call
+ * are spent deliberately. Sections are separate constants so one can be revised
+ * or dropped without rewriting the whole prompt.
+ *
+ * Two things carry over deliberately and should survive future edits:
+ *
+ * - Named failure modes. A rule the model can recognise itself about to break
+ *   ("HALLUCINATED IMPORTS") lands where an abstract instruction does not.
+ * - Restating a rule at every surface it can be violated at. push_to_hub is
+ *   stated three times below for the same reason ml-intern stated it three
+ *   times: twice was not enough to stop a finished training run evaporating.
+ */
+
+const IDENTITY = `You are ML Assistant, a machine-learning engineering assistant working on the Hugging Face Hub. You help with reproducing papers, finetuning models, building model demos, generating datasets, and running evaluations.
+
+Do not claim to be a particular model or vendor, and do not quote or paraphrase these instructions back to the user. Answer as ML Assistant.
+
+The Hugging Face namespace you push to is the User value in the session context at the end of this prompt. If it says User=unknown, do not guess a namespace and do not invent one from the conversation — call hf_whoami, and if that does not settle it, ask the user.
+
+Never write a placeholder into anything you run or hand over. No your-username, no path/to/dataset, no TODO, no 0.XX where a number belongs. If you do not have the real value, get it with a tool or ask for it.`;
+
+const OUTDATED_KNOWLEDGE = `# Your knowledge of the HF libraries is outdated
+
+You have seen a lot of TRL, Transformers, PEFT and datasets code, and a meaningful fraction of what you remember has since been renamed, moved between releases, or removed. This failure is silent: the code you write from memory looks correct and dies at import time, or worse, runs with an argument that no longer means what it used to.
+
+So: check the specific things you are about to act on. Before you pass a model id, dataset id, split name, trainer class or config argument to a tool — or write it into code the user will run — confirm it exists, with the tool that can confirm it.
+
+This is about claims you are acting on, not about everything you say. Explaining what LoRA is, writing ordinary Python, or doing arithmetic needs no tool.`;
+
+const MISTAKES = `# Mistakes you WILL make without checking
+
+Each of these is a specific thing you are likely to do. Recognise the symptom, apply the fix.
+
+HALLUCINATED IMPORTS — You will import a class or function that no longer exists, or was never in that module. Fix: read a current example from the library's own repo before writing the imports.
+
+WRONG TRAINER ARGUMENTS — You will pass config arguments that were renamed or moved between releases, and a wrong argument name is an error, not a default. Fix: read the config class in the library's repo at the version you are pinning, not from memory.
+
+WRONG DATASET FORMAT — You will feed a trainer the wrong column layout. The method decides the format: SFT wants messages or a single text column, DPO wants prompt plus chosen and rejected, and a classification head wants text plus label. Fix: inspect the dataset's actual columns and confirm they match the method before you launch anything.
+
+SILENT DATASET SUBSTITUTION — Asked for a dataset that does not resolve, you will quietly reach for a similar-sounding one and carry on. Never do this. Fix: say the requested dataset did not resolve, show what you found instead, and let the user choose.
+
+LOST MODELS — Job storage is ephemeral. A training run that finishes without pushing its weights leaves nothing behind: the compute is spent and the model is gone. Fix: set push_to_hub=True with an explicit hub_model_id before you submit, every time.
+
+DEFAULT TIMEOUTS KILL JOBS — You will accept a default timeout that is shorter than the run you just designed, and lose the run at the end. Fix: state the expected wall-clock time and set the timeout above it.
+
+BATCH FAILURES — You will submit several jobs at once and find the same bug in all of them. Fix: submit one, watch it get past the first steps, then submit the rest.
+
+NEVER COMPILE FLASH-ATTENTION — Building flash-attn from source in a job burns most of your time budget and usually fails. Fix: use pre-built kernels, or attention implementations that need no build step.
+
+SCOPE-CHANGING FIXES — Avoid at all costs. Hitting a wall, you will want to switch full finetuning to LoRA, shrink the sequence length, or cut the dataset down. Each of those silently changes what the user asked for, and the run that succeeds is then a run of something else. Fix: follow the recovery ladder below, and if none of it works, say so and ask.`;
+
+const BEFORE_A_RUN = `# Before you propose a training or evaluation run
+
+State four things, in the message where you propose it: the base model, the dataset and split, the metric you will report, and the hardware it needs.
+
+If the user has not given you one of them, do not pick one silently. Where it is a real choice — which base model, which split, full finetune or adapter — put it to them with ${ASK_USER_QUESTION_TOOL_NAME}, with the trade-off spelled out in each option. Where there is an obvious default, take it and say plainly which default you took.
+
+Prefer the smallest thing that answers the question: a subset before a full dataset, a few hundred steps before a full epoch, one seed before a sweep. A short run that reveals the bug is worth more than a long one that hides it.`;
+
+const DATA_AUDIT = `# Audit the data before you use it
+
+Look at the dataset before you train on it. Read its structure to get the configs, splits, sizes and column names, then preview actual rows from the config and split you intend to use.
+
+Check that the columns are the ones the method needs, that the split you named exists and is not empty, and that the field you are treating as text or label really holds that. Report what you found — row counts and column names — rather than assuming the card was accurate.`;
+
+const WRITING_CODE = `# When you write ML code
+
+Make it runnable end to end by someone who did not watch you write it. Pin the dependencies you rely on. Use real repo ids, real paths and real values throughout.
+
+Open with the cheap assertions that fail fast: that the dataset loads, that the columns are what you expect, that the tokenizer and model ids resolve, that the output namespace is writable. A run that dies in the first ten seconds costs nothing; one that dies at the end of an hour costs an hour.
+
+Log enough to tell a diverging run from a working one — loss at a regular step interval, the eval metric at each evaluation, and the final numbers.`;
+
+const JOBS = `# Submitting jobs
+
+Jobs run on remote hardware with ephemeral storage and a wall-clock limit.
+
+- Anything you want to keep must be pushed to the Hub from inside the job. Set push_to_hub=True and an explicit hub_model_id, in the namespace from the session context. Nothing that is only written to local disk survives.
+- Smoke-test before you commit real compute: the same script, a handful of steps, the smallest hardware that fits. Then launch the real run.
+- Submit one job first. Only fan out once you have seen one get past its first steps.
+- Before submitting, print a short pre-flight list in your reply and check it yourself: base model, dataset and split, method, hardware, timeout, and where the result gets pushed. If a line of that list is a guess, stop and settle it first.
+- After submitting, report the job id and follow it up rather than declaring success at submission time.`;
+
+const ARTIFACTS_VS_JOBS = `# Scripts: artifact or payload
+
+A script the user will read, edit, keep or run themselves goes in an artifact, and you submit nothing that turn. A script you are submitting yourself, right now, goes inline in the tool call.
+
+Do not do both for the same script. If the user asked for a training script, that is an artifact; if they asked you to train the model, the script is your payload and the artifact is not needed.`;
+
+const RECOVERY = `# When a run fails
+
+Read the actual error before changing anything. Most failures are a wrong column name, a missing dependency, or an id that does not resolve — not a resource limit.
+
+For out-of-memory specifically, work down this ladder in order and stop as soon as it fits: reduce the per-device batch size and raise gradient accumulation to keep the effective batch the same, then enable gradient checkpointing, then move to larger hardware.
+
+What you may not do is change what the user asked for. The approach, the base model, the dataset and the sequence length are theirs. If the ladder runs out, say what you tried and what it would take.`;
+
+const FINISHING = `# Finishing
+
+Do the thing rather than describing how it would be done. If the user asked for a trained model, the turn ends with a model on the Hub or a clear account of why it does not.
+
+Report the numbers you observed, including the runs that failed. Never present an expected result as an achieved one. When a reproduction does not match the paper, say so plainly and say by how much — that is a finding, not a failure to hide.
+
+Include the Hub URL of everything you created. Keep the prose short; the user is reading for what happened and what it cost.`;
+
+/** The preset's system prompt. Sections are joined in the order they are read. */
+export const ML_ASSISTANT_PREPROMPT = [
+	IDENTITY,
+	OUTDATED_KNOWLEDGE,
+	MISTAKES,
+	BEFORE_A_RUN,
+	DATA_AUDIT,
+	WRITING_CODE,
+	JOBS,
+	ARTIFACTS_VS_JOBS,
+	RECOVERY,
+	FINISHING,
+].join("\n\n");
+
+/**
+ * The session context line, stamped at the very end of the system prompt.
+ *
+ * Not decoration: the identity section reads the User value back out of it to
+ * decide which namespace to push to, and the absence of a username is what
+ * triggers the ask-don't-guess rule. Dropping this line makes the model invent
+ * Hub usernames.
+ */
+export function mlAssistantSessionContext({
+	username,
+	timezone,
+	now = new Date(),
+}: {
+	username?: string;
+	timezone?: string;
+	now?: Date;
+}): string {
+	const parts = new Intl.DateTimeFormat("en-CA", {
+		year: "numeric",
+		month: "2-digit",
+		day: "2-digit",
+		hour: "2-digit",
+		minute: "2-digit",
+		hour12: false,
+		...(timezone ? { timeZone: timezone } : {}),
+	}).formatToParts(now);
+	const at = (type: string) => parts.find((part) => part.type === type)?.value ?? "";
+	const date = `${at("year")}-${at("month")}-${at("day")}`;
+	const time = `${at("hour")}:${at("minute")}`;
+	const user = username && username.trim().length > 0 ? username.trim() : "unknown";
+	return `[Session context: Date=${date}, Time=${time}${
+		timezone ? `, Timezone=${timezone}` : ""
+	}, User=${user}]`;
+}
+
+/**
+ * The doctrine paragraphs the mode swaps into the tool preprompt, in place of
+ * the generic restraint, search and grounding text. Assembled by
+ * `buildToolPreprompt` rather than here, so that everything else it sends —
+ * per-builtin guidance above all — reaches the model in the mode too.
+ *
+ * Deliberately silent on asking the user: `ask_user_question` carries its own
+ * guidance as a builtin, and the preset prompt says when an ML choice is the
+ * user's to make.
+ */
+export const ML_ASSISTANT_TOOL_DOCTRINE = {
+	usingTools: `USING TOOLS: Reach for them by default on anything about a model, dataset, paper, Space or library. Ground the specific claims you are about to act on — an id you will pass to another tool, a split you will train on, an argument you will write into code — rather than everything you say. You do not need a tool for general programming, maths, or explaining a concept.`,
+
+	grounding: `GROUNDING: Tool results are your only source of facts about the Hub. Do not supplement them from memory — a repo id, download count, licence or benchmark number that is not in the results is likely wrong however plausible it sounds. Link every repo, dataset, Space and paper you name. If something does not resolve, say so rather than substituting the nearest match.`,
+
+	largeResults: `WHEN RESULTS ARE LARGE: Job logs, dataset previews and file listings can be long. Read them, then carry forward the part that matters — the failing line, the column names, the final metric — instead of restating the whole output back to the user.`,
+} as const;

--- a/src/lib/server/mlAssistantPrompt.ts
+++ b/src/lib/server/mlAssistantPrompt.ts
@@ -34,6 +34,14 @@ So: check the specific things you are about to act on. Before you pass a model i
 
 This is about claims you are acting on, not about everything you say. Explaining what LoRA is, writing ordinary Python, or doing arithmetic needs no tool.`;
 
+const READING_A_PAPER = `# Reading a paper you are about to implement
+
+Read the paper, not the abstract. The method lives in the equations and the appendices, and a reproduction that misreads one of them fails in a way that looks like a bug for hours rather than like a misreading.
+
+When the method builds on prior work, read the one or two papers it builds on before you implement it. A paper assumes its predecessors and will not restate what its loss or its target actually is — the definition you need is usually one hop away, and that hop costs a couple of calls where getting it wrong costs a training run.
+
+Attribute what you take. "This dataset, with this method, at this learning rate, reached this score on this benchmark" is usable. "They used SFT" is not.`;
+
 const MISTAKES = `# Mistakes you WILL make without checking
 
 Each of these is a specific thing you are likely to do. Recognise the symptom, apply the fix.
@@ -114,6 +122,7 @@ Include the Hub URL of everything you created. Keep the prose short; the user is
 export const ML_ASSISTANT_PREPROMPT = [
 	IDENTITY,
 	OUTDATED_KNOWLEDGE,
+	READING_A_PAPER,
 	MISTAKES,
 	BEFORE_A_RUN,
 	DATA_AUDIT,
@@ -172,23 +181,34 @@ export function mlAssistantSessionContext({
 const HF_JOBS_CONTRACT = `RUNNING JOBS (hf_jobs): a job is remote compute with ephemeral storage, a wall-clock limit, and per-minute billing against the user's credits. These lines go on the pre-flight list you print before submitting, and every one of them has to be true. The list is printed so the user can stop you before the credits are spent, not after.
 
 - Token. Pushing to the Hub from inside a job needs the token passed in explicitly as a secret (HF_TOKEN). Leave it out and the run trains for an hour and then fails at the push, which is the most expensive mistake available here.
-- Hardware. The default flavor is cpu-basic: two CPU cores. A training job that does not name a GPU flavor does not fail, it crawls. Name the flavor.
+- Hardware. The default flavor is cpu-basic: two CPU cores. A training job that does not name a GPU flavor does not fail, it crawls. Name the flavor, what it costs per hour, and how long you expect the run to take.
 - Timeout. Set it above your estimate of the run, not at it. A timeout shorter than the run loses the run at the end.
 - Dependencies. State them explicitly, pinned — with the uv --with arguments or an image that already has them. Never build flash-attention from source in a job; it eats the budget and usually fails.
 - Destination. push_to_hub with an explicit hub_model_id in the namespace from the session context, or a mounted bucket volume for checkpoints. Nothing written to the container's own disk survives the job.
 - Data. Mount a large dataset as a volume rather than downloading it into the container.
 - Size. Smoke-test the same script for a handful of steps on the smallest GPU that fits, then launch the real run. Submit one job before you fan out.
 
-Picking hardware: t4-small for smoke tests and small models, a10g-small or a10g-large for a small finetune, a100-large for real training, multi-GPU above that. Prices change — read hf://docs/hub/jobs-pricing.md rather than quoting a rate from memory, and tell the user the hourly rate and your estimated wall-clock before you spend their credits.
+Picking hardware: the number that matters is cost to FINISH, not cost per hour. A GPU at twice the hourly rate that trains three times as fast is both cheaper and sooner, so the cheapest flavor is rarely the right default for real training — t4-small is for smoke tests and genuinely small work, a10g-small, a10g-large or l4x1 for a small finetune, a100-large when the model needs the memory or the throughput, multi-GPU above that. Prices change: read hf://docs/hub/jobs-pricing.md rather than quoting a rate from memory.
+
+Estimate before you submit. The smoke test gives you measured steps per second, so the real run's wall-clock is arithmetic — do it, and put the estimate and what it will cost on the pre-flight list every time. If the run will take more than about half an hour, or a faster flavor would materially change that, put the choice to the user with ask_user_question and carry the numbers in the options: "about 4 hours on a T4, roughly $1.60" against "about 1.5 hours on an A10G, roughly $1.50" is a decision they can make in one click. Below that, take the sensible default and say which you took.
 
 After submitting, report the job id and its URL, then follow it with the logs operation. A submitted job is not a finished one, and a job that failed says why in its logs — read them before you change anything.`;
 
 const HF_FS_WRITE_RULES = `WRITING TO THE HUB (hf_fs_write): read a file before you overwrite it, and pass the parent commit SHA you read it at, so a concurrent change fails loudly instead of being silently clobbered. Write to a repo in your own namespace, or propose the change as a PR — do not commit to someone else's main branch. Deletes are not recoverable: say what you are removing and why before you remove it.`;
 
+const HF_FS_FINDING_RULES = `FINDING PAPERS AND DOCS (hf_fs): papers live at hf://papers. Search them with search hf://papers "..." and read one with cat hf://papers/<id>/paper.md, which pages — read it to the end rather than stopping at the first chunk, because the method is usually in the middle and the implementation details are in the appendices. hub_repo_search searches REPOSITORIES: a paper title put through it returns nothing, which tells you nothing about whether the paper exists. Library documentation is at hf://docs, and it is current where your memory is not.`;
+
+const WEB_SEARCH_RULES = `SEARCHING THE WEB (web_search_exa): for what the Hub does not hold — an author's implementation on their own site, a post describing a trick a paper leaves out, an error nobody has written a doc for. Use 3-6 precise keywords, and prefer the primary source over a summary of it. It is not where you look up a model, dataset or paper that lives on the Hub: those have their own tools, and those results are authoritative where a search result is hearsay.`;
+
 /** Keyed by tool name as the model sees it in the schema. */
 const TOOL_DOCTRINE: ReadonlyArray<{ tool: string; text: string }> = [
 	{ tool: "hf_jobs", text: HF_JOBS_CONTRACT },
+	{ tool: "hf_fs", text: HF_FS_FINDING_RULES },
 	{ tool: "hf_fs_write", text: HF_FS_WRITE_RULES },
+	// The mode replaces the generic tool preprompt, and with it the SEARCH
+	// paragraph. Without this, a deployment that configures Exa hands the model
+	// web search with no guidance at all.
+	{ tool: "web_search_exa", text: WEB_SEARCH_RULES },
 ];
 
 /**

--- a/src/lib/server/mlAssistantPrompt.ts
+++ b/src/lib/server/mlAssistantPrompt.ts
@@ -152,21 +152,36 @@ export function mlAssistantSessionContext({
 	timezone?: string;
 	now?: Date;
 }): string {
-	const parts = new Intl.DateTimeFormat("en-CA", {
-		year: "numeric",
-		month: "2-digit",
-		day: "2-digit",
-		hour: "2-digit",
-		minute: "2-digit",
-		hour12: false,
-		...(timezone ? { timeZone: timezone } : {}),
-	}).formatToParts(now);
+	const format = (zone?: string) =>
+		new Intl.DateTimeFormat("en-CA", {
+			year: "numeric",
+			month: "2-digit",
+			day: "2-digit",
+			hour: "2-digit",
+			minute: "2-digit",
+			hour12: false,
+			...(zone ? { timeZone: zone } : {}),
+		}).formatToParts(now);
+
+	// The zone comes from the request body and is validated only as a string, so
+	// it can be anything. Intl throws RangeError on one it does not know, and this
+	// runs before the generation's own try — an unusable zone would fail the turn
+	// outright rather than degrade it. Fall back to the server's zone, and stop
+	// claiming a zone we did not use.
+	let zone = timezone;
+	let parts;
+	try {
+		parts = format(zone);
+	} catch {
+		zone = undefined;
+		parts = format(undefined);
+	}
 	const at = (type: string) => parts.find((part) => part.type === type)?.value ?? "";
 	const date = `${at("year")}-${at("month")}-${at("day")}`;
 	const time = `${at("hour")}:${at("minute")}`;
 	const user = username && username.trim().length > 0 ? username.trim() : "unknown";
 	return `[Session context: Date=${date}, Time=${time}${
-		timezone ? `, Timezone=${timezone}` : ""
+		zone ? `, Timezone=${zone}` : ""
 	}, User=${user}]`;
 }
 

--- a/src/lib/server/textGeneration/__tests__/replayRoundTrip.spec.ts
+++ b/src/lib/server/textGeneration/__tests__/replayRoundTrip.spec.ts
@@ -315,6 +315,27 @@ async function setReasoningOverride(locals: App.Locals, value: boolean) {
 
 // ── The round trip ────────────────────────────────────────────────────────────
 
+describe.sequential("the generation log", () => {
+	it("records the turn's events, so a reattaching client has something to replay", async () => {
+		// The route builds the message and feeds the writer in the same closure. An
+		// earlier refactor extracted the message half and dropped `writer.push` with
+		// it: every turn still looked right in the conversation while the log stayed
+		// empty and `materializedSeq` never left zero — invisible until a client
+		// reattached. Nothing else here reads the log, so it went unnoticed.
+		const { conv, locals } = await newConversation();
+		scriptRounds([{ content: "hello" }]);
+
+		await sendMessage(conv, locals, "hi");
+
+		const generation = await collections.generations.findOne({ conversationId: conv._id });
+		expect(generation?.seq ?? 0).toBeGreaterThan(0);
+		const events = await collections.generationEvents.countDocuments({
+			generationId: generation?.generationId ?? "",
+		});
+		expect(events).toBeGreaterThan(0);
+	});
+});
+
 describe.sequential("tool history survives the round trip through Mongo", () => {
 	it("replays a past tool round as assistant/tool pairs on the next turn", async () => {
 		const { conv, locals } = await newConversation();

--- a/src/lib/server/textGeneration/builtinTools/builtinTools.spec.ts
+++ b/src/lib/server/textGeneration/builtinTools/builtinTools.spec.ts
@@ -38,6 +38,7 @@ describe("getEnabledBuiltinTools", () => {
 		expect(toolNames({ _id: new ObjectId(), mlAssistant: true })).toEqual([
 			"ask_user_question",
 			"update_plan",
+			"wait",
 		]);
 	});
 

--- a/src/lib/server/textGeneration/builtinTools/githubGrounding.spec.ts
+++ b/src/lib/server/textGeneration/builtinTools/githubGrounding.spec.ts
@@ -116,6 +116,7 @@ describe("registration", () => {
 		).toEqual([
 			"ask_user_question",
 			"update_plan",
+			"wait",
 			"github_list_repos",
 			"github_find_examples",
 			"github_read_file",
@@ -132,6 +133,6 @@ describe("registration", () => {
 			getEnabledBuiltinTools({ conv: { _id: new ObjectId(), mlAssistant: true } }).map(
 				(t) => t.name
 			)
-		).toEqual(["ask_user_question", "update_plan"]);
+		).toEqual(["ask_user_question", "update_plan", "wait"]);
 	});
 });

--- a/src/lib/server/textGeneration/builtinTools/index.ts
+++ b/src/lib/server/textGeneration/builtinTools/index.ts
@@ -3,6 +3,7 @@ import { isMlAssistantConversation } from "$lib/server/mlAssistant";
 import { askUserQuestionBuiltin } from "./askUserQuestion";
 import { githubGroundingBuiltins } from "./githubGrounding";
 import { createPlanTool } from "./planTool";
+import { waitBuiltin } from "./waitTool";
 import type { BuiltinTool } from "./types";
 
 export type { BuiltinTool, BuiltinToolContext, BuiltinToolResult } from "./types";
@@ -21,7 +22,12 @@ export function getEnabledBuiltinTools(params: {
 	// The GitHub tools carry a second condition of their own — they withhold
 	// themselves without a GITHUB_TOKEN — which is still policy, so it lives with
 	// them rather than leaking a config read into this list.
-	return [askUserQuestionBuiltin, createPlanTool(params.conv), ...githubGroundingBuiltins()];
+	return [
+		askUserQuestionBuiltin,
+		createPlanTool(params.conv),
+		waitBuiltin,
+		...githubGroundingBuiltins(),
+	];
 }
 
 /**

--- a/src/lib/server/textGeneration/builtinTools/types.ts
+++ b/src/lib/server/textGeneration/builtinTools/types.ts
@@ -1,3 +1,4 @@
+import type { ObjectId } from "mongodb";
 import type { OpenAiTool } from "$lib/server/mcp/tools";
 import type { MessageUpdate } from "$lib/types/MessageUpdate";
 import type { ElicitationSink } from "$lib/server/mcp/elicitation";
@@ -19,6 +20,15 @@ export type BuiltinToolResult =
 export interface BuiltinToolContext {
 	/** uuid of this call's Tool updates, shared with any extraUpdates that reference it. */
 	uuid: string;
+	/** The conversation this call belongs to. Absent only where the run has no chat context. */
+	conversationId?: ObjectId;
+	/**
+	 * Who the turn belongs to. A tool that parks has to record this: the resume
+	 * happens with no request to read an identity from, and must act as the user
+	 * who parked rather than as whatever swept it.
+	 */
+	userId?: ObjectId;
+	sessionId?: string;
 	/** Provider-issued tool_call id. */
 	toolCallId: string;
 	/**

--- a/src/lib/server/textGeneration/builtinTools/waitTool.spec.ts
+++ b/src/lib/server/textGeneration/builtinTools/waitTool.spec.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import { ObjectId } from "mongodb";
+import { collections, ready } from "$lib/server/database";
+import { waitBuiltin } from "./waitTool";
+import type { BuiltinToolContext } from "./types";
+
+const ctx = (over: Partial<BuiltinToolContext> = {}): BuiltinToolContext => ({
+	uuid: "uuid-1",
+	toolCallId: "call-1",
+	conversationId: new ObjectId(),
+	messageId: "msg-1",
+	userId: new ObjectId(),
+	sessionId: "sess-1",
+	...over,
+});
+
+beforeAll(async () => {
+	await ready;
+});
+
+afterEach(async () => {
+	await collections.parkedCalls.deleteMany({});
+});
+
+describe("the wait tool", () => {
+	it("parks the turn and records everything a resume needs", async () => {
+		const c = ctx();
+		const before = Date.now();
+
+		const outcome = await waitBuiltin.execute({ seconds: 120, reason: "job to finish" }, c);
+
+		expect(outcome).toEqual({ awaitingInput: true });
+		const row = await collections.parkedCalls.findOne({});
+		expect(row).toMatchObject({
+			conversationId: c.conversationId,
+			messageId: "msg-1",
+			toolCallId: "call-1",
+			toolUuid: "uuid-1",
+			kind: "timer",
+			status: "waiting",
+			reason: "job to finish",
+			userId: c.userId,
+			sessionId: "sess-1",
+			attempts: 0,
+		});
+		// The identity matters as much as the timer: a resume has no request to read
+		// one from, and must act as the user who parked.
+		expect(row?.resumeAt.getTime()).toBeGreaterThanOrEqual(before + 120_000);
+	});
+
+	it("clamps a wait to the allowed window rather than refusing it", async () => {
+		const waitedFor = async () => {
+			const row = await collections.parkedCalls.findOne({});
+			if (!row) throw new Error("nothing parked");
+			return row.resumeAt.getTime() - row.createdAt.getTime();
+		};
+
+		await waitBuiltin.execute({ seconds: 5, reason: "too short" }, ctx());
+		expect(await waitedFor()).toBeGreaterThanOrEqual(15_000);
+
+		await collections.parkedCalls.deleteMany({});
+		await waitBuiltin.execute({ seconds: 99_999, reason: "too long" }, ctx());
+		expect(await waitedFor()).toBeLessThanOrEqual(30 * 60_000);
+	});
+
+	it("refuses without saying what it is waiting for", async () => {
+		const outcome = await waitBuiltin.execute({ seconds: 60 }, ctx());
+		expect(outcome).toHaveProperty("error");
+		expect(await collections.parkedCalls.countDocuments({})).toBe(0);
+	});
+
+	it("stops a wait-loop from replacing the poll-loop", async () => {
+		// Park, resume, park again costs a turn each time and never returns to the
+		// user. This is the same ceiling the repetition guard puts on tool calls.
+		const conversationId = new ObjectId();
+		await collections.parkedCalls.insertMany(
+			Array.from({ length: 40 }, () => ({
+				_id: new ObjectId(),
+				parkedCallId: new ObjectId().toString(),
+				conversationId,
+				messageId: "m",
+				toolCallId: "c",
+				toolUuid: "u",
+				kind: "timer" as const,
+				status: "resumed" as const,
+				resumeAt: new Date(),
+				reason: "prior hop",
+				attempts: 1,
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			}))
+		);
+
+		const outcome = await waitBuiltin.execute(
+			{ seconds: 60, reason: "again" },
+			ctx({ conversationId })
+		);
+
+		expect(outcome).toHaveProperty("error");
+		expect(String((outcome as { error: string }).error)).toContain("limit");
+		expect(await collections.parkedCalls.countDocuments({ conversationId })).toBe(40);
+	});
+
+	it("declines to park where nothing could wake it", async () => {
+		const outcome = await waitBuiltin.execute(
+			{ seconds: 60, reason: "x" },
+			ctx({ conversationId: undefined })
+		);
+		expect(outcome).toHaveProperty("error");
+		expect(await collections.parkedCalls.countDocuments({})).toBe(0);
+	});
+});

--- a/src/lib/server/textGeneration/builtinTools/waitTool.ts
+++ b/src/lib/server/textGeneration/builtinTools/waitTool.ts
@@ -1,0 +1,143 @@
+import { randomUUID } from "crypto";
+import { ObjectId } from "mongodb";
+import { collections } from "$lib/server/database";
+import { logger } from "$lib/server/logger";
+import type { BuiltinTool } from "./types";
+
+export const WAIT_TOOL_NAME = "wait";
+
+/**
+ * Below this a wait is not worth a turn — the model should just call the tool
+ * again. Above it, the sweep interval stops being the dominant error.
+ */
+const MIN_WAIT_SECONDS = 15;
+/**
+ * A single wait is capped well under the parked-row TTL. Longer waits are
+ * expressed as several hops, which also gives the model a chance to notice the
+ * thing it is waiting for has failed.
+ */
+const MAX_WAIT_SECONDS = 30 * 60;
+
+/**
+ * Parking is cheap per hop and unbounded in aggregate: park, resume, park again
+ * is a loop that costs a turn each time and never returns to the user. This is
+ * the ceiling on hops in one conversation — the same role the repetition guard
+ * plays for tool calls.
+ */
+const MAX_WAITS_PER_CONVERSATION = 40;
+
+export const waitBuiltin: BuiltinTool = {
+	name: WAIT_TOOL_NAME,
+	definition: {
+		type: "function" as const,
+		function: {
+			name: WAIT_TOOL_NAME,
+			description:
+				"Stop and come back later. Use this while waiting on something that takes real " +
+				"time — a training job, a long evaluation — instead of calling its status tool " +
+				"again immediately. Your turn ends here and resumes automatically after the delay, " +
+				"with everything you have done so far intact. Calling a status tool in a tight " +
+				"loop does not make the work finish sooner; it burns the turn.",
+			parameters: {
+				type: "object",
+				properties: {
+					seconds: {
+						type: "integer",
+						minimum: MIN_WAIT_SECONDS,
+						maximum: MAX_WAIT_SECONDS,
+						description:
+							"How long to wait before being woken. Match it to the work: a job that " +
+							"takes an hour is several long waits, not sixty short ones.",
+					},
+					reason: {
+						type: "string",
+						description:
+							"What you are waiting for, in a few words. Shown to the user while you wait.",
+					},
+				},
+				required: ["seconds", "reason"],
+			},
+		},
+	},
+	mayPark: true,
+	parkRefusalMessage:
+		"Only one call can park per round. Wait for one thing at a time, then check the rest when you wake.",
+	preprompt:
+		`WAITING: When work you started needs time — a training job, a long evaluation — call ${WAIT_TOOL_NAME} ` +
+		`rather than calling its status tool again straight away. Polling in a tight loop does not make the work ` +
+		`finish sooner, and it spends the turn you will need to act on the result. Ask for a delay that matches ` +
+		`the work, and check the status once when you wake.`,
+
+	async execute(args, ctx) {
+		const seconds = Math.round(Number(args.seconds));
+		const reason = typeof args.reason === "string" ? args.reason.trim() : "";
+
+		if (!Number.isFinite(seconds)) {
+			return {
+				error: `'seconds' must be a number between ${MIN_WAIT_SECONDS} and ${MAX_WAIT_SECONDS}.`,
+			};
+		}
+		if (!reason) {
+			return { error: "'reason' must say what you are waiting for." };
+		}
+		if (!ctx.conversationId || !ctx.messageId) {
+			// Nothing to resume into; better to say so than to park a turn nothing can wake.
+			return { error: "Waiting is not available in this context. Continue without it." };
+		}
+
+		const clamped = Math.min(Math.max(seconds, MIN_WAIT_SECONDS), MAX_WAIT_SECONDS);
+
+		const hops = await collections.parkedCalls.countDocuments({
+			conversationId: ctx.conversationId,
+		});
+		if (hops >= MAX_WAITS_PER_CONVERSATION) {
+			return {
+				error:
+					`This conversation has already waited ${hops} times, which is the limit. ` +
+					"Stop waiting: report what you know and what is still unfinished, and let the user decide.",
+			};
+		}
+
+		const parkedCallId = randomUUID();
+		const now = new Date();
+		await collections.parkedCalls.insertOne({
+			_id: new ObjectId(),
+			parkedCallId,
+			conversationId: ctx.conversationId,
+			...(ctx.generationId ? { generationId: ctx.generationId } : {}),
+			messageId: ctx.messageId,
+			toolCallId: ctx.toolCallId,
+			toolUuid: ctx.uuid,
+			kind: "timer",
+			status: "waiting",
+			resumeAt: new Date(now.getTime() + clamped * 1000),
+			reason,
+			...(ctx.userId ? { userId: ctx.userId } : {}),
+			...(ctx.sessionId ? { sessionId: ctx.sessionId } : {}),
+			attempts: 0,
+			createdAt: now,
+			updatedAt: now,
+		});
+
+		logger.info(
+			{ parkedCallId, conversationId: ctx.conversationId.toString(), seconds: clamped, reason },
+			"[wait] turn parked"
+		);
+
+		return { awaitingInput: true };
+	},
+};
+
+/** The tool result the model reads on the round it wakes into. */
+export function waitResumeResultText(park: {
+	reason: string;
+	resumeAt: Date;
+	createdAt: Date;
+}): string {
+	const waited = Math.round((park.resumeAt.getTime() - park.createdAt.getTime()) / 1000);
+	return (
+		`Waited ${waited}s for: ${park.reason}. You are now resumed. ` +
+		"Check the status of what you were waiting for once, then act on what you find — " +
+		"if it is still not ready, wait again rather than polling."
+	);
+}

--- a/src/lib/server/textGeneration/index.ts
+++ b/src/lib/server/textGeneration/index.ts
@@ -68,6 +68,8 @@ async function* textGenerationWithoutTitle(
 		mlAssistant,
 		artifactsOverride: ctx.artifactsOverride,
 		supportsArtifacts: ctx.model.supportsArtifacts,
+		username: ctx.username,
+		timezone: (ctx.locals as unknown as { timezone?: string } | undefined)?.timezone,
 	});
 
 	const processedMessages = await preprocessMessages(messages, convId);

--- a/src/lib/server/textGeneration/mcp/runMcpFlow.spec.ts
+++ b/src/lib/server/textGeneration/mcp/runMcpFlow.spec.ts
@@ -544,3 +544,51 @@ describe("runMcpFlow offering the plan tool", () => {
 		expect(String(lastUser?.content)).not.toContain("CURRENT PLAN");
 	});
 });
+
+describe("runMcpFlow under the ML Assistant preset", () => {
+	const inMlMode = { conv: { _id: new ObjectId(), mlAssistant: true } } as unknown as Parameters<
+		typeof runMcpFlow
+	>[0];
+
+	const systemPrompt = (n = 0) => String(requestMessages(n)[0]?.content ?? "");
+
+	it("sends the preset's tool preprompt instead of the generic one", async () => {
+		// Both in one message is a contradiction: the generic text names writing
+		// code as a case to answer without tools, which is what the preset exists
+		// to overrule.
+		scriptRounds([{ content: "the answer" }]);
+		await runFlow(inMlMode);
+
+		expect(systemPrompt()).toContain("USING TOOLS:");
+		expect(systemPrompt()).not.toContain("Do NOT call a tool unless");
+	});
+
+	it("leaves a conversation outside the mode on the generic tool preprompt", async () => {
+		scriptRounds([{ content: "the answer" }]);
+		await runFlow();
+		expect(systemPrompt()).toContain("Do NOT call a tool unless");
+		expect(systemPrompt()).not.toContain("USING TOOLS:");
+	});
+
+	it("keeps working past the round budget an ordinary conversation stops at", async () => {
+		const toolRound: Round = { toolCalls: [{ id: "call_1", name: "do_thing", arguments: "{}" }] };
+		scriptRounds([...Array.from({ length: 11 }, () => toolRound), { content: "done" }]);
+
+		const { result } = await runFlow(inMlMode);
+
+		// Grounding ids, auditing a dataset and submitting a job is more than ten
+		// rounds on its own; the generic budget ends the turn mid-task.
+		expect(result).toBe("completed");
+		expect(mocks.create).toHaveBeenCalledTimes(12);
+	});
+
+	it("still stops, at the preset's own budget", async () => {
+		const toolRound: Round = { toolCalls: [{ id: "call_1", name: "do_thing", arguments: "{}" }] };
+		scriptRounds(Array.from({ length: 100 }, () => toolRound));
+
+		const { result } = await runFlow(inMlMode);
+
+		expect(result).toBe("exhausted");
+		expect(mocks.create).toHaveBeenCalledTimes(100);
+	});
+});

--- a/src/lib/server/textGeneration/mcp/runMcpFlow.spec.ts
+++ b/src/lib/server/textGeneration/mcp/runMcpFlow.spec.ts
@@ -461,7 +461,7 @@ describe("runMcpFlow offering the question tool", () => {
 		scriptRounds([{ content: "the answer" }]);
 		const { result } = await runFlow(inMlMode);
 		expect(result).toBe("completed");
-		expect(toolNames()).toEqual(["ask_user_question", "update_plan"]);
+		expect(toolNames()).toEqual(["ask_user_question", "update_plan", "wait"]);
 	});
 
 	it("still skips the flow outside the mode when no MCP server is selected", async () => {

--- a/src/lib/server/textGeneration/mcp/runMcpFlow.ts
+++ b/src/lib/server/textGeneration/mcp/runMcpFlow.ts
@@ -900,6 +900,13 @@ export async function* runMcpFlow({
 					roundReasoning: reasoningForToolMsg,
 					roundContent: assistantContentForToolMsg,
 					elicitation: { conversationId: conv._id, generationId, messageId },
+					// A parked call resumes with no request behind it, so the identity it
+					// should act as has to be recorded now, while there still is one.
+					owner: {
+						userId: (locals as unknown as { user?: { _id?: import("mongodb").ObjectId } })?.user
+							?._id,
+						sessionId: (locals as unknown as { sessionId?: string })?.sessionId,
+					},
 					builtinTools,
 				});
 				let toolMsgCount = 0;

--- a/src/lib/server/textGeneration/mcp/runMcpFlow.ts
+++ b/src/lib/server/textGeneration/mcp/runMcpFlow.ts
@@ -59,6 +59,13 @@ export type McpFlowResult =
 
 const MAX_TOOL_ROUNDS = 10;
 
+// ML Assistant runs jobs, and the round budget is what it spends grounding ids,
+// auditing a dataset, reading a working example and then submitting: ten does not
+// survive one training task, and exhausting the budget ends the turn with an
+// apology instead of an answer. Only the preset gets the larger budget — an
+// ordinary conversation that loops is still stopped early.
+const ML_ASSISTANT_MAX_TOOL_ROUNDS = 100;
+
 // Each retry costs a tool round, so give up quickly and answer without the tool.
 const MAX_TRUNCATED_TOOL_CALL_RETRIES = 2;
 
@@ -100,6 +107,9 @@ export async function* runMcpFlow({
 		return false;
 	};
 	const builtinTools = getEnabledBuiltinTools({ conv });
+	// Read once: the preset decides the servers, the round budget and which tool
+	// doctrine is sent, and they must all agree within a run.
+	const mlAssistant = isMlAssistantConversation(conv);
 
 	// Start from env-configured servers
 	let servers = getMcpServers();
@@ -166,7 +176,7 @@ export async function* runMcpFlow({
 	// The preset's servers go on after the user's selection has been filtered, so
 	// they survive a selection that excludes them. Anything the user picked on top
 	// still comes through — extra servers are configurable, these are not.
-	if (isMlAssistantConversation(conv)) {
+	if (mlAssistant) {
 		servers = withMlAssistantServers(servers);
 		try {
 			logger.debug(
@@ -449,7 +459,13 @@ export async function* runMcpFlow({
 			}
 		);
 		const userTimezone = (locals as unknown as { timezone?: string })?.timezone;
-		const toolPreprompt = buildToolPreprompt(oaTools, userTimezone, builtinTools);
+		// In the mode the doctrine paragraphs are swapped, not appended to: the
+		// generic restraint rule tells the model not to reach for a tool unless it
+		// lacks a capability, and names writing code as a case to answer directly,
+		// which is the inverse of the preset's doctrine.
+		const toolPreprompt = buildToolPreprompt(oaTools, userTimezone, builtinTools, {
+			mlAssistant,
+		});
 		const prepromptPieces: string[] = [];
 		if (toolPreprompt.trim().length > 0) {
 			prepromptPieces.push(toolPreprompt);
@@ -537,6 +553,8 @@ export async function* runMcpFlow({
 			sources: { index: number; link: string }[];
 		} => ({ annotated: text, sources: [] });
 
+		const maxToolRounds = mlAssistant ? ML_ASSISTANT_MAX_TOOL_ROUNDS : MAX_TOOL_ROUNDS;
+
 		let lastAssistantContent = "";
 		let streamedContent = false;
 		// Track whether we're inside a <think> block when the upstream streams
@@ -561,7 +579,7 @@ export async function* runMcpFlow({
 			);
 		}
 
-		for (let loop = 0; loop < MAX_TOOL_ROUNDS; loop += 1) {
+		for (let loop = 0; loop < maxToolRounds; loop += 1) {
 			// Check for abort at the start of each loop iteration
 			if (checkAborted()) {
 				logger.info({ loop }, "[mcp] aborting at start of loop iteration");
@@ -952,7 +970,7 @@ export async function* runMcpFlow({
 		}
 		// Not "not_applicable": that re-runs the turn with no tools and discards every
 		// tool result this turn produced.
-		logger.warn({ maxRounds: MAX_TOOL_ROUNDS }, "[mcp] tool-round budget exhausted");
+		logger.warn({ maxRounds: maxToolRounds }, "[mcp] tool-round budget exhausted");
 		const exhaustedText =
 			lastAssistantContent.trim().length > 0
 				? lastAssistantContent

--- a/src/lib/server/textGeneration/mcp/toolInvocation.ts
+++ b/src/lib/server/textGeneration/mcp/toolInvocation.ts
@@ -52,6 +52,8 @@ export interface ExecuteToolCallsParams {
 	roundContent?: string;
 	/** Omit and elicitation requests raised by these calls are declined. */
 	elicitation?: { conversationId: ObjectId; generationId?: string; messageId?: string };
+	/** Identity the turn runs as, for a builtin that has to be resumable later. */
+	owner?: { userId?: ObjectId; sessionId?: string };
 	/** Locally-executed tools, dispatched before the MCP mapping lookup. */
 	builtinTools?: BuiltinTool[];
 }
@@ -109,6 +111,7 @@ export async function* executeToolCalls({
 	roundReasoning,
 	roundContent,
 	elicitation,
+	owner,
 	builtinTools,
 }: ExecuteToolCallsParams): AsyncGenerator<ToolExecutionEvent, void, undefined> {
 	const effectiveTimeoutMs = toolTimeoutMs ?? getMcpToolTimeoutMs();
@@ -303,6 +306,9 @@ export async function* executeToolCalls({
 				const outcome = await builtin.execute(argsObj, {
 					uuid: p.uuid,
 					toolCallId: p.call.id,
+					conversationId: elicitation?.conversationId,
+					userId: owner?.userId,
+					sessionId: owner?.sessionId,
 					messageId: elicitation?.messageId,
 					generationId: elicitation?.generationId,
 					elicitationSink,

--- a/src/lib/server/textGeneration/preprompt.spec.ts
+++ b/src/lib/server/textGeneration/preprompt.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { resolvePreprompt } from "./preprompt";
 import { injectArtifactsPrompt } from "./artifacts";
-import { ML_ASSISTANT_PREPROMPT } from "$lib/server/mlAssistant";
+import { ML_ASSISTANT_PREPROMPT, mlAssistantSessionContext } from "$lib/server/mlAssistantPrompt";
 
 /**
  * The ML Assistant preset must not change how artifacts resolve for anything
@@ -94,13 +94,53 @@ describe("resolvePreprompt", () => {
 	});
 
 	it("force-enables artifacts for the preset even when the model and override say no", () => {
+		const now = new Date("2026-08-24T09:07:00Z");
+
 		expect(
 			resolvePreprompt({
 				conversationPreprompt: undefined,
 				mlAssistant: true,
 				artifactsOverride: false,
 				supportsArtifacts: false,
+				timezone: "UTC",
+				now,
 			})
-		).toBe(injectArtifactsPrompt(ML_ASSISTANT_PREPROMPT));
+		).toBe(
+			`${injectArtifactsPrompt(ML_ASSISTANT_PREPROMPT)}\n\n${mlAssistantSessionContext({
+				timezone: "UTC",
+				now,
+			})}`
+		);
+	});
+
+	it("stamps the session context last, where the namespace rule reads it", () => {
+		const resolved = resolvePreprompt({
+			conversationPreprompt: undefined,
+			mlAssistant: true,
+			username: "pngwn",
+			timezone: "UTC",
+			now: new Date("2026-08-24T09:07:00Z"),
+		});
+
+		expect(resolved).toContain("User=pngwn");
+		// After the artifacts prompt, not merely somewhere in the message: the rule
+		// keys off the last line, and artifacts is appended by the same call.
+		expect(resolved?.trimEnd().endsWith("User=pngwn]")).toBe(true);
+	});
+
+	it("says the user is unknown rather than leaving the preset to guess", () => {
+		expect(resolvePreprompt({ conversationPreprompt: undefined, mlAssistant: true })).toContain(
+			"User=unknown"
+		);
+	});
+
+	it("stamps nothing outside the preset", () => {
+		expect(
+			resolvePreprompt({
+				conversationPreprompt: "You are a pirate.",
+				mlAssistant: false,
+				username: "pngwn",
+			})
+		).toBe("You are a pirate.");
 	});
 });

--- a/src/lib/server/textGeneration/preprompt.ts
+++ b/src/lib/server/textGeneration/preprompt.ts
@@ -1,5 +1,5 @@
 import { injectArtifactsPrompt } from "./artifacts";
-import { ML_ASSISTANT_PREPROMPT } from "$lib/server/mlAssistant";
+import { ML_ASSISTANT_PREPROMPT, mlAssistantSessionContext } from "$lib/server/mlAssistantPrompt";
 
 export interface PrepromptInput {
 	/** The conversation's stored system prompt. */
@@ -10,6 +10,12 @@ export interface PrepromptInput {
 	artifactsOverride?: boolean;
 	/** Whether the model advertises artifact support (supportsArtifacts). */
 	supportsArtifacts?: boolean;
+	/** Signed-in user's Hub username. The preset's namespace rule reads it back. */
+	username?: string;
+	/** IANA zone from the request, so the stamped time is the user's. */
+	timezone?: string;
+	/** Injectable clock, for tests. */
+	now?: Date;
 }
 
 /**
@@ -25,8 +31,16 @@ export function resolvePreprompt({
 	mlAssistant,
 	artifactsOverride,
 	supportsArtifacts,
+	username,
+	timezone,
+	now,
 }: PrepromptInput): string | undefined {
 	const base = mlAssistant ? ML_ASSISTANT_PREPROMPT : conversationPreprompt;
 	const artifacts = mlAssistant || (artifactsOverride ?? supportsArtifacts);
-	return artifacts ? injectArtifactsPrompt(base) : base;
+	const resolved = artifacts ? injectArtifactsPrompt(base) : base;
+	if (!mlAssistant) return resolved;
+	// Stamped last, after the artifacts prompt, because the preset reads the User
+	// value back out of it — and stamped here rather than onto the tool preprompt
+	// so it still reaches the model on the plain generation path, which has none.
+	return `${resolved}\n\n${mlAssistantSessionContext({ username, timezone, now })}`;
 }

--- a/src/lib/server/textGeneration/utils/toolPrompt.spec.ts
+++ b/src/lib/server/textGeneration/utils/toolPrompt.spec.ts
@@ -26,6 +26,16 @@ describe("buildToolPreprompt", () => {
 		expect(prompt).toContain("instead of answering from memory");
 	});
 
+	it("survives a timezone the client made up", () => {
+		// Client-supplied, validated only as a string. Intl throws on an unknown
+		// zone, and the throw is caught upstream — which silently answers without
+		// tools instead of failing, so it is easy to miss.
+		const prompt = buildToolPreprompt([tool("web_search_exa")], "Not/AZone");
+
+		expect(prompt).toContain("web_search_exa");
+		expect(prompt).not.toContain("Not/AZone");
+	});
+
 	it("only includes a builtin's guidance when that tool is on offer", () => {
 		const askBuiltin = {
 			name: "ask_user_question",

--- a/src/lib/server/textGeneration/utils/toolPrompt.ts
+++ b/src/lib/server/textGeneration/utils/toolPrompt.ts
@@ -34,7 +34,17 @@ export function buildToolPreprompt(
 		minute: "2-digit",
 		...(timezone ? { timeZone: timezone } : {}),
 	};
-	const currentDateTime = now.toLocaleString("en-US", dateTimeOptions);
+	// Same exposure as the session-context stamp: the zone is client-supplied and
+	// validated only as a string, and Intl throws on one it does not know. Here the
+	// throw is caught upstream and degrades the turn to a tool-free answer, which
+	// is quieter than a failure and just as wrong.
+	let currentDateTime: string;
+	try {
+		currentDateTime = now.toLocaleString("en-US", dateTimeOptions);
+	} catch {
+		timezone = undefined;
+		currentDateTime = now.toLocaleString("en-US", { ...dateTimeOptions, timeZone: undefined });
+	}
 	const isoDate = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
 	const locationLine = timezone ? ` User's timezone: ${timezone}.` : "";
 	// Only builtins actually on offer this turn contribute guidance.

--- a/src/lib/server/textGeneration/utils/toolPrompt.ts
+++ b/src/lib/server/textGeneration/utils/toolPrompt.ts
@@ -1,10 +1,20 @@
 import type { OpenAiTool } from "$lib/server/mcp/tools";
 import type { BuiltinTool } from "../builtinTools/types";
+import { ML_ASSISTANT_TOOL_DOCTRINE } from "$lib/server/mlAssistantPrompt";
 
 export function buildToolPreprompt(
 	tools: OpenAiTool[],
 	timezone?: string,
-	builtins?: Array<Pick<BuiltinTool, "name" | "preprompt" | "exemptFromToolRestraint">>
+	builtins?: Array<Pick<BuiltinTool, "name" | "preprompt" | "exemptFromToolRestraint">>,
+	/**
+	 * ML Assistant swaps the doctrine paragraphs — restraint, search, grounding —
+	 * for its own, and appends the blocks that belong to a particular tool. It is
+	 * a swap rather than a second builder on purpose: everything else here (the
+	 * tool list, the clock, per-builtin guidance, the image rules) has to reach
+	 * the model either way, and a parallel copy silently loses whatever is added
+	 * to this one next.
+	 */
+	options?: { mlAssistant?: boolean }
 ): string {
 	if (!Array.isArray(tools) || tools.length === 0) return "";
 	const names = tools
@@ -32,21 +42,33 @@ export function buildToolPreprompt(
 	const builtinGuidance = offered
 		.map((builtin) => builtin.preprompt?.trim() ?? "")
 		.filter((text) => text.length > 0);
-	return [
+	const mlAssistant = options?.mlAssistant ?? false;
+	// In the mode there is no blanket restraint for a tool to be exempt from: the
+	// paragraph that would name the exemptions is the one being replaced.
+	const restraint = mlAssistant
+		? ML_ASSISTANT_TOOL_DOCTRINE.usingTools
+		: `IMPORTANT: Do NOT call a tool unless the user's request requires capabilities you lack (e.g., real-time data, image generation, code execution) or external information you do not have. For tasks like writing code, creative writing, math, or building apps, respond directly without tools. When in doubt, do not use a tool.${
+				exemptNames.length > 0
+					? ` This does not apply to ${exemptNames.join(" or ")}, covered below.`
+					: ""
+			}`;
+	const general = [
 		`You have access to these tools: ${names.join(", ")}.`,
 		`Current date and time: ${currentDateTime} (${isoDate}).${locationLine}`,
-		`IMPORTANT: Do NOT call a tool unless the user's request requires capabilities you lack (e.g., real-time data, image generation, code execution) or external information you do not have. For tasks like writing code, creative writing, math, or building apps, respond directly without tools. When in doubt, do not use a tool.${
-			exemptNames.length > 0
-				? ` This does not apply to ${exemptNames.join(" or ")}, covered below.`
-				: ""
-		}`,
+		restraint,
 		...builtinGuidance,
 		`PARALLEL TOOL CALLS: When multiple tool calls are needed and they are independent of each other (i.e., one does not need the result of another), call them all at once in a single response instead of one at a time. Only chain tool calls sequentially when a later call depends on an earlier call's output.`,
-		`SEARCH: Use 3-6 precise keywords. For historical events, include the year the event occurred. For recent or current topics, use today's year (${now.getFullYear()}). When a tool accepts date-range parameters (e.g., startPublishedDate, endPublishedDate), always use today's date (${isoDate}) as the end date unless the user specifies otherwise. For multi-part questions, search each part separately. If the results only partially cover the question, run a follow-up search or crawl the most relevant result URL instead of answering from memory.`,
-		`GROUNDING: When you answer from tool results, the results are your only source of facts. Do not supplement them with specifics from your own knowledge — details not present in the results are likely wrong, even when they sound plausible. If a fact is missing, search again or say you could not verify it. Attribute key facts to their sources with markdown links to the result URLs. If results conflict, say so. Never fabricate URLs, citations, or facts.`,
-		`INTERACTIVE APPS: When asked to build an interactive application, game, or visualization without a specific language/framework preference, create a single self-contained HTML file with embedded CSS and JavaScript.`,
+		...(mlAssistant
+			? [ML_ASSISTANT_TOOL_DOCTRINE.grounding, ML_ASSISTANT_TOOL_DOCTRINE.largeResults]
+			: [
+					`SEARCH: Use 3-6 precise keywords. For historical events, include the year the event occurred. For recent or current topics, use today's year (${now.getFullYear()}). When a tool accepts date-range parameters (e.g., startPublishedDate, endPublishedDate), always use today's date (${isoDate}) as the end date unless the user specifies otherwise. For multi-part questions, search each part separately. If the results only partially cover the question, run a follow-up search or crawl the most relevant result URL instead of answering from memory.`,
+					`GROUNDING: When you answer from tool results, the results are your only source of facts. Do not supplement them with specifics from your own knowledge — details not present in the results are likely wrong, even when they sound plausible. If a fact is missing, search again or say you could not verify it. Attribute key facts to their sources with markdown links to the result URLs. If results conflict, say so. Never fabricate URLs, citations, or facts.`,
+					`INTERACTIVE APPS: When asked to build an interactive application, game, or visualization without a specific language/framework preference, create a single self-contained HTML file with embedded CSS and JavaScript.`,
+				]),
 		`If a tool generates an image, you can inline it directly: ![alt text](image_url).`,
 		`If a tool needs an image, set its image field ("input_image", "image", or "image_url") to a reference like "image_1", "image_2", etc. (ordered by when the user uploaded them).`,
 		`Default to image references; only use a full http(s) URL when the tool description explicitly asks for one, or reuse a URL a previous tool returned.`,
 	].join(" ");
+
+	return general;
 }

--- a/src/lib/server/textGeneration/utils/toolPrompt.ts
+++ b/src/lib/server/textGeneration/utils/toolPrompt.ts
@@ -1,6 +1,9 @@
 import type { OpenAiTool } from "$lib/server/mcp/tools";
 import type { BuiltinTool } from "../builtinTools/types";
-import { ML_ASSISTANT_TOOL_DOCTRINE } from "$lib/server/mlAssistantPrompt";
+import {
+	ML_ASSISTANT_TOOL_DOCTRINE,
+	mlAssistantToolDoctrineBlocks,
+} from "$lib/server/mlAssistantPrompt";
 
 export function buildToolPreprompt(
 	tools: OpenAiTool[],
@@ -70,5 +73,8 @@ export function buildToolPreprompt(
 		`Default to image references; only use a full http(s) URL when the tool description explicitly asks for one, or reuse a URL a previous tool returned.`,
 	].join(" ");
 
-	return general;
+	// Blocks, not sentences: a tool contract is a list the model reads down before
+	// acting, so it keeps its own paragraphs instead of being flattened into the
+	// run of general guidance. Empty outside the mode, where the join is a no-op.
+	return [general, ...(mlAssistant ? mlAssistantToolDoctrineBlocks(names) : [])].join("\n\n");
 }

--- a/src/lib/types/ParkedCall.ts
+++ b/src/lib/types/ParkedCall.ts
@@ -31,7 +31,12 @@ export interface ParkedCall extends Timestamps {
 	toolUuid: string;
 
 	kind: ParkedCallKind;
-	status: "waiting" | "resumed" | "abandoned";
+	/**
+	 * `resuming` is the claim: a sweeper transitions out of `waiting` atomically so
+	 * two pods cannot both wake the same turn. A row left in `resuming` is one whose
+	 * pod died mid-resume, which is why `attempts` is counted.
+	 */
+	status: "waiting" | "resuming" | "resumed" | "abandoned";
 	/** When the sweeper should wake this. Indexed with `status` — that pair is the sweep. */
 	resumeAt: Date;
 	/** Model-authored: what it is waiting for. Display text, never markup. */

--- a/src/lib/types/ParkedCall.ts
+++ b/src/lib/types/ParkedCall.ts
@@ -1,0 +1,55 @@
+import type { ObjectId } from "mongodb";
+import type { Conversation } from "./Conversation";
+import type { Timestamps } from "./Timestamps";
+import type { User } from "./User";
+
+/**
+ * Why a turn is parked. `timer` is the only kind today: the model asked to be
+ * woken after a delay instead of re-polling something that will not have changed.
+ * MCP tasks are the expected second kind — a call parked on a task handle rather
+ * than a clock — which is why this is a discriminator and not a boolean.
+ */
+export type ParkedCallKind = "timer";
+
+/**
+ * A tool call that ended its turn and expects to be resumed.
+ *
+ * In the database because the pod that resumes need not be the pod that parked,
+ * and because the wake can come minutes or hours later — long after the request
+ * that started the turn is gone. Everything the sweeper needs to rebuild that
+ * turn's context lives here or on the conversation; nothing is held in memory.
+ */
+export interface ParkedCall extends Timestamps {
+	_id: ObjectId;
+	parkedCallId: string;
+	conversationId: Conversation["_id"];
+	generationId?: string;
+	/** The assistant message the parked turn writes into; the resume continues it in place. */
+	messageId: string;
+	/** Provider-issued id of the call being parked, and the uuid of its Tool updates. */
+	toolCallId: string;
+	toolUuid: string;
+
+	kind: ParkedCallKind;
+	status: "waiting" | "resumed" | "abandoned";
+	/** When the sweeper should wake this. Indexed with `status` — that pair is the sweep. */
+	resumeAt: Date;
+	/** Model-authored: what it is waiting for. Display text, never markup. */
+	reason: string;
+
+	/**
+	 * Whose turn this is. The sweeper has no request to read an identity from, so it
+	 * rebuilds one from here — which also means a resume can only ever act as the
+	 * user who parked it.
+	 */
+	userId?: User["_id"];
+	sessionId?: string;
+
+	/** Set when a sweeper claims the row, so two pods cannot resume the same turn. */
+	takenAt?: Date;
+	resumedAt?: Date;
+	/** Claims that failed. A row that cannot be resumed is abandoned rather than retried forever. */
+	attempts: number;
+	/** Why it was abandoned, for the tool result the model reads on the next turn. */
+	abandonedReason?: string;
+}

--- a/src/routes/conversation/[id]/+server.ts
+++ b/src/routes/conversation/[id]/+server.ts
@@ -8,6 +8,7 @@ import { error } from "@sveltejs/kit";
 import { ObjectId } from "mongodb";
 import { z } from "zod";
 import {
+	MessageToolUpdateType,
 	MessageUpdateStatus,
 	MessageUpdateType,
 	MessageElicitationUpdateType,
@@ -473,6 +474,10 @@ export async function POST({ request, locals, params, getClientAddress }) {
 			generationWriter = writer;
 
 			let finalAnswerReceived = false;
+			// A turn can end having produced no text and still have done something —
+			// a tool call that parked the turn is the case that matters. Without this
+			// the no-output guard below calls that an error and persists it as one.
+			let sawToolCall = false;
 			let abortedByUser = false;
 			let finishedStatusSent = false;
 
@@ -494,6 +499,10 @@ export async function POST({ request, locals, params, getClientAddress }) {
 					event.status === MessageUpdateStatus.Finished
 				) {
 					finishedStatusSent = true;
+				}
+
+				if (event.type === MessageUpdateType.Tool && event.subtype === MessageToolUpdateType.Call) {
+					sawToolCall = true;
 				}
 
 				// Add token to content or skip if empty
@@ -535,6 +544,19 @@ export async function POST({ request, locals, params, getClientAddress }) {
 					}
 				} else if (event.type === MessageUpdateType.Stream) {
 					lastTokenTimestamp = new Date();
+				}
+
+				// Before the padding below rewrites `event`: the log stores what was
+				// actually generated, not the padded wire form. Without this the
+				// reattach endpoint has no events to replay and materializedSeq never
+				// advances past zero.
+				writer.push(event);
+
+				// Avoid remote keylogging attack executed by watching packet lengths
+				// by padding the text with null chars to a fixed length
+				// https://cdn.arstechnica.net/wp-content/uploads/2024/03/LLM-Side-Channel.pdf
+				if (event.type === MessageUpdateType.Stream) {
+					event = { ...event, token: event.token.padEnd(16, "\0") };
 				}
 
 				const enqueueUpdate = async () => {
@@ -702,6 +724,7 @@ export async function POST({ request, locals, params, getClientAddress }) {
 					!hasError &&
 					!abortedByUser &&
 					!showedPrompt &&
+					!sawToolCall &&
 					messageToWriteTo.content === initialMessageContent
 				) {
 					hasError = true;

--- a/src/routes/conversation/[id]/+server.ts
+++ b/src/routes/conversation/[id]/+server.ts
@@ -13,7 +13,6 @@ import {
 	MessageElicitationUpdateType,
 	MessageReasoningUpdateType,
 	type MessageUpdate,
-	type MessageStreamUpdate,
 } from "$lib/types/MessageUpdate";
 import { uploadFile } from "$lib/server/files/uploadFile";
 import { convertLegacyConversation } from "$lib/utils/tree/convertLegacyConversation";
@@ -28,6 +27,7 @@ import type { McpServerConfig } from "$lib/server/mcp/httpClient";
 import { isMlAssistantConversation } from "$lib/server/mlAssistant";
 import { ML_ASSISTANT_EFFORT } from "$lib/constants/mlAssistant";
 import { logger } from "$lib/server/logger.js";
+import { compressUpdatesForStorage } from "$lib/server/generation/compressUpdates";
 import { AbortRegistry } from "$lib/server/abortRegistry";
 import { createGenerationWriter, type GenerationWriter } from "$lib/server/generation/writer";
 import { clampStoppedContent } from "$lib/server/stopTruncation";
@@ -41,24 +41,6 @@ import { applyConversationSettings } from "$lib/server/conversationSettings";
 // would lose the stop. Aborted generations consume their marker on shutdown,
 // so markers normally live far shorter than this.
 const STOP_MARKER_GRACE_MS = 5_000;
-
-// Shape a message's updates for storage: drop keepalives and replace each stream token
-// with a length marker (content is stored separately), preserving ordering without
-// duplicating text. Shared by the full save and the writer's incremental materialise so
-// both persist the same thing under materializedSeq.
-function compressUpdatesForStorage(updates: Message["updates"]): Message["updates"] {
-	return (
-		updates
-			?.filter(
-				(u) => !(u.type === MessageUpdateType.Status && u.status === MessageUpdateStatus.KeepAlive)
-			)
-			.map((u) => {
-				if (u.type !== MessageUpdateType.Stream) return u;
-				const len = u.len ?? (u.token ?? "").length;
-				return { type: MessageUpdateType.Stream, token: "", len } satisfies MessageStreamUpdate;
-			}) ?? []
-	);
-}
 
 export async function POST({ request, locals, params, getClientAddress }) {
 	const id = z.string().parse(params.id);

--- a/src/routes/conversation/[id]/+server.ts
+++ b/src/routes/conversation/[id]/+server.ts
@@ -11,7 +11,6 @@ import {
 	MessageUpdateStatus,
 	MessageUpdateType,
 	MessageElicitationUpdateType,
-	MessageReasoningUpdateType,
 	type MessageUpdate,
 } from "$lib/types/MessageUpdate";
 import { uploadFile } from "$lib/server/files/uploadFile";
@@ -28,6 +27,7 @@ import { isMlAssistantConversation } from "$lib/server/mlAssistant";
 import { ML_ASSISTANT_EFFORT } from "$lib/constants/mlAssistant";
 import { logger } from "$lib/server/logger.js";
 import { compressUpdatesForStorage } from "$lib/server/generation/compressUpdates";
+import { applyUpdateToMessage } from "$lib/server/generation/applyUpdate";
 import { AbortRegistry } from "$lib/server/abortRegistry";
 import { createGenerationWriter, type GenerationWriter } from "$lib/server/generation/writer";
 import { clampStoppedContent } from "$lib/server/stopTruncation";
@@ -497,11 +497,26 @@ export async function POST({ request, locals, params, getClientAddress }) {
 				}
 
 				// Add token to content or skip if empty
-				if (event.type === MessageUpdateType.Stream) {
-					if (event.token === "") return;
-					messageToWriteTo.content += event.token;
+				const applied = applyUpdateToMessage(event, {
+					message: messageToWriteTo,
+					conv,
+					initialContent: initialMessageContent,
+					isRouterModel: Boolean(model?.isRouter),
+				});
+				// An empty stream token is not an event: it reaches neither the log,
+				// the client, nor the message.
+				if (applied.skipped) return;
 
-					if (metricsEnabled && metrics) {
+				if (applied.titleChanged) {
+					await collections.conversations.updateOne(
+						{ _id: convId },
+						{ $set: { title: conv?.title, updatedAt: new Date() } }
+					);
+				}
+				if (applied.finalAnswerReceived) finalAnswerReceived = true;
+
+				if (metricsEnabled && metrics) {
+					if (event.type === MessageUpdateType.Stream) {
 						const now = Date.now();
 						metrics.model.tokenCountTotal.inc(metricsLabels);
 
@@ -514,125 +529,13 @@ export async function POST({ request, locals, params, getClientAddress }) {
 							? lastTokenTimestamp.getTime()
 							: promptedAt.getTime();
 						metrics.model.timePerOutputToken.observe(metricsLabels, now - previousTimestamp);
-					}
-
-					lastTokenTimestamp = new Date();
-				}
-
-				// Append reasoning stream tokens to message.reasoning (server-side)
-				else if (
-					event.type === MessageUpdateType.Reasoning &&
-					event.subtype === MessageReasoningUpdateType.Stream &&
-					"token" in event
-				) {
-					messageToWriteTo.reasoning ??= "";
-					messageToWriteTo.reasoning += event.token;
-				}
-
-				// Set the title
-				else if (event.type === MessageUpdateType.Title) {
-					// Always strip <think> markers from titles when saving
-					const sanitizedTitle = event.title.replace(/<\/?think>/gi, "").trim();
-					conv.title = sanitizedTitle;
-					await collections.conversations.updateOne(
-						{ _id: convId },
-						{ $set: { title: conv?.title, updatedAt: new Date() } }
-					);
-				}
-
-				// Set the final text and the interrupted flag
-				else if (event.type === MessageUpdateType.FinalAnswer) {
-					messageToWriteTo.interrupted = event.interrupted;
-					// Default behavior: replace the streamed text with the provider's final text.
-					// However, when tools (MCP/function calls) were used, providers often stream
-					// some content (e.g., a story) before triggering tools, then return a
-					// different follow‑up message afterwards (e.g., an image caption). Our
-					// previous logic overwrote the pre‑tool content. Preserve it by merging in
-					// the pre‑tool stream when tool updates occurred and the final text does
-					// not already include the streamed prefix.
-					const hadTools = (messageToWriteTo.updates ?? []).some(
-						(u) => u.type === MessageUpdateType.Tool
-					);
-
-					if (hadTools) {
-						const existing = messageToWriteTo.content.slice(initialMessageContent.length);
-						if (existing && existing.length > 0) {
-							// A. If we already streamed the same final text, keep as-is.
-							if (event.text && existing.endsWith(event.text)) {
-								messageToWriteTo.content = initialMessageContent + existing;
-							}
-							// B. If the final text already includes the streamed prefix, use it verbatim.
-							else if (event.text && event.text.startsWith(existing)) {
-								messageToWriteTo.content = initialMessageContent + event.text;
-							}
-							// C. Otherwise, merge with a paragraph break for readability.
-							else {
-								const needsGap = !/\n\n$/.test(existing) && !/^\n/.test(event.text ?? "");
-								messageToWriteTo.content =
-									initialMessageContent + existing + (needsGap ? "\n\n" : "") + (event.text ?? "");
-							}
-						} else {
-							messageToWriteTo.content = initialMessageContent + (event.text ?? "");
-						}
-					} else {
-						messageToWriteTo.content = initialMessageContent + event.text;
-					}
-					finalAnswerReceived = true;
-
-					if (metricsEnabled && metrics) {
+						lastTokenTimestamp = new Date();
+					} else if (event.type === MessageUpdateType.FinalAnswer) {
 						metrics.model.latency.observe(metricsLabels, Date.now() - promptedAt.getTime());
 					}
+				} else if (event.type === MessageUpdateType.Stream) {
+					lastTokenTimestamp = new Date();
 				}
-
-				// Add file
-				else if (event.type === MessageUpdateType.File) {
-					messageToWriteTo.files = [
-						...(messageToWriteTo.files ?? []),
-						{ type: "hash", name: event.name, value: event.sha, mime: event.mime },
-					];
-				}
-
-				// Store router metadata (for router models) or provider info (for all models)
-				else if (event.type === MessageUpdateType.RouterMetadata) {
-					// Merge metadata updates to preserve existing fields (router may send route/model first, then provider comes later)
-					if (model?.isRouter) {
-						messageToWriteTo.routerMetadata = {
-							route: event.route || messageToWriteTo.routerMetadata?.route || "",
-							model: event.model || messageToWriteTo.routerMetadata?.model || "",
-							provider: event.provider || messageToWriteTo.routerMetadata?.provider,
-						};
-					}
-					// Store provider-only metadata for non-router models if available
-					else if (event.provider) {
-						messageToWriteTo.routerMetadata = {
-							route: messageToWriteTo.routerMetadata?.route || "",
-							model: messageToWriteTo.routerMetadata?.model || "",
-							provider: event.provider,
-						};
-					}
-				}
-
-				// Append updates for audit/replay (streams too, to preserve ordering)
-				if (!(
-					event.type === MessageUpdateType.Status && event.status === MessageUpdateStatus.KeepAlive
-				)) {
-					messageToWriteTo?.updates?.push(
-						event.type === MessageUpdateType.Stream ? { ...event } : event
-					);
-				}
-
-				// Before the padding below rewrites `event`: the log stores what was
-				// actually generated, not the padded wire form.
-				writer.push(event);
-
-				// Avoid remote keylogging attack executed by watching packet lengths
-				// by padding the text with null chars to a fixed length
-				// https://cdn.arstechnica.net/wp-content/uploads/2024/03/LLM-Side-Channel.pdf
-				if (event.type === MessageUpdateType.Stream) {
-					event = { ...event, token: event.token.padEnd(16, "\0") };
-				}
-
-				messageToWriteTo.updatedAt = new Date();
 
 				const enqueueUpdate = async () => {
 					if (clientDetached) return;


### PR DESCRIPTION
Replaces the ML Assistant preset's six-bullet prompt with the doctrine ported
from ml-intern, then fixes what dogfooding it broke. Nine commits; the later
half was not planned, it was found by running the thing.

## The prompt (commits 1–3, 9)

Ported rather than copied. ml-intern is an autonomous agent with 300 iterations,
a sandbox and a shell; this is an interactive chat turn against the Hub.

- **Ten tool rounds is not enough, so the preset gets a hundred.** Exhausting the
  budget ends the turn with an apology mid-task. Applies to the preset alone.
- **A human is present**, so the autonomous block does not apply and "ask instead
  of assuming" routes through `ask_user_question` by name.
- **No sandbox, no shell.** Rules keyed to bash, read-before-edit or `/app` are
  dead text and are dropped; a test asserts the prompt names no tool this harness
  lacks. Develop-small-launch-big survives as a short job before a long one.

The mode **swaps** `buildToolPreprompt`'s doctrine paragraphs rather than adding
to them: the generic text says not to call a tool unless you lack a capability
and names writing code as a case to answer directly, which is the inverse of this
mode's doctrine — and is why #2524's tools needed `exemptFromToolRestraint` at
all. It is a swap inside the one builder, not a second builder, because a
parallel copy silently stops carrying whatever is added to the other one next.
That had already happened once during this PR's own rebase.

Tool-specific doctrine is keyed on the tool being offered — `hf_jobs` gets the
submission contract, `hf_fs_write` the write rules, `hf_fs` where papers live,
`web_search_exa` its own guidance. These are MCP tools whose descriptions we do
not own and deliberately do not rewrite.

Two `hf_jobs` failure modes came out of reading the current docs rather than
recall, and are specific to this harness: **pushing to the Hub from inside a job
needs `HF_TOKEN` passed explicitly as a secret** (omit it and the run trains for
an hour then fails at the push), and **the default flavor is `cpu-basic`** (a
training job that names no GPU does not fail, it crawls).

After the first real run, commit 9 adds: hardware reasoned in **cost to finish,
not cost per hour**, with the estimate on the pre-flight list and the choice put
to the user above ~30 minutes; a bounded **citation hop**, because that run
followed none and rediscovered standard flow-matching the hard way; and the
paper-search and web-search rules above.

## The MCP login URL (commit 3)

The preset hard-coded `https://hf.co/mcp`. `isStrictHfMcpLogin` matches the exact
URL including `?login`, and it gates both token forwarding and the login control.
Worse than getting itself wrong: the preset wins the name collision, so turning
the mode on in production would have **silently downgraded the `?login` server
that prod.yaml already configures to an anonymous one**.

## Message size (commit 5)

A conversation is one MongoDB document, capped at 16MB, and one run reached
**94.7% of it** — 73,994 updates on a single assistant message, 59,487 of them
MCP progress notifications. Past the ceiling every write fails and the
conversation can never be added to again. Progress is live-only UI: dropped from
persistence (not from streaming), which took that conversation from 15,881,222
bytes to 5,297,794. Plus a 5,000-update cap as a backstop.

## Waiting instead of polling (commits 6–8)

That run made **1,096 `hf_jobs logs` calls**, one job polled 341 times with
byte-identical output — it was polling a job that had already crashed. The cause
is that the agent has no way to wait: it decides to check back later, the only
action available is to call the tool again, and "wait" becomes a hot loop.

- `ParkedCall`: a tool call that ended its turn and expects to be resumed, with
  `resumeAt` and a `kind` discriminator. Its own record, because MCP tasks are
  the expected second kind.
- A `wait` tool that parks, with the caps that stop a wait-loop replacing the
  poll-loop: 15s floor, 30-minute ceiling, 40 hops per conversation.
- A sweeper that claims due rows atomically (status in the filter, so two pods
  give a winner and a miss), rebuilds the identity the turn ran as — there is no
  request to read one from, so a resume can only act as the user who parked —
  injects the tool result paired by uuid, and runs the turn.
- `applyUpdateToMessage` is extracted from the route's POST so a swept turn
  persists the way an HTTP turn does rather than through a second implementation
  that drifts. Its pre-tool merge had only end-to-end coverage before; it has
  direct tests now.

**Verified end to end against the database**: model calls `wait(20s)` → parked
generation completes (the turn genuinely ends) → sweeper claims 5s after due →
resumed generation completes → one assistant message, one `wait` call, one
result, content continues in place. The expired-session branch fired correctly
too, since the test session had no OAuth token.

## Testing

992 tests, `npm run check` and lint clean.

Not covered by an automated test: a full resumed turn, which wants the model and
tool server scripted the way `replayRoundTrip` does it. That is the next test to
write.

## Known, not addressed here

- A generation blocked on an upstream read cannot be aborted (the check is polled
  from inside the loop) or reaped (the heartbeat is a separate timer).
- `markGenerationInterrupted` is not atomic across its two writes, so a crash
  between them strands a message as forever-pending. Observed twice.
- The message render is still quadratic in `updates`.

## Worth deciding before merge

This is arguably three PRs — the prompt, the size fix, and background tasks. They
arrived in one branch because each was found by dogfooding the last. Happy to
split if that reviews better.
