### PR TITLE
ML Intern mode: UI/UX fixes

### DIFF
--- a/src/lib/components/GenerationLiveWatcher.svelte
+++ b/src/lib/components/GenerationLiveWatcher.svelte
@@ -6,7 +6,10 @@
 	import { get } from "svelte/store";
 	import { loading } from "$lib/stores/loading";
 	import { useConversationsStore } from "$lib/stores/conversations.svelte";
-	import { useActiveGenerationsStore } from "$lib/stores/activeGenerations.svelte";
+	import {
+		useActiveGenerationsStore,
+		type ParkedTurnStatus,
+	} from "$lib/stores/activeGenerations.svelte";
 	import { useNotificationsStore } from "$lib/stores/notifications.svelte";
 	import type { GenerationStatus } from "$lib/types/Generation";
 
@@ -23,6 +26,10 @@
 		title: string;
 		status: GenerationStatus;
 	}
+	interface ParkedEntry {
+		conversationId: string;
+		status: ParkedTurnStatus;
+	}
 
 	// While a run this tab started is still registering, keep looking this often; its DB
 	// record can lag $loading, which won't re-fire to reopen us.
@@ -38,7 +45,7 @@
 		source = es;
 
 		es.addEventListener("sync", (event) => {
-			let payload: { running: RunningEntry[]; ended: EndedEntry[] };
+			let payload: { running: RunningEntry[]; ended: EndedEntry[]; parked?: ParkedEntry[] };
 			try {
 				payload = JSON.parse((event as MessageEvent).data);
 			} catch {
@@ -46,6 +53,7 @@
 			}
 
 			activeGenerations.setRunning(payload.running.map((run) => run.conversationId));
+			activeGenerations.setParked(payload.parked ?? []);
 			for (const run of payload.running) {
 				if (run.title) convsStore.update(run.conversationId, { title: run.title });
 			}

--- a/src/lib/components/GenerationLiveWatcher.svelte
+++ b/src/lib/components/GenerationLiveWatcher.svelte
@@ -29,6 +29,8 @@
 	interface ParkedEntry {
 		conversationId: string;
 		status: ParkedTurnStatus;
+		/** Epoch ms after which a failed flag stops being shown. */
+		expiresAt?: number;
 	}
 
 	// While a run this tab started is still registering, keep looking this often; its DB
@@ -90,10 +92,18 @@
 		source = null;
 	}
 
+	// Failed flags expire client-side (see pruneExpired): the feed is closed by
+	// the time their window lapses, so only a timer can retire them.
+	const PRUNE_INTERVAL_MS = 60_000;
+
 	onMount(() => {
 		// Catch runs already in flight (e.g. started elsewhere before this load).
 		open();
-		return close;
+		const pruneTimer = setInterval(() => activeGenerations.pruneExpired(), PRUNE_INTERVAL_MS);
+		return () => {
+			clearInterval(pruneTimer);
+			close();
+		};
 	});
 
 	// Reopen when a generation starts in this tab, so navigating away keeps it tracked.

--- a/src/lib/components/NavConversationItem.svelte
+++ b/src/lib/components/NavConversationItem.svelte
@@ -6,6 +6,7 @@
 
 	import CarbonTrashCan from "~icons/carbon/trash-can";
 	import CarbonEdit from "~icons/carbon/edit";
+	import CarbonMachineLearning from "~icons/carbon/machine-learning";
 	import LucideEllipsis from "~icons/lucide/ellipsis";
 	import type { ConvSidebar } from "$lib/types/ConvSidebar";
 
@@ -82,17 +83,18 @@
 >
 	{#if conv.mlAssistant}
 		{@const ml = ML_TURN_BADGE[activeGenerations.statusFor(conv.id) ?? "idle"]}
-		<!-- Neutral pill on purpose: the status dot carries the color, and an orange
-		     chip fought with it. Same recipe as the sidebar's count badges. -->
+		<!-- Neutral marker on purpose: the status dot carries the color, and an
+		     orange treatment fought with it. An icon rather than an "ML" chip, so
+		     a run of mode conversations doesn't read as a wall of repeated text. -->
 		<span
-			class="flex flex-none items-center gap-1 rounded-sm bg-gray-500/10 px-1 py-px text-[10px] font-medium text-gray-500 dark:bg-gray-500/20 dark:text-gray-400"
+			class="flex flex-none items-center gap-1 text-gray-400 dark:text-gray-500"
 			title="ML Intern — {ml.label}"
 		>
-			ML
+			<CarbonMachineLearning class="size-3.5" />
 			{#if ml.dot}
 				<span class="size-1.5 rounded-full {ml.dot}"></span>
 			{/if}
-			<span class="sr-only">Intern — {ml.label}</span>
+			<span class="sr-only">ML Intern — {ml.label}</span>
 		</span>
 	{:else if activeGenerations.has(conv.id)}
 		<span

--- a/src/lib/components/NavConversationItem.svelte
+++ b/src/lib/components/NavConversationItem.svelte
@@ -12,9 +12,27 @@
 	import EditConversationModal from "$lib/components/EditConversationModal.svelte";
 	import DeleteConversationModal from "$lib/components/DeleteConversationModal.svelte";
 	import { requireAuthUser } from "$lib/utils/auth";
-	import { useActiveGenerationsStore } from "$lib/stores/activeGenerations.svelte";
+	import {
+		useActiveGenerationsStore,
+		type LiveTurnStatus,
+	} from "$lib/stores/activeGenerations.svelte";
 
 	const activeGenerations = useActiveGenerationsStore();
+
+	// One entry per turn status an ML Intern row can be in (idle = no live turn).
+	// One hue per state so they read apart at dot size: orange = generating,
+	// blue = needs an answer, red = failed, gray = parked on a timer. The two
+	// states that move (or want the user) pulse; the settled ones hold still.
+	const ML_TURN_BADGE: Record<LiveTurnStatus | "idle", { label: string; dot?: string }> = {
+		running: { label: "Generating…", dot: "animate-pulse bg-[#ea580c] dark:bg-[#fb923c]" },
+		waiting: { label: "Waiting to resume", dot: "bg-gray-400 dark:bg-gray-500" },
+		awaiting_input: {
+			label: "Needs your answer",
+			dot: "animate-pulse bg-blue-500 dark:bg-blue-400",
+		},
+		failed: { label: "Failed", dot: "bg-red-500 dark:bg-red-400" },
+		idle: { label: "Idle" },
+	};
 
 	interface Props {
 		conv: ConvSidebar;
@@ -62,7 +80,21 @@
 	class="group flex h-8 flex-none items-center gap-1.5 rounded-lg pr-1.5 pl-2 text-base text-gray-600 hover:bg-gray-100 max-sm:h-10 sm:text-sm dark:text-gray-300 dark:hover:bg-gray-700
 		{conv.id === page.params.id ? 'bg-gray-100 dark:bg-gray-700' : ''}"
 >
-	{#if activeGenerations.has(conv.id)}
+	{#if conv.mlAssistant}
+		{@const ml = ML_TURN_BADGE[activeGenerations.statusFor(conv.id) ?? "idle"]}
+		<!-- Neutral pill on purpose: the status dot carries the color, and an orange
+		     chip fought with it. Same recipe as the sidebar's count badges. -->
+		<span
+			class="flex flex-none items-center gap-1 rounded-sm bg-gray-500/10 px-1 py-px text-[10px] font-medium text-gray-500 dark:bg-gray-500/20 dark:text-gray-400"
+			title="ML Intern — {ml.label}"
+		>
+			ML
+			{#if ml.dot}
+				<span class="size-1.5 rounded-full {ml.dot}"></span>
+			{/if}
+			<span class="sr-only">Intern — {ml.label}</span>
+		</span>
+	{:else if activeGenerations.has(conv.id)}
 		<span
 			class="size-1.5 flex-none animate-pulse rounded-full bg-blue-500 dark:bg-blue-400"
 			title="Generating…"

--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { Message, MessageFile } from "$lib/types/Message";
-	import { onDestroy, untrack } from "svelte";
+	import { onDestroy, tick, untrack } from "svelte";
+	import { goto } from "$app/navigation";
 
 	import ArtifactPanel from "./ArtifactPanel.svelte";
 	import { collectArtifacts } from "$lib/utils/artifacts";
@@ -62,6 +63,7 @@
 	import LucideHammer from "~icons/lucide/hammer";
 	import LucideSparkles from "~icons/lucide/sparkles";
 	import MlAssistantStrip from "./MlAssistantStrip.svelte";
+	import MlAssistantPromo from "./MlAssistantPromo.svelte";
 	import { ML_ASSISTANT_MODE } from "$lib/utils/mlAssistantFlag";
 	import { mlAssistant } from "$lib/stores/mlAssistant.svelte";
 	import { planStepsToMlSteps } from "$lib/utils/planProgress";
@@ -528,6 +530,32 @@
 		mlAssistant.toggle(next);
 	}
 
+	// The mode can't be switched on once a conversation starts without it, so the
+	// strip's slot offers the next best thing: a fresh ML Intern chat seeded with
+	// the question. First exchange only — beyond that the conversation has
+	// history worth keeping — and dismissable per conversation.
+	let mlPromoVisible = $derived(
+		ML_ASSISTANT_MODE &&
+			!shared &&
+			!isReadOnly &&
+			!mlModeOn &&
+			!mlTaskRunning &&
+			Boolean(page.params?.id) &&
+			messages.filter((message) => message.from === "user").length === 1 &&
+			!mlAssistant.promoDismissed(page.params?.id)
+	);
+
+	async function askInMlIntern() {
+		if (requireAuthUser()) return;
+		const question = messages.find((message) => message.from === "user")?.content ?? "";
+		await goto(`${base}/`);
+		// Let the home composer's sync effect release the old conversation before
+		// the mode goes on — the release resets the store, which would wipe it.
+		await tick();
+		mlAssistant.toggle(true);
+		if (question) pendingComposerPayload.set({ text: question });
+	}
+
 	let activeRouterExamplePrompt = $state<string | null>(null);
 	// ML Assistant mode brings its own chip set; otherwise use MCP examples when all
 	// base servers are enabled, and router examples when they are not.
@@ -596,6 +624,14 @@
 
 	async function startExample(example: RouterExample) {
 		if (requireAuthUser()) return;
+
+		// ML Intern chips seed the composer instead of dispatching: their prompts
+		// name "this paper/dataset/model", so the user still has details to add.
+		if (mlModeOn) {
+			draft = example.prompt;
+			return;
+		}
+
 		activeRouterExamplePrompt = example.prompt;
 
 		if (browser && example.attachments?.length) {
@@ -973,6 +1009,11 @@
 							statusLabel={mlAssistant.statusLabel}
 							complete={mlAssistant.complete}
 							ontoggle={toggleMlMode}
+						/>
+						<MlAssistantPromo
+							visible={mlPromoVisible}
+							onask={askInMlIntern}
+							ondismiss={() => mlAssistant.dismissPromo(page.params?.id)}
 						/>
 					{/if}
 					<!-- The composer box is a column so the ML Assistant strip can stack on

--- a/src/lib/components/chat/MlAssistantPromo.svelte
+++ b/src/lib/components/chat/MlAssistantPromo.svelte
@@ -1,0 +1,66 @@
+<script lang="ts">
+	import LucideX from "~icons/lucide/x";
+	import { ML_ASSISTANT_PROMO_NOTE } from "$lib/constants/mlAssistant";
+
+	interface Props {
+		/** Collapses the banner out of the composer when false, rather than unmounting it. */
+		visible: boolean;
+		/** Starts a fresh ML Intern chat seeded with this conversation's question. */
+		onask: () => void;
+		ondismiss: () => void;
+	}
+
+	let { visible, onask, ondismiss }: Props = $props();
+</script>
+
+<!-- Shown where the mode strip would sit, on conversations that started without
+     the mode: the toggle is locked out of them, so this offers the next best
+     thing instead of silently dropping the affordance. -->
+<div class="ml-promo-collapse" class:is-open={visible} inert={!visible}>
+	<div
+		class="flex items-center gap-[9px] border-b border-[#ececee] px-4 py-[9px] text-[13.5px] text-[#9a9aa0] dark:border-gray-700 dark:text-gray-500"
+	>
+		<button
+			type="button"
+			class="flex-none cursor-pointer font-medium text-[#c2410c] hover:underline dark:text-[#fdba74]"
+			onclick={onask}
+		>
+			Ask in ML Intern
+		</button>
+		<span class="truncate text-[#c2c2c8] dark:text-gray-600">{ML_ASSISTANT_PROMO_NOTE}</span>
+		<button
+			type="button"
+			class="-my-1 -mr-2 ml-auto flex size-8 flex-none cursor-pointer items-center justify-center rounded-md text-[#c2c2c8] hover:bg-black/5 hover:text-[#9a9aa0] dark:text-gray-600 dark:hover:bg-white/10 dark:hover:text-gray-400"
+			onclick={ondismiss}
+			aria-label="Dismiss"
+		>
+			<LucideX class="size-3.5" />
+		</button>
+	</div>
+</div>
+
+<style>
+	/* Same collapse treatment as the mode strip, so the two trade places in the
+	   composer without a layout jump (see MlAssistantStrip.svelte). */
+	.ml-promo-collapse {
+		max-height: 0;
+		opacity: 0;
+		overflow: hidden;
+		border-top-left-radius: calc(0.75rem - 1px);
+		border-top-right-radius: calc(0.75rem - 1px);
+		transition:
+			max-height 0.45s cubic-bezier(0.4, 0, 0.2, 1),
+			opacity 0.3s ease;
+	}
+
+	.ml-promo-collapse.is-open {
+		max-height: 56px;
+		opacity: 1;
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.ml-promo-collapse {
+			transition: none;
+		}
+	}
+</style>

--- a/src/lib/components/chat/MlAssistantPromo.svelte.test.ts
+++ b/src/lib/components/chat/MlAssistantPromo.svelte.test.ts
@@ -1,0 +1,59 @@
+import MlAssistantPromo from "./MlAssistantPromo.svelte";
+import { render } from "vitest-browser-svelte";
+import { describe, expect, it, vi } from "vitest";
+
+function mount(props: Partial<Parameters<typeof render<typeof MlAssistantPromo>>[1]> = {}) {
+	return render(MlAssistantPromo, {
+		visible: true,
+		onask: () => {},
+		ondismiss: () => {},
+		...props,
+	});
+}
+
+const find = (root: ParentNode, selector: string): HTMLElement => {
+	const el = root.querySelector<HTMLElement>(selector);
+	if (!el) throw new Error(`no element matching ${selector}`);
+	return el;
+};
+
+describe("MlAssistantPromo", () => {
+	it("offers the mode by name, with a note saying what the offer does", () => {
+		const { container } = mount();
+
+		expect(container.textContent).toContain("Ask in ML Intern");
+		expect(container.textContent).toContain("— takes your question to a new chat with ML tools");
+	});
+
+	it("fires onask from the call to action", () => {
+		const onask = vi.fn();
+		const { container } = mount({ onask });
+
+		const buttons = [...container.querySelectorAll("button")];
+		const cta = buttons.find((b) => b.textContent?.includes("Ask in ML Intern"));
+		cta?.click();
+
+		expect(onask).toHaveBeenCalledOnce();
+	});
+
+	it("fires ondismiss from a labelled dismiss button", () => {
+		const ondismiss = vi.fn();
+		const { container } = mount({ ondismiss });
+
+		find(container, 'button[aria-label="Dismiss"]').click();
+
+		expect(ondismiss).toHaveBeenCalledOnce();
+	});
+
+	it("collapses out of the composer when hidden", () => {
+		const shown = getComputedStyle(find(mount().container, ".ml-promo-collapse"));
+		expect(shown.maxHeight).toBe("56px");
+		expect(shown.opacity).toBe("1");
+
+		const hidden = getComputedStyle(
+			find(mount({ visible: false }).container, ".ml-promo-collapse")
+		);
+		expect(hidden.maxHeight).toBe("0px");
+		expect(hidden.opacity).toBe("0");
+	});
+});

--- a/src/lib/components/chat/MlAssistantStrip.svelte
+++ b/src/lib/components/chat/MlAssistantStrip.svelte
@@ -14,23 +14,9 @@
 		statusLabel: string;
 		complete: boolean;
 		ontoggle: (enabled: boolean) => void;
-		/**
-		 * Opens the preset's tool and prompt configuration. That panel doesn't exist
-		 * yet, so the link renders as designed but does nothing until one is passed.
-		 */
-		onconfigure?: () => void;
 	}
 
-	let {
-		visible,
-		enabled,
-		taskRunning,
-		steps,
-		statusLabel,
-		complete,
-		ontoggle,
-		onconfigure,
-	}: Props = $props();
+	let { visible, enabled, taskRunning, steps, statusLabel, complete, ontoggle }: Props = $props();
 </script>
 
 <div class="ml-strip-collapse" class:is-open={visible} inert={!visible}>
@@ -79,18 +65,6 @@
 			</span>
 		{:else}
 			<span class="truncate text-[#c2c2c8] dark:text-gray-600">{ML_ASSISTANT_NOTE_OFF}</span>
-		{/if}
-
-		<span class="ml-auto"></span>
-
-		{#if enabled && !taskRunning}
-			<button
-				type="button"
-				class="flex-none cursor-pointer text-[13.5px] text-[#7f8cd8] hover:underline"
-				onclick={onconfigure}
-			>
-				Configure
-			</button>
 		{/if}
 	</div>
 </div>

--- a/src/lib/components/chat/MlAssistantStrip.svelte.test.ts
+++ b/src/lib/components/chat/MlAssistantStrip.svelte.test.ts
@@ -65,12 +65,12 @@ describe("MlAssistantStrip", () => {
 		expect(style(strip).borderBottomColor).toBe("rgb(236, 236, 238)");
 	});
 
-	it("renders the on state with the preset tool list, Configure link and accent tint", () => {
+	it("renders the on state with the preset tool list and accent tint", () => {
 		const { container } = mount({ enabled: true });
 		const strip = find(container, ".ml-strip");
 
 		expect(strip.textContent).toContain("papers · training · spaces · datasets · eval · hub");
-		expect(container.textContent).toContain("Configure");
+		expect(container.textContent).not.toContain("Configure");
 		expect(style(strip).backgroundColor).toBe("rgb(255, 244, 234)");
 		expect(style(strip).borderBottomColor).toBe("rgb(251, 228, 204)");
 		expect(style(strip).color).toBe(ACCENT_TEXT);
@@ -85,15 +85,14 @@ describe("MlAssistantStrip", () => {
 		expect(strip.fontSize).toBe("13.5px");
 	});
 
-	it("truncates the tool note rather than pushing Configure off a narrow composer", () => {
+	it("truncates the tool note rather than overflowing a narrow composer", () => {
 		const { container } = mount({ enabled: true });
 		container.style.width = "375px";
 		const note = find(container, ".ml-strip span.truncate");
-		const configure = find(container, "button:not(.ml-switch)");
 
 		expect(style(note).textOverflow).toBe("ellipsis");
 		expect(note.scrollWidth).toBeGreaterThan(note.clientWidth);
-		expect(configure.getBoundingClientRect().right).toBeLessThanOrEqual(
+		expect(note.getBoundingClientRect().right).toBeLessThanOrEqual(
 			Math.ceil(find(container, ".ml-strip").getBoundingClientRect().right)
 		);
 	});
@@ -135,7 +134,7 @@ describe("MlAssistantStrip", () => {
 		expect(hidden.opacity).toBe("0");
 	});
 
-	it("collapses the switch and drops Configure once a task is running", () => {
+	it("collapses the switch once a task is running", () => {
 		const { container } = mount({
 			enabled: true,
 			taskRunning: true,
@@ -149,7 +148,6 @@ describe("MlAssistantStrip", () => {
 		expect(slot.width).toBe("0px");
 		expect(slot.marginRight).toBe("-9px");
 		expect(slot.opacity).toBe("0");
-		expect(container.textContent).not.toContain("Configure");
 		expect(container.textContent).not.toContain("papers · training");
 	});
 

--- a/src/lib/components/chat/ToolUpdate.svelte
+++ b/src/lib/components/chat/ToolUpdate.svelte
@@ -10,6 +10,7 @@
 	import { ToolResultStatus, type ToolFront } from "$lib/types/Tool";
 	import { page } from "$app/state";
 	import CarbonChevronRight from "~icons/carbon/chevron-right";
+	import LucideTriangleAlert from "~icons/lucide/triangle-alert";
 	import BlockWrapper from "./BlockWrapper.svelte";
 
 	interface Props {
@@ -109,14 +110,16 @@
 				onclick={() => (isOpen = !isOpen)}
 				aria-label={isOpen ? "Collapse" : "Expand"}
 			>
+				<!-- Errors here are often recoverable (the model retries or works around
+				     them), so the header stays in the same muted gray as every other
+				     state; the amber icon is the only signal until the row is expanded. -->
+				{#if toolError}
+					<LucideTriangleAlert class="size-3.5 shrink-0 text-amber-500 dark:text-amber-400" />
+				{/if}
 				<span
-					class="shrink-0 text-sm font-medium transition-colors {toolError
-						? `group-hover/header:text-red-700 dark:group-hover/header:text-red-300 ${
-								isOpen ? 'text-red-700 dark:text-red-300' : 'text-red-600 dark:text-red-400'
-							}`
-						: `group-hover/header:text-gray-600 dark:group-hover/header:text-gray-300 ${
-								isOpen ? 'text-gray-600 dark:text-gray-300' : 'text-gray-500 dark:text-gray-400'
-							}`}"
+					class="shrink-0 text-sm font-medium transition-colors group-hover/header:text-gray-600 dark:group-hover/header:text-gray-300 {isOpen
+						? 'text-gray-600 dark:text-gray-300'
+						: 'text-gray-500 dark:text-gray-400'}"
 					class:router-shimmer={isExecuting}
 				>
 					{toolError ? "Error calling" : toolDone ? "Called" : "Calling"} tool
@@ -153,11 +156,11 @@
 						</div>
 					{:else if update.subtype === MessageToolUpdateType.Error}
 						<div class="space-y-1">
-							<div class="text-[10px] font-semibold text-red-500 uppercase dark:text-red-400">
+							<div class="text-[10px] font-semibold text-amber-600 uppercase dark:text-amber-400">
 								Error
 							</div>
 							<pre
-								class="rounded-lg bg-red-50 p-2 font-mono text-xs break-all whitespace-pre-wrap text-red-600 dark:bg-red-900/20 dark:text-red-400">{update.message}</pre>
+								class="rounded-lg bg-amber-50 p-2 font-mono text-xs break-all whitespace-pre-wrap text-amber-700 dark:bg-amber-900/20 dark:text-amber-300">{update.message}</pre>
 						</div>
 					{:else if isMessageToolResultUpdate(update) && update.result.status === ToolResultStatus.Success && update.result.display}
 						<div class="space-y-1">
@@ -194,11 +197,11 @@
 						</div>
 					{:else if isMessageToolResultUpdate(update) && update.result.status === ToolResultStatus.Error && update.result.display}
 						<div class="space-y-1">
-							<div class="text-[10px] font-semibold text-red-500 uppercase dark:text-red-400">
+							<div class="text-[10px] font-semibold text-amber-600 uppercase dark:text-amber-400">
 								Error
 							</div>
 							<pre
-								class="rounded-lg bg-red-50 p-2 font-mono text-xs break-all whitespace-pre-wrap text-red-600 dark:bg-red-900/20 dark:text-red-400">{update
+								class="rounded-lg bg-amber-50 p-2 font-mono text-xs break-all whitespace-pre-wrap text-amber-700 dark:bg-amber-900/20 dark:text-amber-300">{update
 									.result.message}</pre>
 						</div>
 					{/if}

--- a/src/lib/constants/mlAssistant.ts
+++ b/src/lib/constants/mlAssistant.ts
@@ -12,6 +12,9 @@ export const ML_ASSISTANT_TOOLS = ["papers", "training", "spaces", "datasets", "
 export const ML_ASSISTANT_NOTE_OFF =
 	"— tools and prompts for papers, finetuning, demos and datasets";
 
+/** Note beside the "Ask in ML Intern" banner on conversations started without the mode. */
+export const ML_ASSISTANT_PROMO_NOTE = "— takes your question to a new chat with ML tools";
+
 /** Composer placeholder while the mode is on. */
 export const ML_ASSISTANT_PLACEHOLDER = "Describe the ML task — paper URL, model id, or dataset";
 

--- a/src/lib/server/database.ts
+++ b/src/lib/server/database.ts
@@ -346,6 +346,19 @@ export class Database {
 		turnStates
 			.createIndex({ endedAt: 1 }, { expireAfterSeconds: 7 * 24 * 60 * 60 })
 			.catch((e) => logger.error(e, "Error creating TTL index for turnStates by endedAt"));
+		// Serve the live feed's per-tick owner scan, like the same pair on `generations`.
+		turnStates
+			.createIndex(
+				{ userId: 1, updatedAt: -1 },
+				{ partialFilterExpression: { userId: { $exists: true } } }
+			)
+			.catch((e) => logger.error(e, "Error creating index for turnStates by userId"));
+		turnStates
+			.createIndex(
+				{ sessionId: 1, updatedAt: -1 },
+				{ partialFilterExpression: { sessionId: { $exists: true } } }
+			)
+			.catch((e) => logger.error(e, "Error creating index for turnStates by sessionId"));
 
 		parkedCalls
 			.createIndex({ parkedCallId: 1 }, { unique: true })

--- a/src/lib/stores/activeGenerations.svelte.ts
+++ b/src/lib/stores/activeGenerations.svelte.ts
@@ -23,9 +23,15 @@ export const ACTIVE_GENERATIONS_CONTEXT_KEY = "activeGenerationsStore";
 export type ParkedTurnStatus = "waiting" | "awaiting_input" | "failed";
 export type LiveTurnStatus = "running" | ParkedTurnStatus;
 
+export interface ParkedTurn {
+	status: ParkedTurnStatus;
+	/** Epoch ms after which the flag stops being shown. Failed turns only. */
+	expiresAt?: number;
+}
+
 class ActiveGenerationsStore {
 	#ids = new SvelteSet<string>();
-	#parked = new SvelteMap<string, ParkedTurnStatus>();
+	#parked = new SvelteMap<string, ParkedTurn>();
 
 	has(conversationId: string | ObjectId): boolean {
 		return this.#ids.has(String(conversationId));
@@ -39,7 +45,11 @@ class ActiveGenerationsStore {
 	statusFor(conversationId: string | ObjectId): LiveTurnStatus | undefined {
 		const id = String(conversationId);
 		if (this.#ids.has(id)) return "running";
-		return this.#parked.get(id);
+		const parked = this.#parked.get(id);
+		if (!parked) return undefined;
+		// Backstop only — pruneExpired() is what makes an expiry re-render.
+		if (parked.expiresAt !== undefined && parked.expiresAt <= Date.now()) return undefined;
+		return parked.status;
 	}
 
 	/** Replace the running set with the latest snapshot from the server. */
@@ -51,16 +61,38 @@ class ActiveGenerationsStore {
 	}
 
 	/** Replace the parked set with the latest snapshot from the server. */
-	setParked(entries: Array<{ conversationId: string; status: ParkedTurnStatus }>): void {
-		const next = new Map(entries.map((entry) => [String(entry.conversationId), entry.status]));
+	setParked(entries: Array<{ conversationId: string } & ParkedTurn>): void {
+		const next = new Map<string, ParkedTurn>(
+			entries.map((entry) => [
+				String(entry.conversationId),
+				{
+					status: entry.status,
+					...(entry.expiresAt !== undefined ? { expiresAt: entry.expiresAt } : {}),
+				},
+			])
+		);
 		if (
 			next.size === this.#parked.size &&
-			[...next].every(([id, status]) => this.#parked.get(id) === status)
+			[...next].every(([id, turn]) => {
+				const seen = this.#parked.get(id);
+				return seen?.status === turn.status && seen?.expiresAt === turn.expiresAt;
+			})
 		) {
 			return;
 		}
 		this.#parked.clear();
-		for (const [id, status] of next) this.#parked.set(id, status);
+		for (const [id, turn] of next) this.#parked.set(id, turn);
+	}
+
+	/**
+	 * Drops flags whose display window has passed. The live feed closes once
+	 * only failed turns remain (they are terminal, nothing will change), so
+	 * without this sweep a long-lived tab would show a failed badge forever.
+	 */
+	pruneExpired(now = Date.now()): void {
+		for (const [id, turn] of this.#parked) {
+			if (turn.expiresAt !== undefined && turn.expiresAt <= now) this.#parked.delete(id);
+		}
 	}
 }
 

--- a/src/lib/stores/activeGenerations.svelte.ts
+++ b/src/lib/stores/activeGenerations.svelte.ts
@@ -1,5 +1,6 @@
 /**
- * Which conversations have a generation running right now, kept separate from the
+ * Which conversations have a generation running right now — plus, for ML Intern
+ * conversations, turns parked on the wait/ask tools — kept separate from the
  * sidebar store on purpose: that store does a last-write-wins full replace on every
  * conversation invalidation, which would wipe a generating flag stored on the row.
  * Holding this state alongside it — not on it — sidesteps that entirely.
@@ -9,16 +10,36 @@
  */
 
 import { getContext, setContext } from "svelte";
-import { SvelteSet } from "svelte/reactivity";
+import { SvelteMap, SvelteSet } from "svelte/reactivity";
 import type { ObjectId } from "mongodb";
 
 export const ACTIVE_GENERATIONS_CONTEXT_KEY = "activeGenerationsStore";
 
+/**
+ * Statuses the live feed reports from the turn-state docs (see
+ * $lib/types/TurnState): the two parked states, plus recent failures so the
+ * sidebar can flag a run that died while nobody was looking.
+ */
+export type ParkedTurnStatus = "waiting" | "awaiting_input" | "failed";
+export type LiveTurnStatus = "running" | ParkedTurnStatus;
+
 class ActiveGenerationsStore {
 	#ids = new SvelteSet<string>();
+	#parked = new SvelteMap<string, ParkedTurnStatus>();
 
 	has(conversationId: string | ObjectId): boolean {
 		return this.#ids.has(String(conversationId));
+	}
+
+	/**
+	 * The conversation's live turn status, or undefined when it is idle. A
+	 * running producer wins over a stale parked row: the resume rewrites the
+	 * turn state to running, but the two snapshots arrive on the same tick.
+	 */
+	statusFor(conversationId: string | ObjectId): LiveTurnStatus | undefined {
+		const id = String(conversationId);
+		if (this.#ids.has(id)) return "running";
+		return this.#parked.get(id);
 	}
 
 	/** Replace the running set with the latest snapshot from the server. */
@@ -27,6 +48,19 @@ class ActiveGenerationsStore {
 		if (next.size === this.#ids.size && [...next].every((id) => this.#ids.has(id))) return;
 		this.#ids.clear();
 		for (const id of next) this.#ids.add(id);
+	}
+
+	/** Replace the parked set with the latest snapshot from the server. */
+	setParked(entries: Array<{ conversationId: string; status: ParkedTurnStatus }>): void {
+		const next = new Map(entries.map((entry) => [String(entry.conversationId), entry.status]));
+		if (
+			next.size === this.#parked.size &&
+			[...next].every(([id, status]) => this.#parked.get(id) === status)
+		) {
+			return;
+		}
+		this.#parked.clear();
+		for (const [id, status] of next) this.#parked.set(id, status);
 	}
 }
 

--- a/src/lib/stores/conversations.svelte.ts
+++ b/src/lib/stores/conversations.svelte.ts
@@ -32,6 +32,7 @@ interface ConversationListItem {
 	title: string;
 	updatedAt: Date | string;
 	model?: string;
+	mlAssistant?: boolean;
 }
 
 class ConversationsStore {
@@ -86,6 +87,7 @@ class ConversationsStore {
 				title: conv.title.trim(),
 				model: conv.model ?? defaultModel,
 				updatedAt: new Date(conv.updatedAt),
+				mlAssistant: conv.mlAssistant ?? false,
 			}));
 			this.#list = freshList;
 		} catch (err) {

--- a/src/lib/stores/mlAssistant.svelte.ts
+++ b/src/lib/stores/mlAssistant.svelte.ts
@@ -1,3 +1,4 @@
+import { SvelteSet } from "svelte/reactivity";
 import type { MlPlanStep, MlPlanStepStatus } from "$lib/types/MlAssistant";
 
 /**
@@ -19,6 +20,21 @@ class MlAssistantStore {
 
 	/** Conversation the state above belongs to, so a different one starts clean. */
 	#conversationKey: string | undefined;
+
+	/**
+	 * Conversations whose "Ask in ML Intern" banner the user closed. Deliberately
+	 * session-scoped and outside `reset()`: the banner only shows on a
+	 * conversation's first exchange, so a dismissal has nothing to outlive.
+	 */
+	#promoDismissed = new SvelteSet<string>();
+
+	promoDismissed(key: string | undefined): boolean {
+		return key !== undefined && this.#promoDismissed.has(key);
+	}
+
+	dismissPromo(key: string | undefined): void {
+		if (key !== undefined) this.#promoDismissed.add(key);
+	}
 
 	/** The switch stops being interactive once the mode is locked in. */
 	get locked() {

--- a/src/lib/types/ConvSidebar.ts
+++ b/src/lib/types/ConvSidebar.ts
@@ -6,4 +6,6 @@ export interface ConvSidebar {
 	updatedAt: Date;
 	model?: string;
 	avatarUrl?: string | Promise<string | undefined>;
+	/** Started in ML Intern mode — the sidebar marks these and shows their turn status. */
+	mlAssistant?: boolean;
 }

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -9,6 +9,7 @@ interface ConversationListItem {
 	title: string;
 	updatedAt: Date | string;
 	model?: string;
+	mlAssistant?: boolean;
 }
 
 interface UserInfo {
@@ -83,6 +84,7 @@ export const load = async ({ fetch, url }) => {
 			title: conv.title,
 			model: conv.model ?? defaultModel?.id,
 			updatedAt: new Date(conv.updatedAt),
+			mlAssistant: conv.mlAssistant ?? false,
 		} satisfies ConvSidebar;
 	});
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -110,6 +110,9 @@
 				title: "New Chat",
 				model,
 				updatedAt: new Date(),
+				// Latched before the create request, so the sidebar row carries the
+				// mode's designation from the moment it appears.
+				mlAssistant: mlAssistant.taskStarted,
 			});
 			await goto(`${base}/conversation/${conversationId}`, {
 				state: { pendingMessage: message, pendingFilesNonce },

--- a/src/routes/api/v2/conversations/+server.ts
+++ b/src/routes/api/v2/conversations/+server.ts
@@ -14,10 +14,11 @@ export const GET: RequestHandler = async ({ locals, url }) => {
 
 	const convs = await collections.conversations
 		.find(authCondition(locals))
-		.project<Pick<Conversation, "_id" | "title" | "updatedAt" | "model">>({
+		.project<Pick<Conversation, "_id" | "title" | "updatedAt" | "model" | "mlAssistant">>({
 			title: 1,
 			updatedAt: 1,
 			model: 1,
+			mlAssistant: 1,
 		})
 		.sort({ updatedAt: -1 })
 		.skip(p * pageSize)
@@ -32,6 +33,7 @@ export const GET: RequestHandler = async ({ locals, url }) => {
 		updatedAt: conv.updatedAt,
 		model: conv.model,
 		modelId: conv.model, // legacy param iOS
+		...(conv.mlAssistant ? { mlAssistant: true } : {}),
 	}));
 
 	return superjsonResponse({ conversations: res, hasMore });

--- a/src/routes/api/v2/generations/live/+server.ts
+++ b/src/routes/api/v2/generations/live/+server.ts
@@ -4,19 +4,25 @@ import { collections } from "$lib/server/database";
 import { authCondition } from "$lib/server/auth";
 
 /**
- * Cross-conversation liveness feed. Reports the user's own running generations so
- * the sidebar can show which conversations are generating and toast when a
- * background one finishes — without a per-conversation stream for each.
+ * Cross-conversation liveness feed. Reports the user's own running generations —
+ * plus turns parked on the wait or ask tools — so the sidebar can show each
+ * conversation's status and toast when a background one finishes, without a
+ * per-conversation stream for each.
  *
  * Scoped by `authCondition` against the denormalised user/session on `generations`
- * (no join). SSE: `event: sync {running, ended}` each tick; `event: idle` when the
- * user has no running generations, after which the client closes rather than
- * reconnecting (a plain lifetime-cap close, by contrast, means reconnect).
+ * and `turnStates` (no join). SSE: `event: sync {running, ended, parked}` each
+ * tick; `event: idle` when the user has no running generations AND no parked
+ * turns, after which the client closes rather than reconnecting (a plain
+ * lifetime-cap close, by contrast, means reconnect). A parked turn therefore
+ * holds the feed open: its resume happens server-side with no client action, so
+ * only a live feed can ever report it.
  */
 const TICK_MS = 2_000;
 const MAX_LIFETIME_MS = 5 * 60_000;
 // Release the connection once nothing is running; the client reopens on the next run.
 const IDLE_TICKS_BEFORE_CLOSE = 2;
+// How long a failed turn keeps its sidebar flag (the state doc itself lives a week).
+const FAILED_WINDOW_MS = 24 * 60 * 60 * 1000;
 
 export const GET: RequestHandler = async ({ locals, request }) => {
 	let auth: ReturnType<typeof authCondition>;
@@ -59,6 +65,28 @@ export const GET: RequestHandler = async ({ locals, request }) => {
 					)
 					.toArray();
 
+				// Parked turns have no running generation, so they come from the
+				// authoritative turn-state docs instead. Recent failures ride along so
+				// the sidebar can flag a run that died in the background — bounded to a
+				// day because the docs themselves live a week (see the TTL), and a
+				// week-old failure is history, not a status.
+				const parked = await collections.turnStates
+					.find(
+						{
+							...auth,
+							$or: [
+								{ status: { $in: ["waiting", "awaiting_input"] } },
+								{ status: "failed", endedAt: { $gt: new Date(Date.now() - FAILED_WINDOW_MS) } },
+							],
+						},
+						{ projection: { conversationId: 1, status: 1 } }
+					)
+					.toArray();
+				const parkedPayload = parked.map((turn) => ({
+					conversationId: turn.conversationId.toString(),
+					status: turn.status,
+				}));
+
 				const currentIds = new Set(running.map((g) => g.generationId));
 				const endedIds = [...prevRunning].filter((id) => !currentIds.has(id));
 
@@ -84,9 +112,13 @@ export const GET: RequestHandler = async ({ locals, request }) => {
 					}));
 				}
 
-				send("sync", { running: runningPayload, ended: endedPayload });
+				send("sync", { running: runningPayload, ended: endedPayload, parked: parkedPayload });
 				prevRunning = currentIds;
-				idleTicks = currentIds.size === 0 ? idleTicks + 1 : 0;
+				// Failed turns are terminal: they never change server-side, so unlike
+				// the parked states they must not hold the feed open. The last sync
+				// before the idle close already delivered them.
+				const liveParked = parked.some((turn) => turn.status !== "failed");
+				idleTicks = currentIds.size === 0 && !liveParked ? idleTicks + 1 : 0;
 				return idleTicks < IDLE_TICKS_BEFORE_CLOSE;
 			};
 

--- a/src/routes/api/v2/generations/live/+server.ts
+++ b/src/routes/api/v2/generations/live/+server.ts
@@ -66,25 +66,36 @@ export const GET: RequestHandler = async ({ locals, request }) => {
 					.toArray();
 
 				// Parked turns have no running generation, so they come from the
-				// authoritative turn-state docs instead. Recent failures ride along so
-				// the sidebar can flag a run that died in the background — bounded to a
-				// day because the docs themselves live a week (see the TTL), and a
-				// week-old failure is history, not a status.
-				const parked = await collections.turnStates
-					.find(
-						{
-							...auth,
-							$or: [
-								{ status: { $in: ["waiting", "awaiting_input"] } },
-								{ status: "failed", endedAt: { $gt: new Date(Date.now() - FAILED_WINDOW_MS) } },
-							],
-						},
-						{ projection: { conversationId: 1, status: 1 } }
-					)
+				// authoritative turn-state docs instead. Only a conversation's LATEST
+				// turn counts: a retry runs as a fresh turn document, and reporting an
+				// older failed one would flag a conversation that has since recovered.
+				// Recent failures ride along so the sidebar can flag a run that died in
+				// the background — bounded to a day because the docs themselves live a
+				// week (see the TTL), and a week-old failure is history, not a status.
+				const turnDocs = await collections.turnStates
+					.find(auth, { projection: { conversationId: 1, status: 1, updatedAt: 1, endedAt: 1 } })
 					.toArray();
+				const latestByConversation = new Map<string, (typeof turnDocs)[number]>();
+				for (const turn of turnDocs) {
+					const key = turn.conversationId.toString();
+					const seen = latestByConversation.get(key);
+					if (!seen || turn.updatedAt > seen.updatedAt) latestByConversation.set(key, turn);
+				}
+				const failedCutoff = Date.now() - FAILED_WINDOW_MS;
+				const parked = [...latestByConversation.values()].filter(
+					(turn) =>
+						turn.status === "waiting" ||
+						turn.status === "awaiting_input" ||
+						(turn.status === "failed" && (turn.endedAt?.getTime() ?? 0) > failedCutoff)
+				);
 				const parkedPayload = parked.map((turn) => ({
 					conversationId: turn.conversationId.toString(),
 					status: turn.status,
+					// Failed flags outlive the feed (failed turns don't hold it open), so
+					// the client needs the deadline to prune them itself.
+					...(turn.status === "failed" && turn.endedAt
+						? { expiresAt: turn.endedAt.getTime() + FAILED_WINDOW_MS }
+						: {}),
 				}));
 
 				const currentIds = new Set(running.map((g) => g.generationId));

--- a/src/routes/models/[...model]/+page.svelte
+++ b/src/routes/models/[...model]/+page.svelte
@@ -80,6 +80,9 @@
 				title: "New Chat",
 				model: modelId,
 				updatedAt: new Date(),
+				// Latched before the create request, so the sidebar row carries the
+				// mode's designation from the moment it appears.
+				mlAssistant: mlAssistant.taskStarted,
 			});
 			await goto(`${base}/conversation/${conversationId}`, {
 				state: { pendingMessage: message, pendingFilesNonce },

--- a/tests/generation-live.spec.ts
+++ b/tests/generation-live.spec.ts
@@ -2,9 +2,11 @@
  * Live generations feed (P4): GET /api/v2/generations/live.
  *
  * Reports the caller's own running generations so the sidebar can show which
- * conversations are generating and toast when a background one finishes. It is scoped
- * to the caller — another user's runs never appear — and releases the connection with
- * an `idle` event once nothing is running.
+ * conversations are generating and toast when a background one finishes — plus
+ * parked turns (waiting / awaiting_input) and recent failures from the turn-state
+ * docs. It is scoped to the caller — another user's runs never appear — and
+ * releases the connection with an `idle` event once nothing is running and no
+ * turn is parked (terminal failures don't hold it open).
  */
 import { test, expect, E2E_APP_URL, SESSION_COOKIE_NAME } from "./fixtures.ts";
 import { ObjectId, type Db } from "mongodb";
@@ -33,6 +35,7 @@ function parseFrame(raw: string): SseFrame {
 interface SyncPayload {
 	running: Array<{ conversationId: string; title: string }>;
 	ended: Array<{ conversationId: string; status: string; title: string }>;
+	parked: Array<{ conversationId: string; status: string; expiresAt?: number }>;
 }
 
 const syncFrames = (frames: SseFrame[]): SyncPayload[] =>
@@ -233,6 +236,156 @@ test("does not report another session's running generation", async ({ db, sessio
 	const running = syncFrames(frames).flatMap((s) => s.running);
 	expect(
 		running.some((r) => r.conversationId === convId),
+		"must not leak across sessions"
+	).toBe(false);
+});
+
+/** Seed a conversation + a turn-state doc owned by the given session. */
+async function seedTurnState(
+	db: Db,
+	sessionId: string,
+	opts: {
+		status: "waiting" | "awaiting_input" | "failed" | "done";
+		title: string;
+		convId?: ObjectId;
+		updatedAt?: Date;
+		endedAt?: Date;
+	}
+): Promise<{ convId: ObjectId }> {
+	const now = new Date();
+	const conversationId = opts.convId ?? new ObjectId();
+	if (!opts.convId) {
+		await db.collection("conversations").insertOne({
+			_id: conversationId,
+			sessionId,
+			model: "test-org/test-model",
+			title: opts.title,
+			messages: [],
+			createdAt: now,
+			updatedAt: now,
+		} as never);
+	}
+	await db.collection("turnStates").insertOne({
+		_id: new ObjectId(),
+		conversationId,
+		messageId: randomUUID(),
+		sessionId,
+		status: opts.status,
+		producerId: randomUUID(),
+		createdAt: now,
+		updatedAt: opts.updatedAt ?? now,
+		...(opts.endedAt ? { endedAt: opts.endedAt } : {}),
+	} as never);
+	return { convId: conversationId };
+}
+
+test("reports parked turns and holds the feed open for them", async ({ db, session }) => {
+	test.setTimeout(20_000);
+	const waiting = await seedTurnState(db, session.sessionId, {
+		status: "waiting",
+		title: "parked on a timer",
+	});
+	const asking = await seedTurnState(db, session.sessionId, {
+		status: "awaiting_input",
+		title: "parked on a question",
+	});
+
+	// Long enough for the no-parked idle close (~2 ticks); idle must never come.
+	const { frames } = await collectLive({
+		secret: session.secret,
+		until: (f) => f.event === "idle",
+		timeoutMs: 8_000,
+	});
+
+	expect(
+		frames.some((f) => f.event === "idle"),
+		"a parked turn must hold the feed open"
+	).toBe(false);
+	const parked = syncFrames(frames).flatMap((s) => s.parked);
+	expect(parked.find((p) => p.conversationId === waiting.convId.toString())?.status).toBe(
+		"waiting"
+	);
+	expect(parked.find((p) => p.conversationId === asking.convId.toString())?.status).toBe(
+		"awaiting_input"
+	);
+});
+
+test("reports a recent failure but still lets the feed go idle", async ({ db, session }) => {
+	test.setTimeout(20_000);
+	const failedAt = new Date();
+	const { convId } = await seedTurnState(db, session.sessionId, {
+		status: "failed",
+		title: "died in the background",
+		endedAt: failedAt,
+	});
+
+	const { frames } = await collectLive({
+		secret: session.secret,
+		until: (f) => f.event === "idle",
+		timeoutMs: 15_000,
+	});
+
+	expect(
+		frames.some((f) => f.event === "idle"),
+		"a terminal failure must not hold the feed open"
+	).toBe(true);
+	const row = syncFrames(frames)
+		.flatMap((s) => s.parked)
+		.find((p) => p.conversationId === convId.toString());
+	expect(row?.status, "the failure should be reported before the close").toBe("failed");
+	// The display window the client prunes against: endedAt + 24h.
+	expect(row?.expiresAt).toBe(failedAt.getTime() + 24 * 60 * 60 * 1000);
+});
+
+test("a conversation's newer turn shadows its older failed one", async ({ db, session }) => {
+	test.setTimeout(20_000);
+	const failed = await seedTurnState(db, session.sessionId, {
+		status: "failed",
+		title: "retried and recovered",
+		updatedAt: new Date(Date.now() - 60_000),
+		endedAt: new Date(Date.now() - 60_000),
+	});
+	// The retry's turn: a separate doc on the same conversation, ending well.
+	await seedTurnState(db, session.sessionId, {
+		status: "done",
+		title: "retried and recovered",
+		convId: failed.convId,
+		endedAt: new Date(),
+	});
+
+	const { frames } = await collectLive({
+		secret: session.secret,
+		until: (f) => f.event === "idle",
+		timeoutMs: 15_000,
+	});
+
+	const parked = syncFrames(frames).flatMap((s) => s.parked);
+	expect(
+		parked.some((p) => p.conversationId === failed.convId.toString()),
+		"only the latest turn's state may speak for the conversation"
+	).toBe(false);
+});
+
+test("does not report another session's parked turn", async ({ db, session }) => {
+	test.setTimeout(20_000);
+	const { convId } = await seedTurnState(db, "someone-elses-session", {
+		status: "awaiting_input",
+		title: "someone else's question",
+	});
+
+	const { frames } = await collectLive({
+		secret: session.secret,
+		until: (f) => f.event === "idle",
+		timeoutMs: 15_000,
+	});
+
+	expect(
+		frames.some((f) => f.event === "idle"),
+		"another caller's parked turn must not hold this feed open"
+	).toBe(true);
+	const parked = syncFrames(frames).flatMap((s) => s.parked);
+	expect(
+		parked.some((p) => p.conversationId === convId.toString()),
 		"must not leak across sessions"
 	).toBe(false);
 });


### PR DESCRIPTION
### Remove the dead Configure button
The strip's Configure link did nothing; removed along with its prop.

### ML Intern designation + live status in the sidebar
ML Intern conversations get a neutral `ML` chip with a status dot: orange pulse = generating, blue pulse = needs your answer, red = failed (last 24h), gray = waiting, no dot = idle. The generations live feed now also reports parked and recently-failed turn states, and stays open while a turn is parked so resumes surface without a reload.

https://github.com/user-attachments/assets/fd6c8467-2f8c-4d57-889e-ba2f40b7fa26


### Example prompts prefill instead of auto-sending
In ML mode the example chips seed the composer (the prompts reference "this paper/dataset"), so details can be added before sending.

### "Ask in ML Intern" banner
Conversations started without the mode show a dismissable banner in the toggle's slot during the first exchange; the CTA opens a new chat with the mode on and the question prefilled.

<img width="979" height="221" alt="Screenshot 2026-08-28 at 22 34 14" src="https://github.com/user-attachments/assets/9186c01f-02bd-4716-9e73-b3c5d93f294a" />

### Softer tool errors
"Error calling tool" keeps the muted header style with a small amber icon; the expanded error details go amber instead of red. Errors here are often recoverable, so the header no longer shouts.
<img width="345" height="61" alt="Screenshot 2026-08-28 at 22 35 47" src="https://github.com/user-attachments/assets/ba9f2e4f-4c36-499e-9982-76de3c8b575f" />
