### PR TITLE
Show the fixed task model in application settings

### DIFF
--- a/src/lib/server/api/__tests__/misc.spec.ts
+++ b/src/lib/server/api/__tests__/misc.spec.ts
@@ -27,10 +27,12 @@ describe("GET /api/v2/feature-flags", () => {
 		expect(data).toHaveProperty("loginEnabled");
 		expect(data).toHaveProperty("isAdmin");
 		expect(data).toHaveProperty("transcriptionEnabled");
+		expect(data).toHaveProperty("taskModelId");
 		expect(typeof data.enableAssistants).toBe("boolean");
 		expect(typeof data.loginEnabled).toBe("boolean");
 		expect(typeof data.isAdmin).toBe("boolean");
 		expect(typeof data.transcriptionEnabled).toBe("boolean");
+		expect(data.taskModelId === null || typeof data.taskModelId === "string").toBe(true);
 	});
 
 	it("reflects isAdmin from locals for non-admin user", async () => {

--- a/src/lib/server/api/types.ts
+++ b/src/lib/server/api/types.ts
@@ -42,4 +42,6 @@ export interface FeatureFlags {
 	loginEnabled: boolean;
 	isAdmin: boolean;
 	transcriptionEnabled: boolean;
+	/** Fixed model used for background tasks (e.g. conversation titles); null when tasks follow the conversation's model */
+	taskModelId: string | null;
 }

--- a/src/routes/api/v2/feature-flags/+server.ts
+++ b/src/routes/api/v2/feature-flags/+server.ts
@@ -8,9 +8,10 @@ export const GET: RequestHandler = async ({ locals }) => {
 	// Mirror the title-generation resolution (generateFromDefaultEndpoint): the
 	// live TASK_MODEL value wins over the startup-resolved task model, so the
 	// reported id stays correct when TASK_MODEL changes via the config manager.
+	// With LLM_SUMMARIZATION off, titles never invoke a model, so report none.
 	let taskModelId: string | null = null;
 	const configuredTaskModel = config.TASK_MODEL;
-	if (configuredTaskModel?.trim()) {
+	if (config.LLM_SUMMARIZATION === "true" && configuredTaskModel?.trim()) {
 		try {
 			const { models, taskModel } = await import("$lib/server/models");
 			taskModelId = (models.find((m) => m.id === configuredTaskModel) ?? taskModel)?.id ?? null;

--- a/src/routes/api/v2/feature-flags/+server.ts
+++ b/src/routes/api/v2/feature-flags/+server.ts
@@ -5,10 +5,25 @@ import { config } from "$lib/server/config";
 import type { FeatureFlags } from "$lib/server/api/types";
 
 export const GET: RequestHandler = async ({ locals }) => {
+	// Mirror the title-generation resolution (generateFromDefaultEndpoint): the
+	// live TASK_MODEL value wins over the startup-resolved task model, so the
+	// reported id stays correct when TASK_MODEL changes via the config manager.
+	let taskModelId: string | null = null;
+	const configuredTaskModel = config.TASK_MODEL;
+	if (configuredTaskModel?.trim()) {
+		try {
+			const { models, taskModel } = await import("$lib/server/models");
+			taskModelId = (models.find((m) => m.id === configuredTaskModel) ?? taskModel)?.id ?? null;
+		} catch {
+			taskModelId = null;
+		}
+	}
+
 	return superjsonResponse({
 		enableAssistants: config.ENABLE_ASSISTANTS === "true",
 		loginEnabled,
 		isAdmin: locals.isAdmin,
 		transcriptionEnabled: !!config.get("TRANSCRIPTION_MODEL"),
+		taskModelId,
 	} satisfies FeatureFlags);
 };

--- a/src/routes/settings/(nav)/application/+page.svelte
+++ b/src/routes/settings/(nav)/application/+page.svelte
@@ -96,7 +96,31 @@
 	});
 
 	let themePref = $state<ThemePreference>(browser ? getThemePreference() : "system");
+
+	const taskModelId = $derived((page.data as { taskModelId?: string | null }).taskModelId ?? null);
+	const showTaskModelInBilling = $derived(publicConfig.isHuggingChat && !!page.data.user);
 </script>
+
+{#snippet taskModelRow()}
+	<div class="flex flex-col gap-2 py-3 sm:flex-row sm:items-start sm:justify-between">
+		<div>
+			<div class="text-[13px] font-medium text-gray-800 dark:text-gray-200">Task model</div>
+			<p class="text-[12px] text-gray-500 dark:text-gray-400">
+				{#if publicConfig.isHuggingChat}
+					Generates conversation titles. Extremely cheap.
+				{:else}
+					Generates conversation titles. Set via <code class="font-mono">TASK_MODEL</code>.
+				{/if}
+			</p>
+		</div>
+		<select
+			disabled
+			class="max-w-full cursor-not-allowed self-start rounded-md border border-gray-300 bg-white px-1 py-1 text-xs text-gray-800 sm:self-auto dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200"
+		>
+			<option>{taskModelId}</option>
+		</select>
+	</div>
+{/snippet}
 
 <div class="flex w-full flex-col gap-4">
 	<h2 class="text-center text-lg font-semibold text-gray-800 md:text-left dark:text-gray-200">
@@ -227,6 +251,10 @@
 						<option value="dark">Dark</option>
 					</select>
 				</div>
+
+				{#if taskModelId && !showTaskModelInBilling}
+					{@render taskModelRow()}
+				{/if}
 			</div>
 		</div>
 
@@ -263,6 +291,9 @@
 							{/if}
 						</div>
 					</div>
+					{#if taskModelId}
+						{@render taskModelRow()}
+					{/if}
 					<!-- Providers Usage -->
 					<div class="flex items-start justify-between py-3">
 						<div>


### PR DESCRIPTION
## What

Adds a read-only "Task model" row to Settings > Application, shown as a single-option select you cannot change, displaying the model configured via `TASK_MODEL`.

- On HuggingChat (logged in), the row appears in the Billing card, between "Billing" and "Providers Usage", with the subtitle "Generates conversation titles. Extremely cheap."
- On self-hosted deployments (or logged out), it appears in the general settings card with the subtitle "Generates conversation titles. Set via `TASK_MODEL`.", since the cost claim depends on whichever model the operator picked.
- When `TASK_MODEL` is not set, the row is hidden entirely: titles then follow the conversation's own model, so there is no fixed model to disclose.

## Why

Title generation runs on a fixed cheap model (currently Llama-3.1-8B-Instruct) authenticated as the user, so it shows up in their Inference Providers usage. A user filed a support ticket because they could not tell where those requests and charges came from. This makes the task model visible where a user investigating charges would look.

## How

- `GET /api/v2/feature-flags` now returns `taskModelId` (string or null). It rides the existing payload the root layout already spreads into `page.data`, so no extra request.
- The id is resolved the same way the title path resolves it (live `TASK_MODEL` id first, then the startup-resolved task model), so the displayed model stays correct even if `TASK_MODEL` is changed at runtime through the config manager.

## Notes for reviewers

- The select is `disabled` but keeps the same text color as the other selects (only the cursor signals it is locked).
- The row stacks vertically on small screens so the long model id does not crush the label column.
- Existing feature-flags shape test extended to cover `taskModelId`.