### PR TITLE
Fix word wrapping in ServerCard tools list

### DIFF
--- a/src/lib/components/mcp/ServerCard.svelte
+++ b/src/lib/components/mcp/ServerCard.svelte
@@ -187,7 +187,7 @@
 				<summary class="cursor-pointer text-xs font-medium text-gray-700 dark:text-gray-300">
 					Available Tools ({server.tools.length})
 				</summary>
-				<ul class="mt-2 space-y-1 text-xs">
+				<ul class="mt-2 space-y-1 text-xs wrap-break-word">
 					{#each server.tools as tool}
 						<li class="text-gray-600 dark:text-gray-400">
 							<span class="font-medium text-gray-900 dark:text-gray-100">{tool.name}</span>


### PR DESCRIPTION
## Summary
Add word wrapping support to the tools list in the MCP ServerCard component to prevent long tool names from breaking the layout.

## Changes
- Added `wrap-break-word` class to the tools list `<ul>` element in `ServerCard.svelte`
- This ensures tool names that exceed the container width will wrap to the next line instead of overflowing

## Details
The tools list was displaying with `text-xs` but lacked word-wrapping behavior, which could cause layout issues when tool names were particularly long. The `wrap-break-word` utility class provides proper text wrapping while maintaining the compact styling of the tools list.

https://claude.ai/code/session_012Q56LjmTrZFAnteNZzcHcB