### PR TITLE
ML Intern pill: focus ring, tinted badge, spacing

### DIFF
--- a/src/lib/components/FeatureAnnouncementToast.svelte
+++ b/src/lib/components/FeatureAnnouncementToast.svelte
@@ -31,7 +31,7 @@
 		class="rounded-2xl border border-gray-200/80 bg-white/85 p-4 shadow-md shadow-black/5 backdrop-blur-md dark:border-gray-700/60 dark:bg-gray-800/85 dark:shadow-black/20"
 	>
 		<div
-			class="flex items-center gap-1.5 text-xs font-semibold tracking-wider text-blue-600 uppercase dark:text-blue-400"
+			class="flex items-center gap-1.5 text-xs font-semibold text-blue-600 uppercase dark:text-blue-400"
 		>
 			<IconSparkles class="size-3.5" />
 			New

--- a/src/lib/components/chat/ChatInput.svelte
+++ b/src/lib/components/chat/ChatInput.svelte
@@ -415,7 +415,7 @@
 	{#if !showNoTools || showMlPill}
 		<div
 			class={[
-				"-ml-0.5 scrollbar-custom flex max-w-[calc(100%-40px)] flex-wrap items-center justify-start gap-2.5 px-3 pt-1.5 pb-2.5 text-gray-500 max-md:flex-nowrap max-md:overflow-x-auto sm:gap-2 dark:text-gray-400",
+				"-ml-0.5 scrollbar-custom flex max-w-[calc(100%-40px)] flex-wrap items-center justify-start gap-1.5 px-3 pt-1.5 pb-2.5 text-gray-500 max-md:flex-nowrap max-md:overflow-x-auto dark:text-gray-400",
 			]}
 		>
 			{#if showFileUpload}

--- a/src/lib/components/chat/MlInternPill.svelte
+++ b/src/lib/components/chat/MlInternPill.svelte
@@ -39,7 +39,9 @@
      this is the mode's only entry point, and nothing could bring it back. -->
 <div
 	class={[
-		"inline-flex h-8 flex-none items-center gap-1.5 rounded-full px-2.5 text-xs font-semibold transition-colors sm:h-7",
+		// Horizontal padding matches the gap above/below the 17px track (and the
+		// ~16px badge): 7.5px at h-8, 5.5px at h-7. px-2.5 left the ends looking loose.
+		"inline-flex h-8 flex-none items-center gap-1.5 rounded-full px-2 text-xs font-semibold transition-colors sm:h-7 sm:px-1.5",
 		// Keyboard focus lands on the inner switch button; ring the whole pill so
 		// the indicator follows its rounded shape instead of the button's box.
 		"has-focus-visible:outline-2 has-focus-visible:outline-offset-2 has-focus-visible:outline-blue-500/60 dark:has-focus-visible:outline-blue-400/60",
@@ -50,7 +52,7 @@
 >
 	<!-- h-full so the tap target is the pill's full height, not the 17px track. -->
 	<Switch.Root
-		class="ml-pill-switch flex h-full cursor-pointer items-center gap-1.5 whitespace-nowrap select-none"
+		class="ml-pill-switch flex h-full cursor-pointer items-center gap-1.25 whitespace-nowrap select-none"
 		checked={enabled}
 		onCheckedChange={ontoggle}
 		aria-label="ML Intern mode"

--- a/src/lib/components/chat/MlInternPill.svelte
+++ b/src/lib/components/chat/MlInternPill.svelte
@@ -63,7 +63,7 @@
 		ML Intern
 		<!-- Tinted accent with orange text, like the MCP pill's inner button. -->
 		<span
-			class="rounded-md bg-[#ea580c]/20 px-[5px] py-[3px] text-[10px] leading-none font-bold tracking-wide text-[#c2410c] dark:bg-[#ea580c]/25 dark:text-[#fdba74]"
+			class="rounded-md bg-[#ea580c]/20 px-[5px] py-[3px] text-[10px] leading-none font-bold text-[#c2410c] dark:bg-[#ea580c]/25 dark:text-[#fdba74]"
 		>
 			NEW
 		</span>

--- a/src/lib/components/chat/MlInternPill.svelte
+++ b/src/lib/components/chat/MlInternPill.svelte
@@ -59,10 +59,9 @@
 			<Switch.Thumb class="ml-pill-knob" />
 		</span>
 		ML Intern
-		<!-- The darker text-orange, not the surface accent: white 10px text on
-		     #ea580c is 3.56:1, on #c2410c it clears the 4.5:1 floor. -->
+		<!-- Tinted accent with orange text, like the MCP pill's inner button. -->
 		<span
-			class="rounded-md bg-[#c2410c] px-[5px] py-[3px] text-[10px] leading-none font-bold tracking-wide text-white"
+			class="rounded-md bg-[#ea580c]/20 px-[5px] py-[3px] text-[10px] leading-none font-bold tracking-wide text-[#c2410c] dark:bg-[#ea580c]/25 dark:text-[#fdba74]"
 		>
 			NEW
 		</span>

--- a/src/lib/components/chat/MlInternPill.svelte
+++ b/src/lib/components/chat/MlInternPill.svelte
@@ -40,6 +40,9 @@
 <div
 	class={[
 		"inline-flex h-8 flex-none items-center gap-1.5 rounded-full px-2.5 text-xs font-semibold transition-colors sm:h-7",
+		// Keyboard focus lands on the inner switch button; ring the whole pill so
+		// the indicator follows its rounded shape instead of the button's box.
+		"has-focus-visible:outline-2 has-focus-visible:outline-offset-2 has-focus-visible:outline-blue-500/60 dark:has-focus-visible:outline-blue-400/60",
 		enabled
 			? "bg-[#fff4ea] text-[#c2410c] dark:bg-[#2b1c0e] dark:text-[#fdba74]"
 			: "bg-gray-500/10 text-gray-500 dark:bg-gray-500/15 dark:text-gray-400",
@@ -92,9 +95,12 @@
 {/if}
 
 <style>
+	/* The pill draws the focus ring (see has-focus-visible: below), so the
+	   button's own rectangular UA outline would only double it up. */
 	:global(.ml-pill-switch) {
 		padding: 0;
 		border: 0;
+		outline: 0;
 		background: transparent;
 		color: inherit;
 	}
@@ -121,11 +127,6 @@
 
 	:global(.dark) .ml-pill-track.is-on {
 		background: #3b5ce0;
-	}
-
-	:global(.ml-pill-switch:focus-visible) .ml-pill-track {
-		outline: 2px solid #ea580c;
-		outline-offset: 2px;
 	}
 
 	:global(.ml-pill-knob) {

--- a/src/lib/components/chat/MlInternPill.svelte.test.ts
+++ b/src/lib/components/chat/MlInternPill.svelte.test.ts
@@ -5,8 +5,8 @@ import { flushSync } from "svelte";
 import { writable } from "svelte/store";
 import { mlAssistant } from "$lib/stores/mlAssistant.svelte";
 
-// Vibrant accent for surfaces (switch track), darker orange for anything that
-// has to carry legible white text (NEW badge) — same split as the strip.
+// Vibrant accent for surfaces (switch track, the NEW badge's tint), darker
+// orange for text on light ground (the badge label) — same split as the strip.
 const ACCENT = "rgb(234, 88, 12)";
 const ACCENT_TEXT = "rgb(194, 65, 12)";
 
@@ -54,8 +54,10 @@ describe("MlInternPill", () => {
 		const badge = [...control.querySelectorAll("span")].find((s) =>
 			s.textContent?.includes("NEW")
 		) as HTMLElement;
-		expect(style(badge).backgroundColor).toBe(ACCENT_TEXT);
-		expect(style(badge).color).toBe("rgb(255, 255, 255)");
+		// A 20% tint of the accent: Tailwind emits color-mix(), which Chromium
+		// resolves to an oklab() colour but keeps the alpha channel verbatim.
+		expect(style(badge).backgroundColor).toMatch(/\/ 0\.2\)$/);
+		expect(style(badge).color).toBe(ACCENT_TEXT);
 	});
 
 	it("keeps the switch tappable across the pill's full height", () => {

--- a/src/lib/utils/deployBadge.ts
+++ b/src/lib/utils/deployBadge.ts
@@ -45,7 +45,6 @@ a {
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08), 0 6px 16px rgba(0, 0, 0, 0.06);
   color: #111827;
   font: 500 11px/1 ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
-  letter-spacing: 0.01em;
   text-decoration: none;
   white-space: nowrap;
   opacity: 0.72;

--- a/src/routes/settings/(nav)/+layout.svelte
+++ b/src/routes/settings/(nav)/+layout.svelte
@@ -145,7 +145,7 @@
 		>
 			<!-- Section Headers -->
 			<h3
-				class="px-3 pt-2 pb-1 text-xs font-semibold tracking-wide text-gray-600 md:text-left dark:text-gray-400"
+				class="px-3 pt-2 pb-1 text-xs font-semibold text-gray-600 md:text-left dark:text-gray-400"
 			>
 				Models
 			</h3>


### PR DESCRIPTION
Visual polish on the ML Intern composer pill, following up on #2547.

- **One focus ring, on the pill.** Keyboard focus used to draw two rings: the browser's rectangular outline on the switch button, plus a custom orange ring on the track. Both are gone. The pill itself now draws a single rounded ring via `has-focus-visible:`, in the same blue the app uses for focus elsewhere.
- **Tinted NEW badge.** A 20% accent tint with the pill's own orange text, the same treatment as the MCP pill's inner button, instead of the solid dark-orange block with white text. The label's contrast on the tint is about 3.5:1 (10px bold), a deliberate trade for a lighter badge.
- **Spacing.** The pill's end padding now matches the gap above and below the track (6px at the desktop height, 8px on mobile), the track-to-label gap goes from 6px to 5px, and the MCP-to-ML Intern gap now equals the +-to-MCP gap (6px).
- **No letter-spacing tweaks anywhere.** Every `tracking-*` utility is removed (the NEW badge, the feature announcement toast label, the settings nav headings), along with the deploy badge's `letter-spacing` rule.

The pill test's badge assertions are updated for the tint. The vitest browser workspace would not start on my machine (a SvelteKit dev-server error before any test is collected, on untouched test files too), so CI is the first run of the updated test.
