### PR TITLE
Add focus ring styling to chat message pane

### DIFF
--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -708,9 +708,11 @@
 		{/if}
 		<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
 		<!-- tabindex: the document never scrolls in this app, so without it
-		     keyboard-only users cannot scroll the conversation at all. -->
+		     keyboard-only users cannot scroll the conversation at all. Keyboard
+		     focus draws a soft inset ring instead of the browser's default
+		     outline around the whole pane; mouse focus draws nothing. -->
 		<div
-			class="scrollbar-custom h-full [scrollbar-gutter:stable_both-edges] overflow-y-auto overscroll-contain"
+			class="scrollbar-custom h-full [scrollbar-gutter:stable_both-edges] overflow-y-auto overscroll-contain focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-blue-500/60 dark:focus-visible:outline-blue-400/60"
 			tabindex="0"
 			aria-label="Conversation messages"
 			use:chatScroll.attach={{


### PR DESCRIPTION
## Summary
Improves keyboard accessibility of the chat message pane by adding visible focus indicators when navigated via keyboard, while maintaining a clean appearance for mouse users.

## Changes
- Added `focus-visible` styling to the conversation messages container div
- Keyboard focus now displays a soft 2px blue outline with -2px offset (inset ring effect)
- Uses `outline-blue-500/60` in light mode and `outline-blue-400/60` in dark mode for appropriate contrast
- Mouse focus remains invisible (no outline), preserving the visual design for pointer users
- Updated comment to document the focus behavior

## Implementation Details
The change leverages CSS's `:focus-visible` pseudo-class to distinguish between keyboard and pointer focus, following modern accessibility best practices. The soft inset ring provides clear focus indication for keyboard-only users without disrupting the UI for mouse users.

https://claude.ai/code/session_01F36B58ENzYQos1LKNi26Tq