### PR TITLE
Render markdown tables in a card with copy/download/fullscreen controls

### DIFF
--- a/src/lib/components/chat/MarkdownBlock.svelte
+++ b/src/lib/components/chat/MarkdownBlock.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { Token } from "$lib/utils/markedLight";
 	import CodeBlock from "../CodeBlock.svelte";
+	import MarkdownTable from "./MarkdownTable.svelte";
 
 	interface Props {
 		tokens: Token[];
@@ -19,5 +20,7 @@
 		{@html token.html}
 	{:else if token.type === "code"}
 		<CodeBlock code={token.code} rawCode={token.rawCode} loading={loading && !token.isClosed} />
+	{:else if token.type === "table"}
+		<MarkdownTable html={token.html} />
 	{/if}
 {/each}

--- a/src/lib/components/chat/MarkdownRenderer.svelte.test.ts
+++ b/src/lib/components/chat/MarkdownRenderer.svelte.test.ts
@@ -63,6 +63,34 @@ describe("MarkdownRenderer", () => {
 		const { baseElement } = render(MarkdownRenderer, { content: "$foo < bar > baz$" });
 		await vi.waitFor(() => expect(baseElement.querySelectorAll(".katex")).toHaveLength(1));
 	});
+	it("renders tables in a scrollable wrapper with copy/download/fullscreen controls", async () => {
+		const { baseElement } = render(MarkdownRenderer, {
+			content: "| Model | Params |\n| --- | --- |\n| Qwen | 32B |",
+		});
+		await vi.waitFor(() => {
+			const table = baseElement.querySelector(".md-table table");
+			expect(table).not.toBeNull();
+			expect(table?.querySelector("th")?.textContent).toBe("Model");
+			expect(table?.querySelector("td")?.textContent).toBe("Qwen");
+		});
+		await expect.element(page.getByRole("button", { name: "Copy table" })).toBeInTheDocument();
+		await expect.element(page.getByRole("button", { name: "Download table" })).toBeInTheDocument();
+		await expect.element(page.getByRole("button", { name: "View fullscreen" })).toBeInTheDocument();
+	});
+	it("opens and closes the fullscreen table view", async () => {
+		const { baseElement } = render(MarkdownRenderer, {
+			content: "| Model | Params |\n| --- | --- |\n| Qwen | 32B |",
+		});
+		await vi.waitFor(() => expect(baseElement.querySelector(".md-table table")).not.toBeNull());
+
+		await page.getByRole("button", { name: "View fullscreen" }).click();
+		const dialog = page.getByRole("dialog", { name: "Table" });
+		await expect.element(dialog).toBeInTheDocument();
+		expect(baseElement.querySelectorAll(".md-table table")).toHaveLength(2);
+
+		await page.getByRole("button", { name: "Exit fullscreen" }).click();
+		await vi.waitFor(() => expect(baseElement.querySelectorAll(".md-table table")).toHaveLength(1));
+	});
 });
 
 describe("MarkdownRenderer streaming", () => {

--- a/src/lib/components/chat/MarkdownTable.svelte
+++ b/src/lib/components/chat/MarkdownTable.svelte
@@ -1,0 +1,219 @@
+<script lang="ts">
+	import { DropdownMenu } from "bits-ui";
+	import { onDestroy } from "svelte";
+	import Portal from "../Portal.svelte";
+	import {
+		extractTableData,
+		saveFile,
+		tableDataToCSV,
+		tableDataToMarkdown,
+		tableDataToTSV,
+	} from "$lib/utils/tableData";
+	import { confirm as hapticConfirm } from "$lib/utils/haptics";
+	import CarbonCopy from "~icons/carbon/copy";
+	import CarbonCheckmark from "~icons/carbon/checkmark";
+	import CarbonDownload from "~icons/carbon/download";
+	import CarbonMaximize from "~icons/carbon/maximize";
+	import CarbonClose from "~icons/carbon/close";
+
+	interface Props {
+		/** `<table>` markup produced by the markdown pipeline (see marked.ts). */
+		html: string;
+	}
+
+	let { html }: Props = $props();
+
+	let inlineEl: HTMLDivElement | undefined = $state();
+	let fullscreenEl: HTMLDivElement | undefined = $state();
+	let fullscreen = $state(false);
+	let copied = $state(false);
+	let copiedTimeout: ReturnType<typeof setTimeout>;
+
+	type Format = "md" | "csv" | "tsv";
+
+	// Both views render the same markup, so read from whichever one is on screen.
+	function currentTable(): HTMLTableElement | null {
+		return (fullscreen ? fullscreenEl : inlineEl)?.querySelector("table") ?? null;
+	}
+
+	function serialize(format: Format): { content: string; mimeType: string } | undefined {
+		const table = currentTable();
+		if (!table) return undefined;
+		const data = extractTableData(table);
+		if (format === "csv") {
+			return { content: tableDataToCSV(data), mimeType: "text/csv" };
+		}
+		if (format === "tsv") {
+			return { content: tableDataToTSV(data), mimeType: "text/tab-separated-values" };
+		}
+		return { content: tableDataToMarkdown(data), mimeType: "text/markdown" };
+	}
+
+	async function copyAs(format: Format) {
+		const table = currentTable();
+		const serialized = serialize(format);
+		if (!table || !serialized) return;
+
+		try {
+			// The table's HTML goes on the clipboard alongside the text so pasting into a
+			// doc or a spreadsheet keeps the grid instead of landing in a single cell.
+			if (window.isSecureContext && navigator.clipboard?.write && "ClipboardItem" in window) {
+				await navigator.clipboard.write([
+					new ClipboardItem({
+						"text/plain": new Blob([serialized.content], { type: "text/plain" }),
+						"text/html": new Blob([table.outerHTML], { type: "text/html" }),
+					}),
+				]);
+			} else {
+				await navigator.clipboard.writeText(serialized.content);
+			}
+			hapticConfirm();
+			copied = true;
+			clearTimeout(copiedTimeout);
+			copiedTimeout = setTimeout(() => (copied = false), 1000);
+		} catch (err) {
+			console.error(err);
+		}
+	}
+
+	function downloadAs(format: "csv" | "md") {
+		const serialized = serialize(format);
+		if (!serialized) return;
+		saveFile(`table.${format}`, serialized.content, serialized.mimeType);
+	}
+
+	// The overlay is portalled to <body>, so marking the app inert keeps focus and
+	// screen readers inside it while it is open. Escape is bound here rather than on
+	// <svelte:window> so a conversation full of tables doesn't accumulate listeners.
+	$effect(() => {
+		if (!fullscreen) return;
+
+		const app = document.getElementById("app");
+		app?.setAttribute("inert", "true");
+		const previouslyFocused = document.activeElement as HTMLElement | null;
+
+		const onKeydown = (event: KeyboardEvent) => {
+			if (event.key === "Escape") {
+				event.preventDefault();
+				fullscreen = false;
+			}
+		};
+		window.addEventListener("keydown", onKeydown, { capture: true });
+
+		return () => {
+			window.removeEventListener("keydown", onKeydown, { capture: true });
+			app?.removeAttribute("inert");
+			previouslyFocused?.focus();
+		};
+	});
+
+	function focusOnMount(node: HTMLElement) {
+		node.focus();
+	}
+
+	onDestroy(() => clearTimeout(copiedTimeout));
+
+	const controlBtn =
+		"rounded-md p-1 text-gray-400 transition-colors hover:bg-gray-200/70 hover:text-gray-700 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-gray-200";
+	const menuContent =
+		"z-50 min-w-32 rounded-xl border border-gray-200 bg-white/95 p-1 text-gray-800 shadow-lg backdrop-blur-sm dark:border-gray-700/60 dark:bg-gray-800/95 dark:text-gray-100";
+	const menuItem =
+		"flex h-8 cursor-pointer items-center rounded-md px-2 text-sm select-none focus-visible:outline-hidden data-highlighted:bg-gray-100 dark:data-highlighted:bg-white/10";
+</script>
+
+{#snippet controls(showFullscreen: boolean)}
+	<DropdownMenu.Root>
+		<DropdownMenu.Trigger class={controlBtn} title="Copy table" aria-label="Copy table">
+			{#if copied}
+				<CarbonCheckmark class="size-3.5" />
+			{:else}
+				<CarbonCopy class="size-3.5" />
+			{/if}
+		</DropdownMenu.Trigger>
+		<DropdownMenu.Portal>
+			<DropdownMenu.Content class={menuContent} align="end" sideOffset={6}>
+				<DropdownMenu.Item class={menuItem} onSelect={() => copyAs("md")}
+					>Markdown</DropdownMenu.Item
+				>
+				<DropdownMenu.Item class={menuItem} onSelect={() => copyAs("csv")}>CSV</DropdownMenu.Item>
+				<DropdownMenu.Item class={menuItem} onSelect={() => copyAs("tsv")}>TSV</DropdownMenu.Item>
+			</DropdownMenu.Content>
+		</DropdownMenu.Portal>
+	</DropdownMenu.Root>
+
+	<DropdownMenu.Root>
+		<DropdownMenu.Trigger class={controlBtn} title="Download table" aria-label="Download table">
+			<CarbonDownload class="size-3.5" />
+		</DropdownMenu.Trigger>
+		<DropdownMenu.Portal>
+			<DropdownMenu.Content class={menuContent} align="end" sideOffset={6}>
+				<DropdownMenu.Item class={menuItem} onSelect={() => downloadAs("csv")}
+					>CSV</DropdownMenu.Item
+				>
+				<DropdownMenu.Item class={menuItem} onSelect={() => downloadAs("md")}>
+					Markdown
+				</DropdownMenu.Item>
+			</DropdownMenu.Content>
+		</DropdownMenu.Portal>
+	</DropdownMenu.Root>
+
+	{#if showFullscreen}
+		<button
+			type="button"
+			class={controlBtn}
+			title="View fullscreen"
+			aria-label="View fullscreen"
+			onclick={() => (fullscreen = true)}
+		>
+			<CarbonMaximize class="size-3.5" />
+		</button>
+	{/if}
+{/snippet}
+
+<div
+	class="not-prose md-table my-4 flex flex-col gap-2 rounded-lg border border-gray-200 bg-gray-50 p-2 dark:border-gray-700 dark:bg-gray-800/40"
+>
+	<div class="flex items-center justify-end gap-0.5">
+		{@render controls(true)}
+	</div>
+	<div
+		bind:this={inlineEl}
+		class="scrollbar-custom overflow-x-auto rounded-md border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-900"
+	>
+		<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+		{@html html}
+	</div>
+</div>
+
+{#if fullscreen}
+	<Portal>
+		<div
+			role="dialog"
+			aria-modal="true"
+			aria-label="Table"
+			tabindex="-1"
+			use:focusOnMount
+			class="not-prose md-table fixed inset-0 z-50 flex flex-col bg-white outline-hidden dark:bg-gray-900"
+		>
+			<div class="flex items-center justify-end gap-0.5 p-3">
+				{@render controls(false)}
+				<button
+					type="button"
+					class={controlBtn}
+					title="Exit fullscreen"
+					aria-label="Exit fullscreen"
+					onclick={() => (fullscreen = false)}
+				>
+					<CarbonClose class="size-5" />
+				</button>
+			</div>
+			<div
+				bind:this={fullscreenEl}
+				class="scrollbar-custom flex-1 overflow-auto px-3 pb-3 [&_thead]:sticky [&_thead]:top-0 [&_thead]:z-10"
+			>
+				<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+				{@html html}
+			</div>
+		</div>
+	</Portal>
+{/if}

--- a/src/lib/utils/marked.spec.ts
+++ b/src/lib/utils/marked.spec.ts
@@ -34,6 +34,26 @@ describe("marked basic rendering", () => {
 	});
 });
 
+describe("marked tables", () => {
+	const table = "| Model | Params |\n| --- | --- |\n| Qwen | 32B |";
+
+	test("emits a table token rather than folding the table into a text token", () => {
+		const tokens = processTokensSync(table, []);
+		expect(tokens).toHaveLength(1);
+		expect(tokens[0].type).toBe("table");
+		expect(tokens[0].type === "table" && tokens[0].html).toContain("<th>Model</th>");
+		expect(tokens[0].type === "table" && tokens[0].html).toContain("<td>Qwen</td>");
+	});
+
+	test("keeps surrounding prose in its own text tokens", () => {
+		// `space` tokens between the blocks also render as (empty) text tokens.
+		const tokens = processTokensSync(`before\n\n${table}\n\nafter`, []).filter(
+			(token) => token.type !== "text" || token.html !== ""
+		);
+		expect(tokens.map((token) => token.type)).toEqual(["text", "table", "text"]);
+	});
+});
+
 describe("marked image renderer", () => {
 	test("renders video extensions as <video>", () => {
 		const html = renderHtml("![](https://example.com/clip.mp4)");

--- a/src/lib/utils/marked.ts
+++ b/src/lib/utils/marked.ts
@@ -38,7 +38,7 @@ import { escapeHTML, type BlockToken, type Token } from "./markedLight";
 // ./markedLight directly — importing this module eagerly pulls KaTeX +
 // highlight.js into the entry bundle.
 export { escapeHTML, fallbackBlocks } from "./markedLight";
-export type { BlockToken, CodeToken, TextToken, Token } from "./markedLight";
+export type { BlockToken, CodeToken, TableToken, TextToken, Token } from "./markedLight";
 
 const bundledLanguages: [string, LanguageFn][] = [
 	["javascript", javascript],
@@ -437,47 +437,35 @@ function cacheKey(index: number, blockContent: string, sources: SimpleSource[]) 
 	return `${index}-${hashString(blockContent)}|${sourceKey}`;
 }
 
+function renderToken(marked: Marked, token: Tokens.Generic): Token {
+	if (token.type === "code") {
+		return {
+			type: "code" as const,
+			lang: token.lang,
+			code: highlightCode(token.text, token.lang),
+			rawCode: token.text,
+			isClosed: isFencedBlockClosed(token.raw ?? ""),
+		};
+	}
+	// Tables get their own token so MarkdownTable can wrap them in a scroll
+	// container with copy/download/fullscreen controls.
+	if (token.type === "table") {
+		return { type: "table" as const, html: marked.parse(token.raw) as string };
+	}
+	return { type: "text" as const, html: marked.parse(token.raw) };
+}
+
 export async function processTokens(content: string, sources: SimpleSource[]): Promise<Token[]> {
 	const marked = createMarkedInstance(sources);
 	const tokens = marked.lexer(content);
 
-	const processedTokens = await Promise.all(
-		tokens.map(async (token) => {
-			if (token.type === "code") {
-				return {
-					type: "code" as const,
-					lang: token.lang,
-					code: highlightCode(token.text, token.lang),
-					rawCode: token.text,
-					isClosed: isFencedBlockClosed(token.raw ?? ""),
-				};
-			} else {
-				return {
-					type: "text" as const,
-					html: marked.parse(token.raw),
-				};
-			}
-		})
-	);
-
-	return processedTokens;
+	return await Promise.all(tokens.map(async (token) => renderToken(marked, token)));
 }
 
 export function processTokensSync(content: string, sources: SimpleSource[]): Token[] {
 	const marked = createMarkedInstance(sources);
 	const tokens = marked.lexer(content);
-	return tokens.map((token) => {
-		if (token.type === "code") {
-			return {
-				type: "code" as const,
-				lang: token.lang,
-				code: highlightCode(token.text, token.lang),
-				rawCode: token.text,
-				isClosed: isFencedBlockClosed(token.raw ?? ""),
-			};
-		}
-		return { type: "text" as const, html: marked.parse(token.raw) };
-	});
+	return tokens.map((token) => renderToken(marked, token));
 }
 
 /**

--- a/src/lib/utils/markedLight.ts
+++ b/src/lib/utils/markedLight.ts
@@ -18,7 +18,17 @@ export type TextToken = {
 	html: string | Promise<string>;
 };
 
-export type Token = CodeToken | TextToken;
+/**
+ * GFM tables are split out of the text stream so they can be rendered by
+ * MarkdownTable (scroll container + copy/download/fullscreen controls) instead of
+ * being dropped into the prose flow as bare `<table>` markup.
+ */
+export type TableToken = {
+	type: "table";
+	html: string;
+};
+
+export type Token = CodeToken | TextToken | TableToken;
 
 export type BlockToken = {
 	id: string;

--- a/src/lib/utils/tableData.spec.ts
+++ b/src/lib/utils/tableData.spec.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { tableDataToCSV, tableDataToMarkdown, tableDataToTSV } from "./tableData";
+
+describe("tableDataToCSV", () => {
+	it("emits the header row followed by the body rows", () => {
+		expect(
+			tableDataToCSV({
+				headers: ["Model", "Params"],
+				rows: [
+					["Qwen", "32B"],
+					["Llama", "70B"],
+				],
+			})
+		).toBe("Model,Params\nQwen,32B\nLlama,70B");
+	});
+
+	it("quotes cells containing a separator, quote or newline", () => {
+		expect(
+			tableDataToCSV({
+				headers: ["a", "b", "c"],
+				rows: [["x,y", 'say "hi"', "line\nbreak"]],
+			})
+		).toBe('a,b,c\n"x,y","say ""hi""","line\nbreak"');
+	});
+
+	it("omits the header row when there are no headers", () => {
+		expect(tableDataToCSV({ headers: [], rows: [["a"]] })).toBe("a");
+	});
+});
+
+describe("tableDataToTSV", () => {
+	it("escapes tabs and newlines instead of quoting", () => {
+		expect(tableDataToTSV({ headers: ["a", "b"], rows: [["with\ttab", "with\nnewline"]] })).toBe(
+			"a\tb\nwith\\ttab\twith\\nnewline"
+		);
+	});
+});
+
+describe("tableDataToMarkdown", () => {
+	it("round-trips a simple table", () => {
+		expect(
+			tableDataToMarkdown({
+				headers: ["Model", "Params"],
+				rows: [["Qwen", "32B"]],
+			})
+		).toBe("| Model | Params |\n| --- | --- |\n| Qwen | 32B |");
+	});
+
+	it("escapes backslashes and pipes, and turns newlines into <br>", () => {
+		expect(tableDataToMarkdown({ headers: ["a"], rows: [["a|b"], ["c\\d"], ["e\nf"]] })).toBe(
+			"| a |\n| --- |\n| a\\|b |\n| c\\\\d |\n| e<br>f |"
+		);
+	});
+
+	it("pads short rows to the header's column count", () => {
+		expect(tableDataToMarkdown({ headers: ["a", "b", "c"], rows: [["1"]] })).toBe(
+			"| a | b | c |\n| --- | --- | --- |\n| 1 |  |  |"
+		);
+	});
+
+	it("returns an empty string without headers, since the syntax requires them", () => {
+		expect(tableDataToMarkdown({ headers: [], rows: [["a"]] })).toBe("");
+	});
+});

--- a/src/lib/utils/tableData.ts
+++ b/src/lib/utils/tableData.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2023 Vercel, Inc.
+ * Adapted from: https://github.com/vercel/streamdown/blob/main/packages/streamdown/lib/table/utils.ts
+ */
+
+export interface TableData {
+	headers: string[];
+	rows: string[][];
+}
+
+/**
+ * Text content of a cell, with <br> turned back into a newline. Cells are rendered
+ * markdown (links, emphasis, code spans), so the visible text is what gets exported
+ * rather than the inline HTML.
+ */
+function extractCellText(node: Node): string {
+	if (node.nodeType === Node.TEXT_NODE) {
+		return node.textContent ?? "";
+	}
+	if (node.nodeType !== Node.ELEMENT_NODE) {
+		return "";
+	}
+	const element = node as HTMLElement;
+	if (element.tagName === "BR") {
+		return "\n";
+	}
+	return Array.from(element.childNodes).map(extractCellText).join("");
+}
+
+export function extractTableData(tableElement: HTMLElement): TableData {
+	const headers = Array.from(tableElement.querySelectorAll("thead th")).map((cell) =>
+		extractCellText(cell).trim()
+	);
+	const rows = Array.from(tableElement.querySelectorAll("tbody tr")).map((row) =>
+		Array.from(row.querySelectorAll("td")).map((cell) => extractCellText(cell).trim())
+	);
+	return { headers, rows };
+}
+
+function escapeCsvCell(value: string): string {
+	return /[",\n\r]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value;
+}
+
+export function tableDataToCSV({ headers, rows }: TableData): string {
+	const lines = headers.length ? [headers] : [];
+	return [...lines, ...rows].map((row) => row.map(escapeCsvCell).join(",")).join("\n");
+}
+
+function escapeTsvCell(value: string): string {
+	return value.replace(/\t/g, "\\t").replace(/\r/g, "\\r").replace(/\n/g, "\\n");
+}
+
+export function tableDataToTSV({ headers, rows }: TableData): string {
+	const lines = headers.length ? [headers] : [];
+	return [...lines, ...rows].map((row) => row.map(escapeTsvCell).join("\t")).join("\n");
+}
+
+// Backslashes must be escaped before pipes, otherwise the backslash pass would
+// double-escape the ones just added for pipes.
+function escapeMarkdownCell(value: string): string {
+	return value.replace(/\\/g, "\\\\").replace(/\|/g, "\\|").replace(/\n/g, "<br>");
+}
+
+export function tableDataToMarkdown({ headers, rows }: TableData): string {
+	if (headers.length === 0) {
+		return "";
+	}
+	const lines = [
+		`| ${headers.map(escapeMarkdownCell).join(" | ")} |`,
+		`| ${headers.map(() => "---").join(" | ")} |`,
+	];
+	for (const row of rows) {
+		// Short rows are padded so every line keeps the header's column count.
+		const cells = Array.from({ length: headers.length }, (_, i) =>
+			i < row.length ? escapeMarkdownCell(row[i]) : ""
+		);
+		lines.push(`| ${cells.join(" | ")} |`);
+	}
+	return lines.join("\n");
+}
+
+/** Triggers a browser download of `content` as `filename`. */
+export function saveFile(filename: string, content: string, mimeType: string) {
+	// Excel on Windows guesses the system ANSI codepage for CSV without a BOM,
+	// which corrupts non-ASCII text.
+	const bom = mimeType.startsWith("text/csv") ? "\uFEFF" : "";
+	const url = URL.createObjectURL(new Blob([bom + content], { type: mimeType }));
+	const a = document.createElement("a");
+	a.href = url;
+	a.download = filename;
+	document.body.appendChild(a);
+	a.click();
+	document.body.removeChild(a);
+	URL.revokeObjectURL(url);
+}

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -207,14 +207,43 @@ body {
 	margin-top: 0.8em;
 }
 
-.prose table {
-	@apply scrollbar-thin block max-w-full scrollbar-thumb-black/10 scrollbar-track-transparent overflow-x-auto scrollbar-thumb-rounded-full dark:scrollbar-thumb-white/10 scrollbar-hover:scrollbar-thumb-black/20 dark:scrollbar-hover:scrollbar-thumb-white/20;
+/* Tables are rendered by MarkdownTable.svelte, which opts its subtree out of `prose`
+   (`not-prose`) so the inline table and its fullscreen copy — portalled outside any
+   prose container — look identical. Everything the cells need is therefore restated
+   here rather than inherited from the typography plugin. */
+.md-table table {
+	@apply m-0 w-full border-collapse text-sm;
 }
 
-/* Prevent columns from squishing on narrow viewports; long content wraps instead of dominating. */
-.prose :is(th, td) {
-	min-width: 6rem;
-	max-width: 16rem;
+/* Opaque, because the fullscreen view makes the header sticky over the scrolling rows. */
+.md-table thead {
+	@apply bg-gray-100 dark:bg-gray-800;
+}
+
+.md-table tbody tr {
+	@apply border-t border-gray-200 dark:border-gray-700;
+}
+
+.md-table :is(th, td) {
+	/* Prevent columns from squishing on narrow viewports; long content wraps instead
+	   of dominating, and the wrapper scrolls horizontally past that. */
+	@apply max-w-64 min-w-24 px-4 py-2 align-top;
+}
+
+.md-table th {
+	@apply text-left font-semibold whitespace-nowrap;
+}
+
+.md-table a {
+	@apply font-medium underline;
+}
+
+.md-table strong {
+	@apply font-medium;
+}
+
+.md-table code {
+	@apply rounded-md bg-gray-200/60 px-[0.4em] py-[0.2em] text-[85%] dark:bg-gray-700;
 }
 
 .prose hr {


### PR DESCRIPTION
Brings table rendering in line with [streamdown](https://github.com/vercel/streamdown), which chat-ui already borrows from for block splitting and incomplete-markdown repairs.

## Before

Tables were plain `marked` output dropped into the prose flow and styled only by Tailwind Typography, plus two rules in `main.css`. The `<table>` element itself was the horizontal scroll container (`display: block; overflow-x-auto`), so there was no card, no header background, and no controls.

## After

Tables are split out of the text token stream into their own token and rendered by a new `MarkdownTable` component, following streamdown's structure:

- outer card wrapper
- a controls row: copy (Markdown / CSV / TSV), download (CSV / Markdown), fullscreen
- an inner bordered `overflow-x-auto` scroll container holding the table

Copy puts both the serialized text and the table's HTML on the clipboard, so pasting into a doc or a spreadsheet keeps the grid instead of landing in a single cell. Fullscreen is a portalled dialog with a sticky header, Escape to close, `inert` on the app, and focus restore.

## Notes

- The wrapper carries `not-prose`, so the inline table and its portalled fullscreen copy (which lives outside any prose container) style identically instead of half-inheriting from the typography plugin. The `.prose table` rules are replaced by `.md-table` rules.
- Deliberate differences from streamdown: its shadcn tokens are mapped to our gray palette, `bits-ui` `DropdownMenu` is used instead of hand-rolled dropdowns, the header background is opaque rather than translucent (the fullscreen view makes it sticky over scrolling rows), and cells keep the existing `min-width: 6rem` / `max-width: 16rem`, which is also what makes wide tables scroll rather than squish.
- Controls stay enabled while a table is still streaming, unlike streamdown which disables them during its animation. `loading` applies to the whole message rather than the individual block, so there is no cheap "this table is still growing" signal, and copying a partial table is harmless.

## Testing

`npm run check`, `npm run lint` and `npm run build` are clean, and 379 server-side tests pass, including new specs for the export helpers (`tableData.spec.ts`) and for the table token (`marked.spec.ts`).

The two new client cases in `MarkdownRenderer.svelte.test.ts` (table wrapper plus controls, fullscreen open/close) are written but were not executed locally: the browser test workspace does not start on my machine, failing the same way on untouched test files. They need CI to confirm.

Light mode, dark mode, and horizontal scrolling of a wide table were verified against the compiled CSS in a browser.