### PR TITLE
Add the research sub-agent builtin tool

### DIFF
--- a/src/lib/constants/mlAssistant.ts
+++ b/src/lib/constants/mlAssistant.ts
@@ -18,6 +18,15 @@ export const ML_ASSISTANT_PLACEHOLDER = "Describe the ML task — paper URL, mod
 /** Reasoning effort the preset runs at. */
 export const ML_ASSISTANT_EFFORT = "high" as const;
 
+/**
+ * Completion-token floor for the preset. Catalog max_tokens values are sized
+ * for chat answers; a high-effort reasoning turn regularly outruns them and
+ * gets cut mid-think, costing a retry round or an interrupted turn. A floor,
+ * not an override — a catalog value above it wins. Providers that cap lower
+ * clamp it themselves.
+ */
+export const ML_ASSISTANT_MIN_COMPLETION_TOKENS = 32_768;
+
 /** Suggestion chips that replace the default set while the mode is on. */
 export const mlAssistantExamples: RouterExample[] = [
 	{

--- a/src/lib/server/generation/compressUpdates.spec.ts
+++ b/src/lib/server/generation/compressUpdates.spec.ts
@@ -65,9 +65,10 @@ describe("compressUpdatesForStorage", () => {
 		expect(compressUpdatesForStorage(updates)).toEqual(updates);
 	});
 
-	it("sheds stream markers before tool history when over the cap", () => {
-		// The text itself lives on the message; a marker only says where a tool
-		// card sat relative to it. The calls and results are the transcript.
+	it("merges adjacent stream markers, so a long turn keeps its layout AND its transcript", () => {
+		// Consecutive markers carry no more layout information than their sum;
+		// unmerged, a 30-minute reasoning turn crossed the cap and the backstop
+		// dropped every marker — the message rendered as one unanchored blob.
 		const updates = [
 			...Array.from({ length: 6000 }, (_, i) => token(`t${i}`)),
 			...Array.from({ length: 100 }, (_, i) => call(`c${i}`)),
@@ -75,7 +76,21 @@ describe("compressUpdatesForStorage", () => {
 
 		const compressed = compressUpdatesForStorage(updates) ?? [];
 
-		expect(compressed).toHaveLength(100);
+		expect(compressed).toHaveLength(101);
+		const merged = compressed[0];
+		const totalLen = Array.from({ length: 6000 }, (_, i) => `t${i}`).join("").length;
+		expect(merged).toMatchObject({ type: MessageUpdateType.Stream, token: "", len: totalLen });
+		expect(compressed.slice(1).every((u) => u.type === MessageUpdateType.Tool)).toBe(true);
+	});
+
+	it("sheds unmergeable stream markers before tool history when over the cap", () => {
+		// Markers cannot merge across a tool card. The text itself lives on the
+		// message; the calls and results are the transcript, so they survive.
+		const updates = Array.from({ length: 3000 }, (_, i) => [token(`t${i}`), call(`c${i}`)]).flat();
+
+		const compressed = compressUpdatesForStorage(updates) ?? [];
+
+		expect(compressed).toHaveLength(3000);
 		expect(compressed.every((u) => u.type === MessageUpdateType.Tool)).toBe(true);
 	});
 

--- a/src/lib/server/generation/compressUpdates.ts
+++ b/src/lib/server/generation/compressUpdates.ts
@@ -34,17 +34,34 @@ const MAX_PERSISTED_UPDATES = 5_000;
  * client as it always did.
  */
 export function compressUpdatesForStorage(updates: Message["updates"]): Message["updates"] {
-	const kept = (updates ?? [])
-		.filter(
-			(u) =>
-				!(u.type === MessageUpdateType.Status && u.status === MessageUpdateStatus.KeepAlive) &&
-				!(u.type === MessageUpdateType.Tool && u.subtype === MessageToolUpdateType.Progress)
-		)
-		.map((u) => {
-			if (u.type !== MessageUpdateType.Stream) return u;
-			const len = u.len ?? (u.token ?? "").length;
-			return { type: MessageUpdateType.Stream, token: "", len } satisfies MessageStreamUpdate;
-		});
+	const kept: NonNullable<Message["updates"]> = [];
+	for (const u of updates ?? []) {
+		if (u.type === MessageUpdateType.Status && u.status === MessageUpdateStatus.KeepAlive) {
+			continue;
+		}
+		if (u.type === MessageUpdateType.Tool && u.subtype === MessageToolUpdateType.Progress) {
+			continue;
+		}
+		if (u.type !== MessageUpdateType.Stream) {
+			kept.push(u);
+			continue;
+		}
+		// Stream markers exist ONLY to position tool cards relative to the text
+		// (the renderer slices message.content by their lens), so consecutive
+		// markers carry no more information than their sum. Merging them is what
+		// keeps a long turn's marker count proportional to its tool cards rather
+		// than its tokens — an unmerged 30-minute reasoning turn crossed the cap
+		// below, the backstop dropped every marker, and the whole message
+		// rendered as one unanchored blob with no tool calls in sight.
+		const len = u.len ?? (u.token ?? "").length;
+		if (len === 0) continue;
+		const last = kept.at(-1);
+		if (last?.type === MessageUpdateType.Stream) {
+			last.len = (last.len ?? 0) + len;
+		} else {
+			kept.push({ type: MessageUpdateType.Stream, token: "", len } satisfies MessageStreamUpdate);
+		}
+	}
 
 	if (kept.length <= MAX_PERSISTED_UPDATES) return kept;
 

--- a/src/lib/server/generation/parkedSweeper.ts
+++ b/src/lib/server/generation/parkedSweeper.ts
@@ -231,17 +231,15 @@ export async function resumeParkedCall(park: ParkedCall): Promise<void> {
 		};
 
 		for await (const event of textGeneration(ctx)) apply(event);
-		// A resumed turn may park again — on another wait, or on a question. Calling
-		// it finished would tell the client the work is over while a row sits waiting
-		// to wake it.
-		const parkedAgain = await collections.parkedCalls.countDocuments({
-			conversationId: conv._id,
-			messageId: message.id,
-			status: "waiting",
-		});
-		if (parkedAgain === 0) {
-			apply({ type: MessageUpdateType.Status, status: MessageUpdateStatus.Finished });
-		}
+		// A resumed turn may park again — on another wait, or on a question. Either
+		// way this run's lifecycle closes with `finished`, matching what the route
+		// does when a fresh turn parks: the client derives liveness from the LAST
+		// lifecycle event (see generationState.ts), so the next resume's `started`
+		// is what reopens the message, and a parked one reads terminal — the same
+		// from every producer. Leaving `started` as the last event here instead
+		// made a reloading client reattach to the already-ended generation in a
+		// refresh loop.
+		apply({ type: MessageUpdateType.Status, status: MessageUpdateStatus.Finished });
 	} catch (err) {
 		hasError = true;
 		logger.error({ err, parkedCallId: park.parkedCallId }, "[parked] resumed turn failed");

--- a/src/lib/server/mlAssistantPrompt.spec.ts
+++ b/src/lib/server/mlAssistantPrompt.spec.ts
@@ -26,7 +26,7 @@ describe("ML Assistant preprompt", () => {
 	it("keeps every section that carries a rule", () => {
 		for (const heading of [
 			"# Your knowledge of the HF libraries is outdated",
-			"# Reading a paper you are about to implement",
+			"# Reproducing or implementing a paper",
 			"# Mistakes you WILL make without checking",
 			"# Before you propose a training or evaluation run",
 			"# Audit the data before you use it",

--- a/src/lib/server/mlAssistantPrompt.ts
+++ b/src/lib/server/mlAssistantPrompt.ts
@@ -34,11 +34,11 @@ So: check the specific things you are about to act on. Before you pass a model i
 
 This is about claims you are acting on, not about everything you say. Explaining what LoRA is, writing ordinary Python, or doing arithmetic needs no tool.`;
 
-const READING_A_PAPER = `# Reading a paper you are about to implement
+const READING_A_PAPER = `# Reproducing or implementing a paper
 
-Read the paper, not the abstract. The method lives in the equations and the appendices, and a reproduction that misreads one of them fails in a way that looks like a bug for hours rather than like a misreading.
+Start with the research tool, not with the paper. Give it the paper id or URL and what you intend to do, and let it read the paper, its foundations and its successors in its own context: it returns the recipe — datasets, method, hyperparameters, scores — attributed to what produced them. This is not optional for research-shaped work; do not crawl papers in this conversation, where every page you read is context the rest of the turn pays for.
 
-When the method builds on prior work, read the one or two papers it builds on before you implement it. A paper assumes its predecessors and will not restate what its loss or its target actually is — the definition you need is usually one hop away, and that hop costs a couple of calls where getting it wrong costs a training run.
+Implement from the summary it returns. When a specific detail you are about to act on is missing or ambiguous — the exact loss, what the target actually is, an appendix hyperparameter — fetch that one section yourself and read it closely, rather than re-reading the literature. A reproduction that misreads one equation fails in a way that looks like a bug for hours rather than like a misreading.
 
 Attribute what you take. "This dataset, with this method, at this learning rate, reached this score on this benchmark" is usable. "They used SFT" is not.`;
 
@@ -221,7 +221,7 @@ Work in repos you created. Your access covers what this assistant makes, not wha
 
 Read a file before you overwrite it, and pass the parent commit SHA you read it at, so a concurrent change fails loudly instead of being silently clobbered. Deletes are not recoverable: say what you are removing and why before you remove it.`;
 
-const HF_FS_FINDING_RULES = `FINDING PAPERS AND DOCS (hf_fs): papers live at hf://papers. Search them with search hf://papers "..." and read one with cat hf://papers/<id>/paper.md, which pages — read it to the end rather than stopping at the first chunk, because the method is usually in the middle and the implementation details are in the appendices. hub_repo_search searches REPOSITORIES: a paper title put through it returns nothing, which tells you nothing about whether the paper exists. Library documentation is at hf://docs, and it is current where your memory is not.`;
+const HF_FS_FINDING_RULES = `FINDING PAPERS AND DOCS (hf_fs): papers live at hf://papers. Search them with search hf://papers "..." and read one with cat hf://papers/<id>/paper.md, which pages — read it to the end rather than stopping at the first chunk, because the method is usually in the middle and the implementation details are in the appendices. hub_repo_search searches REPOSITORIES: a paper title put through it returns nothing, which tells you nothing about whether the paper exists. Library documentation is at hf://docs, and it is current where your memory is not. Reading beyond a targeted check — a whole paper, a literature pass — belongs to the research tool, not to this conversation.`;
 
 const WEB_SEARCH_RULES = `SEARCHING THE WEB (web_search_exa): for what the Hub does not hold — an author's implementation on their own site, a post describing a trick a paper leaves out, an error nobody has written a doc for. Use 3-6 precise keywords, and prefer the primary source over a summary of it. It is not where you look up a model, dataset or paper that lives on the Hub: those have their own tools, and those results are authoritative where a search result is hearsay.`;
 

--- a/src/lib/server/textGeneration/builtinTools/builtinTools.spec.ts
+++ b/src/lib/server/textGeneration/builtinTools/builtinTools.spec.ts
@@ -34,11 +34,12 @@ beforeEach(() => {
 });
 
 describe("getEnabledBuiltinTools", () => {
-	it("offers both builtin tools in an ML Assistant conversation", () => {
+	it("offers the preset's builtin tools in an ML Assistant conversation", () => {
 		expect(toolNames({ _id: new ObjectId(), mlAssistant: true })).toEqual([
 			"ask_user_question",
 			"update_plan",
 			"wait",
+			"research",
 		]);
 	});
 

--- a/src/lib/server/textGeneration/builtinTools/githubGrounding.spec.ts
+++ b/src/lib/server/textGeneration/builtinTools/githubGrounding.spec.ts
@@ -120,6 +120,7 @@ describe("registration", () => {
 			"github_list_repos",
 			"github_find_examples",
 			"github_read_file",
+			"research",
 		]);
 	});
 
@@ -133,6 +134,6 @@ describe("registration", () => {
 			getEnabledBuiltinTools({ conv: { _id: new ObjectId(), mlAssistant: true } }).map(
 				(t) => t.name
 			)
-		).toEqual(["ask_user_question", "update_plan", "wait"]);
+		).toEqual(["ask_user_question", "update_plan", "wait", "research"]);
 	});
 });

--- a/src/lib/server/textGeneration/builtinTools/index.ts
+++ b/src/lib/server/textGeneration/builtinTools/index.ts
@@ -4,14 +4,16 @@ import { askUserQuestionBuiltin } from "./askUserQuestion";
 import { githubGroundingBuiltins } from "./githubGrounding";
 import { createPlanTool } from "./planTool";
 import { waitBuiltin } from "./waitTool";
+import { createResearchTool } from "./researchTool";
 import type { BuiltinTool } from "./types";
 
 export type { BuiltinTool, BuiltinToolContext, BuiltinToolResult } from "./types";
 export { PLAN_TOOL_NAME } from "./planTool";
+export { RESEARCH_TOOL_NAME, isResearchTool } from "./researchTool";
 
 /**
  * Enablement policy lives here, per tool — never in the dispatch or gate
- * plumbing, which treats every builtin the same. Both tools are part of the
+ * plumbing, which treats every builtin the same. All of these are part of the
  * ML Assistant preset: outside a mode conversation (or in a build without the
  * mode) there are no builtin tools at all.
  */
@@ -21,12 +23,15 @@ export function getEnabledBuiltinTools(params: {
 	if (!isMlAssistantConversation(params.conv)) return [];
 	// The GitHub tools carry a second condition of their own — they withhold
 	// themselves without a GITHUB_TOKEN — which is still policy, so it lives with
-	// them rather than leaking a config read into this list.
+	// them rather than leaking a config read into this list. The research tool's
+	// definition is static too, but its nested loop needs the turn's request
+	// plumbing, which runMcpFlow binds onto it once that exists.
 	return [
 		askUserQuestionBuiltin,
 		createPlanTool(params.conv),
 		waitBuiltin,
 		...githubGroundingBuiltins(),
+		createResearchTool(),
 	];
 }
 

--- a/src/lib/server/textGeneration/builtinTools/researchPrompt.ts
+++ b/src/lib/server/textGeneration/builtinTools/researchPrompt.ts
@@ -1,0 +1,211 @@
+import { GITHUB_FIND_EXAMPLES, GITHUB_LIST_REPOS, GITHUB_READ_FILE } from "$lib/server/github";
+
+/**
+ * The research sub-agent's prompts, ported from ml-intern's
+ * agent/tools/research_tool.py (RESEARCH_SYSTEM_PROMPT and the three
+ * budget/stop prompts). The loop mechanics live in researchTool.ts.
+ *
+ * Deliberate deviations from the source:
+ * - ml-intern's `hf_papers` tool was Semantic Scholar-backed, so its prompt
+ *   could order a citation-graph crawl. This mode has no citation index, so
+ *   the crawl is rewritten to what the tools can do: walk the bibliography
+ *   already present in paper.md (upstream), and find successor work by
+ *   search (downstream) — stated as search-based so the model never claims
+ *   citation coverage it doesn't have.
+ * - The source's soft nudge said "75%" while firing at 85%; here the text
+ *   matches the threshold.
+ * - The output-format section stated "Code patterns" twice; deduplicated.
+ */
+
+const WEB_SEARCH_TOOL = "web_search_exa";
+const WEB_CRAWL_TOOL = "crawling_exa";
+const WEB_CODE_TOOL = "get_code_context_exa";
+
+/**
+ * Sections that reference a tool are included only when that tool is offered,
+ * for the same reason the mode's own preprompt works that way: doctrine that
+ * names an absent tool costs the model a failed round to discover it.
+ */
+export function buildResearchSystemPrompt(availableTools: ReadonlySet<string>): string {
+	const hasWebSearch = availableTools.has(WEB_SEARCH_TOOL);
+	const hasWebCrawl = availableTools.has(WEB_CRAWL_TOOL);
+	const hasWebCode = availableTools.has(WEB_CODE_TOOL);
+	const hasGithub =
+		availableTools.has(GITHUB_FIND_EXAMPLES) && availableTools.has(GITHUB_READ_FILE);
+
+	const successorSearchTools = hasWebSearch
+		? `\`${WEB_SEARCH_TOOL}\` (the anchor's title plus terms like "builds on" or "improves") and \`hf_fs\` paper search (the method's distinctive terms)`
+		: "`hf_fs` paper search with the method's distinctive terms";
+
+	const codeStep = hasGithub
+		? `7. **Find code**: Now find working implementation code via \`${GITHUB_FIND_EXAMPLES}\` and \`${GITHUB_READ_FILE}\`. Use the docs (\`hf_fs\` search over hf://docs) to fill in API details.`
+		: `7. **Find code**: Now find working implementation code: search the docs (\`hf_fs\` search over hf://docs) and read reference implementations in Hub repos (\`hf_fs\` ls/cat).`;
+
+	const sections: string[] = [];
+
+	sections.push(`You are a research sub-agent for an ML engineering assistant.
+Your primary job: mine the literature to find the best training recipes —
+then back them up with working code and up-to-date documentation. The main
+agent will use your findings to implement the actual solution.
+
+# Start from the literature
+
+Your default approach is a deep literature crawl. Do not start from docs or
+example scripts — start from papers. Papers contain the results, and results
+tell you what actually works.
+
+## The crawl
+
+1. **Find anchor papers**: If the task names a paper id or URL, that is your anchor — read it directly (an arXiv id maps to hf://papers/<arxiv_id>/paper.md), no search needed. Otherwise search the paper index (\`hf_fs\` search over hf://papers) for the task/domain and identify the landmark paper(s) — recent, widely built on, or both. Papers are searched ONLY this way; \`hub_repo_search\` searches model/dataset/Space repos, not papers.
+2. **Read methodology, not abstracts**: Read the paper with \`hf_fs\` cat of hf://papers/<arxiv_id>/paper.md. Output is paged — keep reading with --offset until the end of the file. The method is usually mid-document (sections 3-5) and the implementation details are often in the appendices. Extract:
+   - The exact dataset(s) used (name, source, size, any filtering/preprocessing)
+   - The training method and configuration (optimizer, lr, schedule, epochs, batch size)
+   - The results those choices produced (benchmark scores, metrics, comparisons)
+3. **Walk the references**: The bibliography at the end of paper.md carries the arXiv id of every cited paper inline. Fetch the cited papers that ground the method — the prior work an anchor builds on is one cat away, and misreading a method because you skipped its foundations is the classic failure.
+4. **Find successor work**: You do NOT have a citation index, so downstream work — papers that built on the anchor — is found by SEARCH: ${successorSearchTools}. Favor recent results. Report how you searched, so the main agent knows successor coverage is search-based, not exhaustive.
+5. **Attribute results to recipes**: This is the critical step. Every finding must link a RESULT to the RECIPE that produced it. "Dataset X + method Y + lr Z → score W on benchmark V" is useful. "They used SFT" is not.
+6. **Validate datasets**: For the most promising datasets, check they exist on the Hub with \`hub_repo_details\` and inspect their structure and sample rows. Verify the format matches the training method. Report if it doesn't.
+${codeStep}
+
+## When to go deeper
+
+- If the anchor paper is old (>1 year), assume it has been superseded — spend your budget on step 4, searching for successor work, rather than re-reading the anchor.
+- If a newer paper reports significantly better results, restart the crawl from it: read its methodology, walk its bibliography, search for ITS successors.`);
+
+	const toolSections: string[] = [
+		`# How to use your tools
+
+## Papers (USE FIRST)
+- \`hf_fs\` search over hf://papers: search the paper index. The ONLY paper search — never \`hub_repo_search\`.
+- \`hf_fs\` cat of hf://papers/<arxiv_id>/paper.md: read a paper. Paged — continue with --offset until the end. Bibliography (with cited arXiv ids) is at the very end.
+
+## Dataset & repo inspection
+- \`hub_repo_details\`: dataset/model metadata, structure and sample rows.
+  CRITICAL for training: verify the column format matches the training method:
+  - SFT: needs "messages", "text", or "prompt"/"completion"
+  - DPO: needs "prompt", "chosen", "rejected"
+  - GRPO: needs "prompt" only
+- \`hub_repo_search\`: find model/dataset/Space repos by keyword (never papers).
+- \`hf_fs\` ls/cat: list and read files in any Hub repo (model, dataset, Space).
+
+## Documentation
+- \`hf_fs\` search over hf://docs: search the HF docs (trl, transformers, datasets, peft, accelerate, ...), then cat the resulting URI for the full page.`,
+	];
+
+	if (hasGithub) {
+		toolSections.push(`## GitHub code research
+- \`${GITHUB_FIND_EXAMPLES}\`: find working example scripts in HF repos (trl, transformers, etc.)
+- \`${GITHUB_READ_FILE}\`: read the actual implementation code. Use line_start/line_end for large files.${
+			availableTools.has(GITHUB_LIST_REPOS)
+				? `\n- \`${GITHUB_LIST_REPOS}\`: discover repos when you don't know which one holds the example.`
+				: ""
+		}`);
+	}
+
+	if (hasWebSearch || hasWebCrawl || hasWebCode) {
+		const lines = [
+			"## Web search",
+			...(hasWebSearch
+				? [
+						`- \`${WEB_SEARCH_TOOL}\`: search the current web — successor work, blog posts, release notes, when papers/docs are not enough.`,
+					]
+				: []),
+			...(hasWebCrawl ? [`- \`${WEB_CRAWL_TOOL}\`: fetch a specific URL surfaced by search.`] : []),
+			...(hasWebCode
+				? [`- \`${WEB_CODE_TOOL}\`: find code usage examples across public repos.`]
+				: []),
+		];
+		toolSections.push(lines.join("\n"));
+	}
+
+	sections.push(toolSections.join("\n\n"));
+
+	const exampleLines = [
+		"# Correct research pattern",
+		"",
+		"Calls shown in shorthand; use each tool's real argument schema.",
+		"",
+		"```",
+		"# 1. Find anchor paper(s) for the task",
+		'hf_fs search hf://papers "GPQA graduate-level QA"',
+		"",
+		"# 2. Read the anchor end to end: method mid-document, appendices, bibliography last",
+		"hf_fs cat hf://papers/2311.12022/paper.md",
+		"hf_fs cat hf://papers/2311.12022/paper.md --offset 60000",
+		"",
+		"# 3. Follow the references that ground the method (arXiv ids are inline in the bibliography)",
+		"hf_fs cat hf://papers/2009.03300/paper.md",
+		"",
+		"# 4. Search for successor work — no citation index, so search for it",
+		...(hasWebSearch
+			? ['web_search_exa "benchmarks building on GPQA graduate-level questions"']
+			: []),
+		'hf_fs search hf://papers "graduate-level science QA benchmark"',
+		"",
+		"# 5. Validate datasets exist and have the right format",
+		'hub_repo_details "Idavidrein/gpqa"',
+		...(hasGithub
+			? [
+					"",
+					"# 6. Get working code for the training method",
+					'github_find_examples {"repo": "trl", "keyword": "sft"}',
+					'github_read_file {"repo": "huggingface/trl", "path": "examples/scripts/sft.py"}',
+				]
+			: ["", "# 6. Get working code for the training method"]),
+		'hf_fs search hf://docs "SFTConfig parameters"',
+		"```",
+	];
+	sections.push(exampleLines.join("\n"));
+
+	sections.push(`# Output format
+
+Your output MUST be structured as a ranked list of training recipes, each attributed to published results:
+
+## Recipe table (REQUIRED)
+For each promising approach found, report:
+- **Paper**: title, arxiv_id, date, venue
+- **Result**: exact benchmark scores and what they were measured on
+- **Dataset(s)**: name, size, source, HF Hub availability, format verified (yes/no)
+- **Method**: training approach, key hyperparameters (lr, epochs, batch size, optimizer, schedule)
+- **What made it work**: the specific insight or trick that drove the result (data curation, curriculum, loss function, etc.)
+
+Rank recipes by result quality. The main agent will pick the best one that's feasible.
+
+## Code patterns
+- Key imports, configurations, and usage patterns from working examples
+- Specific file paths, URLs, function names from docs
+
+## Recommendations
+- Which recipe to implement first and why
+- What datasets to use (with HF Hub paths, verified)
+- Any gaps: datasets that need preprocessing, methods that need adaptation
+
+## SOTA landscape
+Current best models, datasets, and methods for the task (from recent papers). Flag anything outdated.
+
+## Essential references
+Specific file paths, URLs, function names, doc sections, and code snippets the main agent should use directly.
+
+Be concise. Your output goes into another agent's context — every token counts.
+Aim for 500-1500 words max. Include actual code snippets from examples you read,
+not paraphrased descriptions.`);
+
+	return sections.join("\n\n");
+}
+
+export const RESEARCH_CONTEXT_WARN_PROMPT =
+	"[SYSTEM: You have used 85% of your context budget. Start wrapping up: finish any critical lookups, then produce your final summary within the next 1-2 iterations.]";
+
+export const RESEARCH_CONTEXT_MAX_PROMPT =
+	"[SYSTEM: CONTEXT LIMIT REACHED] You have used all available context. Summarize your findings NOW. Do NOT call any more tools.";
+
+export const RESEARCH_ITERATION_LIMIT_PROMPT =
+	"[SYSTEM: ITERATION LIMIT] You have reached the maximum number of research iterations. Summarize ALL findings so far. Do NOT call any more tools.";
+
+/**
+ * Stand-in for ml-intern's doom-loop detector, which chat-ui has not ported
+ * yet (that is the P2 guards work). When the full detector lands it should
+ * run on the sub-agent's message list too and replace this.
+ */
+export const RESEARCH_REPETITION_PROMPT =
+	"[SYSTEM: You have repeated the same tool call with identical arguments. Its result will not change. Change strategy — a different tool or different arguments — or summarize what you have.]";

--- a/src/lib/server/textGeneration/builtinTools/researchTool.spec.ts
+++ b/src/lib/server/textGeneration/builtinTools/researchTool.spec.ts
@@ -193,6 +193,32 @@ describe("the nested loop", () => {
 		expect(finalMessages[finalMessages.length - 1].content).toContain("[SYSTEM: ITERATION LIMIT]");
 	});
 
+	it("reserves the completion allowance before computing the budget thresholds", async () => {
+		// Window 200, reserve 100 → usable 100: a run at 96 tokens must force the
+		// summary even though it is far from 95% of the raw window, because the
+		// next request (96 prompt + 100 completion) would already exceed it.
+		createCompletion
+			.mockResolvedValueOnce(
+				respond({
+					toolCalls: [{ id: "t1", name: "hf_fs", arguments: '{"q":"a"}' }],
+					totalTokens: 96,
+				})
+			)
+			.mockResolvedValueOnce(respond({ content: "reserved summary" }));
+
+		const outcome = await boundTool({
+			contextLengthTokens: 200,
+			completionBase: { model: "test-model", stream: true, max_tokens: 100 },
+		}).execute({ task: "t" }, ctx);
+
+		expect(outcome).toEqual({ resultText: "reserved summary" });
+		const finalRequest = createCompletion.mock.calls[1][0];
+		expect(finalRequest.tools).toBeUndefined();
+		expect((finalRequest.messages as ChatCompletionMessageParam[]).at(-1)?.content).toBe(
+			RESEARCH_CONTEXT_MAX_PROMPT
+		);
+	});
+
 	it("nudges at 85% of context and hard-stops at 95% with a tool-less request", async () => {
 		createCompletion
 			.mockResolvedValueOnce(

--- a/src/lib/server/textGeneration/builtinTools/researchTool.spec.ts
+++ b/src/lib/server/textGeneration/builtinTools/researchTool.spec.ts
@@ -1,0 +1,337 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { OpenAI } from "openai";
+import type { ChatCompletionMessageParam } from "openai/resources/chat/completions";
+
+vi.mock("$lib/server/logger", () => ({
+	logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+vi.mock("$lib/server/mcp/httpClient", () => ({
+	callMcpTool: vi.fn(),
+	getMcpToolTimeoutMs: () => 1_000,
+}));
+vi.mock("$lib/server/mcp/clientPool", () => ({
+	getClient: vi.fn(async () => ({})),
+}));
+
+const {
+	createResearchTool,
+	isResearchTool,
+	truncateResearchToolOutput,
+	MAX_RESEARCH_ITERATIONS,
+	RESEARCH_TOOL_NAME,
+} = await import("./researchTool");
+const { RESEARCH_CONTEXT_MAX_PROMPT, RESEARCH_CONTEXT_WARN_PROMPT, RESEARCH_REPETITION_PROMPT } =
+	await import("./researchPrompt");
+type ResearchRuntimeDeps = import("./researchTool").ResearchRuntimeDeps;
+type BuiltinTool = import("./types").BuiltinTool;
+
+const createCompletion = vi.fn();
+const openai = {
+	chat: { completions: { create: createCompletion } },
+} as unknown as OpenAI;
+
+/** A non-stream chat completion response. */
+const respond = (params: {
+	content?: string | null;
+	toolCalls?: { id: string; name: string; arguments: string }[];
+	totalTokens?: number;
+	finishReason?: string;
+}) => ({
+	choices: [
+		{
+			message: {
+				content: params.content ?? null,
+				tool_calls: params.toolCalls?.map((call) => ({
+					id: call.id,
+					type: "function" as const,
+					function: { name: call.name, arguments: call.arguments },
+				})),
+			},
+			finish_reason: params.finishReason ?? (params.toolCalls?.length ? "tool_calls" : "stop"),
+		},
+	],
+	usage: { total_tokens: params.totalTokens ?? 1_000 },
+});
+
+const hfFsExecute = vi.fn(async () => ({ resultText: "search results" }));
+const fakeHfFs: BuiltinTool = {
+	name: "hf_fs",
+	definition: { type: "function", function: { name: "hf_fs", parameters: { type: "object" } } },
+	execute: hfFsExecute,
+};
+
+const makeDeps = (over: Partial<ResearchRuntimeDeps> = {}): ResearchRuntimeDeps => ({
+	openai,
+	completionBase: {
+		model: "test-model",
+		stream: true,
+		tools: [],
+		tool_choice: "auto",
+		reasoning_effort: "high",
+	},
+	requestHeaders: { "ChatUI-Conversation-ID": "conv-1" },
+	servers: [],
+	mapping: {},
+	mcpTools: [],
+	hostBuiltinTools: [fakeHfFs],
+	...over,
+});
+
+const ctx = { uuid: "u1", toolCallId: "c1" };
+
+const boundTool = (over: Partial<ResearchRuntimeDeps> = {}) => {
+	const tool = createResearchTool();
+	tool.bind(makeDeps(over));
+	return tool;
+};
+
+/** Messages of the nth request made to the mocked client. */
+const requestMessages = (n: number) =>
+	(createCompletion.mock.calls[n][0] as { messages: ChatCompletionMessageParam[] }).messages;
+
+beforeEach(() => {
+	createCompletion.mockReset();
+	hfFsExecute.mockClear();
+	hfFsExecute.mockResolvedValue({ resultText: "search results" });
+});
+
+describe("createResearchTool", () => {
+	it("is recognized by the type guard; other builtins are not", () => {
+		expect(isResearchTool(createResearchTool())).toBe(true);
+		expect(isResearchTool(fakeHfFs)).toBe(false);
+	});
+
+	it("errors before bind instead of dereferencing missing deps", async () => {
+		const outcome = await createResearchTool().execute({ task: "t" }, ctx);
+		expect("error" in outcome && outcome.error).toContain("not initialized");
+	});
+
+	it("requires a task and at least one available research tool", async () => {
+		expect(await boundTool().execute({}, ctx)).toEqual({ error: "No research task provided." });
+		expect(await boundTool({ hostBuiltinTools: [] }).execute({ task: "t" }, ctx)).toEqual({
+			error: "No research tools are available in this deployment.",
+		});
+	});
+});
+
+describe("the nested loop", () => {
+	it("runs on a fresh two-message context and returns the first no-tools response", async () => {
+		createCompletion.mockResolvedValueOnce(respond({ content: "the summary" }));
+
+		const outcome = await boundTool().execute(
+			{ task: "find recipes", context: "user builds X" },
+			ctx
+		);
+
+		expect(outcome).toEqual({ resultText: "the summary" });
+		expect(createCompletion).toHaveBeenCalledTimes(1);
+		const request = createCompletion.mock.calls[0][0];
+		expect(request.stream).toBe(false);
+		expect(request.model).toBe("test-model");
+		// Only the allowlisted defs are offered — never the parent's tool set.
+		expect(request.tools.map((t: { function: { name: string } }) => t.function.name)).toEqual([
+			"hf_fs",
+		]);
+		expect(request.messages).toEqual([
+			{ role: "system", content: expect.stringContaining("research sub-agent") },
+			{ role: "user", content: "Context: user builds X\n\nResearch task: find recipes" },
+		]);
+	});
+
+	it("executes an allowlisted call, feeds the result back, and truncates long outputs", async () => {
+		hfFsExecute.mockResolvedValueOnce({ resultText: "x".repeat(10_000) });
+		createCompletion
+			.mockResolvedValueOnce(
+				respond({ toolCalls: [{ id: "t1", name: "hf_fs", arguments: '{"q":"a"}' }] })
+			)
+			.mockResolvedValueOnce(respond({ content: "done" }));
+
+		const outcome = await boundTool().execute({ task: "t" }, ctx);
+
+		expect(outcome).toEqual({ resultText: "done" });
+		expect(hfFsExecute).toHaveBeenCalledTimes(1);
+		const toolMessage = requestMessages(1).find((m) => m.role === "tool") as {
+			content: string;
+			tool_call_id: string;
+		};
+		expect(toolMessage.tool_call_id).toBe("t1");
+		expect(toolMessage.content).toContain("...(truncated)...");
+		expect(toolMessage.content.length).toBe(4800 + 3200 + "\n...(truncated)...\n".length);
+	});
+
+	it("refuses tools outside the allowlist without executing anything", async () => {
+		createCompletion
+			.mockResolvedValueOnce(
+				respond({ toolCalls: [{ id: "t1", name: "hf_jobs", arguments: "{}" }] })
+			)
+			.mockResolvedValueOnce(respond({ content: "done" }));
+
+		await boundTool().execute({ task: "t" }, ctx);
+
+		expect(hfFsExecute).not.toHaveBeenCalled();
+		expect(requestMessages(1)).toContainEqual({
+			role: "tool",
+			tool_call_id: "t1",
+			content: "Tool 'hf_jobs' not available for research.",
+		});
+	});
+
+	it("forces the summary at the iteration limit by dropping tools from the request", async () => {
+		createCompletion.mockImplementation(async (request: { tools?: unknown }) =>
+			request.tools
+				? respond({ toolCalls: [{ id: "t", name: "hf_fs", arguments: `{"i":${Math.random()}}` }] })
+				: respond({ content: "salvaged summary" })
+		);
+
+		const outcome = await boundTool().execute({ task: "t" }, ctx);
+
+		expect(outcome).toEqual({ resultText: "salvaged summary" });
+		expect(createCompletion).toHaveBeenCalledTimes(MAX_RESEARCH_ITERATIONS + 1);
+		const finalRequest = createCompletion.mock.calls[MAX_RESEARCH_ITERATIONS][0];
+		expect(finalRequest.tools).toBeUndefined();
+		const finalMessages = finalRequest.messages as ChatCompletionMessageParam[];
+		expect(finalMessages[finalMessages.length - 1].content).toContain("[SYSTEM: ITERATION LIMIT]");
+	});
+
+	it("nudges at 85% of context and hard-stops at 95% with a tool-less request", async () => {
+		createCompletion
+			.mockResolvedValueOnce(
+				respond({
+					toolCalls: [{ id: "t1", name: "hf_fs", arguments: '{"q":"a"}' }],
+					totalTokens: 90, // ≥ 85% of 100
+				})
+			)
+			.mockResolvedValueOnce(
+				respond({
+					toolCalls: [{ id: "t2", name: "hf_fs", arguments: '{"q":"b"}' }],
+					totalTokens: 96, // ≥ 95% of 100
+				})
+			)
+			.mockResolvedValueOnce(respond({ content: "budget summary" }));
+
+		const outcome = await boundTool({ contextLengthTokens: 100 }).execute({ task: "t" }, ctx);
+
+		expect(outcome).toEqual({ resultText: "budget summary" });
+		// Second request carries the soft nudge…
+		expect(requestMessages(1).map((m) => m.content)).toContain(RESEARCH_CONTEXT_WARN_PROMPT);
+		// …and the third is the forced summary: hard-stop message, no tools.
+		const finalRequest = createCompletion.mock.calls[2][0];
+		expect(finalRequest.tools).toBeUndefined();
+		expect((finalRequest.messages as ChatCompletionMessageParam[]).at(-1)?.content).toBe(
+			RESEARCH_CONTEXT_MAX_PROMPT
+		);
+	});
+
+	it("injects the repetition nudge once when the same call repeats three times", async () => {
+		let round = 0;
+		createCompletion.mockImplementation(async (request: { tools?: unknown }) => {
+			if (!request.tools) return respond({ content: "s" });
+			round += 1;
+			return round <= 4
+				? respond({ toolCalls: [{ id: `t${round}`, name: "hf_fs", arguments: '{"q":"same"}' }] })
+				: respond({ content: "recovered" });
+		});
+
+		const outcome = await boundTool().execute({ task: "t" }, ctx);
+
+		expect(outcome).toEqual({ resultText: "recovered" });
+		const nudges = requestMessages(4).filter((m) => m.content === RESEARCH_REPETITION_PROMPT);
+		expect(nudges).toHaveLength(1);
+	});
+
+	it("nudges instead of returning a summary that was cut by the output limit", async () => {
+		createCompletion
+			.mockResolvedValueOnce(respond({ content: "half a thou", finishReason: "length" }))
+			.mockResolvedValueOnce(respond({ content: "full summary" }));
+
+		const outcome = await boundTool().execute({ task: "t" }, ctx);
+
+		expect(outcome).toEqual({ resultText: "full summary" });
+		const retry = requestMessages(1);
+		expect(retry.at(-2)?.role).toBe("assistant");
+		expect(String(retry.at(-1)?.content)).toContain("output limit");
+	});
+
+	it("absorbs a transient 429 with backoff instead of discarding the run", async () => {
+		vi.useFakeTimers();
+		try {
+			const rateLimit = Object.assign(new Error('429 "Rate limit exceeded"'), { status: 429 });
+			createCompletion
+				.mockRejectedValueOnce(rateLimit)
+				.mockResolvedValueOnce(respond({ content: "recovered summary" }));
+
+			const pending = boundTool().execute({ task: "t" }, ctx);
+			await vi.advanceTimersByTimeAsync(10_000);
+			expect(await pending).toEqual({ resultText: "recovered summary" });
+			expect(createCompletion).toHaveBeenCalledTimes(2);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("tells the model to wait and re-call when rate-limit retries run out", async () => {
+		vi.useFakeTimers();
+		try {
+			createCompletion.mockRejectedValue(
+				Object.assign(new Error('429 "Rate limit exceeded"'), { status: 429 })
+			);
+
+			const pending = boundTool().execute({ task: "t" }, ctx);
+			await vi.advanceTimersByTimeAsync(10_000 + 25_000 + 60_000);
+			const outcome = await pending;
+			expect("error" in outcome && outcome.error).toContain("Call wait");
+			// The initial call plus one per backoff step.
+			expect(createCompletion).toHaveBeenCalledTimes(4);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("reports an aborted run as an error and surfaces LLM failures", async () => {
+		const aborted = new AbortController();
+		aborted.abort();
+		expect(
+			await boundTool().execute({ task: "t" }, { ...ctx, abortSignal: aborted.signal })
+		).toEqual({ error: "Aborted by user" });
+
+		createCompletion.mockRejectedValueOnce(new Error("boom"));
+		expect(await boundTool().execute({ task: "t" }, ctx)).toEqual({
+			error: "Research agent LLM error: boom",
+		});
+	});
+});
+
+describe("truncateResearchToolOutput", () => {
+	it("keeps short outputs intact and head/tails long ones", () => {
+		expect(truncateResearchToolOutput("short")).toBe("short");
+		const long = "a".repeat(5000) + "b".repeat(5000);
+		const truncated = truncateResearchToolOutput(long);
+		expect(truncated.startsWith("a".repeat(4800))).toBe(true);
+		expect(truncated.endsWith("b".repeat(3200))).toBe(true);
+		expect(truncated).toContain("...(truncated)...");
+	});
+
+	it("never leaves a lone surrogate at a slice boundary", () => {
+		// 😀 is a surrogate pair; place one so the head slice cuts it in half, and
+		// another so the tail slice starts on its low half. One lone surrogate
+		// in a message 400s every request that carries it, permanently.
+		const headSplit = "a".repeat(4799) + "😀" + "b".repeat(5000);
+		const tailSplit = "x".repeat(5000) + "😀" + "y".repeat(3199);
+		for (const input of [headSplit, tailSplit]) {
+			const truncated = truncateResearchToolOutput(input);
+			expect(truncated).not.toMatch(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/);
+			expect(truncated).not.toMatch(/(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/);
+			// Sanity: it still round-trips through strict JSON.
+			expect(() => JSON.parse(JSON.stringify(truncated))).not.toThrow();
+		}
+	});
+});
+
+describe("the tool definition", () => {
+	it("names itself research and requires a task", () => {
+		const tool = createResearchTool();
+		expect(tool.name).toBe(RESEARCH_TOOL_NAME);
+		expect(tool.exemptFromToolRestraint).toBe(true);
+		expect(tool.definition.function.parameters).toMatchObject({ required: ["task"] });
+	});
+});

--- a/src/lib/server/textGeneration/builtinTools/researchTool.ts
+++ b/src/lib/server/textGeneration/builtinTools/researchTool.ts
@@ -1,0 +1,465 @@
+import type { OpenAI } from "openai";
+import type {
+	ChatCompletionCreateParamsNonStreaming,
+	ChatCompletionCreateParamsStreaming,
+	ChatCompletionMessageParam,
+} from "openai/resources/chat/completions";
+import { logger } from "$lib/server/logger";
+import { GITHUB_FIND_EXAMPLES, GITHUB_LIST_REPOS, GITHUB_READ_FILE } from "$lib/server/github";
+import type { McpToolMapping, OpenAiTool } from "$lib/server/mcp/tools";
+import type { McpServerConfig } from "$lib/server/mcp/httpClient";
+import { MessageToolUpdateType, MessageUpdateType } from "$lib/types/MessageUpdate";
+import { executeToolCalls, type NormalizedToolCall } from "../mcp/toolInvocation";
+import { parseToolArguments } from "../mcp/toolArgs";
+import { stripLoneSurrogates } from "../utils/loneSurrogates";
+import { isRateLimitError, withRateLimitRetry } from "../utils/rateLimitRetry";
+import {
+	buildResearchSystemPrompt,
+	RESEARCH_CONTEXT_MAX_PROMPT,
+	RESEARCH_CONTEXT_WARN_PROMPT,
+	RESEARCH_ITERATION_LIMIT_PROMPT,
+	RESEARCH_REPETITION_PROMPT,
+} from "./researchPrompt";
+import type { BuiltinTool, BuiltinToolContext, BuiltinToolResult } from "./types";
+
+/**
+ * The research sub-agent, ported from ml-intern's research_tool.py: a complete
+ * nested agent loop behind one tool call. It runs on a fresh message array —
+ * nothing inherited from the parent conversation — against a read-only tool
+ * allowlist, and only its final summary ever reaches the main context. That is
+ * the point: a literature pass costs the main turn one round, and no raw
+ * search results land in it.
+ */
+
+export const RESEARCH_TOOL_NAME = "research";
+
+/**
+ * Read-only set only. Absent entries are simply not offered (no Exa server
+ * configured, no GITHUB_TOKEN); the system prompt adjusts to what exists.
+ * `research` itself is deliberately not here — no recursive sub-agents.
+ */
+const RESEARCH_ALLOWED_TOOLS: ReadonlySet<string> = new Set([
+	"hf_fs",
+	"hub_repo_details",
+	"hub_repo_search",
+	GITHUB_FIND_EXAMPLES,
+	GITHUB_READ_FILE,
+	GITHUB_LIST_REPOS,
+	"web_search_exa",
+	"get_code_context_exa",
+	"crawling_exa",
+]);
+
+export const MAX_RESEARCH_ITERATIONS = 60;
+
+// Fractions of the resolved model's context at which the budget prompts fire.
+// The absolute fallbacks are the source's constants for a 200k model, used
+// when the model reports no context length.
+const CONTEXT_WARN_FRACTION = 0.85;
+const CONTEXT_MAX_FRACTION = 0.95;
+const FALLBACK_CONTEXT_WARN = 170_000;
+const FALLBACK_CONTEXT_MAX = 190_000;
+
+// Head/tail split preserved from the source: the head carries the finding,
+// the tail carries the footer/totals a long listing usually ends with.
+const TOOL_OUTPUT_MAX_CHARS = 8000;
+const TOOL_OUTPUT_HEAD = 4800;
+const TOOL_OUTPUT_TAIL = 3200;
+
+const NESTED_CALL_TIMEOUT_MS = 120_000;
+
+export function truncateResearchToolOutput(output: string): string {
+	if (output.length <= TOOL_OUTPUT_MAX_CHARS) return output;
+	// Both slice points can land mid-surrogate-pair; see loneSurrogates.ts for
+	// why one such character 400s every request that carries the message.
+	return stripLoneSurrogates(
+		output.slice(0, TOOL_OUTPUT_HEAD) + "\n...(truncated)...\n" + output.slice(-TOOL_OUTPUT_TAIL)
+	);
+}
+
+export type ResearchCompletionBase = Omit<ChatCompletionCreateParamsStreaming, "messages"> & {
+	reasoning_effort?: "low" | "medium" | "high";
+};
+
+export interface ResearchRuntimeDeps {
+	openai: OpenAI;
+	/**
+	 * The main loop's request base. The nested loop swaps stream/tools/messages
+	 * and inherits everything else — model, sampling, reasoning effort. ml-intern
+	 * downgraded max/xhigh reasoning to "high" for this sub-call; this codebase's
+	 * effort type already tops out at "high", so inheriting is the cap.
+	 */
+	completionBase: ResearchCompletionBase;
+	requestHeaders: Record<string, string>;
+	servers: McpServerConfig[];
+	mapping: Record<string, McpToolMapping>;
+	mcpTools: OpenAiTool[];
+	/** Every builtin offered this turn, research itself included; filtered by the allowlist here. */
+	hostBuiltinTools: BuiltinTool[];
+	contextLengthTokens?: number;
+}
+
+export interface ResearchBuiltinTool extends BuiltinTool {
+	bind(deps: ResearchRuntimeDeps): void;
+}
+
+export function isResearchTool(tool: BuiltinTool): tool is ResearchBuiltinTool {
+	return tool.name === RESEARCH_TOOL_NAME && "bind" in tool;
+}
+
+const RESEARCH_DOCTRINE =
+	`RESEARCH DELEGATION: ${RESEARCH_TOOL_NAME} is how you ground research-shaped work, and research-shaped work ALWAYS starts with it. ` +
+	`Reproducing or implementing a paper, surveying training recipes, comparing methods, finding and reading reference implementations before writing training code — for every one of these your first call is ${RESEARCH_TOOL_NAME}; do not do the crawling in this conversation. ` +
+	`The sub-agent runs its own search-and-read loop in a separate context and returns a short attributed summary, so a full literature pass costs this conversation one tool round and no raw dumps land in your context. ` +
+	`Give it a specific task — the paper id or URL, the libraries, models and datasets you already know — plus a sentence of conversation context. ` +
+	`The only lookups that skip it are single already-named facts: one model id, one dataset's schema, one doc page.`;
+
+const definition: OpenAiTool = {
+	type: "function",
+	function: {
+		name: RESEARCH_TOOL_NAME,
+		description:
+			"Spawn a research sub-agent to explore papers, documentation, datasets and code WITHOUT " +
+			"polluting the main conversation context. The sub-agent gets its own independent context " +
+			"window with read-only research tools and returns a concise summary of findings.\n\n" +
+			"ALWAYS use this first for:\n" +
+			"- Reproducing or implementing a paper (pass the paper id or URL in the task)\n" +
+			"- Surveying the literature for training recipes before implementing an ML task\n" +
+			"- Researching current API usage before writing code (find examples + read docs)\n" +
+			"- Reading papers, auditing datasets, analyzing repos — any research where raw tool " +
+			"outputs would be too verbose\n\n" +
+			"The sub-agent knows how to use the paper index, hub_repo_details, the GitHub grounding " +
+			"tools, web search, etc. Just describe what you need researched.",
+		parameters: {
+			type: "object",
+			properties: {
+				task: {
+					type: "string",
+					description:
+						"Detailed description of what to research. Be specific: include library names, " +
+						"trainer types, dataset names, repo names, or doc pages to explore. Example: " +
+						"'Research current TRL SFTTrainer usage: find working example scripts, read the " +
+						"SFT documentation, and check SFTConfig parameters. Also validate that dataset " +
+						"HuggingFaceH4/ultrachat_200k has the right format for SFT.'",
+				},
+				context: {
+					type: "string",
+					description:
+						"Optional context from the current conversation that the research agent needs " +
+						"(e.g., what the user wants to build, constraints, what's been tried).",
+				},
+			},
+			required: ["task"],
+		},
+	},
+};
+
+/** JSON with object keys sorted at every depth, so arg order can't defeat the repetition check. */
+const stableStringify = (value: unknown): string =>
+	JSON.stringify(value, (_key, val: unknown) =>
+		val && typeof val === "object" && !Array.isArray(val)
+			? Object.fromEntries(
+					Object.entries(val as Record<string, unknown>).sort(([a], [b]) => a.localeCompare(b))
+				)
+			: val
+	) ?? "";
+
+export function createResearchTool(): ResearchBuiltinTool {
+	// Definition and enablement are static; the request plumbing (client,
+	// sampling params, the turn's listed MCP tools) only exists inside
+	// runMcpFlow, which binds it here before the tool loop starts.
+	let deps: ResearchRuntimeDeps | undefined;
+	return {
+		name: RESEARCH_TOOL_NAME,
+		definition,
+		preprompt: RESEARCH_DOCTRINE,
+		exemptFromToolRestraint: true,
+		bind(next: ResearchRuntimeDeps) {
+			deps = next;
+		},
+		async execute(args, ctx) {
+			return runResearch(args, ctx, deps);
+		},
+	};
+}
+
+async function runResearch(
+	args: Record<string, unknown>,
+	ctx: BuiltinToolContext,
+	deps: ResearchRuntimeDeps | undefined
+): Promise<BuiltinToolResult> {
+	const task = typeof args.task === "string" ? args.task.trim() : "";
+	const context = typeof args.context === "string" ? args.context.trim() : "";
+	if (!task) return { error: "No research task provided." };
+	if (!deps) return { error: "Research tool not initialized for this request." };
+
+	const allowedBuiltins = deps.hostBuiltinTools.filter((tool) =>
+		RESEARCH_ALLOWED_TOOLS.has(tool.name)
+	);
+	const builtinNames = new Set(allowedBuiltins.map((tool) => tool.name));
+	const nestedTools: OpenAiTool[] = [
+		...allowedBuiltins.map((tool) => tool.definition),
+		...deps.mcpTools.filter(
+			(tool) =>
+				RESEARCH_ALLOWED_TOOLS.has(tool.function.name) && !builtinNames.has(tool.function.name)
+		),
+	];
+	if (nestedTools.length === 0) {
+		return { error: "No research tools are available in this deployment." };
+	}
+	const availableNames = new Set(nestedTools.map((tool) => tool.function.name));
+
+	let messages: ChatCompletionMessageParam[] = [
+		{ role: "system", content: buildResearchSystemPrompt(availableNames) },
+		{
+			role: "user",
+			content: context ? `Context: ${context}\n\nResearch task: ${task}` : `Research task: ${task}`,
+		},
+	];
+
+	const contextWarnAt = deps.contextLengthTokens
+		? Math.floor(deps.contextLengthTokens * CONTEXT_WARN_FRACTION)
+		: FALLBACK_CONTEXT_WARN;
+	const contextMaxAt = deps.contextLengthTokens
+		? Math.floor(deps.contextLengthTokens * CONTEXT_MAX_FRACTION)
+		: FALLBACK_CONTEXT_MAX;
+
+	// The parent's tool set and tool_choice never reach the sub-agent; stream
+	// is overridden per request below.
+	const base = { ...deps.completionBase };
+	delete base.tools;
+	delete base.tool_choice;
+
+	const complete = async (withTools: boolean) => {
+		const request: ChatCompletionCreateParamsNonStreaming = {
+			...base,
+			stream: false,
+			messages,
+			// Omitting `tools` entirely is what forces the final summary: the
+			// budget prompt alone is a suggestion the model can ignore; an
+			// absent tool list is a constraint it can't.
+			...(withTools ? { tools: nestedTools, tool_choice: "auto" as const } : {}),
+		};
+		return deps.openai.chat.completions.create(request, {
+			signal: ctx.abortSignal,
+			headers: deps.requestHeaders,
+			timeout: NESTED_CALL_TIMEOUT_MS,
+		});
+	};
+
+	const emitProgress = (iteration: number, message: string) => {
+		ctx.elicitationSink?.emit({
+			type: MessageUpdateType.Tool,
+			subtype: MessageToolUpdateType.Progress,
+			uuid: ctx.uuid,
+			progress: iteration,
+			total: MAX_RESEARCH_ITERATIONS,
+			message,
+		});
+	};
+
+	// A 429 mid-run must not discard the iterations already spent; the run is
+	// minutes long anyway, so it absorbs the backoff itself. Only when the
+	// schedule runs out does the error surface — with instructions to wait, so
+	// the model reaches for the wait tool instead of hammering research again.
+	const completeWithRetry = (withTools: boolean, iteration: number) =>
+		withRateLimitRetry(() => complete(withTools), {
+			signal: ctx.abortSignal,
+			onBackoff: (attempt, delayMs) => {
+				logger.warn(
+					{ attempt, delayMs, iteration },
+					"[research] rate limited; backing off in-loop"
+				);
+				emitProgress(iteration, `Rate limited — retrying in ${Math.round(delayMs / 1000)}s`);
+			},
+		});
+
+	const forcedSummary = async (
+		stopPrompt: string,
+		failureText: string
+	): Promise<BuiltinToolResult> => {
+		messages = [...messages, { role: "user", content: stopPrompt }];
+		try {
+			const response = await completeWithRetry(false, MAX_RESEARCH_ITERATIONS);
+			const content = response.choices[0]?.message?.content ?? "";
+			return content ? { resultText: content } : { error: failureText };
+		} catch (err) {
+			logger.warn({ err: String(err) }, "[research] forced summary call failed");
+			return { error: failureText };
+		}
+	};
+
+	let totalTokens = 0;
+	let warned = false;
+	const callCounts = new Map<string, number>();
+	let repetitionNudged = false;
+	let lengthCutRetries = 0;
+
+	emitProgress(0, "Starting research sub-agent");
+
+	for (let iteration = 0; iteration < MAX_RESEARCH_ITERATIONS; iteration += 1) {
+		if (ctx.abortSignal?.aborted) return { error: "Aborted by user" };
+
+		if (totalTokens >= contextMaxAt) {
+			logger.warn({ totalTokens, iteration }, "[research] context max reached; forcing summary");
+			emitProgress(iteration, "Context limit reached — wrapping up");
+			return forcedSummary(
+				RESEARCH_CONTEXT_MAX_PROMPT,
+				"Research context exhausted and no summary was produced."
+			);
+		}
+		if (!warned && totalTokens >= contextWarnAt) {
+			warned = true;
+			messages = [...messages, { role: "user", content: RESEARCH_CONTEXT_WARN_PROMPT }];
+		}
+
+		let response: Awaited<ReturnType<typeof complete>>;
+		try {
+			response = await completeWithRetry(true, iteration);
+		} catch (err) {
+			if (ctx.abortSignal?.aborted) return { error: "Aborted by user" };
+			const message = err instanceof Error ? err.message : String(err);
+			logger.warn({ err: message, iteration }, "[research] sub-agent LLM call failed");
+			if (isRateLimitError(err)) {
+				return {
+					error:
+						"Research is rate-limited and in-loop retries were exhausted. " +
+						"Call wait for at least 120 seconds, then call research again with the same task.",
+				};
+			}
+			return { error: `Research agent LLM error: ${message}` };
+		}
+
+		totalTokens =
+			response.usage?.total_tokens ??
+			// No usage from this provider: a rough absolute estimate keeps the
+			// budget stop functional instead of never firing.
+			Math.ceil(JSON.stringify(messages).length / 4);
+
+		const msg = response.choices[0]?.message;
+		const finishReason = response.choices[0]?.finish_reason;
+		const toolCalls = msg?.tool_calls ?? [];
+		if (!msg || toolCalls.length === 0) {
+			// Cut by the output limit is not a finished summary — with reasoning
+			// models it usually died mid-think. Nudge it to answer within budget;
+			// after two cuts, surface whatever content exists rather than looping.
+			if (finishReason === "length" && lengthCutRetries < 2) {
+				lengthCutRetries += 1;
+				logger.warn(
+					{ iteration, attempt: lengthCutRetries },
+					"[research] response cut by the output limit; nudging to finish"
+				);
+				messages = [
+					...messages,
+					{
+						role: "assistant",
+						content:
+							msg?.content?.trim() || "(Response cut off by the output limit mid-reasoning.)",
+					},
+					{
+						role: "user",
+						content:
+							"[SYSTEM: Your previous response hit the output limit before it finished. Continue: finish the step or produce the summary now, with minimal further reasoning.]",
+					},
+				];
+				continue;
+			}
+			const content = msg?.content ?? "";
+			emitProgress(iteration + 1, "Research complete");
+			return content
+				? { resultText: content }
+				: { error: "Research completed but no summary was generated." };
+		}
+
+		// Wire-safe rebuild: only role/content/tool_calls go back. The raw
+		// message can carry provider fields (reasoning_content and friends)
+		// that OpenAI-compatible backends reject when echoed; content is
+		// omitted when empty because some backends 400 on empty text next to
+		// tool_calls.
+		messages = [
+			...messages,
+			{
+				role: "assistant",
+				tool_calls: toolCalls,
+				...(typeof msg.content === "string" && msg.content.trim().length > 0
+					? { content: msg.content }
+					: {}),
+			},
+		];
+
+		const allowedCalls: NormalizedToolCall[] = [];
+		const refusals: ChatCompletionMessageParam[] = [];
+		let sawRepetition = false;
+		for (const call of toolCalls) {
+			const name = call.function?.name ?? "";
+			if (!availableNames.has(name)) {
+				refusals.push({
+					role: "tool",
+					tool_call_id: call.id,
+					content: `Tool '${name}' not available for research.`,
+				});
+				continue;
+			}
+			const rawArguments = call.function?.arguments ?? "";
+			const key = `${name}|${stableStringify(parseToolArguments(rawArguments) ?? rawArguments)}`;
+			const count = (callCounts.get(key) ?? 0) + 1;
+			callCounts.set(key, count);
+			if (count >= 3) sawRepetition = true;
+			allowedCalls.push({ id: call.id, name, arguments: rawArguments });
+		}
+
+		let toolMessages: ChatCompletionMessageParam[] = [];
+		if (allowedCalls.length > 0) {
+			emitProgress(
+				iteration + 1,
+				allowedCalls.map((call) => `▸ ${call.name} ${call.arguments.slice(0, 80)}`).join("  ")
+			);
+			const exec = executeToolCalls({
+				calls: allowedCalls,
+				mapping: deps.mapping,
+				servers: deps.servers,
+				parseArgs: parseToolArguments,
+				toPrimitive: (value) =>
+					typeof value === "string" || typeof value === "number" || typeof value === "boolean"
+						? value
+						: undefined,
+				processToolOutput: (text) => ({ annotated: text, sources: [] }),
+				abortSignal: ctx.abortSignal,
+				builtinTools: allowedBuiltins,
+				// No `elicitation`: the sub-agent has no chat to ask, so an
+				// input-required response comes back as an ordinary tool error.
+			});
+			for await (const event of exec) {
+				// The sub-agent's raw Call/Result updates stay internal — the
+				// whole point is that only the summary reaches the outer
+				// conversation. Progress is reported on the research call itself.
+				if (event.type === "complete") {
+					toolMessages = event.summary.toolMessages;
+				}
+			}
+		}
+
+		messages = [
+			...messages,
+			...refusals,
+			...toolMessages.map((message) =>
+				message.role === "tool" && typeof message.content === "string"
+					? { ...message, content: truncateResearchToolOutput(message.content) }
+					: message
+			),
+		];
+
+		if (sawRepetition && !repetitionNudged) {
+			repetitionNudged = true;
+			logger.warn({ iteration }, "[research] repetition guard activated");
+			messages = [...messages, { role: "user", content: RESEARCH_REPETITION_PROMPT }];
+		}
+	}
+
+	logger.warn({}, "[research] iteration limit reached; extracting summary");
+	emitProgress(MAX_RESEARCH_ITERATIONS, "Iteration limit reached — extracting summary");
+	return forcedSummary(
+		RESEARCH_ITERATION_LIMIT_PROMPT,
+		`Research agent hit the iteration limit (${MAX_RESEARCH_ITERATIONS}) and no summary was produced — try a more focused task.`
+	);
+}

--- a/src/lib/server/textGeneration/builtinTools/researchTool.ts
+++ b/src/lib/server/textGeneration/builtinTools/researchTool.ts
@@ -52,13 +52,12 @@ const RESEARCH_ALLOWED_TOOLS: ReadonlySet<string> = new Set([
 
 export const MAX_RESEARCH_ITERATIONS = 60;
 
-// Fractions of the resolved model's context at which the budget prompts fire.
-// The absolute fallbacks are the source's constants for a 200k model, used
-// when the model reports no context length.
+// Fractions of the model's usable context (window minus the completion
+// reserve) at which the budget prompts fire — the source fired at 170k/190k
+// of an assumed 200k window, which these reproduce when no reserve is set.
 const CONTEXT_WARN_FRACTION = 0.85;
 const CONTEXT_MAX_FRACTION = 0.95;
-const FALLBACK_CONTEXT_WARN = 170_000;
-const FALLBACK_CONTEXT_MAX = 190_000;
+const FALLBACK_CONTEXT_WINDOW = 200_000;
 
 // Head/tail split preserved from the source: the head carries the finding,
 // the tail carries the footer/totals a long listing usually ends with.
@@ -217,18 +216,23 @@ async function runResearch(
 		},
 	];
 
-	const contextWarnAt = deps.contextLengthTokens
-		? Math.floor(deps.contextLengthTokens * CONTEXT_WARN_FRACTION)
-		: FALLBACK_CONTEXT_WARN;
-	const contextMaxAt = deps.contextLengthTokens
-		? Math.floor(deps.contextLengthTokens * CONTEXT_MAX_FRACTION)
-		: FALLBACK_CONTEXT_MAX;
-
 	// The parent's tool set and tool_choice never reach the sub-agent; stream
 	// is overridden per request below.
 	const base = { ...deps.completionBase };
 	delete base.tools;
 	delete base.tool_choice;
+
+	// Budget thresholds are fractions of the USABLE window: what remains after
+	// reserving the completion allowance every request asks for. Without the
+	// reservation, a large max_tokens lets a request exceed the window between
+	// the 85% nudge and the 95% stop — an unrecoverable provider error instead
+	// of a forced summary. The floor guards a degenerate reserve that would
+	// leave no room to research at all.
+	const windowTokens = deps.contextLengthTokens ?? FALLBACK_CONTEXT_WINDOW;
+	const completionReserve = typeof base.max_tokens === "number" ? base.max_tokens : 0;
+	const usableTokens = Math.max(windowTokens - completionReserve, Math.floor(windowTokens / 4));
+	const contextWarnAt = Math.floor(usableTokens * CONTEXT_WARN_FRACTION);
+	const contextMaxAt = Math.floor(usableTokens * CONTEXT_MAX_FRACTION);
 
 	const complete = async (withTools: boolean) => {
 		const request: ChatCompletionCreateParamsNonStreaming = {

--- a/src/lib/server/textGeneration/mcp/runMcpFlow.spec.ts
+++ b/src/lib/server/textGeneration/mcp/runMcpFlow.spec.ts
@@ -6,6 +6,7 @@ import {
 	type MessageUpdate,
 } from "$lib/types/MessageUpdate";
 import type { ChatCompletionMessageParam } from "openai/resources/chat/completions";
+import { ML_ASSISTANT_MIN_COMPLETION_TOKENS } from "$lib/constants/mlAssistant";
 import type { McpFlowResult, RunMcpFlowContext } from "./runMcpFlow";
 
 // ---------------------------------------------------------------------------
@@ -334,6 +335,72 @@ describe("runMcpFlow truncated tool calls", () => {
 	});
 });
 
+describe("runMcpFlow rate limits", () => {
+	it("absorbs a router 429 with backoff instead of failing a turn mid-flight", async () => {
+		vi.useFakeTimers();
+		try {
+			scriptRounds([
+				{ error: Object.assign(new Error('429 "Rate limit exceeded"'), { status: 429 }) },
+				{ content: "the answer" },
+			]);
+
+			const pending = runFlow();
+			// The backoff timer only exists once the flow reaches the throttled
+			// call; step the clock until the retry has landed.
+			for (let i = 0; i < 20 && mocks.create.mock.calls.length < 2; i += 1) {
+				await vi.advanceTimersByTimeAsync(1_000);
+			}
+			const { updates, result } = await pending;
+
+			expect(result).toBe("completed");
+			expect(finalAnswer(updates)).toBe("the answer");
+			expect(mocks.create).toHaveBeenCalledTimes(2);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("still surfaces a non-429 upstream failure", async () => {
+		scriptRounds([{ error: new Error("boom") }]);
+		const { result } = await runFlow();
+		// Fails before any output: the flow falls back rather than erroring the turn.
+		expect(result).toBe("not_applicable");
+	});
+});
+
+describe("runMcpFlow answers cut by the output limit", () => {
+	it("retries once when the final answer dies mid-reasoning instead of finalizing the half-thought", async () => {
+		scriptRounds([
+			{ reasoning: "the method is defined as", finishReason: "length" },
+			{ content: "the recovered answer" },
+		]);
+
+		const { updates, result } = await runFlow();
+
+		expect(result).toBe("completed");
+		expect(finalAnswer(updates)).toBe("the recovered answer");
+		const retry = requestMessages(1);
+		// Reasoning-only rounds leave no prose; the synthesized assistant turn keeps
+		// the nudge from being a second consecutive user message.
+		expect(retry.at(-2)?.role).toBe("assistant");
+		expect(String(retry.at(-2)?.content ?? "")).not.toHaveLength(0);
+		expect(String(retry.at(-1)?.content)).toContain("output limit");
+	});
+
+	it("finalizes as interrupted when the retry is cut too", async () => {
+		scriptRounds([
+			{ reasoning: "first half-thought", finishReason: "length" },
+			{ reasoning: "second half-thought", finishReason: "length" },
+		]);
+
+		const { updates, result } = await runFlow();
+
+		expect(result).toBe("completed");
+		const answer = updates.find((u) => u.type === MessageUpdateType.FinalAnswer);
+		expect(answer?.type === MessageUpdateType.FinalAnswer && answer.interrupted).toBe(true);
+	});
+});
+
 describe("runMcpFlow termination", () => {
 	it("finalizes instead of reporting it never ran when the tool rounds run out", async () => {
 		const toolRound: Round = {
@@ -461,7 +528,7 @@ describe("runMcpFlow offering the question tool", () => {
 		scriptRounds([{ content: "the answer" }]);
 		const { result } = await runFlow(inMlMode);
 		expect(result).toBe("completed");
-		expect(toolNames()).toEqual(["ask_user_question", "update_plan", "wait"]);
+		expect(toolNames()).toEqual(["ask_user_question", "update_plan", "wait", "research"]);
 	});
 
 	it("still skips the flow outside the mode when no MCP server is selected", async () => {
@@ -568,6 +635,18 @@ describe("runMcpFlow under the ML Assistant preset", () => {
 		await runFlow();
 		expect(systemPrompt()).toContain("Do NOT call a tool unless");
 		expect(systemPrompt()).not.toContain("USING TOOLS:");
+	});
+
+	it("floors the completion budget so reasoning turns are not cut mid-think", async () => {
+		scriptRounds([{ content: "the answer" }]);
+		await runFlow(inMlMode);
+		expect(mocks.create.mock.calls[0][0].max_tokens).toBe(ML_ASSISTANT_MIN_COMPLETION_TOKENS);
+	});
+
+	it("leaves the catalog completion budget alone outside the mode", async () => {
+		scriptRounds([{ content: "the answer" }]);
+		await runFlow();
+		expect(mocks.create.mock.calls[0][0].max_tokens).toBeUndefined();
 	});
 
 	it("keeps working past the round budget an ordinary conversation stops at", async () => {

--- a/src/lib/server/textGeneration/mcp/runMcpFlow.spec.ts
+++ b/src/lib/server/textGeneration/mcp/runMcpFlow.spec.ts
@@ -337,7 +337,11 @@ describe("runMcpFlow truncated tool calls", () => {
 
 describe("runMcpFlow rate limits", () => {
 	it("absorbs a router 429 with backoff instead of failing a turn mid-flight", async () => {
-		vi.useFakeTimers();
+		// Fake only the timer pair the backoff sleep uses: the flow crosses real
+		// async boundaries (dynamic import, mocked promises) before it ever
+		// schedules the sleep, and a blanket fake would starve those of event-loop
+		// turns — the CI-only hang this test once had.
+		vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
 		try {
 			scriptRounds([
 				{ error: Object.assign(new Error('429 "Rate limit exceeded"'), { status: 429 }) },
@@ -345,10 +349,11 @@ describe("runMcpFlow rate limits", () => {
 			]);
 
 			const pending = runFlow();
-			// The backoff timer only exists once the flow reaches the throttled
-			// call; step the clock until the retry has landed.
-			for (let i = 0; i < 20 && mocks.create.mock.calls.length < 2; i += 1) {
+			// Alternate fake-clock advances with real event-loop turns until the
+			// retry lands, however late the flow registers its backoff timer.
+			for (let i = 0; i < 200 && mocks.create.mock.calls.length < 2; i += 1) {
 				await vi.advanceTimersByTimeAsync(1_000);
+				await new Promise((resolve) => setImmediate(resolve));
 			}
 			const { updates, result } = await pending;
 

--- a/src/lib/server/textGeneration/mcp/runMcpFlow.spec.ts
+++ b/src/lib/server/textGeneration/mcp/runMcpFlow.spec.ts
@@ -643,6 +643,21 @@ describe("runMcpFlow under the ML Assistant preset", () => {
 		expect(mocks.create.mock.calls[0][0].max_tokens).toBe(ML_ASSISTANT_MIN_COMPLETION_TOKENS);
 	});
 
+	it("clamps the completion floor to half a small model window", async () => {
+		scriptRounds([{ content: "the answer" }]);
+		await runFlow({
+			...inMlMode,
+			model: {
+				id: "small/model",
+				name: "small/model",
+				supportsTools: true,
+				parameters: {},
+				contextLength: 16_384,
+			},
+		} as unknown as Parameters<typeof runMcpFlow>[0]);
+		expect(mocks.create.mock.calls[0][0].max_tokens).toBe(8_192);
+	});
+
 	it("leaves the catalog completion budget alone outside the mode", async () => {
 		scriptRounds([{ content: "the answer" }]);
 		await runFlow();

--- a/src/lib/server/textGeneration/mcp/runMcpFlow.ts
+++ b/src/lib/server/textGeneration/mcp/runMcpFlow.ts
@@ -445,10 +445,18 @@ export async function* runMcpFlow({
 			(parameters?.max_tokens as number | undefined) ??
 			(parameters?.max_new_tokens as number | undefined) ??
 			(parameters?.max_completion_tokens as number | undefined);
+		const targetContextLength = (targetModel as unknown as { contextLength?: number })
+			.contextLength;
 		// The preset floors the reply allowance — see the constant for why. The
-		// research sub-agent inherits this through completionBase.
+		// floor never claims more than half the model's window: prompt plus reply
+		// must fit it, and a backend that enforces the sum would reject the very
+		// first request of a small-window model. A catalog value above the floor
+		// still wins. The research sub-agent inherits this through completionBase.
+		const clampedFloor = targetContextLength
+			? Math.min(ML_ASSISTANT_MIN_COMPLETION_TOKENS, Math.floor(targetContextLength / 2))
+			: ML_ASSISTANT_MIN_COMPLETION_TOKENS;
 		const maxTokens = mlAssistant
-			? Math.max(catalogMaxTokens ?? 0, ML_ASSISTANT_MIN_COMPLETION_TOKENS)
+			? Math.max(catalogMaxTokens ?? 0, clampedFloor)
 			: catalogMaxTokens;
 
 		let messagesOpenAI: ChatCompletionMessageParam[] = await prepareMessagesWithFiles(
@@ -467,7 +475,7 @@ export async function* runMcpFlow({
 				// the alias itself has none, and the candidate is what serves this
 				// request. Tool schemas are prepended after this returns, which is
 				// part of what CONTEXT_RESERVE_TOKENS holds back.
-				contextLengthTokens: (targetModel as unknown as { contextLength?: number }).contextLength,
+				contextLengthTokens: targetContextLength,
 				maxOutputTokens: maxTokens,
 			}
 		);
@@ -569,7 +577,7 @@ export async function* runMcpFlow({
 			mapping,
 			mcpTools,
 			hostBuiltinTools: builtinTools,
-			contextLengthTokens: (targetModel as unknown as { contextLength?: number }).contextLength,
+			contextLengthTokens: targetContextLength,
 		});
 
 		const toPrimitive = (value: unknown) => {
@@ -855,17 +863,30 @@ export async function* runMcpFlow({
 						{ loop },
 						"[mcp] missing tool_call id in stream; retrying non-stream to recover ids"
 					);
-					const nonStream = await openai.chat.completions.create(
-						{ ...completionBase, messages: messagesOpenAI, stream: false },
+					// Same throttle absorption as the streaming call above: this recovery
+					// request is mid-round, where a surfaced 429 costs the whole turn.
+					const nonStream = await withRateLimitRetry(
+						() =>
+							openai.chat.completions.create(
+								{ ...completionBase, messages: messagesOpenAI, stream: false },
+								{
+									signal: abortSignal,
+									headers: {
+										"ChatUI-Conversation-ID": conv._id.toString(),
+										"X-use-cache": "false",
+										...(config.USE_USER_TOKEN === "true" && locals?.token
+											? { Authorization: `Bearer ${locals.token}` }
+											: {}),
+									},
+								}
+							),
 						{
 							signal: abortSignal,
-							headers: {
-								"ChatUI-Conversation-ID": conv._id.toString(),
-								"X-use-cache": "false",
-								...(config.USE_USER_TOKEN === "true" && locals?.token
-									? { Authorization: `Bearer ${locals.token}` }
-									: {}),
-							},
+							onBackoff: (attempt, delayMs) =>
+								logger.warn(
+									{ loop, attempt, delayMs },
+									"[mcp] rate limited on id recovery; backing off in-loop"
+								),
 						}
 					);
 					const tc = nonStream.choices?.[0]?.message?.tool_calls ?? [];

--- a/src/lib/server/textGeneration/mcp/runMcpFlow.ts
+++ b/src/lib/server/textGeneration/mcp/runMcpFlow.ts
@@ -29,7 +29,9 @@ import { logger } from "$lib/server/logger";
 import { AbortedGenerations } from "$lib/server/abortedGenerations";
 import { withoutContentLength } from "$lib/server/undiciCompat";
 import { isMlAssistantConversation, withMlAssistantServers } from "$lib/server/mlAssistant";
-import { getEnabledBuiltinTools, shouldSkipMcpFlow } from "../builtinTools";
+import { ML_ASSISTANT_MIN_COMPLETION_TOKENS } from "$lib/constants/mlAssistant";
+import { withRateLimitRetry } from "../utils/rateLimitRetry";
+import { getEnabledBuiltinTools, isResearchTool, shouldSkipMcpFlow } from "../builtinTools";
 import { injectPlanState, PLAN_TOOL_NAME } from "../builtinTools/planTool";
 
 export type RunMcpFlowContext = Pick<
@@ -68,6 +70,12 @@ const ML_ASSISTANT_MAX_TOOL_ROUNDS = 100;
 
 // Each retry costs a tool round, so give up quickly and answer without the tool.
 const MAX_TRUNCATED_TOOL_CALL_RETRIES = 2;
+
+// One more attempt after a final answer is cut by the output limit mid-answer
+// (usually mid-<think> on reasoning models). If the nudged retry is cut too,
+// the limit is simply too small for this answer and retrying again just burns
+// rounds — finalize what exists, marked interrupted.
+const MAX_LENGTH_CUT_RETRIES = 1;
 
 export async function* runMcpFlow({
 	model,
@@ -433,10 +441,15 @@ export async function* runMcpFlow({
 			string,
 			unknown
 		>;
-		const maxTokens =
+		const catalogMaxTokens =
 			(parameters?.max_tokens as number | undefined) ??
 			(parameters?.max_new_tokens as number | undefined) ??
 			(parameters?.max_completion_tokens as number | undefined);
+		// The preset floors the reply allowance — see the constant for why. The
+		// research sub-agent inherits this through completionBase.
+		const maxTokens = mlAssistant
+			? Math.max(catalogMaxTokens ?? 0, ML_ASSISTANT_MIN_COMPLETION_TOKENS)
+			: catalogMaxTokens;
 
 		let messagesOpenAI: ChatCompletionMessageParam[] = await prepareMessagesWithFiles(
 			messages,
@@ -537,6 +550,28 @@ export async function* runMcpFlow({
 			...(reasoningEffort ? { reasoning_effort: reasoningEffort } : {}),
 		};
 
+		// The research builtin runs a nested tool loop and needs the request
+		// plumbing this turn resolved — client, sampling params, the listed
+		// MCP tools — which only exists here. Its definition and enablement
+		// stayed in builtinTools/; only the runtime binding lives at the
+		// call site.
+		builtinTools.find(isResearchTool)?.bind({
+			openai,
+			completionBase,
+			requestHeaders: {
+				"ChatUI-Conversation-ID": conv._id.toString(),
+				"X-use-cache": "false",
+				...(config.USE_USER_TOKEN === "true" && locals?.token
+					? { Authorization: `Bearer ${locals.token}` }
+					: {}),
+			},
+			servers,
+			mapping,
+			mcpTools,
+			hostBuiltinTools: builtinTools,
+			contextLengthTokens: (targetModel as unknown as { contextLength?: number }).contextLength,
+		});
+
 		const toPrimitive = (value: unknown) => {
 			if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
 				return value;
@@ -566,6 +601,7 @@ export async function* runMcpFlow({
 		// the persisted trace stays byte-exact instead of silently dropping them.
 		let pendingReasoningWhitespace = "";
 		let truncatedToolCallRetries = 0;
+		let lengthCutRetries = 0;
 
 		if (resolvedRoute && candidateModelId) {
 			yield {
@@ -597,17 +633,24 @@ export async function* runMcpFlow({
 				messages: messagesOpenAI,
 			};
 
-			const completionStream: Stream<ChatCompletionChunk> = await openai.chat.completions.create(
-				completionRequest,
+			// A turn several productive rounds deep must not die on one throttled
+			// request; absorb router 429s that outlast the SDK's quick retries.
+			const completionStream: Stream<ChatCompletionChunk> = await withRateLimitRetry(
+				() =>
+					openai.chat.completions.create(completionRequest, {
+						signal: abortSignal,
+						headers: {
+							"ChatUI-Conversation-ID": conv._id.toString(),
+							"X-use-cache": "false",
+							...(config.USE_USER_TOKEN === "true" && locals?.token
+								? { Authorization: `Bearer ${locals.token}` }
+								: {}),
+						},
+					}),
 				{
 					signal: abortSignal,
-					headers: {
-						"ChatUI-Conversation-ID": conv._id.toString(),
-						"X-use-cache": "false",
-						...(config.USE_USER_TOKEN === "true" && locals?.token
-							? { Authorization: `Bearer ${locals.token}` }
-							: {}),
-					},
+					onBackoff: (attempt, delayMs) =>
+						logger.warn({ loop, attempt, delayMs }, "[mcp] rate limited; backing off in-loop"),
 				}
 			);
 
@@ -955,6 +998,35 @@ export async function* runMcpFlow({
 				lastAssistantContent += "</think>";
 				thinkOpen = false;
 			}
+			// A response cut by the output limit is not an answer. With a reasoning
+			// model it usually ends inside the <think> block, so finalizing it
+			// reports a half-thought as a finished turn. Retry once, telling the
+			// model to answer with its remaining budget; a second cut finalizes as
+			// interrupted rather than pretending completion.
+			const cutMidAnswer = finishReason === "length" && !discardedTruncatedToolCalls;
+			if (cutMidAnswer && lengthCutRetries < MAX_LENGTH_CUT_RETRIES) {
+				lengthCutRetries += 1;
+				logger.warn(
+					{ loop, attempt: lengthCutRetries },
+					"[mcp] response cut by the output limit mid-answer; retrying"
+				);
+				const visibleContent = lastAssistantContent
+					.replace(/<think>[\s\S]*?(?:<\/think>|$)/g, "")
+					.trim();
+				messagesOpenAI = [
+					...messagesOpenAI,
+					{
+						role: "assistant" as const,
+						content: visibleContent || "(Response cut off by the output limit mid-reasoning.)",
+					},
+					{
+						role: "user" as const,
+						content:
+							"[SYSTEM: Your previous response hit the output limit before it finished — most of it was internal reasoning. Give your final answer now, with minimal further reasoning and the answer itself kept concise.]",
+					},
+				];
+				continue;
+			}
 			// Without this the turn finalizes empty and the route reports a bare
 			// "No output was generated" instead of what actually happened.
 			if (discardedTruncatedToolCalls && lastAssistantContent.trim().length === 0) {
@@ -967,7 +1039,7 @@ export async function* runMcpFlow({
 			yield {
 				type: MessageUpdateType.FinalAnswer,
 				text: lastAssistantContent,
-				interrupted: false,
+				interrupted: cutMidAnswer,
 			};
 			logger.info(
 				{ length: lastAssistantContent.length, loop },

--- a/src/lib/server/textGeneration/utils/loneSurrogates.ts
+++ b/src/lib/server/textGeneration/utils/loneSurrogates.ts
@@ -1,0 +1,12 @@
+/**
+ * Slicing a JS string at a fixed index can split a UTF-16 surrogate pair,
+ * leaving a lone surrogate. `JSON.stringify` escapes it as a bare `\uD8xx`,
+ * which strict JSON parsers upstream reject — the HF router 400s the whole
+ * request over one character ("unexpected end of hex escape"). Run every
+ * truncated string through this before it goes into a message.
+ */
+const LONE_SURROGATES = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g;
+
+export function stripLoneSurrogates(text: string): string {
+	return text.replace(LONE_SURROGATES, "");
+}

--- a/src/lib/server/textGeneration/utils/prepareFiles.ts
+++ b/src/lib/server/textGeneration/utils/prepareFiles.ts
@@ -3,6 +3,7 @@ import type { EndpointMessage } from "$lib/server/endpoints/endpoints";
 import type { OpenAI } from "openai";
 import { TEXT_MIME_ALLOWLIST } from "$lib/constants/mime";
 import { stripThink } from "$lib/utils/stripThink";
+import { stripLoneSurrogates } from "./loneSurrogates";
 import type { makeImageProcessor } from "$lib/server/endpoints/images";
 import {
 	MessageToolUpdateType,
@@ -347,7 +348,8 @@ function replayAssistantTurn(
 				tool_call_id: idByUuid.get(u.uuid) ?? u.uuid,
 				content:
 					output.length > MAX_REPLAYED_TOOL_OUTPUT_CHARS
-						? output.slice(0, MAX_REPLAYED_TOOL_OUTPUT_CHARS) + "\n[...truncated]"
+						? stripLoneSurrogates(output.slice(0, MAX_REPLAYED_TOOL_OUTPUT_CHARS)) +
+							"\n[...truncated]"
 						: output,
 			});
 		}

--- a/src/lib/server/textGeneration/utils/rateLimitRetry.ts
+++ b/src/lib/server/textGeneration/utils/rateLimitRetry.ts
@@ -1,0 +1,44 @@
+/**
+ * Slow second-line retries for router 429s, shared by the main tool loop and
+ * the research sub-agent's nested loop. The OpenAI SDK's own quick retries run
+ * first; these absorb the limits that outlast them, because a turn that has
+ * already spent ten productive rounds must not die on one throttled request.
+ */
+export const RATE_LIMIT_BACKOFF_MS: readonly number[] = [10_000, 25_000, 60_000];
+
+export const isRateLimitError = (err: unknown): boolean =>
+	(typeof err === "object" && err !== null && (err as { status?: number }).status === 429) ||
+	/\b429\b/.test(String(err));
+
+export const abortableSleep = (ms: number, signal?: AbortSignal): Promise<void> =>
+	new Promise((resolve, reject) => {
+		const finish = (err?: Error) => {
+			clearTimeout(timer);
+			signal?.removeEventListener("abort", onAbort);
+			err ? reject(err) : resolve();
+		};
+		const onAbort = () => finish(new Error("Aborted by user"));
+		const timer = setTimeout(() => finish(), ms);
+		signal?.addEventListener("abort", onAbort, { once: true });
+		if (signal?.aborted) onAbort();
+	});
+
+/**
+ * Run `fn`, absorbing rate limits with backoff. Anything else — and a 429 that
+ * outlasts the whole schedule — is rethrown for the caller's error path.
+ */
+export async function withRateLimitRetry<T>(
+	fn: () => Promise<T>,
+	opts: { signal?: AbortSignal; onBackoff?: (attempt: number, delayMs: number) => void } = {}
+): Promise<T> {
+	for (let attempt = 0; ; attempt += 1) {
+		try {
+			return await fn();
+		} catch (err) {
+			if (!isRateLimitError(err) || attempt >= RATE_LIMIT_BACKOFF_MS.length) throw err;
+			const delayMs = RATE_LIMIT_BACKOFF_MS[attempt];
+			opts.onBackoff?.(attempt + 1, delayMs);
+			await abortableSleep(delayMs, opts.signal);
+		}
+	}
+}

--- a/src/lib/utils/generationState.spec.ts
+++ b/src/lib/utils/generationState.spec.ts
@@ -1,8 +1,17 @@
 import { describe, expect, test } from "vitest";
 
 import type { Message } from "$lib/types/Message";
-import { MessageUpdateStatus, MessageUpdateType } from "$lib/types/MessageUpdate";
-import { isAssistantGenerationTerminal, isConversationGenerationActive } from "./generationState";
+import {
+	MessageToolUpdateType,
+	MessageUpdateStatus,
+	MessageUpdateType,
+} from "$lib/types/MessageUpdate";
+import { ToolResultStatus } from "$lib/types/Tool";
+import {
+	isAssistantGenerationTerminal,
+	isAssistantParkedOnWait,
+	isConversationGenerationActive,
+} from "./generationState";
 
 function assistantMessage(overrides: Partial<Message> = {}): Message {
 	return {
@@ -133,5 +142,97 @@ describe("generationState", () => {
 	test("interrupted wins even without any terminal update present", () => {
 		const message = assistantMessage({ interrupted: true, updates: undefined });
 		expect(isAssistantGenerationTerminal(message)).toBe(true);
+	});
+
+	// A parked-and-resumed turn (the wait tool) has a lifecycle: every park
+	// stamps `finished`, every resume stamps a new `started`. The LAST lifecycle
+	// event decides — "ever finished" would freeze the message at its first park.
+
+	test("a resume after a park makes the message active again", () => {
+		const message = assistantMessage({
+			updates: [
+				{ type: MessageUpdateType.Status, status: MessageUpdateStatus.Started },
+				{ type: MessageUpdateType.Status, status: MessageUpdateStatus.Finished },
+				{ type: MessageUpdateType.Status, status: MessageUpdateStatus.Started },
+				{ type: MessageUpdateType.Stream, token: "resumed output" },
+			],
+		});
+		expect(isAssistantGenerationTerminal(message)).toBe(false);
+		expect(isConversationGenerationActive([message])).toBe(true);
+	});
+
+	test("a turn parked again after a resume reads terminal until the next start", () => {
+		const message = assistantMessage({
+			updates: [
+				{ type: MessageUpdateType.Status, status: MessageUpdateStatus.Started },
+				{ type: MessageUpdateType.Status, status: MessageUpdateStatus.Finished },
+				{ type: MessageUpdateType.Status, status: MessageUpdateStatus.Started },
+				{ type: MessageUpdateType.Status, status: MessageUpdateStatus.Finished },
+			],
+		});
+		expect(isAssistantGenerationTerminal(message)).toBe(true);
+	});
+
+	test("a final answer after the last start is terminal", () => {
+		const message = assistantMessage({
+			updates: [
+				{ type: MessageUpdateType.Status, status: MessageUpdateStatus.Started },
+				{ type: MessageUpdateType.Status, status: MessageUpdateStatus.Finished },
+				{ type: MessageUpdateType.Status, status: MessageUpdateStatus.Started },
+				{ type: MessageUpdateType.FinalAnswer, text: "done", interrupted: false },
+			],
+		});
+		expect(isAssistantGenerationTerminal(message)).toBe(true);
+	});
+});
+
+describe("isAssistantParkedOnWait", () => {
+	const waitCall = (uuid: string) => ({
+		type: MessageUpdateType.Tool as const,
+		subtype: MessageToolUpdateType.Call as const,
+		uuid,
+		call: { name: "wait", parameters: { seconds: 60, reason: "job running" } },
+	});
+	const resultFor = (uuid: string) => ({
+		type: MessageUpdateType.Tool as const,
+		subtype: MessageToolUpdateType.Result as const,
+		uuid,
+		result: {
+			status: ToolResultStatus.Success as const,
+			call: { name: "wait", parameters: {} },
+			outputs: [],
+			display: true,
+		},
+	});
+
+	test("a wait call without a result is parked, even though the run finished", () => {
+		const message = assistantMessage({
+			updates: [
+				waitCall("w1"),
+				{ type: MessageUpdateType.Status, status: MessageUpdateStatus.Finished },
+			],
+		});
+		expect(isAssistantParkedOnWait(message)).toBe(true);
+		expect(isAssistantGenerationTerminal(message)).toBe(true);
+	});
+
+	test("a resumed wait (call with result) is no longer parked", () => {
+		const message = assistantMessage({
+			updates: [waitCall("w1"), resultFor("w1")],
+		});
+		expect(isAssistantParkedOnWait(message)).toBe(false);
+	});
+
+	test("only wait calls count, and interrupted turns are never parked", () => {
+		const otherCall = {
+			type: MessageUpdateType.Tool as const,
+			subtype: MessageToolUpdateType.Call as const,
+			uuid: "t1",
+			call: { name: "hf_fs", parameters: {} },
+		};
+		expect(isAssistantParkedOnWait(assistantMessage({ updates: [otherCall] }))).toBe(false);
+		expect(
+			isAssistantParkedOnWait(assistantMessage({ interrupted: true, updates: [waitCall("w1")] }))
+		).toBe(false);
 	});
 });

--- a/src/lib/utils/generationState.ts
+++ b/src/lib/utils/generationState.ts
@@ -1,21 +1,37 @@
 import type { Message } from "$lib/types/Message";
-import { MessageUpdateStatus, MessageUpdateType } from "$lib/types/MessageUpdate";
+import {
+	MessageToolUpdateType,
+	MessageUpdateStatus,
+	MessageUpdateType,
+} from "$lib/types/MessageUpdate";
 
+/**
+ * A parked-and-resumed turn (the `wait` tool) has a lifecycle, not a single
+ * ending: every park stamps a `finished` status and every server-side resume
+ * stamps a new `started`. "Ever finished" would freeze the message at its
+ * first park — reloads would never reattach and resumes would stay invisible
+ * to an open page — so the LAST lifecycle event decides.
+ */
 export function isAssistantGenerationTerminal(message?: Message): boolean {
 	if (!message || message.from !== "assistant") return true;
 
 	if (message.interrupted === true) return true;
 
 	const updates = message.updates ?? [];
-	const hasFinalAnswer = updates.some((update) => update.type === MessageUpdateType.FinalAnswer);
-	if (hasFinalAnswer) return true;
-
-	return updates.some(
-		(update) =>
-			update.type === MessageUpdateType.Status &&
-			(update.status === MessageUpdateStatus.Error ||
-				update.status === MessageUpdateStatus.Finished)
-	);
+	for (let i = updates.length - 1; i >= 0; i -= 1) {
+		const update = updates[i];
+		if (update.type === MessageUpdateType.FinalAnswer) return true;
+		if (update.type === MessageUpdateType.Status) {
+			if (
+				update.status === MessageUpdateStatus.Error ||
+				update.status === MessageUpdateStatus.Finished
+			) {
+				return true;
+			}
+			if (update.status === MessageUpdateStatus.Started) return false;
+		}
+	}
+	return false;
 }
 
 export function isConversationGenerationActive(messages: Message[]): boolean {
@@ -23,4 +39,36 @@ export function isConversationGenerationActive(messages: Message[]): boolean {
 	if (!lastAssistant) return false;
 
 	return !isAssistantGenerationTerminal(lastAssistant);
+}
+
+/**
+ * Matches WAIT_TOOL_NAME in builtinTools/waitTool.ts, which cannot be imported
+ * here: that module reaches the database, and this one is shared with the
+ * client bundle.
+ */
+const WAIT_TOOL = "wait";
+
+/**
+ * Whether this message's last act was parking on the `wait` tool: a wait call
+ * with no result yet. While parked the message reads terminal — that run's
+ * lifecycle closed with `finished` — but the sweeper will resume it
+ * server-side under a new generationId, so a parked message is a nap, not an
+ * ending, and a page showing one should keep watching for the resume.
+ */
+export function isAssistantParkedOnWait(message?: Message): boolean {
+	if (!message || message.from !== "assistant" || message.interrupted === true) return false;
+
+	const pending = new Set<string>();
+	for (const update of message.updates ?? []) {
+		if (update.type !== MessageUpdateType.Tool) continue;
+		if (update.subtype === MessageToolUpdateType.Call && update.call.name === WAIT_TOOL) {
+			pending.add(update.uuid);
+		} else if (
+			update.subtype === MessageToolUpdateType.Result ||
+			update.subtype === MessageToolUpdateType.Error
+		) {
+			pending.delete(update.uuid);
+		}
+	}
+	return pending.size > 0;
 }

--- a/src/routes/conversation/[id]/+page.svelte
+++ b/src/routes/conversation/[id]/+page.svelte
@@ -38,6 +38,7 @@
 	import {
 		isConversationGenerationActive,
 		isAssistantGenerationTerminal,
+		isAssistantParkedOnWait,
 	} from "$lib/utils/generationState";
 	import { useAPIClient, handleResponse } from "$lib/APIClient";
 	import SharePreviewTags from "$lib/components/SharePreviewTags.svelte";
@@ -657,6 +658,49 @@
 		} else if (!pending) {
 			$loading = false;
 		}
+	});
+
+	// A turn parked on `wait` resumes server-side under a NEW generationId, with
+	// no request from this tab carrying its updates — the open page goes quiet
+	// while a reload would show them. So while the conversation is either active
+	// or parked on a wait, poll the server copy whenever this tab has no stream
+	// of its own (both flags are non-reactive, so they are checked per tick):
+	// when the generationId has moved on, or a turn this tab thought was live
+	// finished elsewhere, refresh — which re-enters the normal reattach path.
+	const DETACHED_POLL_MS = 5_000;
+	let generationActive = $derived(isConversationGenerationActive(messages));
+	let parkedOnWait = $derived(
+		isAssistantParkedOnWait(messages.findLast((m) => m.from === "assistant"))
+	);
+	$effect(() => {
+		if (!browser || (!generationActive && !parkedOnWait)) return;
+		const id = convId;
+		const client = useAPIClient();
+		const timer = setInterval(async () => {
+			if (convId !== id || writeMessageInFlight || reattachController) return;
+			try {
+				const conversation = (await client.conversations({ id }).get().then(handleResponse)) as {
+					messages: Message[];
+				};
+				const localLast = messages.findLast((m) => m.from === "assistant");
+				const remoteLast = conversation.messages.findLast((m) => m.from === "assistant");
+				if (!localLast?.generationId || !remoteLast) return;
+				const generationMovedOn = remoteLast.generationId !== localLast.generationId;
+				// While both copies are parked, remote-terminal is the steady state,
+				// not a transition — only a moved-on generationId means the resume
+				// began. Remote-terminal IS the transition when this tab believed
+				// the turn was still live (it finished while detached).
+				const finishedElsewhere =
+					!isAssistantGenerationTerminal(localLast) &&
+					!isConversationGenerationActive(conversation.messages);
+				if (generationMovedOn || finishedElsewhere) {
+					await Promise.all([safeInvalidate(UrlDependency.Conversation), convsStore.refresh()]);
+				}
+			} catch {
+				// Transient; the next tick retries.
+			}
+		}, DETACHED_POLL_MS);
+		return () => clearInterval(timer);
 	});
 
 	// create a linear list of `messagesPath` from `messages` that is a tree of threaded messages


### PR DESCRIPTION
## What this is

P3 of the ML Intern port ([strategy](#2526)): a `research` builtin tool that is itself a complete agent loop. The sub-agent runs on a fresh message array — nothing inherited from the parent conversation — against a read-only tool allowlist, and only its 500–1500-word attributed summary ever reaches the main context. A literature pass costs the main turn one tool round, and no raw search dumps land in it.

Ported from ml-intern's `research_tool.py`, mechanics intact:

- **Forced summary as a mechanism**: at 85%/95% of the model's context (or the 60-iteration cap) the final request is sent **without `tools`** — the budget prompt is backed by a constraint the model can't ignore.
- Fresh `[system, user]` context; tool outputs head/tail-truncated at 8,000 chars; terminates on the first response with no tool calls; abort propagates into every nested call; progress streams onto the tool card.
- Read-only allowlist: `hf_fs`, `hub_repo_details`, `hub_repo_search`, the three GitHub grounding builtins, the Exa tools. Calls outside it get `Tool '{name}' not available for research.` unexecuted. Never `research` itself.
- The crawl doctrine is rewritten for tools this mode actually has: no citation index, so references come from the bibliography already inline in `paper.md` (upstream) and successor work is found by search (downstream), stated as search-based. Doctrine sections naming Exa/GitHub tools appear only when those tools are offered.
- Runtime deps (client, sampling params, the turn's listed MCP tools) are bound onto the tool inside `runMcpFlow` once they exist; definition and enablement stay in `builtinTools/`. The injection seam also makes the loop testable without module mocks.

Research-first doctrine lands at all four decision surfaces (preset prompt, tool preprompt, tool schema description, `hf_fs` doctrine block): reproducing or implementing a paper **starts** with `research`; the main agent reads a single section itself only to settle a specific detail it is about to act on.

## Hardening from two days of dogfooding

Real ML Assistant runs (30+ minute turns, waits, GPU smoke jobs) surfaced issues fixed here:

- **Rate limits**: shared `withRateLimitRetry` (10s/25s/60s after the SDK's quick retries, abort-aware) wraps both the main loop and the nested loop — a turn ten rounds deep no longer dies on one throttled request. When research exhausts retries, its error tells the model to `wait` then re-call, so the two tools compose.
- **Output-limit cuts**: a final answer cut mid-`<think>` (`finish_reason: "length"`) was silently finalized as a finished turn. Both loops now retry once with a nudge; a second cut finalizes marked `interrupted`. The mode also floors the completion budget (`ML_ASSISTANT_MIN_COMPLETION_TOKENS = 32k`, catalog value wins above it) so high-effort reasoning stops brushing the default caps.
- **Lone surrogates**: fixed truncation slicing surrogate pairs in half — one lone surrogate made the router 400 every request carrying the message, permanently. Also fixes the same pre-existing bug in cross-turn replay truncation (`prepareFiles.ts`).
- **Parked-turn lifecycle**: a parked-and-resumed turn (`wait`) stamps `finished` per park and `started` per resume; terminal state is now decided by the **last** lifecycle event instead of "ever finished", which froze messages at their first park (no reattach on reload, invisible resumes). New `isAssistantParkedOnWait` keeps the page watching through parks; the sweeper closes every resumed run's lifecycle consistently.
- **Persisted layout**: `compressUpdatesForStorage` now merges adjacent stream markers — unmerged, a long reasoning turn crossed the 5,000-update cap and the backstop dropped every marker, collapsing the message into an unanchored blob with no tool cards.

## Known follow-up

Dogfooding also showed the live-visibility layer for parked turns is structurally discovery-based (per-resume generation identity + per-generation seq reset vs. stale client cursors). A separate rearchitecture ("turn continuity": turn-scoped event log, stored turn state, single subscription channel) is planned as its own PR; the fixes above are correct but that design replaces their mechanism.

## Tests

12 new specs for the research loop (allowlist, forced summary drops `tools`, truncation boundaries, budget stops, repetition guard, 429 backoff, length-cut nudges, abort), plus coverage for the rate-limit retry in the main loop, lifecycle semantics, parked-wait detection, and marker merging. Full suite: 1,203 passing; `npm run check` and `npm run lint` clean.