### PR TITLE
Keep process rows flat while a tool turn streams

### DIFF
--- a/src/lib/components/chat/ChatMessage.svelte
+++ b/src/lib/components/chat/ChatMessage.svelte
@@ -409,10 +409,7 @@
 		return units;
 	});
 
-	// Still mid-process (thinking / calling tools, no answer yet) → render the
-	// blocks flat like today. Once the final answer starts streaming the last
-	// block becomes text, so this flips to false and the nested summary takes over.
-	/** Reasoning and a running tool animate; a finished tool and a settled question do not. */
+	/** Reasoning, a running tool and growing text animate; a finished tool and a settled question do not. */
 	let trailingBlockShowsProgress = $derived.by(() => {
 		const last = blocks.at(-1);
 		if (!last) return false;
@@ -422,18 +419,22 @@
 				(update) => isMessageToolResultUpdate(update) || isMessageToolErrorUpdate(update)
 			);
 		}
+		if (last.type === "text") return last.content.trim().length > 0;
 		return false;
 	});
 
+	// A streaming turn with process blocks renders them flat for its whole
+	// duration — mid-turn narration between tool rounds must not regroup the
+	// rows into the collapsed summary, or every new round visibly "re-expands"
+	// them. The nested summary takes over only once the turn is over.
 	let isProcessStreaming = $derived.by(() => {
 		if (!isLast || !loading) return false;
-		const last = blocks.at(-1);
-		return (
-			!!last &&
-			(last.type === "think" ||
-				last.type === "tool" ||
-				last.type === "elicitation" ||
-				last.type === "plan")
+		return blocks.some(
+			(block) =>
+				block.type === "think" ||
+				block.type === "tool" ||
+				block.type === "elicitation" ||
+				block.type === "plan"
 		);
 	});
 
@@ -504,8 +505,8 @@
 					<IconLoading classNames="loading inline ml-2 first:ml-0" />
 				{/if}
 				{#if isProcessStreaming}
-					<!-- Streaming the thinking / tool phase: render every block flat and
-					     inline, exactly like today. Nesting kicks in once the answer starts. -->
+					<!-- A streaming turn that used thinking / tools: every block renders flat
+					     and inline until the turn ends, then the nested summary takes over. -->
 					{#each blocks as block, blockIndex (block.type === "tool" ? `tool-${block.uuid}-${blockIndex}` : block.type === "plan" ? `plan-${block.update.version}` : `block-${blockIndex}`)}
 						{#if block.type === "text"}
 							{#if block.content.trim().length > 0}

--- a/src/lib/components/chat/ChatMessage.svelte.test.ts
+++ b/src/lib/components/chat/ChatMessage.svelte.test.ts
@@ -140,4 +140,47 @@ describe("collapsed process blocks during streaming", () => {
 		expect(open.length).toBe(1);
 		expect(open[0].textContent).toContain("Thinking");
 	});
+
+	it("keeps the flat rows through mid-turn narration instead of regrouping them", async () => {
+		// Models narrate between tool rounds. That text must not collapse the
+		// previous rows into the "Called N tools" summary mid-turn: the next
+		// round would explode the summary back into rows, which reads as the
+		// collapsed blocks re-expanding. Grouping belongs to the finished turn.
+		const steps = [
+			streamCall("u1"),
+			streamResult("u1"),
+			streamCall("u2"),
+			streamResult("u2"),
+			stream("This is excellent research. Let me search more."),
+			streamCall("u3"),
+			streamResult("u3"),
+			stream("Now I have comprehensive data."),
+			streamCall("u4"),
+		];
+		const summaries = (el: HTMLElement) =>
+			[...el.querySelectorAll("button")].filter((b) =>
+				/^Called \d+ tools?/.test(b.textContent?.trim() ?? "")
+			);
+		const toolRows = (el: HTMLElement) => el.querySelectorAll("code").length;
+
+		const updates: unknown[] = [];
+		const screen = mount([]);
+		let previousRows = 0;
+		for (const step of steps) {
+			updates.push(step);
+			await screen.rerender({
+				message: { id: "m1", from: "assistant", content: "", children: [], updates: [...updates] },
+			} as never);
+			await tick();
+			const el = screen.baseElement as HTMLElement;
+			expect(summaries(el).length).toBe(0);
+			expect(toolRows(el)).toBeGreaterThanOrEqual(previousRows);
+			previousRows = toolRows(el);
+		}
+
+		// Once the turn is over, the finished-turn grouping takes over.
+		await screen.rerender({ loading: false } as never);
+		await tick();
+		expect(summaries(screen.baseElement as HTMLElement).length).toBeGreaterThan(0);
+	});
 });


### PR DESCRIPTION
## What

Follow-up to #2539. During a multi-round tool turn, previously collapsed "Called tool" / "Thinking" rows still appeared to re-expand whenever a new round started.

## Why it happened

Tool rows have no auto-expand at all, so this was not row state: it was the message flipping between its two layouts mid-turn. `isProcessStreaming` looked only at the LAST block. Models narrate between tool rounds ("This is excellent research. Let me now do a targeted search..."), and that text made the last block a text block, which flipped the message into the finished-turn presentation: all previous think/tool rows regrouped into the collapsed "Called N tools" summary. The next round's tool call flipped it back, exploding the summary into individual rows again. Watching live, the collapsed blocks visibly re-expand on every round.

A test-harness replay of the conversation shape confirms the thrash on the old code (tool rows per step): 1, 1, 2, 2, then narration collapses them to 0 rows + a "Called 2 tools" summary, then the next call explodes back to 3 rows, and again at the next narration.

## Fix

While the turn is still streaming (`isLast && loading`), render the flat rows for the whole turn whenever any process block exists. The grouped "Called N tools" summary takes over only once the turn is over, so there is exactly one presentation change per turn instead of one per round. Because the rows now keep their component instances for the whole turn, manual expand/collapse choices also survive until the turn ends.

A trailing text block that is still growing now counts as "shows progress", so the loading ellipsis does not double up under streaming narration (matching the previous behavior of the grouped view).

## Tests

New regression test replays a 4-round turn with narration between rounds and asserts that no "Called N tools" summary appears at any step while streaming, that the row count never shrinks, and that the grouped summary does take over once loading ends. Fails on the old code. Full suite, `npm run check`, and lint pass (one pre-existing flaky spec in `replayRoundTrip.spec.ts` fails intermittently on unrelated Mongo-backed replay tests; it passes in isolation and on re-runs).