### PR TITLE
Fix collapsed reasoning blocks re-expanding during streaming

### DIFF
--- a/src/lib/components/chat/ChatMessage.svelte
+++ b/src/lib/components/chat/ChatMessage.svelte
@@ -531,9 +531,12 @@
 						{:else}
 							<div data-exclude-from-copy class="not-last:mb-1 has-[+.prose]:mb-2! [.prose+&]:mt-3">
 								{#if block.type === "think"}
+									<!-- Only the trailing block can still be streaming: an earlier
+									     unclosed think is a stream artifact (e.g. a lost close marker)
+									     and must not keep shimmering or re-expanding on every render. -->
 									<OpenReasoningResults
 										content={block.content}
-										loading={isLast && loading && !block.closed}
+										loading={isLast && loading && !block.closed && blockIndex === blocks.length - 1}
 									/>
 								{:else}
 									<ToolUpdate tool={block.updates} {loading} />

--- a/src/lib/components/chat/ChatMessage.svelte.test.ts
+++ b/src/lib/components/chat/ChatMessage.svelte.test.ts
@@ -1,6 +1,7 @@
 import ChatMessage from "./ChatMessage.svelte";
 import { render } from "vitest-browser-svelte";
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { tick } from "svelte";
 
 beforeEach(() => vi.stubGlobal("fetch", async () => new Response("{}", { status: 200 })));
 afterEach(() => vi.unstubAllGlobals());
@@ -83,5 +84,60 @@ describe("a run still working with nothing streaming", () => {
 		// class, so anything here would be ours doubling up.
 		const { baseElement } = mount([], "<think>weighing the options");
 		expect(spinners(baseElement)).toBe(0);
+	});
+});
+
+describe("collapsed process blocks during streaming", () => {
+	const stream = (token: string) => ({ type: "stream", token });
+	const streamCall = (uuid: string) => ({
+		type: "tool",
+		subtype: "call",
+		uuid,
+		call: { name: "hf_fs", parameters: {} },
+	});
+	const streamResult = (uuid: string) => ({
+		type: "tool",
+		subtype: "result",
+		uuid,
+		result: {
+			status: 0,
+			call: { name: "hf_fs", parameters: {} },
+			outputs: [{ text: "ok" }],
+			display: true,
+		},
+	});
+	const expanded = (el: HTMLElement) => el.querySelectorAll('button[aria-label="Collapse"]');
+
+	it("never expands more than the active block, even after a lost think closer", async () => {
+		// Round 1's reasoning never receives its </think> (the closer can get lost
+		// when tool-call deltas mute the content stream server-side). That stale
+		// block must not shimmer or re-expand each time a later block goes active.
+		const steps = [
+			stream("<think>Reading the repo"),
+			streamCall("u1"),
+			streamResult("u1"),
+			stream("Let me dig into the README."),
+			stream("<think>Checking metadata</think>"),
+			streamCall("u2"),
+			streamResult("u2"),
+			stream("Grabbing the repo metadata too."),
+			stream("<think>Final synthesis"),
+		];
+
+		const updates: unknown[] = [];
+		const screen = mount([]);
+		for (const step of steps) {
+			updates.push(step);
+			await screen.rerender({
+				message: { id: "m1", from: "assistant", content: "", children: [], updates: [...updates] },
+			} as never);
+			await tick();
+			expect(expanded(screen.baseElement as HTMLElement).length).toBeLessThanOrEqual(1);
+		}
+
+		// The active think block streams at the end; it alone is expanded.
+		const open = expanded(screen.baseElement as HTMLElement);
+		expect(open.length).toBe(1);
+		expect(open[0].textContent).toContain("Thinking");
 	});
 });

