### PR TITLE
Announce GLM-5.3-Flash in the feature banner

### DIFF
--- a/chart/env/dev.yaml
+++ b/chart/env/dev.yaml
@@ -60,7 +60,7 @@ envVars:
   PUBLIC_ORIGIN: ""
   PUBLIC_PLAUSIBLE_SCRIPT_URL: "https://plausible.io/js/pa-Io_oigECawqdlgpf5qvHb.js"
   PUBLIC_FEATURE_ANNOUNCEMENTS: >
-    [{"title": "Gemma-4-31B at 700 tokens/s", "description": "Run Gemma-4-31B at 700 tokens/s thanks to Cerebras inference.", "link": "/models/google/gemma-4-31B-it", "cta": "Go to the model", "maxDate": "2026-08-01"}, {"title": "Kimi K3 is here", "description": "Moonshot's 2.8T open-weight MoE, with native vision and a 1M-token context window.", "link": "/models/moonshotai/Kimi-K3", "cta": "Chat with Kimi K3", "maxDate": "2026-09-15"}, {"title": "New DeepSeek V4 Flash", "description": "DeepSeek's updated 284B MoE with adjustable thinking, stronger agentic coding, and a 1M-token context window.", "link": "/models/deepseek-ai/DeepSeek-V4-Flash-0731", "cta": "Chat with V4 Flash", "maxDate": "2026-09-01"}]
+    [{"title": "Kimi K3 is here", "description": "Moonshot's 2.8T open-weight MoE, with native vision and a 1M-token context window.", "link": "/models/moonshotai/Kimi-K3", "cta": "Chat with Kimi K3", "maxDate": "2026-09-15"}, {"title": "New DeepSeek V4 Flash", "description": "DeepSeek's updated 284B MoE with adjustable thinking, stronger agentic coding, and a 1M-token context window.", "link": "/models/deepseek-ai/DeepSeek-V4-Flash-0731", "cta": "Chat with V4 Flash", "maxDate": "2026-09-01"}, {"title": "New GLM-5.3-Flash", "description": "Z.ai's natively multimodal 320B MoE, outperforming GLM-5.2 at one-tenth the price.", "link": "/models/zai-org/GLM-5.3-Flash", "cta": "Chat with GLM-5.3-Flash", "maxDate": "2026-09-30"}]
 
   TASK_MODEL: "meta-llama/Llama-3.1-8B-Instruct"
   # Tombstone: unread by current code, kept so any old pod still on the pre-#2265

--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -70,7 +70,7 @@ envVars:
   PUBLIC_ORIGIN: "https://huggingface.co"
   PUBLIC_PLAUSIBLE_SCRIPT_URL: "https://plausible.io/js/pa-Io_oigECawqdlgpf5qvHb.js"
   PUBLIC_FEATURE_ANNOUNCEMENTS: >
-    [{"title": "Gemma-4-31B at 700 tokens/s", "description": "Run Gemma-4-31B at 700 tokens/s thanks to Cerebras inference.", "link": "/models/google/gemma-4-31B-it", "cta": "Go to the model", "maxDate": "2026-08-01"}, {"title": "Kimi K3 is here", "description": "Moonshot's 2.8T open-weight MoE, with native vision and a 1M-token context window.", "link": "/models/moonshotai/Kimi-K3", "cta": "Chat with Kimi K3", "maxDate": "2026-09-15"}, {"title": "New DeepSeek V4 Flash", "description": "DeepSeek's updated 284B MoE with adjustable thinking, stronger agentic coding, and a 1M-token context window.", "link": "/models/deepseek-ai/DeepSeek-V4-Flash-0731", "cta": "Chat with V4 Flash", "maxDate": "2026-09-01"}]
+    [{"title": "Kimi K3 is here", "description": "Moonshot's 2.8T open-weight MoE, with native vision and a 1M-token context window.", "link": "/models/moonshotai/Kimi-K3", "cta": "Chat with Kimi K3", "maxDate": "2026-09-15"}, {"title": "New DeepSeek V4 Flash", "description": "DeepSeek's updated 284B MoE with adjustable thinking, stronger agentic coding, and a 1M-token context window.", "link": "/models/deepseek-ai/DeepSeek-V4-Flash-0731", "cta": "Chat with V4 Flash", "maxDate": "2026-09-01"}, {"title": "New GLM-5.3-Flash", "description": "Z.ai's natively multimodal 320B MoE, outperforming GLM-5.2 at one-tenth the price.", "link": "/models/zai-org/GLM-5.3-Flash", "cta": "Chat with GLM-5.3-Flash", "maxDate": "2026-09-30"}]
 
   TASK_MODEL: "meta-llama/Llama-3.1-8B-Instruct"
   # Tombstone: unread by current code, kept so any old pod still on the pre-#2265


### PR DESCRIPTION
## What changed

Adds a GLM-5.3-Flash entry to `PUBLIC_FEATURE_ANNOUNCEMENTS` in `chart/env/prod.yaml` and `chart/env/dev.yaml`, replacing DeepSeek V4 Flash as the active banner:

- **Title**: New GLM-5.3-Flash
- **Description**: "Z.ai's natively multimodal 320B MoE, outperforming GLM-5.2 at one-tenth the price."
- **CTA**: "Chat with GLM-5.3-Flash", linking to `/models/zai-org/GLM-5.3-Flash`
- **maxDate**: 2026-09-30

Also removes the Gemma-4-31B entry, which expired on 2026-08-01 and can no longer be shown.

## Reviewer notes

- `getActiveAnnouncement` picks the last valid, unexpired entry, so the new entry is appended at the end of the array; verified it parses and is selected as the active banner in both files.
- The model itself landed in the config via #2528 (already merged), and the model page is served from the router catalog, so the link is live.