### PR TITLE
Let the user check a parked wait early

### DIFF
--- a/src/lib/components/chat/ChatMessage.svelte
+++ b/src/lib/components/chat/ChatMessage.svelte
@@ -64,7 +64,7 @@
 		message,
 		loading = false,
 		isAuthor: _isAuthor = true,
-		readOnly: _readOnly = false,
+		readOnly = false,
 		isTapped = $bindable(false),
 		alternatives = [],
 		editMsdgId = $bindable(null),
@@ -93,7 +93,6 @@
 	$effect(() => {
 		// referenced to appease linter for currently-unused props
 		void _isAuthor;
-		void _readOnly;
 	});
 	function handleKeyDown(e: KeyboardEvent) {
 		if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
@@ -595,7 +594,13 @@
 			</div>
 
 			{#if waitingState}
-				<TurnWaitBanner until={waitingState.until ?? 0} reason={waitingState.reason} />
+				<TurnWaitBanner
+					until={waitingState.until ?? 0}
+					reason={waitingState.reason}
+					conversationId={page.params.id ?? ""}
+					messageId={message.id}
+					canWake={!readOnly}
+				/>
 			{/if}
 		</div>
 

--- a/src/lib/components/chat/ChatMessage.svelte
+++ b/src/lib/components/chat/ChatMessage.svelte
@@ -63,7 +63,7 @@
 	let {
 		message,
 		loading = false,
-		isAuthor: _isAuthor = true,
+		isAuthor = true,
 		readOnly = false,
 		isTapped = $bindable(false),
 		alternatives = [],
@@ -90,10 +90,6 @@
 		}
 	}
 
-	$effect(() => {
-		// referenced to appease linter for currently-unused props
-		void _isAuthor;
-	});
 	function handleKeyDown(e: KeyboardEvent) {
 		if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
 			editFormEl?.requestSubmit();
@@ -599,7 +595,7 @@
 					reason={waitingState.reason}
 					conversationId={page.params.id ?? ""}
 					messageId={message.id}
-					canWake={!readOnly}
+					canWake={isAuthor && !readOnly}
 				/>
 			{/if}
 		</div>

--- a/src/lib/components/chat/TurnWaitBanner.svelte
+++ b/src/lib/components/chat/TurnWaitBanner.svelte
@@ -11,6 +11,11 @@
 		/** Cutting the wait short is an action, so it needs the live conversation. */
 		conversationId?: string;
 		messageId?: string;
+		/**
+		 * Whether this view may act on the turn: the author's own conversation.
+		 * A shared view is routed by share id, which the wake endpoint cannot
+		 * resolve, so the control must not appear there at all.
+		 */
 		canWake?: boolean;
 	}
 

--- a/src/lib/components/chat/TurnWaitBanner.svelte
+++ b/src/lib/components/chat/TurnWaitBanner.svelte
@@ -1,14 +1,20 @@
 <script lang="ts">
 	import CarbonTime from "~icons/carbon/time";
+	import CarbonContinue from "~icons/carbon/continue";
+	import { base } from "$app/paths";
 	import { serverCorrectedNow } from "$lib/utils/clockSkew.svelte";
 
 	interface Props {
 		/** Absolute deadline, epoch ms (server clock). */
 		until: number;
 		reason?: string;
+		/** Cutting the wait short is an action, so it needs the live conversation. */
+		conversationId?: string;
+		messageId?: string;
+		canWake?: boolean;
 	}
 
-	let { until, reason }: Props = $props();
+	let { until, reason, conversationId, messageId, canWake = false }: Props = $props();
 
 	// Past the deadline by more than the sweeper's cadence, "counting down" would
 	// be a lie — say what is actually happening instead.
@@ -25,6 +31,36 @@
 	let remainingMs = $derived(until - now);
 	let overdue = $derived(remainingMs < -OVERDUE_GRACE_MS);
 
+	// Stays set once the wake is accepted: the banner is replaced by the resumed
+	// turn's own output when the `running` state arrives, so there is nothing to
+	// count down to in the meantime.
+	let waking = $state(false);
+	let wakeError = $state<string | undefined>(undefined);
+
+	let showWakeButton = $derived(
+		canWake && Boolean(conversationId && messageId) && !overdue && !waking
+	);
+
+	async function wakeNow() {
+		if (!conversationId || !messageId || waking) return;
+		waking = true;
+		wakeError = undefined;
+		try {
+			const res = await fetch(`${base}/conversation/${conversationId}/wake`, {
+				method: "POST",
+				// Without Accept, SvelteKit answers `error()` with an HTML page.
+				headers: { "Content-Type": "application/json", Accept: "application/json" },
+				body: JSON.stringify({ messageId }),
+			});
+			if (!res.ok) throw new Error(String(res.status));
+		} catch {
+			// The timer is untouched by a failed request, so the turn still wakes
+			// on its own — say so rather than implying the wait is lost.
+			waking = false;
+			wakeError = "Couldn't check early; still waiting on the timer.";
+		}
+	}
+
 	function formatRemaining(ms: number): string {
 		const totalSeconds = Math.max(0, Math.ceil(ms / 1000));
 		const minutes = Math.floor(totalSeconds / 60);
@@ -36,15 +72,33 @@
 <div
 	role="status"
 	data-exclude-from-copy
-	class="mt-2 flex w-fit items-center gap-1.5 rounded-lg border border-gray-200 bg-gray-50 px-2.5 py-1.5 text-xs text-gray-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400"
+	class="mt-2 flex w-fit items-stretch overflow-hidden rounded-lg border border-gray-200 bg-gray-50 text-xs text-gray-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400"
 >
-	<CarbonTime class="text-[0.8rem] {overdue ? '' : 'animate-pulse'}" />
-	{#if overdue}
-		<span>Waiting{reason ? ` for ${reason}` : ""} — overdue, waking…</span>
-	{:else}
-		<span>
-			Waiting{reason ? ` for ${reason}` : ""} — resumes in
-			<span class="font-mono tabular-nums">{formatRemaining(remainingMs)}</span>
-		</span>
+	<div class="flex items-center gap-1.5 px-2.5 py-1.5">
+		<CarbonTime class="text-[0.8rem] {overdue ? '' : 'animate-pulse'}" />
+		{#if overdue}
+			<span>Waiting{reason ? ` for ${reason}` : ""} — overdue, waking…</span>
+		{:else if waking}
+			<span>Waiting{reason ? ` for ${reason}` : ""} — checking now…</span>
+		{:else}
+			<span>
+				Waiting{reason ? ` for ${reason}` : ""} — resumes in
+				<span class="font-mono tabular-nums">{formatRemaining(remainingMs)}</span>
+			</span>
+		{/if}
+		{#if wakeError}
+			<span class="text-red-500 dark:text-red-400">{wakeError}</span>
+		{/if}
+	</div>
+	{#if showWakeButton}
+		<button
+			type="button"
+			onclick={wakeNow}
+			aria-label="Check now"
+			title="Check on this now instead of waiting out the timer"
+			class="flex cursor-pointer items-center justify-center border-l border-gray-200 px-2 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 dark:border-gray-700 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-gray-300"
+		>
+			<CarbonContinue class="text-[0.7rem]" />
+		</button>
 	{/if}
 </div>

--- a/src/lib/components/chat/TurnWaitBanner.svelte.test.ts
+++ b/src/lib/components/chat/TurnWaitBanner.svelte.test.ts
@@ -1,0 +1,81 @@
+import TurnWaitBanner from "./TurnWaitBanner.svelte";
+import { render } from "vitest-browser-svelte";
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+
+/** The wake is a POST, so what reaches the server is the assertion worth making. */
+let sent: Array<{ url: string; body: Record<string, unknown> }>;
+let respond: () => Response;
+
+beforeEach(() => {
+	sent = [];
+	respond = () => new Response(JSON.stringify({ ok: true }), { status: 200 });
+	vi.stubGlobal("fetch", async (url: string, init?: RequestInit) => {
+		sent.push({ url: String(url), body: JSON.parse(String(init?.body)) });
+		return respond();
+	});
+});
+
+afterEach(() => vi.unstubAllGlobals());
+
+const mount = (over: Record<string, unknown> = {}) =>
+	render(TurnWaitBanner, {
+		until: Date.now() + 120_000,
+		reason: "the training job",
+		conversationId: "conv-1",
+		messageId: "msg-1",
+		canWake: true,
+		...over,
+	} as never);
+
+/** Icon-only, so its accessible name is the only handle on it. */
+const wakeButton = (baseElement: HTMLElement) =>
+	baseElement.querySelector<HTMLButtonElement>('button[aria-label="Check now"]') ?? undefined;
+
+describe("the wait pill", () => {
+	it("counts down to the deadline", () => {
+		expect(mount().baseElement.textContent).toContain("resumes in");
+	});
+
+	it("asks the server to cut the wait short when the user checks now", async () => {
+		const { baseElement } = mount();
+
+		wakeButton(baseElement)?.click();
+
+		await vi.waitFor(() => expect(sent).toHaveLength(1));
+		expect(sent[0].url).toContain("/conversation/conv-1/wake");
+		expect(sent[0].body).toEqual({ messageId: "msg-1" });
+	});
+
+	it("stops counting down once the wake is accepted", async () => {
+		const { baseElement } = mount();
+
+		wakeButton(baseElement)?.click();
+
+		// The countdown would keep ticking against a deadline that no longer
+		// decides anything; the resumed turn's own output replaces the pill.
+		await vi.waitFor(() => expect(baseElement.textContent).toContain("checking now"));
+		expect(baseElement.textContent).not.toContain("resumes in");
+		expect(wakeButton(baseElement)).toBeUndefined();
+	});
+
+	it("puts the countdown back when the request fails, since the timer still stands", async () => {
+		respond = () => new Response("{}", { status: 500 });
+		const { baseElement } = mount();
+
+		wakeButton(baseElement)?.click();
+
+		await vi.waitFor(() => expect(baseElement.textContent).toContain("Couldn't check early"));
+		expect(baseElement.textContent).toContain("resumes in");
+		expect(wakeButton(baseElement)).toBeDefined();
+	});
+
+	it("offers no wake on a read-only view of someone else's chat", () => {
+		expect(wakeButton(mount({ canWake: false }).baseElement)).toBeUndefined();
+	});
+
+	it("offers no wake once the deadline is long past and a sweep owns the turn", () => {
+		const { baseElement } = mount({ until: Date.now() - 60_000 });
+		expect(baseElement.textContent).toContain("overdue");
+		expect(wakeButton(baseElement)).toBeUndefined();
+	});
+});

--- a/src/lib/server/generation/parkedSweeper.spec.ts
+++ b/src/lib/server/generation/parkedSweeper.spec.ts
@@ -204,6 +204,9 @@ describe("wakeParkedCallEarly", () => {
 		expect(after?.status).toBe("waiting");
 		expect(after?.resumeAt.getTime()).toBeLessThanOrEqual(Date.now());
 		expect(after?.wokeEarlyAt).toBeInstanceOf(Date);
+		// The deadline it asked for survives the overwrite, so the resumed round
+		// can tell the model how much of its wait was skipped.
+		expect(after?.plannedResumeAt?.getTime()).toBe(row.resumeAt.getTime());
 	});
 
 	it("only touches the turn it was asked about", async () => {

--- a/src/lib/server/generation/parkedSweeper.spec.ts
+++ b/src/lib/server/generation/parkedSweeper.spec.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeAll, describe, expect, it } from "vitest";
 import { ObjectId } from "mongodb";
 import { collections, ready } from "$lib/server/database";
-import { renewClaim, sweepParkedCalls } from "./parkedSweeper";
+import { renewClaim, sweepParkedCalls, wakeParkedCallEarly } from "./parkedSweeper";
 import type { ParkedCall } from "$lib/types/ParkedCall";
 
 const park = (over: Partial<ParkedCall> = {}): ParkedCall => ({
@@ -187,5 +187,41 @@ describe("renewClaim", () => {
 		const after = await collections.parkedCalls.findOne({});
 		expect(after?.status).toBe("resumed");
 		expect(after?.takenAt?.getTime()).toBe(takenAt.getTime());
+	});
+});
+
+describe("wakeParkedCallEarly", () => {
+	it("makes a waiting row due now and records that the user cut the wait short", async () => {
+		const row = park({ resumeAt: new Date(Date.now() + 10 * 60_000) });
+		await collections.parkedCalls.insertOne(row);
+
+		const woken = await wakeParkedCallEarly(row.conversationId, row.messageId);
+
+		expect(woken).toBe(true);
+		const after = await collections.parkedCalls.findOne({});
+		// Still `waiting`: the ordinary claim decides who resumes it, so an early
+		// wake can never race a sweeper into two producers for one turn.
+		expect(after?.status).toBe("waiting");
+		expect(after?.resumeAt.getTime()).toBeLessThanOrEqual(Date.now());
+		expect(after?.wokeEarlyAt).toBeInstanceOf(Date);
+	});
+
+	it("only touches the turn it was asked about", async () => {
+		const mine = park({ resumeAt: new Date(Date.now() + 10 * 60_000) });
+		const other = park({ messageId: "msg-2", resumeAt: new Date(Date.now() + 10 * 60_000) });
+		await collections.parkedCalls.insertMany([mine, other]);
+
+		await wakeParkedCallEarly(mine.conversationId, mine.messageId);
+
+		const untouched = await collections.parkedCalls.findOne({ messageId: "msg-2" });
+		expect(untouched?.resumeAt.getTime()).toBe(other.resumeAt.getTime());
+		expect(untouched?.wokeEarlyAt).toBeUndefined();
+	});
+
+	it("reports no wake when the turn is not parked on a timer", async () => {
+		const row = park({ status: "resuming" });
+		await collections.parkedCalls.insertOne(row);
+
+		expect(await wakeParkedCallEarly(row.conversationId, row.messageId)).toBe(false);
 	});
 });

--- a/src/lib/server/generation/parkedSweeper.ts
+++ b/src/lib/server/generation/parkedSweeper.ts
@@ -99,9 +99,12 @@ export async function wakeParkedCallEarly(
 	messageId: string
 ): Promise<boolean> {
 	const now = new Date();
+	// A pipeline update so the deadline the model asked for is kept in the same
+	// atomic write that overwrites it — the resumed round needs both to say how
+	// much of the wait was skipped.
 	const result = await collections.parkedCalls.updateOne(
 		{ conversationId, messageId, status: "waiting" },
-		{ $set: { resumeAt: now, wokeEarlyAt: now, updatedAt: now } }
+		[{ $set: { plannedResumeAt: "$resumeAt", resumeAt: now, wokeEarlyAt: now, updatedAt: now } }]
 	);
 	if (result.matchedCount === 0) return false;
 	logger.info(

--- a/src/lib/server/generation/parkedSweeper.ts
+++ b/src/lib/server/generation/parkedSweeper.ts
@@ -85,6 +85,32 @@ async function claimDueCall(now: Date): Promise<ParkedCall | null> {
 	return claimed?.value ?? null;
 }
 
+/**
+ * Cut a wait short because the user asked to: they can see what the turn is
+ * waiting for and often know it is worth a look before the timer is up.
+ *
+ * Moving the deadline is the ENTIRE state change. The row stays `waiting`, so
+ * the ordinary claim still decides which pod resumes it and a racing sweeper
+ * cannot produce a second producer for the turn. The caller kicks a sweep
+ * afterwards purely so the user does not sit through the sweep interval.
+ */
+export async function wakeParkedCallEarly(
+	conversationId: ParkedCall["conversationId"],
+	messageId: string
+): Promise<boolean> {
+	const now = new Date();
+	const result = await collections.parkedCalls.updateOne(
+		{ conversationId, messageId, status: "waiting" },
+		{ $set: { resumeAt: now, wokeEarlyAt: now, updatedAt: now } }
+	);
+	if (result.matchedCount === 0) return false;
+	logger.info(
+		{ conversationId: conversationId.toString(), messageId },
+		"[parked] user asked to wake a parked turn early"
+	);
+	return true;
+}
+
 async function abandon(park: ParkedCall, reason: string): Promise<void> {
 	logger.warn({ parkedCallId: park.parkedCallId, reason }, "[parked] abandoning a parked call");
 	await collections.parkedCalls.updateOne(

--- a/src/lib/server/textGeneration/builtinTools/waitTool.spec.ts
+++ b/src/lib/server/textGeneration/builtinTools/waitTool.spec.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeAll, describe, expect, it } from "vitest";
 import { ObjectId } from "mongodb";
 import { collections, ready } from "$lib/server/database";
-import { waitBuiltin } from "./waitTool";
+import { waitBuiltin, waitResumeResultText } from "./waitTool";
 import type { BuiltinToolContext } from "./types";
 
 const ctx = (over: Partial<BuiltinToolContext> = {}): BuiltinToolContext => ({
@@ -108,5 +108,20 @@ describe("the wait tool", () => {
 		);
 		expect(outcome).toHaveProperty("error");
 		expect(await collections.parkedCalls.countDocuments({})).toBe(0);
+	});
+});
+
+describe("the tool result a resumed turn reads", () => {
+	const park = { reason: "the training job", createdAt: new Date(0), resumeAt: new Date(120_000) };
+
+	it("reports the wait it actually served", () => {
+		const text = waitResumeResultText(park);
+		expect(text).toContain("Waited 120s for: the training job.");
+		expect(text).not.toContain("user asked");
+	});
+
+	it("says when the user cut the wait short, so a short wait is not read as its own choice", () => {
+		const text = waitResumeResultText({ ...park, wokeEarlyAt: new Date(120_000) });
+		expect(text).toContain("The user asked you to check on this early");
 	});
 });

--- a/src/lib/server/textGeneration/builtinTools/waitTool.spec.ts
+++ b/src/lib/server/textGeneration/builtinTools/waitTool.spec.ts
@@ -120,8 +120,21 @@ describe("the tool result a resumed turn reads", () => {
 		expect(text).not.toContain("user asked");
 	});
 
-	it("says when the user cut the wait short, so a short wait is not read as its own choice", () => {
+	it("names the wait the user skipped, so the model does not stretch the next one", () => {
+		// Resumed after 12s of a 300s wait, at the user's request.
+		const text = waitResumeResultText({
+			...park,
+			resumeAt: new Date(12_000),
+			wokeEarlyAt: new Date(12_000),
+			plannedResumeAt: new Date(300_000),
+		});
+		expect(text).toContain("Waited 12s");
+		expect(text).toContain("cutting short a 300s wait");
+		expect(text).toContain("size any further wait as you would have without this check");
+	});
+
+	it("still says the wait was cut short when the original deadline was not recorded", () => {
 		const text = waitResumeResultText({ ...park, wokeEarlyAt: new Date(120_000) });
-		expect(text).toContain("The user asked you to check on this early");
+		expect(text).toContain("cutting short the wait");
 	});
 });

--- a/src/lib/server/textGeneration/builtinTools/waitTool.ts
+++ b/src/lib/server/textGeneration/builtinTools/waitTool.ts
@@ -156,12 +156,20 @@ export function waitResumeResultText(park: {
 	resumeAt: Date;
 	createdAt: Date;
 	wokeEarlyAt?: Date;
+	plannedResumeAt?: Date;
 }): string {
 	const waited = Math.round((park.resumeAt.getTime() - park.createdAt.getTime()) / 1000);
-	// An early wake is a user action, not a clock: say so, or the model reads a
-	// short wait as its own choice and mis-sizes the next one.
+	const planned = park.plannedResumeAt
+		? Math.round((park.plannedResumeAt.getTime() - park.createdAt.getTime()) / 1000)
+		: undefined;
+	// Naming the skipped wait is the load-bearing part: told only that it is
+	// resumed, the model reads the short gap as "not ready after the wait I
+	// asked for" and stretches the NEXT wait — the opposite of what a user
+	// asking to check early wants.
 	const early = park.wokeEarlyAt
-		? "The user asked you to check on this early, so the wait was cut short. "
+		? `The user asked you to check early, cutting short ${planned ? `a ${planned}s wait` : "the wait"}. ` +
+			"The short gap is their doing, not a signal about the work — size any further wait as you " +
+			"would have without this check. "
 		: "";
 	return (
 		`Waited ${waited}s for: ${park.reason}. ${early}You are now resumed. ` +

--- a/src/lib/server/textGeneration/builtinTools/waitTool.ts
+++ b/src/lib/server/textGeneration/builtinTools/waitTool.ts
@@ -155,10 +155,16 @@ export function waitResumeResultText(park: {
 	reason: string;
 	resumeAt: Date;
 	createdAt: Date;
+	wokeEarlyAt?: Date;
 }): string {
 	const waited = Math.round((park.resumeAt.getTime() - park.createdAt.getTime()) / 1000);
+	// An early wake is a user action, not a clock: say so, or the model reads a
+	// short wait as its own choice and mis-sizes the next one.
+	const early = park.wokeEarlyAt
+		? "The user asked you to check on this early, so the wait was cut short. "
+		: "";
 	return (
-		`Waited ${waited}s for: ${park.reason}. You are now resumed. ` +
+		`Waited ${waited}s for: ${park.reason}. ${early}You are now resumed. ` +
 		"Check the status of what you were waiting for once, then act on what you find — " +
 		"if it is still not ready, wait again rather than polling."
 	);

--- a/src/lib/types/ParkedCall.ts
+++ b/src/lib/types/ParkedCall.ts
@@ -56,6 +56,13 @@ export interface ParkedCall extends Timestamps {
 	 * short, which is what the model is told on the round it resumes into.
 	 */
 	wokeEarlyAt?: Date;
+	/**
+	 * The deadline the model actually asked for, kept when an early wake
+	 * overwrites `resumeAt`. Without it the resumed round cannot tell the model
+	 * how much of its wait was skipped, and a 12s gap out of a 300s wait reads
+	 * as "still not ready after the wait I asked for".
+	 */
+	plannedResumeAt?: Date;
 
 	/** Set when a sweeper claims the row, so two pods cannot resume the same turn. */
 	takenAt?: Date;

--- a/src/lib/types/ParkedCall.ts
+++ b/src/lib/types/ParkedCall.ts
@@ -50,6 +50,13 @@ export interface ParkedCall extends Timestamps {
 	userId?: User["_id"];
 	sessionId?: string;
 
+	/**
+	 * Set when the user asked not to wait out the rest of the timer. The wake
+	 * itself is `resumeAt` moved to now; this records that the wait was cut
+	 * short, which is what the model is told on the round it resumes into.
+	 */
+	wokeEarlyAt?: Date;
+
 	/** Set when a sweeper claims the row, so two pods cannot resume the same turn. */
 	takenAt?: Date;
 	resumedAt?: Date;

--- a/src/routes/conversation/[id]/wake/+server.ts
+++ b/src/routes/conversation/[id]/wake/+server.ts
@@ -1,0 +1,44 @@
+import type { RequestHandler } from "./$types";
+import { authCondition } from "$lib/server/auth";
+import { collections } from "$lib/server/database";
+import { sweepParkedCalls, wakeParkedCallEarly } from "$lib/server/generation/parkedSweeper";
+import { logger } from "$lib/server/logger";
+import { error, json } from "@sveltejs/kit";
+import { ObjectId } from "mongodb";
+import { z } from "zod";
+
+const bodySchema = z.object({ messageId: z.string().min(1) });
+
+/**
+ * "Check now": the user would rather not sit out the rest of a parked turn's
+ * timer. Separate from the generation stream for the same reason answering an
+ * elicitation is — by now no run is holding the turn at all, and the pod that
+ * parked it need not be this one.
+ */
+export const POST: RequestHandler = async ({ params, locals, request }) => {
+	if (!locals.user && !locals.sessionId) error(401, "Unauthorized");
+
+	if (!ObjectId.isValid(params.id)) error(404, "Conversation not found");
+	const conversationId = new ObjectId(params.id);
+
+	const conversation = await collections.conversations.findOne(
+		{ _id: conversationId, ...authCondition(locals) },
+		{ projection: { _id: 1 } }
+	);
+	if (!conversation) error(404, "Conversation not found");
+
+	const parsed = bodySchema.safeParse(await request.json().catch(() => null));
+	if (!parsed.success) error(400, "Invalid wake request");
+
+	const woken = await wakeParkedCallEarly(conversationId, parsed.data.messageId);
+	if (!woken) error(409, "That turn is not waiting on a timer");
+
+	// Not awaited: the sweep runs the resumed turn to completion — minutes of
+	// work, not a request's worth. The deadline move above is what makes the
+	// wake durable; this only spares the user the sweep interval.
+	void sweepParkedCalls().catch((err) =>
+		logger.error({ err }, "[parked] the sweep kicked by an early wake failed")
+	);
+
+	return json({ ok: true });
+};


### PR DESCRIPTION

<img width="1760" height="520" alt="check-now-pill" src="https://github.com/user-attachments/assets/54433e44-ebcf-468c-8ec8-d40e94344dad" />


When the ML Intern parks a turn on the `wait` tool, the countdown is not always worth sitting out — the user can see what it is waiting for and often knows the job is worth a look now. Today the only answer is to type a message asking it to check.

The wait pill grows a play control at its end: a connected segment sharing the pill's border, icon only, no label.

### How the wake works

- `POST /conversation/[id]/wake` with the parked message id moves the parked row's `resumeAt` to now, and nothing else. The row stays `waiting`, so the ordinary claim still decides which pod resumes it — an early wake racing a sweeper cannot produce two producers for one turn. The endpoint then kicks a sweep, purely so the user doesn't sit through the sweep interval (10s by default).
- `wokeEarlyAt` on the row is what the model reads on the round it wakes into: *"The user asked you to check on this early, so the wait was cut short."* Without it, a user-shortened wait looks like the model's own choice and it mis-sizes the next one.
- The banner switches to "checking now…" on acceptance and stays there — the resumed turn's own output replaces it when `running` arrives. A failed request puts the countdown back, since the timer is untouched and the turn still wakes on its own.
- No control on a read-only/shared view, or once the deadline is far enough past that a sweep already owns the turn.

### Testing

`wakeParkedCallEarly` (deadline moved, row still claimable, only the turn asked about), the resume tool result's early-check wording, and the pill itself (posts the wake, stops counting down, restores the countdown on failure, hidden when read-only or overdue). Full suite: 1076 passing.