--- a/src/lib/server/textGeneration/mcp/runMcpFlow.spec.ts
+++ b/src/lib/server/textGeneration/mcp/runMcpFlow.spec.ts
@@ -105,6 +105,12 @@ type Round = {
 	content?: string;
 	reasoning?: string;
 	toolCalls?: ScriptedCall[];
+	/**
+	 * Raw delta objects, yielded verbatim before the finish chunk, for rounds
+	 * where the ORDER of reasoning/content/tool_calls matters. Overrides the
+	 * three fields above.
+	 */
+	deltas?: Array<Record<string, unknown>>;
 	/** Defaults to "tool_calls" when the round emits calls, else "stop". */
 	finishReason?: string;
 	/** Throw instead of returning a stream, to script an upstream failure. */
@@ -116,6 +122,13 @@ function chunk(choice: Record<string, unknown>) {
 }
 
 function streamFor(round: Round) {
+	if (round.deltas) {
+		const deltas = round.deltas;
+		return (async function* () {
+			for (const delta of deltas) yield chunk({ delta });
+			yield chunk({ delta: {}, finish_reason: round.finishReason ?? "stop" });
+		})();
+	}
 	return (async function* () {
 		if (round.reasoning) yield chunk({ delta: { reasoning: round.reasoning } });
 		if (round.content) yield chunk({ delta: { content: round.content } });
@@ -273,6 +286,66 @@ describe("runMcpFlow", () => {
 			tool_call_id: "call_1",
 			content: "the tool output",
 		});
+	});
+});
+
+describe("runMcpFlow think-tag balance across tool rounds", () => {
+	const toolCallDelta = {
+		tool_calls: [{ index: 0, id: "call_1", function: { name: "do_thing", arguments: "{}" } }],
+	};
+	const thinkBalance = (text: string) =>
+		(text.match(/<think>/g)?.length ?? 0) - (text.match(/<\/think>/g)?.length ?? 0);
+
+	it("still closes a streamed think block when content arrives after tool-call deltas", async () => {
+		// Reasoning streams (client sees "<think>…"), tool-call deltas mute the
+		// stream, and only then does the content delta close the block. The closer
+		// must still reach the client, or it renders that reasoning as streaming —
+		// and re-expands it — for the rest of the turn.
+		scriptRounds([
+			{
+				deltas: [{ reasoning: "planning the call" }, toolCallDelta, { content: "Calling now." }],
+				finishReason: "tool_calls",
+			},
+			{ content: "done" },
+		]);
+
+		const { updates, result } = await runFlow();
+
+		expect(result).toBe("completed");
+		const streamed = streamedText(updates);
+		expect(streamed).toContain("<think>planning the call");
+		expect(thinkBalance(streamed)).toBe(0);
+	});
+
+	it("closes a streamed think block that tool-call deltas leave open", async () => {
+		scriptRounds([
+			{
+				deltas: [{ reasoning: "planning the call" }, toolCallDelta],
+				finishReason: "tool_calls",
+			},
+			{ content: "done" },
+		]);
+
+		const { updates } = await runFlow();
+
+		expect(thinkBalance(streamedText(updates))).toBe(0);
+	});
+
+	it("streams no stray closer when the opener was never streamed", async () => {
+		// Content streams first, then tool-call deltas mute the stream, then
+		// reasoning opens a think block the client never saw. A bare "</think>"
+		// would render as literal text.
+		scriptRounds([
+			{
+				deltas: [{ content: "Calling now." }, toolCallDelta, { reasoning: "post-call thoughts" }],
+				finishReason: "tool_calls",
+			},
+			{ content: "done" },
+		]);
+
+		const { updates } = await runFlow();
+
+		expect(streamedText(updates)).not.toContain("</think>");
 	});
 });
 

