### PR TITLE
Deflake the runMcpFlow 429 backoff test

### DIFF
--- a/src/lib/server/textGeneration/mcp/runMcpFlow.spec.ts
+++ b/src/lib/server/textGeneration/mcp/runMcpFlow.spec.ts
@@ -7,6 +7,7 @@ import {
 } from "$lib/types/MessageUpdate";
 import type { ChatCompletionMessageParam } from "openai/resources/chat/completions";
 import { ML_ASSISTANT_MIN_COMPLETION_TOKENS } from "$lib/constants/mlAssistant";
+import { RATE_LIMIT_BACKOFF_MS } from "$lib/server/textGeneration/utils/rateLimitRetry";
 import type { McpFlowResult, RunMcpFlowContext } from "./runMcpFlow";
 
 // ---------------------------------------------------------------------------
@@ -413,7 +414,7 @@ describe("runMcpFlow rate limits", () => {
 		// Fake only the timer pair the backoff sleep uses: the flow crosses real
 		// async boundaries (dynamic import, mocked promises) before it ever
 		// schedules the sleep, and a blanket fake would starve those of event-loop
-		// turns — the CI-only hang this test once had.
+		// turns.
 		vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
 		try {
 			scriptRounds([
@@ -422,11 +423,22 @@ describe("runMcpFlow rate limits", () => {
 			]);
 
 			const pending = runFlow();
-			// Alternate fake-clock advances with real event-loop turns until the
-			// retry lands, however late the flow registers its backoff timer.
-			for (let i = 0; i < 200 && mocks.create.mock.calls.length < 2; i += 1) {
-				await vi.advanceTimersByTimeAsync(1_000);
+			let settled = false;
+			const flagSettled = () => {
+				settled = true;
+			};
+			void pending.then(flagSettled, flagSettled);
+			// The backoff sleep is the only fake-timer client here, so its
+			// registration — not a wall-clock budget — is the signal to advance the
+			// clock. A fixed number of advance/yield rounds can be exhausted before a
+			// slow runner even reaches the sleep, leaving its timer to hang forever.
+			// A flow that settles without a timer let the 429 escape; fall through
+			// and let the assertions name that.
+			while (!settled && vi.getTimerCount() === 0) {
 				await new Promise((resolve) => setImmediate(resolve));
+			}
+			if (vi.getTimerCount() > 0) {
+				await vi.advanceTimersByTimeAsync(RATE_LIMIT_BACKOFF_MS[0]);
 			}
 			const { updates, result } = await pending;
 


### PR DESCRIPTION
## What

Hardens `runMcpFlow rate limits > absorbs a router 429 with backoff instead of failing a turn mid-flight` in `src/lib/server/textGeneration/mcp/runMcpFlow.spec.ts`, which timed out at 30s on a GitHub Actions runner (run 33462543653) and passed unchanged on rerun.

## Why it flaked

The test fakes only `setTimeout`/`clearTimeout` (the pair the backoff sleep uses) and then alternated `advanceTimersByTimeAsync(1_000)` with one `setImmediate` turn, capped at 200 iterations. On a fast machine the flow reaches its backoff sleep within a turn or two; on a slow runner the flow is still crossing real async boundaries (dynamic import I/O and the like) while the loop burns all 200 iterations in milliseconds — advancing a clock that has no timers on it. When the flow finally registered the backoff's `setTimeout`, nothing was left to advance the fake clock, so the sleep never fired and the test sat until the 30s timeout.

## The fix

Wait on the deterministic signal instead of racing a fixed advance budget against wall clock. The backoff sleep (`abortableSleep` in `src/lib/server/textGeneration/utils/rateLimitRetry.ts`) is the only client of the faked timer pair, so the test now:

1. yields real event-loop turns until `vi.getTimerCount()` goes nonzero (or the flow settles first — which would mean the 429 escaped, and the existing assertions report that), then
2. advances the clock by exactly `RATE_LIMIT_BACKOFF_MS[0]`, imported from the real module so the delay can't drift out of sync.

The wait is unbounded, so runner slowness only adds cheap iterations. The test's intent (a 429 must not fail the turn, and the retry must land) and its 30s timeout are unchanged.

## Verification

- Reproduced the flake mechanism in a scratch copy of the spec by delaying the scripted 429 behind 2,000 real event-loop turns: the old loop hangs to its timeout, the hardened loop passes in ~50ms. (Scratch copy not included in the PR.)
- All 36 tests in the spec pass; Prettier and ESLint are clean.