### PR TITLE
ML Intern pill: drop the pre-task budget input

### DIFF
--- a/src/lib/components/chat/MlInternPill.svelte
+++ b/src/lib/components/chat/MlInternPill.svelte
@@ -24,12 +24,6 @@
 		onboardingOpen = false;
 		settings.instantSet({ mlInternOnboardingSeen: true });
 	}
-
-	function readDraftBudget(event: Event) {
-		const raw = (event.currentTarget as HTMLInputElement).value.trim();
-		const usd = Number(raw);
-		mlAssistant.draftBudgetUsd = raw !== "" && Number.isFinite(usd) && usd > 0 ? usd : undefined;
-	}
 </script>
 
 <!-- The mode's pre-task switch, sitting beside the MCP pill. Only offered while
@@ -68,27 +62,6 @@
 			NEW
 		</span>
 	</Switch.Root>
-
-	{#if enabled}
-		<!-- Spend authority is granted here, before any run exists: the next send
-		     creates the conversation with exactly this budget, and $0 means every
-		     submission is refused until the user grants one. Outside the switch so
-		     typing a number cannot toggle the mode. -->
-		<label class="flex flex-none items-center gap-0.5 font-mono text-[11px] font-normal">
-			<span>$</span>
-			<input
-				value={mlAssistant.draftBudgetUsd ?? ""}
-				oninput={readDraftBudget}
-				type="number"
-				min="1"
-				max="10000"
-				step="1"
-				placeholder="0"
-				class="ml-pill-budget w-11 rounded border border-current/30 bg-transparent px-1 py-0 text-right text-[11px] placeholder:text-current/40"
-				aria-label="Compute budget for this session in dollars"
-			/>
-		</label>
-	{/if}
 </div>
 
 {#if onboardingOpen}
@@ -144,18 +117,6 @@
 
 	:global(.ml-pill-knob[data-state="checked"]) {
 		left: 15px;
-	}
-
-	/* Spinner arrows would be the only chrome on the pill's compact money
-	   field, and the value is typed, not stepped. */
-	.ml-pill-budget {
-		appearance: textfield;
-	}
-
-	.ml-pill-budget::-webkit-outer-spin-button,
-	.ml-pill-budget::-webkit-inner-spin-button {
-		appearance: none;
-		margin: 0;
 	}
 
 	@media (prefers-reduced-motion: reduce) {

--- a/src/lib/components/chat/MlInternPill.svelte.test.ts
+++ b/src/lib/components/chat/MlInternPill.svelte.test.ts
@@ -1,7 +1,6 @@
 import MlInternPill from "./MlInternPill.svelte";
 import { renderWithApp } from "$lib/components/__tests__/renderWithApp";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { flushSync } from "svelte";
 import { writable } from "svelte/store";
 import { mlAssistant } from "$lib/stores/mlAssistant.svelte";
 
@@ -159,46 +158,5 @@ describe("MlInternPill", () => {
 			);
 			expect(dialog()).toBeNull();
 		});
-	});
-});
-
-describe("MlInternPill budget draft", () => {
-	beforeEach(() => {
-		mlAssistant.reset();
-	});
-
-	it("offers the budget field as soon as the mode is on, and only then", () => {
-		const { container } = render();
-		expect(container.querySelector("input[aria-label^='Compute budget']")).toBeNull();
-
-		mlAssistant.toggle(true);
-		flushSync();
-		const input = find(container, "input[aria-label^='Compute budget']") as HTMLInputElement;
-		expect(input.placeholder).toBe("0");
-		// No spinner arrows: the value is typed, not stepped.
-		expect(style(input).appearance).toBe("textfield");
-	});
-
-	it("writes the typed grant to the store, and clears it on invalid input", () => {
-		mlAssistant.toggle(true);
-		const { container } = render();
-		const input = find(container, "input[aria-label^='Compute budget']") as HTMLInputElement;
-
-		input.value = "25";
-		input.dispatchEvent(new Event("input", { bubbles: true }));
-		expect(mlAssistant.draftBudgetUsd).toBe(25);
-
-		input.value = "-3";
-		input.dispatchEvent(new Event("input", { bubbles: true }));
-		expect(mlAssistant.draftBudgetUsd).toBeUndefined();
-	});
-
-	it("typing in the field does not toggle the mode off", () => {
-		mlAssistant.toggle(true);
-		const { container } = render();
-		const input = find(container, "input[aria-label^='Compute budget']") as HTMLInputElement;
-		input.click();
-		input.dispatchEvent(new Event("input", { bubbles: true }));
-		expect(mlAssistant.enabled).toBe(true);
 	});
 });

