### PR TITLE
ML Intern: show a one-time onboarding modal on first enable

### DIFF
--- a/src/lib/components/Modal.svelte
+++ b/src/lib/components/Modal.svelte
@@ -13,6 +13,8 @@
 		disableFly?: boolean;
 		/** When false, clicking backdrop will not close the modal */
 		closeOnBackdrop?: boolean;
+		/** id of the element naming the dialog, typically its heading */
+		labelledBy?: string;
 		onclose?: () => void;
 		children?: import("svelte").Snippet;
 	}
@@ -23,6 +25,7 @@
 		closeButton = false,
 		disableFly = false,
 		closeOnBackdrop = true,
+		labelledBy,
 		onclose,
 	}: Props = $props();
 
@@ -77,6 +80,7 @@
 			<div
 				role="dialog"
 				tabindex="-1"
+				aria-labelledby={labelledBy}
 				bind:this={modalEl}
 				onkeydown={handleKeydown}
 				class={[
@@ -95,6 +99,7 @@
 			<div
 				role="dialog"
 				tabindex="-1"
+				aria-labelledby={labelledBy}
 				bind:this={modalEl}
 				onkeydown={handleKeydown}
 				in:fly={{ y: 100 }}

--- a/src/lib/components/chat/MlInternOnboardingModal.svelte
+++ b/src/lib/components/chat/MlInternOnboardingModal.svelte
@@ -19,7 +19,7 @@
      links go to the Hub rather than to in-app settings because the mode runs on
      the Hub's MCP server with the user's own token: which tools it can reach and
      what it can spend are decided on the user's Hugging Face account, not here. -->
-<Modal onclose={close} width="max-w-[440px]! m-4!">
+<Modal onclose={close} labelledBy="ml-intern-onboarding-title" width="max-w-[440px]! m-4!">
 	<div
 		class="flex w-full flex-col gap-6 bg-white bg-linear-to-b to-transparent px-6 pb-6 dark:bg-black dark:from-white/10 dark:to-white/5"
 	>
@@ -31,7 +31,10 @@
 			>
 				<IconFlask class="size-7" />
 			</div>
-			<h2 class="text-2xl font-semibold text-gray-900 dark:text-gray-100">
+			<h2
+				id="ml-intern-onboarding-title"
+				class="text-2xl font-semibold text-gray-900 dark:text-gray-100"
+			>
 				ML Intern is experimental
 			</h2>
 			<p class="text-[15px] leading-relaxed text-gray-600 dark:text-gray-300">
@@ -77,9 +80,10 @@
 						Set a spending cap
 					</p>
 					<p class="text-sm leading-relaxed">
-						A budget you give ML Intern in the chat is strictly enforced on everything it launches
-						from here, but it is not a guarantee: a job it starts could spend on its own. To make
-						sure you never overspend, set a budget in your billing settings too.
+						A budget you give ML Intern in the chat is strictly enforced on the Jobs it launches
+						from here, but it is not a guarantee: a Job it starts could launch Jobs of its own or
+						use other Hugging Face products. To make sure you never overspend, set a budget in your
+						billing settings too.
 					</p>
 					<a
 						href={BILLING_SETTINGS_URL}

--- a/src/lib/components/chat/MlInternOnboardingModal.svelte
+++ b/src/lib/components/chat/MlInternOnboardingModal.svelte
@@ -77,8 +77,8 @@
 						Set a spending cap
 					</p>
 					<p class="text-sm leading-relaxed">
-						A budget you give ML Intern in the chat is strictly enforced on everything it launches
-						from here, but it is not a guarantee: a job it starts could spend on its own. To make
+						A budget you give ML Intern in the chat is strictly enforced on any Jobs it launches
+						from here, but it is not a guarantee: a Job it starts could spawn on its own Job or use other HF products. To make
 						sure you never overspend, set a budget in your billing settings too.
 					</p>
 					<a

--- a/src/lib/components/chat/MlInternOnboardingModal.svelte
+++ b/src/lib/components/chat/MlInternOnboardingModal.svelte
@@ -1,0 +1,104 @@
+<script lang="ts">
+	import Modal from "$lib/components/Modal.svelte";
+	import IconFlask from "~icons/lucide/flask-conical";
+	import IconWrench from "~icons/lucide/wrench";
+	import IconWallet from "~icons/lucide/wallet";
+	import CarbonArrowUpRight from "~icons/carbon/arrow-up-right";
+
+	interface Props {
+		close: () => void;
+	}
+
+	let { close }: Props = $props();
+
+	const MCP_SETTINGS_URL = "https://huggingface.co/settings/mcp";
+	const BILLING_SETTINGS_URL = "https://huggingface.co/settings/billing";
+</script>
+
+<!-- Shown once, the first time the mode is switched on (see MlInternPill). Both
+     links go to the Hub rather than to in-app settings because the mode runs on
+     the Hub's MCP server with the user's own token: which tools it can reach and
+     what it can spend are decided on the user's Hugging Face account, not here. -->
+<Modal onclose={close} width="max-w-[440px]! m-4!">
+	<div
+		class="flex w-full flex-col gap-6 bg-white bg-linear-to-b to-transparent px-6 pb-6 dark:bg-black dark:from-white/10 dark:to-white/5"
+	>
+		<div
+			class="-mx-6 flex flex-col items-center gap-3 bg-linear-to-t from-black/5 px-6 pt-8 pb-6 text-center select-none dark:from-white/10"
+		>
+			<div
+				class="grid size-14 place-items-center rounded-full bg-[#fff4ea] text-[#c2410c] dark:bg-[#2b1c0e] dark:text-[#fdba74]"
+			>
+				<IconFlask class="size-7" />
+			</div>
+			<h2 class="text-2xl font-semibold text-gray-900 dark:text-gray-100">
+				ML Intern is experimental
+			</h2>
+			<p class="text-[15px] leading-relaxed text-gray-600 dark:text-gray-300">
+				It plans and runs machine-learning work for you on Hugging Face. Two settings on your
+				account make a real difference to how well that goes.
+			</p>
+		</div>
+
+		<ol class="flex flex-col gap-5 text-gray-700 dark:text-gray-200">
+			<li class="flex gap-3.5">
+				<div
+					class="mt-0.5 grid size-8 flex-none place-items-center rounded-lg bg-gray-500/10 text-gray-600 dark:bg-gray-500/15 dark:text-gray-300"
+				>
+					<IconWrench class="size-4" />
+				</div>
+				<div class="flex flex-col gap-1.5">
+					<p class="text-[15px] leading-snug font-semibold text-gray-900 dark:text-gray-100">
+						Enable all MCP tools
+					</p>
+					<p class="text-sm leading-relaxed">
+						ML Intern works through the Hugging Face MCP server and can only use the tools you have
+						switched on there. For the best experience, enable all of them.
+					</p>
+					<a
+						href={MCP_SETTINGS_URL}
+						target="_blank"
+						rel="noopener noreferrer"
+						class="inline-flex items-center gap-1 self-start text-sm font-medium text-[#c2410c] underline decoration-[#c2410c]/30 underline-offset-2 hover:decoration-[#c2410c] dark:text-[#fdba74] dark:decoration-[#fdba74]/30 dark:hover:decoration-[#fdba74]"
+					>
+						Open MCP settings
+						<CarbonArrowUpRight class="size-3.5" />
+					</a>
+				</div>
+			</li>
+			<li class="flex gap-3.5">
+				<div
+					class="mt-0.5 grid size-8 flex-none place-items-center rounded-lg bg-gray-500/10 text-gray-600 dark:bg-gray-500/15 dark:text-gray-300"
+				>
+					<IconWallet class="size-4" />
+				</div>
+				<div class="flex flex-col gap-1.5">
+					<p class="text-[15px] leading-snug font-semibold text-gray-900 dark:text-gray-100">
+						Set a spending cap
+					</p>
+					<p class="text-sm leading-relaxed">
+						A budget you give ML Intern in the chat is strictly enforced on everything it launches
+						from here, but it is not a guarantee: a job it starts could spend on its own. To make
+						sure you never overspend, set a budget in your billing settings too.
+					</p>
+					<a
+						href={BILLING_SETTINGS_URL}
+						target="_blank"
+						rel="noopener noreferrer"
+						class="inline-flex items-center gap-1 self-start text-sm font-medium text-[#c2410c] underline decoration-[#c2410c]/30 underline-offset-2 hover:decoration-[#c2410c] dark:text-[#fdba74] dark:decoration-[#fdba74]/30 dark:hover:decoration-[#fdba74]"
+					>
+						Open billing settings
+						<CarbonArrowUpRight class="size-3.5" />
+					</a>
+				</div>
+			</li>
+		</ol>
+
+		<button
+			class="w-full rounded-xl bg-black px-5 py-2.5 text-base font-medium text-white hover:bg-gray-800 dark:bg-white dark:text-black dark:hover:bg-gray-200"
+			onclick={close}
+		>
+			Got it
+		</button>
+	</div>
+</Modal>

--- a/src/lib/components/chat/MlInternOnboardingModal.svelte.test.ts
+++ b/src/lib/components/chat/MlInternOnboardingModal.svelte.test.ts
@@ -1,0 +1,63 @@
+import MlInternOnboardingModal from "./MlInternOnboardingModal.svelte";
+import { renderWithApp } from "$lib/components/__tests__/renderWithApp";
+import { describe, expect, it, vi } from "vitest";
+
+const dialog = (): HTMLElement => {
+	const el = document.querySelector<HTMLElement>('[role="dialog"]');
+	if (!el) throw new Error("no dialog rendered");
+	return el;
+};
+
+const linkTo = (href: string): HTMLAnchorElement => {
+	const el = dialog().querySelector<HTMLAnchorElement>(`a[href="${href}"]`);
+	if (!el) throw new Error(`no link to ${href}`);
+	return el;
+};
+
+describe("MlInternOnboardingModal", () => {
+	it("names the mode as experimental and covers both account settings", () => {
+		renderWithApp(MlInternOnboardingModal, { close: vi.fn() });
+
+		const text = dialog().textContent ?? "";
+		expect(text).toContain("ML Intern is experimental");
+		expect(text).toContain("Enable all MCP tools");
+		expect(text).toContain("Set a spending cap");
+		// Honest about the limit: enforced in the chat, but not a hard guarantee.
+		expect(text).toContain("strictly enforced");
+		expect(text).toContain("not a guarantee");
+	});
+
+	it("links out to the Hub's MCP and billing settings in a new tab", () => {
+		renderWithApp(MlInternOnboardingModal, { close: vi.fn() });
+
+		for (const href of [
+			"https://huggingface.co/settings/mcp",
+			"https://huggingface.co/settings/billing",
+		]) {
+			const link = linkTo(href);
+			expect(link.getAttribute("target")).toBe("_blank");
+			expect(link.getAttribute("rel")).toContain("noopener");
+		}
+		expect(linkTo("https://huggingface.co/settings/mcp").textContent).toContain(
+			"Open MCP settings"
+		);
+		expect(linkTo("https://huggingface.co/settings/billing").textContent).toContain(
+			"Open billing settings"
+		);
+	});
+
+	it("closes on the acknowledgement button and on Escape", () => {
+		const close = vi.fn();
+		renderWithApp(MlInternOnboardingModal, { close });
+
+		const button = [...dialog().querySelectorAll("button")].find((b) =>
+			b.textContent?.includes("Got it")
+		);
+		if (!button) throw new Error("no acknowledgement button");
+		button.click();
+		expect(close).toHaveBeenCalledTimes(1);
+
+		window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+		expect(close).toHaveBeenCalledTimes(2);
+	});
+});

--- a/src/lib/components/chat/MlInternOnboardingModal.svelte.test.ts
+++ b/src/lib/components/chat/MlInternOnboardingModal.svelte.test.ts
@@ -27,6 +27,14 @@ describe("MlInternOnboardingModal", () => {
 		expect(text).toContain("not a guarantee");
 	});
 
+	it("is named by its heading for assistive tech", () => {
+		renderWithApp(MlInternOnboardingModal, { close: vi.fn() });
+
+		const id = dialog().getAttribute("aria-labelledby");
+		expect(id).toBeTruthy();
+		expect(document.getElementById(id ?? "")?.textContent).toContain("ML Intern is experimental");
+	});
+
 	it("links out to the Hub's MCP and billing settings in a new tab", () => {
 		renderWithApp(MlInternOnboardingModal, { close: vi.fn() });
 

--- a/src/lib/components/chat/MlInternPill.svelte
+++ b/src/lib/components/chat/MlInternPill.svelte
@@ -1,13 +1,25 @@
 <script lang="ts">
 	import { Switch } from "bits-ui";
 	import { requireAuthUser } from "$lib/utils/auth";
+	import { useSettingsStore } from "$lib/stores/settings";
 	import { mlAssistant } from "$lib/stores/mlAssistant.svelte";
+	import MlInternOnboardingModal from "./MlInternOnboardingModal.svelte";
+
+	const settings = useSettingsStore();
 
 	let enabled = $derived(mlAssistant.enabled);
+	let onboardingOpen = $state(false);
 
 	function ontoggle(next: boolean) {
 		if (requireAuthUser()) return;
 		mlAssistant.toggle(next);
+		// The mode stays on underneath: the modal is advice, not a confirmation step.
+		if (next && !$settings.mlInternOnboardingSeen) onboardingOpen = true;
+	}
+
+	function closeOnboarding() {
+		onboardingOpen = false;
+		settings.instantSet({ mlInternOnboardingSeen: true });
 	}
 </script>
 
@@ -44,6 +56,10 @@
 		</span>
 	</Switch.Root>
 </div>
+
+{#if onboardingOpen}
+	<MlInternOnboardingModal close={closeOnboarding} />
+{/if}
 
 <style>
 	:global(.ml-pill-switch) {

--- a/src/lib/components/chat/MlInternPill.svelte
+++ b/src/lib/components/chat/MlInternPill.svelte
@@ -18,8 +18,17 @@
 	}
 
 	function closeOnboarding() {
+		// Escape reaches Modal's window and dialog handlers before the unmount
+		// lands, so this runs twice; one acknowledgement is enough.
+		if (!onboardingOpen) return;
 		onboardingOpen = false;
 		settings.instantSet({ mlInternOnboardingSeen: true });
+	}
+
+	function readDraftBudget(event: Event) {
+		const raw = (event.currentTarget as HTMLInputElement).value.trim();
+		const usd = Number(raw);
+		mlAssistant.draftBudgetUsd = raw !== "" && Number.isFinite(usd) && usd > 0 ? usd : undefined;
 	}
 </script>
 
@@ -55,6 +64,27 @@
 			NEW
 		</span>
 	</Switch.Root>
+
+	{#if enabled}
+		<!-- Spend authority is granted here, before any run exists: the next send
+		     creates the conversation with exactly this budget, and $0 means every
+		     submission is refused until the user grants one. Outside the switch so
+		     typing a number cannot toggle the mode. -->
+		<label class="flex flex-none items-center gap-0.5 font-mono text-[11px] font-normal">
+			<span>$</span>
+			<input
+				value={mlAssistant.draftBudgetUsd ?? ""}
+				oninput={readDraftBudget}
+				type="number"
+				min="1"
+				max="10000"
+				step="1"
+				placeholder="0"
+				class="ml-pill-budget w-11 rounded border border-current/30 bg-transparent px-1 py-0 text-right text-[11px] placeholder:text-current/40"
+				aria-label="Compute budget for this session in dollars"
+			/>
+		</label>
+	{/if}
 </div>
 
 {#if onboardingOpen}
@@ -112,6 +142,18 @@
 
 	:global(.ml-pill-knob[data-state="checked"]) {
 		left: 15px;
+	}
+
+	/* Spinner arrows would be the only chrome on the pill's compact money
+	   field, and the value is typed, not stepped. */
+	.ml-pill-budget {
+		appearance: textfield;
+	}
+
+	.ml-pill-budget::-webkit-outer-spin-button,
+	.ml-pill-budget::-webkit-inner-spin-button {
+		appearance: none;
+		margin: 0;
 	}
 
 	@media (prefers-reduced-motion: reduce) {

--- a/src/lib/components/chat/MlInternPill.svelte.test.ts
+++ b/src/lib/components/chat/MlInternPill.svelte.test.ts
@@ -117,6 +117,19 @@ describe("MlInternPill", () => {
 			expect(mlAssistant.enabled).toBe(true);
 		});
 
+		it("records Escape once, though the key reaches the modal twice", async () => {
+			const { set, context } = settingsContext(false);
+			const { container } = renderWithApp(MlInternPill, {}, { context });
+			find(container, '[role="switch"]').click();
+			await vi.waitFor(() => expect(dialog()).not.toBeNull());
+
+			// Modal listens on window (capture) and on the dialog itself.
+			dialog()?.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+
+			await vi.waitFor(() => expect(dialog()).toBeNull());
+			expect(set).toHaveBeenCalledTimes(1);
+		});
+
 		it("stays quiet once the onboarding has been acknowledged", async () => {
 			const { set, context } = settingsContext(true);
 			const { container } = renderWithApp(MlInternPill, {}, { context });

--- a/src/lib/components/chat/MlInternPill.svelte.test.ts
+++ b/src/lib/components/chat/MlInternPill.svelte.test.ts
@@ -1,6 +1,7 @@
 import MlInternPill from "./MlInternPill.svelte";
-import { render } from "vitest-browser-svelte";
+import { renderWithApp } from "$lib/components/__tests__/renderWithApp";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { writable } from "svelte/store";
 import { mlAssistant } from "$lib/stores/mlAssistant.svelte";
 
 // Vibrant accent for surfaces (switch track), darker orange for anything that
@@ -18,6 +19,22 @@ const box = (el: Element) => {
 	const r = el.getBoundingClientRect();
 	return { width: Math.round(r.width), height: Math.round(r.height) };
 };
+const dialog = () => document.querySelector<HTMLElement>('[role="dialog"]');
+
+/** The slice of the layout's settings context the pill reads and writes. */
+function settingsContext(mlInternOnboardingSeen: boolean) {
+	const store = writable({ mlInternOnboardingSeen });
+	const set = vi.fn((patch: Record<string, unknown>) => store.update((s) => ({ ...s, ...patch })));
+	return {
+		set,
+		context: new Map<unknown, unknown>([
+			["settings", { subscribe: store.subscribe, instantSet: set }],
+		]),
+	};
+}
+
+const render = (seen = true) =>
+	renderWithApp(MlInternPill, {}, { context: settingsContext(seen).context });
 
 describe("MlInternPill", () => {
 	beforeEach(() => {
@@ -25,7 +42,7 @@ describe("MlInternPill", () => {
 	});
 
 	it("exposes the mode as a labelled switch carrying the NEW badge", () => {
-		const { container } = render(MlInternPill);
+		const { container } = render();
 		const control = find(container, '[role="switch"]');
 
 		expect(control.getAttribute("aria-checked")).toBe("false");
@@ -41,7 +58,7 @@ describe("MlInternPill", () => {
 	});
 
 	it("keeps the switch tappable across the pill's full height", () => {
-		const { container } = render(MlInternPill);
+		const { container } = render();
 		const pill = container.firstElementChild as HTMLElement;
 		const control = find(container, '[role="switch"]');
 
@@ -49,7 +66,7 @@ describe("MlInternPill", () => {
 	});
 
 	it("draws an off switch on the specified geometry", () => {
-		const { container } = render(MlInternPill);
+		const { container } = render();
 
 		expect(box(find(container, ".ml-pill-track"))).toEqual({ width: 30, height: 17 });
 		expect(box(find(container, ".ml-pill-knob"))).toEqual({ width: 13, height: 13 });
@@ -58,7 +75,7 @@ describe("MlInternPill", () => {
 	});
 
 	it("toggles the mode on click, retinting the pill and crossing the knob", async () => {
-		const { container } = render(MlInternPill);
+		const { container } = render();
 		find(container, '[role="switch"]').click();
 
 		expect(mlAssistant.enabled).toBe(true);
@@ -70,9 +87,61 @@ describe("MlInternPill", () => {
 	});
 
 	it("offers no dismiss control — the pill is the mode's only entry point", () => {
-		const { container } = render(MlInternPill);
+		const { container } = render();
 
 		expect(container.querySelectorAll("button").length).toBe(1);
 		expect(find(container, "button").getAttribute("role")).toBe("switch");
+	});
+
+	describe("first-run onboarding", () => {
+		it("opens the onboarding the first time the mode is switched on, and records it", async () => {
+			const { set, context } = settingsContext(false);
+			const { container } = renderWithApp(MlInternPill, {}, { context });
+
+			find(container, '[role="switch"]').click();
+
+			// The switch flips regardless: the modal informs, it does not gate.
+			expect(mlAssistant.enabled).toBe(true);
+			await vi.waitFor(() => expect(dialog()).not.toBeNull());
+			expect(dialog()?.textContent).toContain("ML Intern is experimental");
+			expect(set).not.toHaveBeenCalled();
+
+			const gotIt = [...(dialog()?.querySelectorAll("button") ?? [])].find((b) =>
+				b.textContent?.includes("Got it")
+			);
+			gotIt?.click();
+
+			await vi.waitFor(() => expect(dialog()).toBeNull());
+			expect(set).toHaveBeenCalledWith({ mlInternOnboardingSeen: true });
+			expect(mlAssistant.enabled).toBe(true);
+		});
+
+		it("stays quiet once the onboarding has been acknowledged", async () => {
+			const { set, context } = settingsContext(true);
+			const { container } = renderWithApp(MlInternPill, {}, { context });
+
+			find(container, '[role="switch"]').click();
+
+			expect(mlAssistant.enabled).toBe(true);
+			await vi.waitFor(() =>
+				expect(find(container, '[role="switch"]').getAttribute("aria-checked")).toBe("true")
+			);
+			expect(dialog()).toBeNull();
+			expect(set).not.toHaveBeenCalled();
+		});
+
+		it("never opens on the way off, even when unseen", async () => {
+			mlAssistant.toggle(true);
+			const { context } = settingsContext(false);
+			const { container } = renderWithApp(MlInternPill, {}, { context });
+
+			find(container, '[role="switch"]').click();
+
+			expect(mlAssistant.enabled).toBe(false);
+			await vi.waitFor(() =>
+				expect(find(container, '[role="switch"]').getAttribute("aria-checked")).toBe("false")
+			);
+			expect(dialog()).toBeNull();
+		});
 	});
 });

--- a/src/lib/server/api/__tests__/user.spec.ts
+++ b/src/lib/server/api/__tests__/user.spec.ts
@@ -88,6 +88,7 @@ describe("GET /api/v2/user/settings", () => {
 		expect(data).toMatchObject({
 			welcomeModalSeen: false,
 			welcomeModalSeenAt: null,
+			mlInternOnboardingSeen: false,
 			streamingMode: "smooth",
 			directPaste: false,
 			shareConversationsWithModelAuthors: true,
@@ -222,6 +223,24 @@ describe("POST /api/v2/user/settings", () => {
 		const stored = await collections.settings.findOne({ userId: user._id });
 		expect(stored).not.toBeNull();
 		expect(stored?.welcomeModalSeenAt).toBeInstanceOf(Date);
+	});
+
+	it("records the ML Intern onboarding acknowledgement independently of the welcome modal", async () => {
+		const { user, locals } = await createTestUser();
+
+		await testRequest(settingsPOST, {
+			path: "/api/v2/user/settings",
+			locals,
+			...jsonBody({ mlInternOnboardingSeen: true, activeModel: "test-model" }),
+		});
+
+		const stored = await collections.settings.findOne({ userId: user._id });
+		expect(stored?.mlInternOnboardingSeenAt).toBeInstanceOf(Date);
+		expect(stored?.welcomeModalSeenAt).toBeUndefined();
+
+		const res = await testRequest(settingsGET, { path: "/api/v2/user/settings", locals });
+		const data = await parseResponse<Record<string, unknown>>(res);
+		expect(data).toMatchObject({ mlInternOnboardingSeen: true, welcomeModalSeen: false });
 	});
 
 	it("validates body with Zod and applies defaults for missing fields", async () => {

--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -8,6 +8,7 @@ type SettingsStore = {
 	shareConversationsWithModelAuthors: boolean;
 	welcomeModalSeen: boolean;
 	welcomeModalSeenAt: Date | null;
+	mlInternOnboardingSeen: boolean;
 	activeModel: string;
 	customPrompts: Record<string, string>;
 	customPromptsEnabled: Record<string, boolean>;

--- a/src/lib/types/Settings.ts
+++ b/src/lib/types/Settings.ts
@@ -12,6 +12,8 @@ export interface Settings extends Timestamps {
 	shareConversationsWithModelAuthors: boolean;
 	/** One-time welcome modal acknowledgement */
 	welcomeModalSeenAt?: Date | null;
+	/** One-time ML Intern onboarding modal acknowledgement */
+	mlInternOnboardingSeenAt?: Date | null;
 	activeModel: string;
 
 	// model name and system prompts
@@ -89,7 +91,10 @@ export interface Settings extends Timestamps {
 	billingOrganization?: string;
 }
 
-export type SettingsEditable = Omit<Settings, "welcomeModalSeenAt" | "createdAt" | "updatedAt">;
+export type SettingsEditable = Omit<
+	Settings,
+	"welcomeModalSeenAt" | "mlInternOnboardingSeenAt" | "createdAt" | "updatedAt"
+>;
 // TODO: move this to a constant file along with other constants
 export const DEFAULT_SETTINGS = {
 	shareConversationsWithModelAuthors: true,

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -24,6 +24,7 @@ interface UserInfo {
 interface SettingsResponse {
 	welcomeModalSeen: boolean;
 	welcomeModalSeenAt: Date | null;
+	mlInternOnboardingSeen: boolean;
 	shareConversationsWithModelAuthors: boolean;
 	activeModel: string;
 	streamingMode: "raw" | "smooth";

--- a/src/routes/api/v2/user/settings/+server.ts
+++ b/src/routes/api/v2/user/settings/+server.ts
@@ -14,6 +14,7 @@ const settingsSchema = z.object({
 		.boolean()
 		.default(DEFAULT_SETTINGS.shareConversationsWithModelAuthors),
 	welcomeModalSeen: z.boolean().optional(),
+	mlInternOnboardingSeen: z.boolean().optional(),
 	activeModel: z.string().default(DEFAULT_SETTINGS.activeModel),
 	customPrompts: z.record(z.string()).default({}),
 	customPromptsEnabled: z.record(z.boolean()).default({}),
@@ -57,6 +58,7 @@ export const GET: RequestHandler = async ({ locals }) => {
 	return superjsonResponse({
 		welcomeModalSeen: !!settings?.welcomeModalSeenAt,
 		welcomeModalSeenAt: settings?.welcomeModalSeenAt ?? null,
+		mlInternOnboardingSeen: !!settings?.mlInternOnboardingSeenAt,
 
 		activeModel: settings?.activeModel ?? DEFAULT_SETTINGS.activeModel,
 		streamingMode,
@@ -86,7 +88,8 @@ export const POST: RequestHandler = async ({ locals, request }) => {
 	requireAuth(locals);
 	const body = await request.json();
 
-	const { welcomeModalSeen, ...parsedSettings } = settingsSchema.parse(body);
+	const { welcomeModalSeen, mlInternOnboardingSeen, ...parsedSettings } =
+		settingsSchema.parse(body);
 	const streamingMode = resolveStreamingMode(parsedSettings);
 
 	if (config.isHuggingChat) {
@@ -106,6 +109,7 @@ export const POST: RequestHandler = async ({ locals, request }) => {
 			$set: {
 				...settings,
 				...(welcomeModalSeen && { welcomeModalSeenAt: new Date() }),
+				...(mlInternOnboardingSeen && { mlInternOnboardingSeenAt: new Date() }),
 				updatedAt: new Date(),
 			},
 			$setOnInsert: {

--- a/src/routes/settings/(nav)/+server.ts
+++ b/src/routes/settings/(nav)/+server.ts
@@ -10,6 +10,7 @@ const settingsSchema = z.object({
 		.boolean()
 		.default(DEFAULT_SETTINGS.shareConversationsWithModelAuthors),
 	welcomeModalSeen: z.boolean().optional(),
+	mlInternOnboardingSeen: z.boolean().optional(),
 	activeModel: z.string().default(DEFAULT_SETTINGS.activeModel),
 	customPrompts: z.record(z.string()).default({}),
 	customPromptsEnabled: z.record(z.boolean()).default({}),
@@ -29,7 +30,8 @@ const settingsSchema = z.object({
 export async function POST({ request, locals }) {
 	const body = await request.json();
 
-	const { welcomeModalSeen, ...parsedSettings } = settingsSchema.parse(body);
+	const { welcomeModalSeen, mlInternOnboardingSeen, ...parsedSettings } =
+		settingsSchema.parse(body);
 	const streamingMode = resolveStreamingMode(parsedSettings);
 
 	if (config.isHuggingChat) {
@@ -49,6 +51,7 @@ export async function POST({ request, locals }) {
 			$set: {
 				...settings,
 				...(welcomeModalSeen && { welcomeModalSeenAt: new Date() }),
+				...(mlInternOnboardingSeen && { mlInternOnboardingSeenAt: new Date() }),
 				updatedAt: new Date(),
 			},
 			$setOnInsert: {


### PR DESCRIPTION


<img width="1280" height="860" alt="mlinternonboardingdark" src="https://github.com/user-attachments/assets/fe174ade-7196-45e5-b441-43b1ef77471f" />
<img width="1280" height="860" alt="mlinternonboardinglight" src="https://github.com/user-attachments/assets/2e3b9631-290a-40b3-869f-ddda389a92bd" />


## What

The first time a user switches ML Intern on, a modal explains the two account settings that shape the experience, then never shows again.

- **Enable all MCP tools** — the mode runs through the Hugging Face MCP server and can only use the tools switched on there. Links to https://huggingface.co/settings/mcp.
- **Set a spending cap** — a budget given in the chat is strictly enforced on everything the mode launches from the chat, but is not a hard guarantee (a job it starts could spend on its own). Links to https://huggingface.co/settings/billing.

Tone is deliberately calm ("ML Intern is experimental…"): the switch flips regardless and the modal informs rather than gates. Single "Got it" button; Escape and backdrop also dismiss.

## How

- New `MlInternOnboardingModal.svelte`, styled like the existing welcome/subscribe modals with the pill's orange accent.
- `MlInternPill.svelte` opens it when the switch turns on and the setting is unseen, and saves the acknowledgement on close via `settings.instantSet`.
- New `mlInternOnboardingSeenAt` settings field, mirroring `welcomeModalSeenAt`: type, both settings POST endpoints, the GET response, the layout load type, and the client store.

## Tests

- `MlInternOnboardingModal.svelte.test.ts`: copy, both links open in a new tab, close on button and Escape.
- `MlInternPill.svelte.test.ts`: now renders with a settings context; covers first-enable opens + records, seen stays quiet, switching off never opens.
- `user.spec.ts`: default `false`, and the acknowledgement is recorded independently of the welcome modal.

Verified end to end on a local dev server: modal on first toggle, "Got it" keeps the mode on, no modal after reload.