### PR TITLE
Small UI changes in: ML Intern: inline budget editor styling, $0 and cents

### DIFF
--- a/src/lib/components/NavConversationItem.svelte
+++ b/src/lib/components/NavConversationItem.svelte
@@ -83,14 +83,17 @@
 >
 	{#if conv.mlAssistant}
 		{@const ml = ML_TURN_BADGE[activeGenerations.statusFor(conv.id) ?? "idle"]}
-		<!-- Neutral marker on purpose: the status dot carries the color, and an
-		     orange treatment fought with it. An icon rather than an "ML" chip, so
-		     a run of mode conversations doesn't read as a wall of repeated text. -->
-		<span
-			class="flex flex-none items-center gap-1 text-gray-400 dark:text-gray-500"
-			title="ML Intern — {ml.label}"
-		>
-			<CarbonMachineLearning class="size-3.5" />
+		<!-- The mode's own gold, in the strip's palette, on a tinted tile: at 14px
+		     a bare glyph in this orange read as a mis-tinted icon rather than a
+		     mark, and the tile is what carries the color while the glyph stays
+		     legible. An icon rather than an "ML" chip, so a run of mode
+		     conversations doesn't read as a wall of repeated text. The status dot
+		     keeps its own hue — it sits outside the tile, so the two no longer
+		     compete for the same 14 pixels. -->
+		<span class="flex flex-none items-center gap-1" title="ML Intern — {ml.label}">
+			<span class="ml-nav-mark flex size-[18px] items-center justify-center rounded-[5px]">
+				<CarbonMachineLearning class="size-3" />
+			</span>
 			{#if ml.dot}
 				<span class="size-1.5 rounded-full {ml.dot}"></span>
 			{/if}
@@ -211,3 +214,24 @@
 		}}
 	/>
 {/if}