--- a/src/lib/stores/mlAssistant.svelte.ts
+++ b/src/lib/stores/mlAssistant.svelte.ts
@@ -18,12 +18,6 @@ class MlAssistantStore {
 	steps = $state<MlPlanStep[]>([]);
 	/** Compute budget ledger, when the conversation carries one. */
 	budget = $state<MlBudgetSnapshot | undefined>(undefined);
-	/**
-	 * Budget the user typed into the strip before the conversation exists. Sent
-	 * with the create request; a conversation created without one starts at $0
-	 * and every submission is refused until the user grants a budget.
-	 */
-	draftBudgetUsd = $state<number | undefined>(undefined);
 
 	/** Conversation the state above belongs to, so a different one starts clean. */
 	#conversationKey: string | undefined;
@@ -97,7 +91,6 @@ class MlAssistantStore {
 		this.taskStarted = false;
 		this.steps = [];
 		this.budget = undefined;
-		this.draftBudgetUsd = undefined;
 	}
 
 	/**

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -61,11 +61,6 @@
 					// The composer latches the mode before handing the message over, so
 					// the conversation this creates is marked with it from the start.
 					mlAssistant: mlAssistant.taskStarted,
-					// The budget granted in the strip travels with the create: absent
-					// means $0, and the gate refuses every submission until one is set.
-					...(mlAssistant.taskStarted && mlAssistant.draftBudgetUsd !== undefined
-						? { mlBudgetUsd: mlAssistant.draftBudgetUsd }
-						: {}),
 				}),
 			});
 

--- a/src/routes/models/[...model]/+page.svelte
+++ b/src/routes/models/[...model]/+page.svelte
@@ -52,11 +52,6 @@
 					// The composer latches the mode before handing the message over, so
 					// the conversation this creates is marked with it from the start.
 					mlAssistant: mlAssistant.taskStarted,
-					// The budget granted in the strip travels with the create: absent
-					// means $0, and the gate refuses every submission until one is set.
-					...(mlAssistant.taskStarted && mlAssistant.draftBudgetUsd !== undefined
-						? { mlBudgetUsd: mlAssistant.draftBudgetUsd }
-						: {}),
 				}),
 			});
 


### PR DESCRIPTION
The ML Intern pill grew a small `$` field next to the switch for granting a compute budget before the conversation exists. It looks cramped, and it duplicates the budget control the status strip already offers in-chat from the first send. This removes it.

### What changed

- `MlInternPill.svelte`: the money field, its `readDraftBudget` handler, and the spinner-suppression CSS are gone. The pill is now just the switch and the NEW badge.
- `mlAssistant.svelte.ts`: `draftBudgetUsd` removed.
- `+page.svelte` / `models/[...model]/+page.svelte`: the now-dead `mlBudgetUsd` field on the create request.
- The three budget-draft tests in `MlInternPill.svelte.test.ts`.

### Behavior

ML conversations are now always created without `mlBudgetUsd`, which the server stores as $0. The budget readout in the status strip appears from the first send and stays editable there, so granting a budget moves entirely into the chat. Until a total is set, the guard refuses job/sandbox submissions — plain chat is unaffected.

`POST /conversation` still accepts `mlBudgetUsd`; only the client stopped sending it.

### Checks

`npm run check` clean, `npm run lint` clean, chat + route tests pass (108).