--- a/src/lib/server/textGeneration/mcp/runMcpFlow.ts
+++ b/src/lib/server/textGeneration/mcp/runMcpFlow.ts
@@ -604,6 +604,12 @@ export async function* runMcpFlow({
 		// Track whether we're inside a <think> block when the upstream streams
 		// provider-specific reasoning tokens (e.g. `reasoning` or `reasoning_content`).
 		let thinkOpen = false;
+		// Whether the CLIENT currently has an unbalanced <think> opener. Diverges
+		// from thinkOpen once tool-call deltas stop the content stream: the close
+		// may then land only in lastAssistantContent, and a client left with an
+		// unclosed block renders that reasoning as still streaming for the rest
+		// of the turn.
+		let clientThinkOpen = false;
 		// Leading whitespace-only reasoning deltas that arrived before the block
 		// opened (thinkOpen still false, so a blank chunk wouldn't otherwise open
 		// one). Held here and flushed once a non-blank delta opens the block, so
@@ -790,6 +796,14 @@ export async function* runMcpFlow({
 						producedOutput = true;
 						yield { type: MessageUpdateType.Stream, token: combined };
 						tokenCount += combined.length;
+						clientThinkOpen = thinkOpen;
+					} else if (clientThinkOpen && !thinkOpen) {
+						// The close landed in `combined` after tool-call deltas already
+						// stopped the content stream. The client saw the opener, so it
+						// must see the closer too, or it renders that reasoning block as
+						// still streaming for the rest of the turn.
+						yield { type: MessageUpdateType.Stream, token: "</think>" };
+						clientThinkOpen = false;
 					}
 				}
 
@@ -815,8 +829,13 @@ export async function* runMcpFlow({
 			// regex matches `<think>` to end-of-string, so an unclosed block would
 			// hide everything that follows.
 			if (thinkOpen) {
-				if (streamedContent) {
+				// Gate on what the client saw, not on streamedContent: a round can
+				// stream content early and open the think block only after tool-call
+				// deltas muted the stream — a bare closer then shows up as literal
+				// "</think>" text.
+				if (clientThinkOpen) {
 					yield { type: MessageUpdateType.Stream, token: "</think>" };
+					clientThinkOpen = false;
 				}
 				lastAssistantContent += "</think>";
 				thinkOpen = false;


### PR DESCRIPTION
## What

During a multi-round tool turn, previously collapsed "Thinking" blocks could spontaneously re-expand (with the streaming shimmer) whenever a new active block started streaming. They should stay collapsed.

## Why it happened

The trigger is a reasoning block whose `</think>` never reaches the client:

- In the MCP loop, once tool-call deltas appear in a round, content is no longer streamed to the client. If the model streamed reasoning, then started tool calls, and only then emitted the content delta that closes the think block, the `</think>` was folded into that muted content and never streamed. The end-of-round auto-close did not fire either, since the block was already closed server-side.
- On the client, `ChatMessage` treats any unclosed think block as "still streaming" (`loading=true`). The message alternates between two layouts while streaming (flat rows during think/tool phases, grouped summary while answer text streams), and each flip remounts the rows. A stale unclosed block remounted in loading state auto-expands itself again, right at the moment the new active block expands.

## Fix

**Server (`runMcpFlow.ts`)**: track what the client has actually seen (`clientThinkOpen`) and emit a bare `</think>` when the closer would otherwise be swallowed after tool-call deltas. The end-of-round auto-close is also gated on it, which fixes a second edge where a round that streamed content early but opened the think block only after tool calls began could emit a stray `</think>` that rendered as literal text.

**Client (`ChatMessage.svelte`)**: only the trailing block can legitimately still be streaming, so an earlier unclosed think no longer gets `loading=true`. This also stops already-persisted conversations that contain a lost closer from shimmering and re-expanding.

## Tests

- New client regression test replays the streaming sequence (including a lost closer) and asserts at every step that only the active block is expanded. Fails without the client fix.
- Three new `runMcpFlow` specs cover think-tag balance around tool rounds (closer after tool-call deltas, closer left open at end of round, no stray closer without a streamed opener). The first and third fail without the server fix.
- Full suite (1070 tests), `npm run check`, and lint pass.