+
+<style>
+	/* The mode's gold, lifted off the row by a warm vertical wash and a hairline
+	   top highlight — the same trick as the composer strip's budget pill, at tile
+	   size. Deliberately low-saturation: these tiles repeat down the sidebar. */
+	.ml-nav-mark {
+		color: #c2410c;
+		background-image: linear-gradient(to bottom, #ffedd5, #fed7aa);
+		box-shadow:
+			inset 0 0 0 1px rgba(234, 88, 12, 0.2),
+			inset 0 1px 0 rgba(255, 255, 255, 0.65);
+	}
+
+	:global(.dark) .ml-nav-mark {
+		color: #fdba74;
+		background-image: linear-gradient(to bottom, rgba(234, 88, 12, 0.32), rgba(234, 88, 12, 0.12));
+		box-shadow:
+			inset 0 0 0 1px rgba(253, 186, 116, 0.18),
+			inset 0 1px 0 rgba(253, 186, 116, 0.16);
+	}
+</style>

--- a/src/lib/components/NavConversationItem.svelte
+++ b/src/lib/components/NavConversationItem.svelte
@@ -6,7 +6,7 @@
 
 	import CarbonTrashCan from "~icons/carbon/trash-can";
 	import CarbonEdit from "~icons/carbon/edit";
-	import CarbonMachineLearning from "~icons/carbon/machine-learning";
+	import BiRobot from "~icons/bi/robot";
 	import LucideEllipsis from "~icons/lucide/ellipsis";
 	import type { ConvSidebar } from "$lib/types/ConvSidebar";
 
@@ -83,17 +83,17 @@
 >
 	{#if conv.mlAssistant}
 		{@const ml = ML_TURN_BADGE[activeGenerations.statusFor(conv.id) ?? "idle"]}
-		<!-- The mode's own gold, in the strip's palette, on a tinted tile: at 14px
-		     a bare glyph in this orange read as a mis-tinted icon rather than a
-		     mark, and the tile is what carries the color while the glyph stays
-		     legible. An icon rather than an "ML" chip, so a run of mode
-		     conversations doesn't read as a wall of repeated text. The status dot
-		     keeps its own hue — it sits outside the tile, so the two no longer
-		     compete for the same 14 pixels. -->
-		<span class="flex flex-none items-center gap-1" title="ML Intern — {ml.label}">
-			<span class="ml-nav-mark flex size-[18px] items-center justify-center rounded-[5px]">
-				<CarbonMachineLearning class="size-3" />
-			</span>
+		<!-- The mode's own gold, in the strip's palette. A filled glyph rather than
+		     an outline: at 14px a hairline robot in this orange reads as a
+		     mis-tinted icon, where a solid one reads as a mark. An icon rather
+		     than an "ML" chip, so a run of mode conversations doesn't read as a
+		     wall of repeated text. The status dot keeps its own hue and sits
+		     beside the mark, so the two never compete for the same pixels. -->
+		<span
+			class="flex flex-none items-center gap-1 text-[#c2410c] dark:text-[#fdba74]"
+			title="ML Intern — {ml.label}"
+		>
+			<BiRobot class="size-[15px]" />
 			{#if ml.dot}
 				<span class="size-1.5 rounded-full {ml.dot}"></span>
 			{/if}
@@ -214,24 +214,3 @@
 		}}
 	/>
 {/if}
-
-<style>
-	/* The mode's gold, lifted off the row by a warm vertical wash and a hairline
-	   top highlight — the same trick as the composer strip's budget pill, at tile
-	   size. Deliberately low-saturation: these tiles repeat down the sidebar. */
-	.ml-nav-mark {
-		color: #c2410c;
-		background-image: linear-gradient(to bottom, #ffedd5, #fed7aa);
-		box-shadow:
-			inset 0 0 0 1px rgba(234, 88, 12, 0.2),
-			inset 0 1px 0 rgba(255, 255, 255, 0.65);
-	}
-
-	:global(.dark) .ml-nav-mark {
-		color: #fdba74;
-		background-image: linear-gradient(to bottom, rgba(234, 88, 12, 0.32), rgba(234, 88, 12, 0.12));
-		box-shadow:
-			inset 0 0 0 1px rgba(253, 186, 116, 0.18),
-			inset 0 1px 0 rgba(253, 186, 116, 0.16);
-	}
-</style>

--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -680,8 +680,9 @@
 	async function startExample(example: RouterExample) {
 		if (requireAuthUser()) return;
 
-		// ML Intern chips seed the composer instead of dispatching: their prompts
-		// name "this paper/dataset/model", so the user still has details to add.
+		// ML Intern chips seed the composer instead of dispatching. Their prompts
+		// are complete, but they name one specific paper, model or dataset, and a
+		// task at this price is one the user should read before it starts.
 		if (mlModeOn) {
 			draft = example.prompt;
 			return;

--- a/src/lib/components/chat/MlAssistantStrip.svelte
+++ b/src/lib/components/chat/MlAssistantStrip.svelte
@@ -24,6 +24,8 @@
 
 	/** Matches the server's ceiling on a budget total (PATCH /api/v2/conversations/[id]). */
 	const MAX_BUDGET_USD = 10_000;
+	/** Room for the widest figure the ceiling allows — "10000.00" — and no more. */
+	const maxlength = `${MAX_BUDGET_USD}.00`.length;
 
 	let editingBudget = $state(false);
 	let budgetDraft = $state("");
@@ -108,9 +110,9 @@
 						oninput={(e) => (budgetDraft = sanitizeDraft(e.currentTarget.value))}
 						onblur={() => (editingBudget = false)}
 						type="text"
-						inputmode="numeric"
+						inputmode="decimal"
 						autocomplete="off"
-						maxlength="5"
+						{maxlength}
 						style:width={`${Math.max(budgetDraft.length, 1)}ch`}
 						class="ml-budget-input min-w-[1ch] border-0 bg-transparent p-0 text-right font-mono text-xs text-current tabular-nums outline-none"
 						aria-label="Session budget in dollars, Enter to save"

--- a/src/lib/components/chat/MlAssistantStrip.svelte
+++ b/src/lib/components/chat/MlAssistantStrip.svelte
@@ -12,7 +12,7 @@
 		complete: boolean;
 		/** Compute budget ledger; absent means the conversation carries none. */
 		budget?: MlBudgetSnapshot;
-		/** Commits a new budget total in whole USD. Absent makes the readout static. */
+		/** Commits a new budget total in USD, cents included. Absent makes the readout static. */
 		onbudgetchange?: (totalUsd: number) => void;
 	}
 
@@ -21,6 +21,9 @@
 	let remainingMicroUsd = $derived(
 		budget ? budget.totalMicroUsd - budget.spentMicroUsd - budget.reservedMicroUsd : 0
 	);
+
+	/** Matches the server's ceiling on a budget total (PATCH /api/v2/conversations/[id]). */
+	const MAX_BUDGET_USD = 10_000;
 
 	let editingBudget = $state(false);
 	let budgetDraft = $state("");
@@ -31,11 +34,20 @@
 		editingBudget = true;
 	}
 
+	/** Digits and at most one two-decimal fraction — money, typed as you'd say it. */
+	function sanitizeDraft(raw: string): string {
+		const [whole, ...rest] = raw.replace(/[^0-9.]/g, "").split(".");
+		return rest.length ? `${whole}.${rest.join("").slice(0, 2)}` : whole;
+	}
+
 	function commitBudget() {
-		const totalUsd = Number(budgetDraft);
+		const draft = budgetDraft.trim();
+		const totalUsd = Number(draft);
 		editingBudget = false;
-		if (!Number.isFinite(totalUsd) || totalUsd <= 0) return;
-		onbudgetchange?.(totalUsd);
+		// Zero is a real setting — it pauses spend without discarding the ledger —
+		// so only an empty field, a bare ".", or an out-of-range figure abandons.
+		if (!draft || !Number.isFinite(totalUsd) || totalUsd < 0 || totalUsd > MAX_BUDGET_USD) return;
+		onbudgetchange?.(Math.round(totalUsd * 100) / 100);
 	}
 
 	/** The editor exists only while open, so focus belongs to mount. */
@@ -76,32 +88,45 @@
 
 		{#if budget}
 			{#if editingBudget}
+				<!-- Shaped like the readout it replaces — same pill, same mono figures,
+				     same "$… left" reading — so opening and committing an edit never
+				     shifts the strip. A text field on purpose: type=number drags in the
+				     UA validation bubble and spinner arrows, neither of which belongs on
+				     a one-figure inline edit. -->
 				<!-- svelte-ignore a11y_no_static_element_interactions -->
 				<span
-					class="flex flex-none items-center gap-1 font-mono text-xs"
+					class="ml-budget-pill flex h-5 flex-none items-center gap-px rounded-full border border-current/30 bg-current/10 pr-2.5 pl-2 font-mono text-xs tabular-nums"
 					onkeydown={(e) => {
 						if (e.key === "Enter") commitBudget();
 						if (e.key === "Escape") editingBudget = false;
 					}}
 				>
-					$<input
+					<span aria-hidden="true">$</span>
+					<input
 						use:focusOnMount
 						bind:value={budgetDraft}
+						oninput={(e) => (budgetDraft = sanitizeDraft(e.currentTarget.value))}
 						onblur={() => (editingBudget = false)}
-						type="number"
-						min="1"
-						max="10000"
-						step="1"
-						class="ml-budget-input w-16 rounded border border-current/30 bg-transparent px-1 py-0 text-right text-xs"
+						type="text"
+						inputmode="numeric"
+						autocomplete="off"
+						maxlength="5"
+						style:width={`${Math.max(budgetDraft.length, 1)}ch`}
+						class="ml-budget-input min-w-[1ch] border-0 bg-transparent p-0 text-right font-mono text-xs text-current tabular-nums outline-none"
 						aria-label="Session budget in dollars, Enter to save"
 					/>
+					<span class="pl-1 opacity-70">left</span>
 				</span>
 			{:else}
 				<button
 					type="button"
 					class={[
-						"flex-none font-mono text-xs tabular-nums",
-						onbudgetchange ? "cursor-pointer hover:underline" : "cursor-default",
+						// Same height, radius and padding as the editor pill it swaps with,
+						// so opening the editor tints a shape that is already there.
+						"flex h-5 flex-none items-center rounded-full border border-transparent px-2 font-mono text-xs tabular-nums",
+						onbudgetchange
+							? "cursor-pointer hover:border-current/20 hover:bg-current/10"
+							: "cursor-default",
 						remainingMicroUsd <= 0 ? "font-semibold text-red-600 dark:text-red-400" : "",
 					]}
 					onclick={openBudgetEditor}
@@ -141,16 +166,11 @@
 		opacity: 1;
 	}
 
-	/* Spinner arrows would be the only chrome on the strip's compact money
-	   field, and the value is typed, not stepped. */
-	.ml-budget-input {
-		appearance: textfield;
-	}
-
-	.ml-budget-input::-webkit-outer-spin-button,
-	.ml-budget-input::-webkit-inner-spin-button {
-		appearance: none;
-		margin: 0;
+	/* The field itself is chromeless, so focus has to show on the pill around it —
+	   and in the strip's own orange (currentColor), not the UA's blue. */
+	.ml-budget-pill:focus-within {
+		border-color: currentColor;
+		box-shadow: 0 0 0 3px color-mix(in srgb, currentColor 18%, transparent);
 	}
 
 	@media (prefers-reduced-motion: reduce) {

--- a/src/lib/components/chat/MlAssistantStrip.svelte
+++ b/src/lib/components/chat/MlAssistantStrip.svelte
@@ -24,8 +24,6 @@
 
 	/** Matches the server's ceiling on a budget total (PATCH /api/v2/conversations/[id]). */
 	const MAX_BUDGET_USD = 10_000;
-	/** Room for the widest figure the ceiling allows — "10000.00" — and no more. */
-	const maxlength = `${MAX_BUDGET_USD}.00`.length;
 
 	let editingBudget = $state(false);
 	let budgetDraft = $state("");
@@ -36,10 +34,19 @@
 		editingBudget = true;
 	}
 
-	/** Digits and at most one two-decimal fraction — money, typed as you'd say it. */
+	/** Room for the widest figure the ceiling allows — "10000.00" — and no more. */
+	const MAX_DRAFT_CHARS = `${MAX_BUDGET_USD}.00`.length;
+
+	/**
+	 * Digits and at most one two-decimal fraction — money, typed as you'd say it.
+	 * The length cap lives here rather than in a maxlength attribute: the UA
+	 * truncates a paste before the input event fires, so "ab12.34" would arrive
+	 * as "ab12." and lose its cents to the letters.
+	 */
 	function sanitizeDraft(raw: string): string {
 		const [whole, ...rest] = raw.replace(/[^0-9.]/g, "").split(".");
-		return rest.length ? `${whole}.${rest.join("").slice(0, 2)}` : whole;
+		const clean = rest.length ? `${whole}.${rest.join("").slice(0, 2)}` : whole;
+		return clean.slice(0, MAX_DRAFT_CHARS);
 	}
 
 	function commitBudget() {
@@ -112,7 +119,6 @@
 						type="text"
 						inputmode="decimal"
 						autocomplete="off"
-						{maxlength}
 						style:width={`${Math.max(budgetDraft.length, 1)}ch`}
 						class="ml-budget-input min-w-[1ch] border-0 bg-transparent p-0 text-right font-mono text-xs text-current tabular-nums outline-none"
 						aria-label="Session budget in dollars, Enter to save"

--- a/src/lib/components/chat/MlAssistantStrip.svelte.test.ts
+++ b/src/lib/components/chat/MlAssistantStrip.svelte.test.ts
@@ -278,15 +278,32 @@ describe("MlAssistantStrip budget", () => {
 		expect(input.value).toBe("10");
 	});
 
-	it("leaves room for the widest total the ceiling allows", async () => {
+	it("keeps a pasted figure's cents, and caps the cleaned figure at the widest total", async () => {
+		// A maxlength attribute would have the UA cut the paste before the
+		// sanitizer sees it, so the letters would cost the cents. The cap has to
+		// apply to the cleaned figure instead. insertText goes through the UA's
+		// own truncation, which a direct value assignment would bypass.
 		const { container } = mount({ budget: BUDGET, onbudgetchange: vi.fn() });
 
 		find(container, "button[aria-label^='Session budget']").click();
 		await Promise.resolve();
 		const input = find(container, "input[aria-label^='Session budget']") as HTMLInputElement;
-		// "10000.00" — a five-character cap would have blocked "1000.50".
-		expect(input.maxLength).toBe(8);
 		expect(input.inputMode).toBe("decimal");
+
+		const paste = async (text: string) => {
+			input.focus();
+			input.select();
+			document.execCommand("insertText", false, text);
+			await Promise.resolve();
+		};
+
+		await paste("abcd12.34");
+		expect(input.value).toBe("12.34");
+		// "10000.00" — a five-character cap would have blocked "1000.50".
+		await paste("1000.50");
+		expect(input.value).toBe("1000.50");
+		await paste("123456789");
+		expect(input.value).toBe("12345678");
 	});
 
 	it("commits zero, which pauses spend rather than abandoning the edit", async () => {

--- a/src/lib/components/chat/MlAssistantStrip.svelte.test.ts
+++ b/src/lib/components/chat/MlAssistantStrip.svelte.test.ts
@@ -245,6 +245,72 @@ describe("MlAssistantStrip budget", () => {
 		expect(onbudgetchange).not.toHaveBeenCalled();
 	});
 
+	it("edits in a chromeless text field rather than a number input", async () => {
+		// type=number would put the UA's validation bubble and spinner arrows on a
+		// pill the strip styles itself, so the field takes digits as plain text.
+		const { container } = mount({ budget: BUDGET, onbudgetchange: vi.fn() });
+
+		find(container, "button[aria-label^='Session budget']").click();
+		await Promise.resolve();
+		const input = find(container, "input[aria-label^='Session budget']") as HTMLInputElement;
+		expect(input.type).toBe("text");
+
+		input.value = "2a5.7.59";
+		input.dispatchEvent(new Event("input", { bubbles: true }));
+		await Promise.resolve();
+		// Letters dropped, and the fraction kept to one point and two places.
+		expect(input.value).toBe("25.75");
+	});
+
+	it("commits zero, which pauses spend rather than abandoning the edit", async () => {
+		const onbudgetchange = vi.fn();
+		const { container } = mount({ budget: BUDGET, onbudgetchange });
+
+		find(container, "button[aria-label^='Session budget']").click();
+		await Promise.resolve();
+		const input = find(container, "input[aria-label^='Session budget']") as HTMLInputElement;
+		input.value = "0";
+		input.dispatchEvent(new Event("input", { bubbles: true }));
+		input.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+		await Promise.resolve();
+
+		expect(onbudgetchange).toHaveBeenCalledWith(0);
+	});
+
+	it("commits cents", async () => {
+		const onbudgetchange = vi.fn();
+		const { container } = mount({ budget: BUDGET, onbudgetchange });
+
+		find(container, "button[aria-label^='Session budget']").click();
+		await Promise.resolve();
+		const input = find(container, "input[aria-label^='Session budget']") as HTMLInputElement;
+		input.value = "1.50";
+		input.dispatchEvent(new Event("input", { bubbles: true }));
+		input.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+		await Promise.resolve();
+
+		expect(onbudgetchange).toHaveBeenCalledWith(1.5);
+	});
+
+	it("abandons an empty or over-ceiling figure instead of committing it", async () => {
+		const onbudgetchange = vi.fn();
+		const { container } = mount({ budget: BUDGET, onbudgetchange });
+
+		const type = async (value: string) => {
+			find(container, "button[aria-label^='Session budget']").click();
+			await Promise.resolve();
+			const input = find(container, "input[aria-label^='Session budget']") as HTMLInputElement;
+			input.value = value;
+			input.dispatchEvent(new Event("input", { bubbles: true }));
+			input.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+			await Promise.resolve();
+		};
+
+		await type("");
+		await type("10001");
+		expect(onbudgetchange).not.toHaveBeenCalled();
+	});
+
 	it("stays a static readout when no change handler is given", async () => {
 		const { container } = mount({ budget: BUDGET });
 		find(container, "button[aria-label^='Session budget']").click();

--- a/src/lib/components/chat/MlAssistantStrip.svelte.test.ts
+++ b/src/lib/components/chat/MlAssistantStrip.svelte.test.ts
@@ -262,6 +262,33 @@ describe("MlAssistantStrip budget", () => {
 		expect(input.value).toBe("25.75");
 	});
 
+	it("takes the field's rejected characters back out of the field", async () => {
+		// The sanitized value can equal what is already in state ("10" + "a" is
+		// still "10"), and a value that does not change cannot re-render the DOM.
+		const { container } = mount({ budget: BUDGET, onbudgetchange: vi.fn() });
+
+		find(container, "button[aria-label^='Session budget']").click();
+		await Promise.resolve();
+		const input = find(container, "input[aria-label^='Session budget']") as HTMLInputElement;
+		expect(input.value).toBe("10");
+
+		input.value = "10a";
+		input.dispatchEvent(new Event("input", { bubbles: true }));
+		await Promise.resolve();
+		expect(input.value).toBe("10");
+	});
+
+	it("leaves room for the widest total the ceiling allows", async () => {
+		const { container } = mount({ budget: BUDGET, onbudgetchange: vi.fn() });
+
+		find(container, "button[aria-label^='Session budget']").click();
+		await Promise.resolve();
+		const input = find(container, "input[aria-label^='Session budget']") as HTMLInputElement;
+		// "10000.00" — a five-character cap would have blocked "1000.50".
+		expect(input.maxLength).toBe(8);
+		expect(input.inputMode).toBe("decimal");
+	});
+
 	it("commits zero, which pauses spend rather than abandoning the edit", async () => {
 		const onbudgetchange = vi.fn();
 		const { container } = mount({ budget: BUDGET, onbudgetchange });

--- a/src/lib/components/chat/MlInternOnboardingModal.svelte
+++ b/src/lib/components/chat/MlInternOnboardingModal.svelte
@@ -39,7 +39,7 @@
 			</h2>
 			<p class="text-[15px] leading-relaxed text-gray-600 dark:text-gray-300">
 				It plans and runs machine-learning work for you on Hugging Face. Two settings on your
-				account make a real difference to how well that goes.
+				account can improve your experience.
 			</p>
 		</div>
 
@@ -81,9 +81,9 @@
 					</p>
 					<p class="text-sm leading-relaxed">
 						A budget you give ML Intern in the chat is strictly enforced on the Jobs it launches
-						from here, but it is not a guarantee: a Job it starts could launch Jobs of its own or
-						use other Hugging Face products. To make sure you never overspend, set a budget in your
-						billing settings too.
+						from here, but it is not a complete guarantee: a Job it starts could launch Jobs of its
+						own or use other Hugging Face products. To make sure you never overspend, set a budget
+						in your billing settings too.
 					</p>
 					<a
 						href={BILLING_SETTINGS_URL}

--- a/src/lib/components/chat/MlInternOnboardingModal.svelte.test.ts
+++ b/src/lib/components/chat/MlInternOnboardingModal.svelte.test.ts
@@ -24,7 +24,7 @@ describe("MlInternOnboardingModal", () => {
 		expect(text).toContain("Set a spending cap");
 		// Honest about the limit: enforced in the chat, but not a hard guarantee.
 		expect(text).toContain("strictly enforced");
-		expect(text).toContain("not a guarantee");
+		expect(text).toContain("not a complete guarantee");
 	});
 
 	it("is named by its heading for assistive tech", () => {

--- a/src/lib/constants/mlAssistant.ts
+++ b/src/lib/constants/mlAssistant.ts
@@ -35,7 +35,7 @@ export const mlAssistantExamples: RouterExample[] = [
 	{
 		title: "Reproduce a paper",
 		prompt:
-			"Reproduce the results of https://huggingface.co/papers/2609.01343 at small scale and report where they diverge.",
+			"Reproduce SMELT: Scaling Laws for Compute-Matched MoE Looped Transformers (https://huggingface.co/papers/2609.01343) at small scale and report where they diverge.",
 	},
 	{
 		title: "Finetune a model",

--- a/src/lib/constants/mlAssistant.ts
+++ b/src/lib/constants/mlAssistant.ts
@@ -23,26 +23,36 @@ export const ML_ASSISTANT_EFFORT = "high" as const;
  */
 export const ML_ASSISTANT_MIN_COMPLETION_TOKENS = 32_768;
 
-/** Suggestion chips that replace the default set while the mode is on. */
+/**
+ * Suggestion chips that replace the default set while the mode is on.
+ *
+ * Each names a real, current Hub artifact rather than "this model" — a chip
+ * that stands up on its own is a chip the user can send, and it doubles as a
+ * worked example of the `@id` mentions the composer completes. They date: when
+ * these ids stop being what the community is working on, replace them.
+ */
 export const mlAssistantExamples: RouterExample[] = [
 	{
 		title: "Reproduce a paper",
-		prompt: "Reproduce the results of this paper and report where they diverge:",
+		prompt:
+			"Reproduce the results of https://huggingface.co/papers/2609.01343 at small scale and report where they diverge.",
 	},
 	{
 		title: "Finetune a model",
-		prompt: "Finetune a small open model on this dataset and evaluate the checkpoint.",
+		prompt:
+			"Finetune @google/gemma-4-E2B-it on @r0b0tlab/qwen3.8-max-glm5.2-kimi-k3-distillation and evaluate the checkpoint.",
 	},
 	{
 		title: "Build a demo",
-		prompt: "Build a Gradio demo Space for this model.",
+		prompt: "Build a Gradio demo Space for @MiniMaxAI/MiniMax-H3.",
 	},
 	{
 		title: "Generate a dataset",
-		prompt: "Generate a synthetic dataset for this task and push it to the Hub.",
+		prompt:
+			"Generate a synthetic function-calling dataset with @zai-org/GLM-5.3-Flash and push it to the Hub.",
 	},
 	{
 		title: "Run an eval",
-		prompt: "Run an evaluation of this model against a held-out split and score it.",
+		prompt: "Evaluate @baidu/Unlimited-OCR on @allenai/olmOCR-bench and score it.",
 	},
 ];

--- a/src/routes/api/v2/conversations/[id]/+server.ts
+++ b/src/routes/api/v2/conversations/[id]/+server.ts
@@ -104,9 +104,11 @@ export const PATCH: RequestHandler = async ({ locals, params, request }) => {
 		if (
 			typeof mlBudgetTotalUsd !== "number" ||
 			!Number.isFinite(mlBudgetTotalUsd) ||
-			mlBudgetTotalUsd <= 0 ||
+			mlBudgetTotalUsd < 0 ||
 			mlBudgetTotalUsd > 10_000
 		) {
+			// Zero is allowed: it pauses spend on the conversation while keeping the
+			// ledger's spend and open holds intact.
 			error(400, "Budget must be a number of dollars between 0 and 10000");
 		}
 	}


### PR DESCRIPTION
- `1fd433c5` — Restyle the strip's inline budget editor as the same pill as the readout (mode-orange focus, no UA focus ring or validation bubble), and accept `$0` and cents (`$1.50`); the PATCH validator now allows a zero total.
- `96f8f204` — Soften the onboarding modal's budget-guarantee copy.
- `06a21ad6` — Sidebar ML Intern marker: gold glyph on a tinted tile instead of a gray icon.
- `b7b6b5b8` — Sidebar ML Intern marker: drop the tile, use `bi/robot`'s filled glyph in the mode's gold.
- `cc2376c3` — Follow the softened onboarding copy in its test.
- `518b0946` — ML Intern suggestion chips now name real, current Hub artifacts as `@id` mentions (one paper link, five orgs, five modalities) instead of "this paper/dataset/model".
- `da472b5c` — Name the paper in the reproduce chip, link in parentheses.
- `a047ce7f` — Address Codex review: `inputmode="decimal"` for cent entry, `maxlength` derived from the $10,000 ceiling (was blocking `1000.50`), plus a test pinning that rejected characters leave the field.

Feel free to cherry pick any of these commits / reject others if you disagree