### PR TITLE
Say that the billing setting covers inference

### DIFF
--- a/src/routes/settings/(nav)/application/+page.svelte
+++ b/src/routes/settings/(nav)/application/+page.svelte
@@ -269,7 +269,8 @@
 						<div>
 							<div class="text-[13px] font-medium text-gray-800 dark:text-gray-200">Billing</div>
 							<p class="text-[12px] text-gray-500 dark:text-gray-400">
-								Select between personal or organization billing (for eligible organizations).
+								Select between personal or organization billing for inference (for eligible
+								organizations).
 							</p>
 						</div>
 						<div class="flex items-center">


### PR DESCRIPTION
Ideally the organization you select in the billing would also be the org that is charged for Jobs, etc. but until we have that, we can add this minimal language to indicate it's only for inference:

- `ad30186d` — Billing setting description now says "for inference": the selection only redirects inference spend (`X-HF-Bill-To` is attached to the OpenAI-compatible client and nothing else reads it), while Jobs bill the namespace they run in.