### PR TITLE
ML Intern: fixed model set with pinned providers, plus a model probe script

### DIFF
--- a/.env
+++ b/.env
@@ -230,6 +230,14 @@ APP_BASE="" # base path of the app, e.g. /chat, left blank as default
 # set). Enforced server-side: submissions reserve their worst case (flavor
 # price x timeout) and settle to actual runtime.
 ML_ASSISTANT_MODE=
+# Models ML Intern conversations may run on, JSON5 array; first entry is the
+# default. Each entry pins the inference provider the model was verified on for
+# 1M-token tool loops (scripts/probe-model.ts) — the user's provider preference
+# and "auto" are ignored for mode conversations. `parameters` merge over the
+# catalog entry's. The router alias cannot be listed. Empty: the mode refuses
+# to start a conversation.
+# e.g. [{"id":"zai-org/GLM-5.3-Flash","provider":"together"},{"id":"moonshotai/Kimi-K3","provider":"together"}]
+ML_ASSISTANT_MODELS=
 ### Body size limit for SvelteKit https://svelte.dev/docs/kit/adapter-node#Environment-variables-BODY_SIZE_LIMIT
 BODY_SIZE_LIMIT=15728640
 PUBLIC_COMMIT_SHA=

--- a/.env
+++ b/.env
@@ -234,8 +234,10 @@ ML_ASSISTANT_MODE=
 # default. Each entry pins the inference provider the model was verified on for
 # 1M-token tool loops (scripts/probe-model.ts) — the user's provider preference
 # and "auto" are ignored for mode conversations. `parameters` merge over the
-# catalog entry's. The router alias cannot be listed. Empty: the mode refuses
-# to start a conversation.
+# catalog entry's. `provider` is required; the router alias is rejected. The pin
+# only applies against the Hugging Face router (HuggingChat) — self-hosted
+# deployments get the model set without it. Empty: the mode refuses to start a
+# conversation and the composer hides the switch.
 # e.g. [{"id":"zai-org/GLM-5.3-Flash","provider":"together"},{"id":"moonshotai/Kimi-K3","provider":"together"}]
 ML_ASSISTANT_MODELS=
 ### Body size limit for SvelteKit https://svelte.dev/docs/kit/adapter-node#Environment-variables-BODY_SIZE_LIMIT

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ models/*
 /playwright-report
 /blob-report
 /playwright/.cache
+.probe-results/

--- a/chart/env/dev.yaml
+++ b/chart/env/dev.yaml
@@ -73,6 +73,12 @@ envVars:
   LLM_ROUTER_ENABLE_TOOLS: "true"
   LLM_ROUTER_TOOLS_MODEL: "moonshotai/Kimi-K2.6"
   TRANSCRIPTION_MODEL: "openai/whisper-large-v3-turbo"
+  # ML Intern model set: provider pinned per model from scripts/probe-model.ts runs
+  # (2026-09-02). GLM-5.3-Flash on together recalled 5/5 at 924k tokens; Kimi-K3 on
+  # baseten 6/6 at 1,046k (fireworks-ai is the alternate: 6/6, slower prefill);
+  # GLM-5.3 degrades above ~800k on every provider — novita was the best of them.
+  ML_ASSISTANT_MODELS: >
+    [{"id": "zai-org/GLM-5.3-Flash", "provider": "together"}, {"id": "moonshotai/Kimi-K3", "provider": "baseten"}, {"id": "zai-org/GLM-5.3", "provider": "novita"}]
   MCP_SERVERS: >
     [{"name": "Web Search (Exa)", "url": "https://mcp.exa.ai/mcp?tools=web_search_exa,get_code_context_exa,crawling_exa"}, {"name": "Hugging Face", "url": "https://hf.co/mcp?login"}]
   MCP_TOOL_TIMEOUT_MS: "120000"

--- a/chart/env/dev.yaml
+++ b/chart/env/dev.yaml
@@ -77,8 +77,11 @@ envVars:
   # (2026-09-02). GLM-5.3-Flash on together recalled 5/5 at 924k tokens; Kimi-K3 on
   # baseten 6/6 at 1,046k (fireworks-ai is the alternate: 6/6, slower prefill);
   # GLM-5.3 degrades above ~800k on every provider — novita was the best of them.
+  # DeepSeek-V4-Pro-0813 on together 5/5 at 911k (fireworks-ai equal; novita and
+  # baseten 0/4 at 761k); DeepSeek-V4-Flash-0731 on novita 5/5 at 911k (together
+  # and baseten 0/4 at 761k, deepinfra 0/5 at 910k).
   ML_ASSISTANT_MODELS: >
-    [{"id": "zai-org/GLM-5.3-Flash", "provider": "together"}, {"id": "moonshotai/Kimi-K3", "provider": "baseten"}, {"id": "zai-org/GLM-5.3", "provider": "novita"}]
+    [{"id": "zai-org/GLM-5.3-Flash", "provider": "together"}, {"id": "moonshotai/Kimi-K3", "provider": "baseten"}, {"id": "zai-org/GLM-5.3", "provider": "novita"}, {"id": "deepseek-ai/DeepSeek-V4-Pro-0813", "provider": "together"}, {"id": "deepseek-ai/DeepSeek-V4-Flash-0731", "provider": "novita"}]
   MCP_SERVERS: >
     [{"name": "Web Search (Exa)", "url": "https://mcp.exa.ai/mcp?tools=web_search_exa,get_code_context_exa,crawling_exa"}, {"name": "Hugging Face", "url": "https://hf.co/mcp?login"}]
   MCP_TOOL_TIMEOUT_MS: "120000"

--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -87,8 +87,11 @@ envVars:
   # (2026-09-02). GLM-5.3-Flash on together recalled 5/5 at 924k tokens; Kimi-K3 on
   # baseten 6/6 at 1,046k (fireworks-ai is the alternate: 6/6, slower prefill);
   # GLM-5.3 degrades above ~800k on every provider — novita was the best of them.
+  # DeepSeek-V4-Pro-0813 on together 5/5 at 911k (fireworks-ai equal; novita and
+  # baseten 0/4 at 761k); DeepSeek-V4-Flash-0731 on novita 5/5 at 911k (together
+  # and baseten 0/4 at 761k, deepinfra 0/5 at 910k).
   ML_ASSISTANT_MODELS: >
-    [{"id": "zai-org/GLM-5.3-Flash", "provider": "together"}, {"id": "moonshotai/Kimi-K3", "provider": "baseten"}, {"id": "zai-org/GLM-5.3", "provider": "novita"}]
+    [{"id": "zai-org/GLM-5.3-Flash", "provider": "together"}, {"id": "moonshotai/Kimi-K3", "provider": "baseten"}, {"id": "zai-org/GLM-5.3", "provider": "novita"}, {"id": "deepseek-ai/DeepSeek-V4-Pro-0813", "provider": "together"}, {"id": "deepseek-ai/DeepSeek-V4-Flash-0731", "provider": "novita"}]
   MCP_SERVERS: >
     [{"name": "Web Search (Exa)", "url": "https://mcp.exa.ai/mcp?tools=web_search_exa,get_code_context_exa,crawling_exa"}, {"name": "Hugging Face", "url": "https://hf.co/mcp?login"}]
   MCP_TOOL_TIMEOUT_MS: "120000"

--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -83,6 +83,12 @@ envVars:
   LLM_ROUTER_ENABLE_TOOLS: "true"
   LLM_ROUTER_TOOLS_MODEL: "moonshotai/Kimi-K2.6"
   TRANSCRIPTION_MODEL: "openai/whisper-large-v3-turbo"
+  # ML Intern model set: provider pinned per model from scripts/probe-model.ts runs
+  # (2026-09-02). GLM-5.3-Flash on together recalled 5/5 at 924k tokens; Kimi-K3 on
+  # baseten 6/6 at 1,046k (fireworks-ai is the alternate: 6/6, slower prefill);
+  # GLM-5.3 degrades above ~800k on every provider — novita was the best of them.
+  ML_ASSISTANT_MODELS: >
+    [{"id": "zai-org/GLM-5.3-Flash", "provider": "together"}, {"id": "moonshotai/Kimi-K3", "provider": "baseten"}, {"id": "zai-org/GLM-5.3", "provider": "novita"}]
   MCP_SERVERS: >
     [{"name": "Web Search (Exa)", "url": "https://mcp.exa.ai/mcp?tools=web_search_exa,get_code_context_exa,crawling_exa"}, {"name": "Hugging Face", "url": "https://hf.co/mcp?login"}]
   MCP_TOOL_TIMEOUT_MS: "120000"

--- a/docs/source/configuration/overview.md
+++ b/docs/source/configuration/overview.md
@@ -84,6 +84,23 @@ ML_ASSISTANT_MODE=true          # Compile in ML Assistant mode (composer header 
 Pass it to `npm run build`, or as a `--build-arg` to `docker build`. Setting it on
 an already-built instance has no effect.
 
+## ML Assistant Models
+
+When the build ships ML Assistant mode, its conversations run on a fixed model set
+rather than whatever the composer has selected. Each entry pins the inference
+provider the model was verified on for long tool loops (`npm run probe-model` runs
+that verification); the user's provider preference and `auto` are ignored for mode
+conversations, and the router alias can't be listed. The first entry is the default.
+
+```ini
+ML_ASSISTANT_MODELS=`[
+  {"id": "zai-org/GLM-5.3-Flash", "provider": "together", "parameters": {"max_tokens": 49152}},
+  {"id": "moonshotai/Kimi-K3", "provider": "together"}
+]`
+```
+
+Leave it empty and the mode refuses to start a conversation.
+
 ## User Authentication
 
 Use OpenID Connect for authentication:

--- a/docs/source/configuration/overview.md
+++ b/docs/source/configuration/overview.md
@@ -90,7 +90,9 @@ When the build ships ML Assistant mode, its conversations run on a fixed model s
 rather than whatever the composer has selected. Each entry pins the inference
 provider the model was verified on for long tool loops (`npm run probe-model` runs
 that verification); the user's provider preference and `auto` are ignored for mode
-conversations, and the router alias can't be listed. The first entry is the default.
+conversations, and the router alias is rejected. The first entry is the default. The
+provider pin is a Hugging Face router feature, so self-hosted deployments get the model set
+without it.
 
 ```ini
 ML_ASSISTANT_MODELS=`[
@@ -99,7 +101,8 @@ ML_ASSISTANT_MODELS=`[
 ]`
 ```
 
-Leave it empty and the mode refuses to start a conversation.
+Leave it empty and the composer hides the switch; a request that still asks for the mode is
+refused.
 
 ## User Authentication
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 		"updateLocalEnv": "vite-node --options.transformMode.ssr='/.*/' scripts/updateLocalEnv.ts",
 		"populate": "vite-node --options.transformMode.ssr='/.*/' scripts/populate.ts",
 		"config": "vite-node --options.transformMode.ssr='/.*/' scripts/config.ts",
+		"probe-model": "vite-node --options.transformMode.ssr='/.*/' scripts/probe-model.ts --",
 		"prepare": "husky"
 	},
 	"devDependencies": {

--- a/scripts/probe-model.ts
+++ b/scripts/probe-model.ts
@@ -1,0 +1,701 @@
+/**
+ * Model/provider probe for the tool-calling flow.
+ *
+ * Sends the request shape runMcpFlow sends (stream, tools, tool_choice auto,
+ * max_tokens) with a generated ML Intern-style history — hf_jobs calls and
+ * training-log tool results — scaled to a target prompt size, then records how
+ * the SSE stream ends. Because the history is generated from a seed, the
+ * `recall` task can be graded byte-for-byte: it asks for the job id and the
+ * exact `step=100` log line of specific jobs buried in the context.
+ *
+ * Verdicts:
+ *   OK         finished normally; recall (when asked) mostly correct
+ *   DEGRADED   coherent transport but wrong/fabricated recall, or degenerate
+ *              output (repetition), or reasoning-only until the cap
+ *   SWALLOWED  provider billed far more completion tokens than it delivered,
+ *              or a tool task ended with "stop" and no tool call
+ *   TRUNCATED  stream ended without [DONE] or without a finish_reason
+ *   ERROR      non-200 response or transport failure
+ *
+ * Usage:
+ *   npm run probe-model -- --model zai-org/GLM-5.3-Flash
+ *   npm run probe-model -- --model zai-org/GLM-5.3-Flash --provider together
+ *   npm run probe-model -- --model moonshotai/Kimi-K3 --size 300000 --task recall
+ *   npm run probe-model -- --model zai-org/GLM-5.3 --suite quick
+ *
+ * Suites (default `standard`): each provider the router lists for the model
+ * (or --provider) runs every step. Sizes are prompt tokens; `%` of the
+ * provider's context window.
+ *   quick     tool@100k, recall@300k
+ *   standard  tool@100k, recall@300k, recall@75%, recall@90%
+ *
+ * Results go to --out (default .probe-results/): a results.jsonl, one .json
+ * summary and one .sse raw capture per run. Needs OPENAI_API_KEY (an HF token)
+ * in the env or .env.local, as the other scripts do.
+ */
+import { existsSync, mkdirSync, readFileSync, writeFileSync, appendFileSync } from "fs";
+import { join } from "path";
+import { Agent, fetch as undiciFetch } from "undici";
+
+type Args = Record<string, string | true>;
+const args: Args = {};
+{
+	const argv = process.argv.slice(2);
+	for (let i = 0; i < argv.length; i++) {
+		const m = /^--([^=]+)(?:=(.*))?$/.exec(argv[i]);
+		if (!m) continue;
+		if (m[2] !== undefined) args[m[1]] = m[2];
+		else if (argv[i + 1] !== undefined && !argv[i + 1].startsWith("--")) args[m[1]] = argv[++i];
+		else args[m[1]] = true;
+	}
+}
+const str = (k: string): string | undefined =>
+	typeof args[k] === "string" ? String(args[k]) : undefined;
+
+function loadEnv(): { baseUrl: string; apiKey: string } {
+	const env = new Map<string, string>();
+	for (const file of [".env", ".env.local"]) {
+		try {
+			for (const line of readFileSync(file, "utf-8").split("\n")) {
+				const match = line.match(/^([A-Z0-9_]+)=(.*)$/);
+				if (match) env.set(match[1], match[2].replace(/^["']|["']$/g, ""));
+			}
+		} catch {
+			// file optional
+		}
+	}
+	const baseUrl =
+		process.env.OPENAI_BASE_URL ?? env.get("OPENAI_BASE_URL") ?? "https://router.huggingface.co/v1";
+	const apiKey = process.env.OPENAI_API_KEY ?? env.get("OPENAI_API_KEY") ?? "";
+	if (!apiKey) throw new Error("No OPENAI_API_KEY found in env or .env.local");
+	return { baseUrl: baseUrl.replace(/\/$/, ""), apiKey };
+}
+const { baseUrl, apiKey } = loadEnv();
+
+const OUT = str("out") ?? ".probe-results";
+mkdirSync(OUT, { recursive: true });
+
+// Prefill of a 1M-token prompt can exceed undici's default 5-minute header
+// timeout; the probe measures that instead of dying on it.
+const agent = new Agent({ headersTimeout: 0, bodyTimeout: 0 });
+
+type OaTool = {
+	type: "function";
+	function: { name: string; description?: string; parameters?: Record<string, unknown> };
+};
+
+// The Hub MCP tool list depends on the account's settings; these three are what
+// the ML Intern prompt names, so they are always advertised (the mode's history
+// calls them, and a call to an unadvertised name is one of the failure modes
+// under test).
+const REQUIRED_TOOLS: OaTool[] = [
+	{
+		type: "function",
+		function: {
+			name: "hf_jobs",
+			description:
+				"Remote compute for Hugging Face workflows. Run Python/UV or Docker jobs to analyze Hub datasets, repos, models and large files; run batch inference/evaluation; or perform long-running work. Includes submit, logs, inspect, cancel, schedule, and volume mounting.",
+			parameters: {
+				type: "object",
+				properties: {
+					operation: {
+						type: "string",
+						enum: ["run", "uv", "ps", "logs", "inspect", "cancel"],
+						description: "Operation to execute.",
+					},
+					args: {
+						type: "object",
+						description: "Operation-specific arguments as a JSON object",
+						additionalProperties: {},
+					},
+				},
+			},
+		},
+	},
+	{
+		type: "function",
+		function: {
+			name: "hf_sandbox_exec",
+			description:
+				"Run a shell command inside a Hugging Face Sandbox. Grammar: exec HANDLE SHELL_COMMAND [--workdir PATH] [--timeout SECONDS] [--detach]. SHELL_COMMAND is one string token and runs via /bin/sh -lc.",
+			parameters: {
+				type: "object",
+				additionalProperties: false,
+				properties: {
+					cmd: { type: "string", enum: ["exec"] },
+					args: { type: "array", items: { type: "string" } },
+				},
+				required: ["cmd", "args"],
+			},
+		},
+	},
+	{
+		type: "function",
+		function: {
+			name: "hf_fs_write",
+			description:
+				"Write or remove files in Hugging Face repositories. Grammar: put URI [--base64] [-m MESSAGE] [--branch BRANCH] [--create-pr]; rm URI [-m MESSAGE]. URI must be an hf://models|datasets|spaces/OWNER/NAME/PATH file URI. Provide file data in the content field.",
+			parameters: {
+				type: "object",
+				properties: {
+					cmd: { type: "string", enum: ["put", "rm"] },
+					args: { type: "array", items: { type: "string" } },
+					content: { type: "string" },
+				},
+				required: ["cmd", "args"],
+			},
+		},
+	},
+];
+
+async function hubTools(): Promise<OaTool[]> {
+	const cache = join(OUT, "hub-tools.json");
+	if (existsSync(cache)) return JSON.parse(readFileSync(cache, "utf-8"));
+	const url = "https://hf.co/mcp?login";
+	const headers = {
+		"content-type": "application/json",
+		accept: "application/json, text/event-stream",
+		authorization: `Bearer ${apiKey}`,
+	};
+	const rpc = async (body: unknown, sid?: string) => {
+		const res = await fetch(url, {
+			method: "POST",
+			headers: { ...headers, ...(sid ? { "mcp-session-id": sid } : {}) },
+			body: JSON.stringify(body),
+		});
+		const text = await res.text();
+		let json: {
+			result?: {
+				tools?: { name: string; description?: string; inputSchema?: Record<string, unknown> }[];
+			};
+		} = {};
+		try {
+			const data = (res.headers.get("content-type") ?? "").includes("event-stream")
+				? text
+						.split("\n")
+						.find((l) => l.startsWith("data:"))
+						?.slice(5)
+				: text;
+			if (data) json = JSON.parse(data);
+		} catch {
+			// a notification response has no body
+		}
+		return { res, json };
+	};
+	let listed: OaTool[] = [];
+	try {
+		const init = await rpc({
+			jsonrpc: "2.0",
+			id: 1,
+			method: "initialize",
+			params: {
+				protocolVersion: "2025-03-26",
+				capabilities: {},
+				clientInfo: { name: "probe-model", version: "0" },
+			},
+		});
+		const sid = init.res.headers.get("mcp-session-id") ?? undefined;
+		await rpc({ jsonrpc: "2.0", method: "notifications/initialized" }, sid);
+		const list = await rpc({ jsonrpc: "2.0", id: 2, method: "tools/list" }, sid);
+		listed = (list.json.result?.tools ?? []).map((t) => ({
+			type: "function" as const,
+			function: { name: t.name, description: t.description, parameters: t.inputSchema },
+		}));
+	} catch (e) {
+		console.warn(`[probe] hub tools/list failed (${String(e)}); using the built-in schemas only`);
+	}
+	const names = new Set(listed.map((t) => t.function.name));
+	const tools = [...REQUIRED_TOOLS.filter((t) => !names.has(t.function.name)), ...listed];
+	writeFileSync(cache, JSON.stringify(tools, null, 1));
+	return tools;
+}
+
+// ---------- generated history ----------
+
+function rng(seed: number) {
+	let s = seed >>> 0;
+	return () => {
+		s = (s * 1664525 + 1013904223) >>> 0;
+		return s / 4294967296;
+	};
+}
+const WORDS =
+	"loss step epoch lr grad_norm eval accuracy tokens throughput checkpoint saved warmup batch shard dataset tokenizer optimizer adamw cosine schedule fp16 bf16 cuda memory allocated reserved wandb logged samples".split(
+		" "
+	);
+
+function trainingScript(i: number): string {
+	return `import torch, datasets
+from transformers import AutoModelForCausalLM, AutoTokenizer, Trainer, TrainingArguments
+ds = datasets.load_dataset("probe/ds-${i}", split="train")
+tok = AutoTokenizer.from_pretrained("Qwen/Qwen2.5-0.5B")
+model = AutoModelForCausalLM.from_pretrained("Qwen/Qwen2.5-0.5B", torch_dtype=torch.bfloat16)
+ds = ds.map(lambda ex: tok(ex["text"], truncation=True, max_length=1024), batched=True, remove_columns=ds.column_names)
+args = TrainingArguments(output_dir="out-${i}", per_device_train_batch_size=8, learning_rate=${(2e-5 + i * 1e-6).toExponential(2)}, num_train_epochs=1, bf16=True, logging_steps=10, save_steps=500, push_to_hub=True, hub_model_id="probe/run-${i}")
+Trainer(model=model, args=args, train_dataset=ds).train()
+`;
+}
+
+type Msg = Record<string, unknown> & { role: string };
+
+const SYSTEM_PROMPT = [
+	"You are ML Intern, an assistant that runs machine-learning work on the Hugging Face Hub on the user's behalf.",
+	"You launch training and evaluation as jobs with hf_jobs, inspect their logs, run quick commands in a sandbox with hf_sandbox_exec, and write files to repositories with hf_fs_write.",
+	"Every job you launch is recorded in this conversation with its id and logs; refer back to them precisely and never invent ids or log lines.",
+	"Ground every claim in the tool results present in the conversation.",
+].join("\n");
+
+const CHARS_PER_TOKEN = Number(str("cpt") ?? 2.05);
+
+function buildHistory(targetTokens: number, tools: OaTool[], seed: number) {
+	const rand = rng(seed);
+	const msgs: Msg[] = [{ role: "system", content: SYSTEM_PROMPT }];
+	let chars = SYSTEM_PROMPT.length + JSON.stringify(tools).length;
+	const budget = targetTokens * CHARS_PER_TOKEN;
+	let i = 0;
+	while (chars < budget) {
+		i += 1;
+		const callId = `call_${i}_${Math.floor(rand() * 1e9).toString(36)}`;
+		const jobId = Math.floor(rand() * 1e12).toString(16);
+		const nlines = 40 + Math.floor(rand() * 80);
+		const lines: string[] = [];
+		for (let k = 0; k < nlines; k++) {
+			const step = k * 10;
+			const loss = (2.9 * Math.exp(-step / (400 + i * 37)) + rand() * 0.08).toFixed(4);
+			const w = WORDS[Math.floor(rand() * WORDS.length)];
+			lines.push(
+				`[${new Date(1756800000000 + i * 3600000 + k * 1500).toISOString()}] step=${step} loss=${loss} lr=${(2e-5 * (1 - step / 4000)).toExponential(3)} grad_norm=${(rand() * 3).toFixed(3)} tok/s=${Math.floor(9000 + rand() * 4000)} ${w}=${(rand() * 100).toFixed(2)}`
+			);
+		}
+		const round: Msg[] = [
+			{
+				role: "user",
+				content:
+					i === 1
+						? "Fine-tune Qwen2.5-0.5B on probe/ds-1 and report the loss curve."
+						: `Now do the same for probe/ds-${i}, but with lr ${(2e-5 + i * 1e-6).toExponential(2)}.`,
+			},
+			{
+				role: "assistant",
+				content: `Launching job ${i} on an a10g-small.`,
+				tool_calls: [
+					{
+						id: callId,
+						type: "function",
+						function: {
+							name: "hf_jobs",
+							arguments: JSON.stringify({
+								operation: "uv",
+								args: {
+									flavor: "a10g-small",
+									timeout: "2h",
+									script: trainingScript(i),
+									secrets: ["HF_TOKEN"],
+								},
+							}),
+						},
+					},
+				],
+			},
+			{
+				role: "tool",
+				tool_call_id: callId,
+				content: `Job ${jobId} launched. Status: COMPLETED\n--- logs ---\n${lines.join("\n")}\n--- end ---`,
+			},
+			{
+				role: "assistant",
+				content: `Job ${i} (id \`${jobId}\`) finished. Final loss ${(0.3 + rand() * 0.2).toFixed(4)} after ${nlines * 10} steps; throughput ~${Math.floor(9000 + rand() * 4000)} tok/s. Model pushed to probe/run-${i}.`,
+			},
+		];
+		for (const m of round) {
+			msgs.push(m);
+			chars += JSON.stringify(m).length;
+		}
+	}
+	return { msgs, rounds: i };
+}
+
+const RECALL_JOBS = [5, 100, 148, 149, 180, 214];
+
+const TASKS: Record<string, string> = {
+	answer:
+		"Write a detailed retrospective (at least 1500 words) of everything we did in this session: one section per job with the job id, learning rate, final loss, and what changed from the previous run, then a markdown table of all jobs, then recommendations for the next 5 experiments.",
+	tool: "Now launch one more job on probe/ds-next with lr 3e-5 using hf_jobs. Write the full training script inline in the tool call like before.",
+	bigtool:
+		"Now launch one more job on probe/ds-next with hf_jobs. The script must be a complete, self-contained training script of at least 300 lines: a custom data collator, a cosine scheduler with warmup, periodic evaluation, checkpoint resumption, W&B logging, and extensive docstrings. Put the whole script inline in the tool call arguments.",
+	dump: "Produce a complete audit document. First a markdown table of EVERY job in this session (id, dataset, learning rate, final loss, steps, throughput). Then, for EVERY job in order, a section with its id and the first 12 log lines reproduced verbatim in a code block. Do not skip or summarize any job; this document must be exhaustive even if it is very long.",
+	recall: `Answer ONLY with a JSON object, no prose. For each of jobs ${RECALL_JOBS.join(", ")} (the Nth job we launched in this session): give the job id (the hex id from the tool result) and reproduce VERBATIM the log line containing step=100 from that job's logs as they appear in the tool result. Format: {"5": {"id": "...", "step100": "..."}, ...}. If a job's logs are genuinely not present in the context, use "NOT_PRESENT" for that field.`,
+};
+
+// ---------- one run ----------
+
+interface RunSpec {
+	model: string;
+	provider?: string;
+	size: number;
+	task: string;
+	maxTokens: number;
+	label: string;
+}
+
+interface RunResult extends RunSpec {
+	modelId: string;
+	status?: number;
+	providerHeader?: string | null;
+	ttfbMs?: number;
+	totalMs?: number;
+	chunks: number;
+	maxGapMs: number;
+	contentChars: number;
+	reasoningChars: number;
+	toolCalls: { name: string; argChars: number; valid: boolean }[];
+	finishReasons: string[];
+	sawDone: boolean;
+	errors: string[];
+	streamError?: string;
+	errorBody?: string;
+	usage?: {
+		prompt_tokens?: number;
+		completion_tokens?: number;
+		prompt_tokens_details?: { cached_tokens?: number };
+	};
+	recall?: { score: number; total: number; detail: string[] };
+	verdict: string;
+	reason: string;
+	contentTail: string;
+}
+
+function gradeRecall(content: string, history: Msg[]) {
+	const tools = history.filter((m) => m.role === "tool");
+	const present = RECALL_JOBS.filter((n) => tools[n - 1]);
+	let answer: Record<string, { id?: string; step100?: string }> = {};
+	try {
+		answer = JSON.parse(/\{[\s\S]*\}/.exec(content)?.[0] ?? "{}");
+	} catch {
+		// unparseable answers score zero
+	}
+	let score = 0;
+	const detail = present.map((n) => {
+		const text = String(tools[n - 1].content);
+		const id = /Job ([0-9a-f]+) launched/.exec(text)?.[1];
+		const line = text.split("\n").find((l) => / step=100 /.test(l));
+		const a = answer[String(n)] ?? {};
+		const good = a.id === id && a.step100 === line;
+		if (good) score++;
+		return `${n}:${good ? "ok" : a.step100 === "NOT_PRESENT" ? "not-present" : "wrong"}`;
+	});
+	return { score, total: present.length, detail };
+}
+
+function uniqueWordRatio(text: string): number {
+	const words = text.split(/\s+/).filter(Boolean);
+	if (words.length < 50) return 1;
+	return new Set(words).size / words.length;
+}
+
+async function runOne(spec: RunSpec, tools: OaTool[]): Promise<RunResult> {
+	const { msgs, rounds } = buildHistory(spec.size, tools, 42);
+	msgs.push({ role: "user", content: TASKS[spec.task] });
+	const modelId = spec.provider ? `${spec.model}:${spec.provider}` : spec.model;
+	const body = {
+		model: modelId,
+		stream: true,
+		messages: msgs,
+		tools,
+		tool_choice: "auto",
+		max_tokens: spec.maxTokens,
+		stream_options: { include_usage: true },
+	};
+	const result: RunResult = {
+		...spec,
+		modelId,
+		chunks: 0,
+		maxGapMs: 0,
+		contentChars: 0,
+		reasoningChars: 0,
+		toolCalls: [],
+		finishReasons: [],
+		sawDone: false,
+		errors: [],
+		verdict: "ERROR",
+		reason: "",
+		contentTail: "",
+	};
+	void rounds;
+	const raw: string[] = [];
+	const t0 = Date.now();
+	let res: Awaited<ReturnType<typeof undiciFetch>>;
+	try {
+		res = await undiciFetch(`${baseUrl}/chat/completions`, {
+			method: "POST",
+			headers: {
+				"content-type": "application/json",
+				authorization: `Bearer ${apiKey}`,
+				"X-use-cache": "false",
+			},
+			body: JSON.stringify(body),
+			dispatcher: agent,
+		});
+	} catch (e) {
+		result.streamError = String(e);
+		result.reason = "fetch failed";
+		return result;
+	}
+	result.status = res.status;
+	result.providerHeader = res.headers.get("x-inference-provider");
+	result.ttfbMs = Date.now() - t0;
+	if (!res.ok || !res.body) {
+		result.errorBody = (await res.text()).slice(0, 2000);
+		result.reason = `HTTP ${res.status}`;
+		return result;
+	}
+
+	let content = "";
+	let reasoning = "";
+	const calls: Record<number, { name: string; args: string }> = {};
+	let buf = "";
+	let lastAt = Date.now();
+	const dec = new TextDecoder();
+	try {
+		for await (const piece of res.body as AsyncIterable<Uint8Array>) {
+			const now = Date.now();
+			result.maxGapMs = Math.max(result.maxGapMs, now - lastAt);
+			lastAt = now;
+			const text = dec.decode(piece, { stream: true });
+			raw.push(text);
+			buf += text;
+			let idx: number;
+			while ((idx = buf.indexOf("\n\n")) !== -1) {
+				const evt = buf.slice(0, idx);
+				buf = buf.slice(idx + 2);
+				for (const line of evt.split("\n")) {
+					if (!line.startsWith("data:")) continue;
+					const data = line.slice(5).trim();
+					if (data === "[DONE]") {
+						result.sawDone = true;
+						continue;
+					}
+					let j: Record<string, unknown>;
+					try {
+						j = JSON.parse(data);
+					} catch {
+						continue;
+					}
+					result.chunks++;
+					if (j.error) result.errors.push(JSON.stringify(j.error).slice(0, 500));
+					if (j.usage) result.usage = j.usage as RunResult["usage"];
+					const choice = (
+						j.choices as { finish_reason?: string; delta?: Record<string, unknown> }[] | undefined
+					)?.[0];
+					if (!choice) continue;
+					if (choice.finish_reason) result.finishReasons.push(choice.finish_reason);
+					const d = choice.delta ?? {};
+					if (typeof d.content === "string") content += d.content;
+					const r = d.reasoning_content ?? d.reasoning ?? d.reasoning_text;
+					if (typeof r === "string") reasoning += r;
+					for (const tc of (d.tool_calls as {
+						index?: number;
+						function?: { name?: string; arguments?: string };
+					}[]) ?? []) {
+						const cur = (calls[tc.index ?? 0] ??= { name: "", args: "" });
+						if (tc.function?.name) cur.name = tc.function.name;
+						if (tc.function?.arguments) cur.args += tc.function.arguments;
+					}
+				}
+			}
+		}
+	} catch (e) {
+		result.streamError = String(e);
+	}
+	result.totalMs = Date.now() - t0;
+	result.contentChars = content.length;
+	result.reasoningChars = reasoning.length;
+	result.contentTail = content.slice(-300);
+	result.toolCalls = Object.values(calls).map((c) => {
+		let valid = true;
+		try {
+			JSON.parse(c.args);
+		} catch {
+			valid = false;
+		}
+		return { name: c.name, argChars: c.args.length, valid };
+	});
+	if (spec.task === "recall") result.recall = gradeRecall(content, msgs);
+	writeFileSync(join(OUT, `${spec.label}.sse`), raw.join(""));
+
+	// ---- verdict ----
+	const finish = result.finishReasons.at(-1);
+	const deliveredTokens =
+		(content.length +
+			reasoning.length +
+			Object.values(calls).reduce((n, c) => n + c.args.length, 0)) /
+		3;
+	const billed = result.usage?.completion_tokens ?? 0;
+	if (result.streamError) {
+		result.verdict = "ERROR";
+		result.reason = result.streamError;
+	} else if (result.errors.length) {
+		result.verdict = "ERROR";
+		result.reason = result.errors[0];
+	} else if (!result.sawDone || !finish) {
+		result.verdict = "TRUNCATED";
+		result.reason = !result.sawDone ? "stream ended without [DONE]" : "no finish_reason";
+	} else if (
+		["tool", "bigtool"].includes(spec.task) &&
+		finish === "stop" &&
+		result.toolCalls.length === 0
+	) {
+		result.verdict = "SWALLOWED";
+		result.reason = `tool task ended with "stop" and no tool call (${billed} tokens billed)`;
+	} else if (billed > 200 && billed > deliveredTokens * 2 + 100) {
+		result.verdict = "SWALLOWED";
+		result.reason = `billed ${billed} completion tokens, delivered ~${Math.round(deliveredTokens)}`;
+	} else if (result.toolCalls.some((c) => !c.valid) && finish !== "length") {
+		result.verdict = "DEGRADED";
+		result.reason = "tool call arguments are not valid JSON";
+	} else if (uniqueWordRatio(content) < 0.3) {
+		result.verdict = "DEGRADED";
+		result.reason = "degenerate repetition in output";
+	} else if (spec.task === "recall" && result.recall && content.trim().length === 0) {
+		result.verdict = "DEGRADED";
+		result.reason =
+			finish === "length" ? "reasoning-only until the output cap; no answer" : "no visible answer";
+	} else if (
+		spec.task === "recall" &&
+		result.recall &&
+		result.recall.score * 2 < result.recall.total
+	) {
+		result.verdict = "DEGRADED";
+		result.reason = `recall ${result.recall.score}/${result.recall.total} [${result.recall.detail.join(" ")}]`;
+	} else {
+		result.verdict = "OK";
+		result.reason =
+			spec.task === "recall" && result.recall
+				? `recall ${result.recall.score}/${result.recall.total}`
+				: result.toolCalls.length
+					? `tool call ${result.toolCalls.map((c) => `${c.name}(${c.argChars} chars)`).join(", ")}`
+					: `finish=${finish}, ${content.length} chars`;
+	}
+	return result;
+}
+
+// ---------- suites ----------
+
+async function providersFor(
+	model: string
+): Promise<{ provider: string; context_length?: number }[]> {
+	const res = await fetch(`${baseUrl}/models`);
+	const json = (await res.json()) as {
+		data: {
+			id: string;
+			providers?: { provider: string; context_length?: number; status?: string }[];
+		}[];
+	};
+	const entry = json.data.find((m) => m.id === model);
+	if (!entry) throw new Error(`model ${model} not in ${baseUrl}/models`);
+	return (entry.providers ?? []).filter((p) => p.status !== "error");
+}
+
+const SUITES: Record<string, { task: string; size: string }[]> = {
+	quick: [
+		{ task: "tool", size: "100000" },
+		{ task: "recall", size: "300000" },
+	],
+	standard: [
+		{ task: "tool", size: "100000" },
+		{ task: "recall", size: "300000" },
+		{ task: "recall", size: "75%" },
+		{ task: "recall", size: "90%" },
+	],
+};
+
+function resolveSize(
+	size: string,
+	contextLength: number | undefined,
+	maxTokens: number
+): number | undefined {
+	if (size.endsWith("%")) {
+		const window = contextLength ?? 131072;
+		const pct = Number(size.slice(0, -1)) / 100;
+		return Math.floor((window - maxTokens) * pct);
+	}
+	const n = Number(size);
+	if (contextLength && n > contextLength - maxTokens) return undefined;
+	return n;
+}
+
+function line(r: RunResult): string {
+	const prompt = r.usage?.prompt_tokens?.toLocaleString("en-US") ?? "-";
+	return [
+		r.verdict.padEnd(9),
+		r.modelId.padEnd(44),
+		`${r.task}@${prompt}`.padEnd(20),
+		`finish=${r.finishReasons.at(-1) ?? "-"}`.padEnd(18),
+		`ttfb=${r.ttfbMs ?? "-"}ms gap=${r.maxGapMs}ms`.padEnd(28),
+		r.reason,
+	].join(" ");
+}
+
+async function main() {
+	const model = str("model");
+	if (!model) {
+		console.error(
+			"usage: npm run probe-model -- --model <id> [--provider p] [--suite quick|standard] [--size N|N%] [--task recall|tool|answer|bigtool|dump] [--max-tokens N] [--out dir]"
+		);
+		process.exit(1);
+	}
+	const maxTokens = Number(str("max-tokens") ?? 32768);
+	const tools = await hubTools();
+	const listed = await providersFor(model);
+	const providers = str("provider")
+		? [
+				{
+					provider: String(str("provider")),
+					context_length: listed.find((p) => p.provider === str("provider"))?.context_length,
+				},
+			]
+		: listed;
+	const steps =
+		str("size") || str("task")
+			? [{ task: str("task") ?? "recall", size: str("size") ?? "300000" }]
+			: SUITES[str("suite") ?? "standard"];
+	if (!steps) throw new Error(`unknown suite ${str("suite")}`);
+
+	console.log(
+		`model ${model}; providers ${providers.map((p) => p.provider).join(", ")}; ${tools.length} tools; out ${OUT}`
+	);
+	const results: RunResult[] = [];
+	for (const p of providers) {
+		for (const step of steps) {
+			const size = resolveSize(step.size, p.context_length, maxTokens);
+			if (size === undefined) {
+				console.log(
+					`SKIP      ${model}:${p.provider} ${step.task}@${step.size} exceeds the provider window`
+				);
+				continue;
+			}
+			const label = `${model.replace("/", "_")}__${p.provider}__${step.task}@${size}`;
+			const spec: RunSpec = {
+				model,
+				provider: p.provider,
+				size,
+				task: step.task,
+				maxTokens,
+				label,
+			};
+			const r = await runOne(spec, tools);
+			results.push(r);
+			appendFileSync(join(OUT, "results.jsonl"), JSON.stringify(r) + "\n");
+			writeFileSync(join(OUT, `${label}.json`), JSON.stringify(r, null, 2));
+			console.log(line(r));
+		}
+	}
+	const bad = results.filter((r) => r.verdict !== "OK");
+	console.log(`\n${results.length} runs, ${bad.length} not OK`);
+	process.exit(bad.length ? 2 : 0);
+}
+
+main().catch((e) => {
+	console.error(e);
+	process.exit(1);
+});

--- a/scripts/probe-model.ts
+++ b/scripts/probe-model.ts
@@ -25,7 +25,7 @@
  *
  * Suites (default `standard`): each provider the router lists for the model
  * (or --provider) runs every step. Sizes are prompt tokens; `%` of the
- * provider's context window.
+ * provider's whole context window, clamped so prompt plus reply still fits.
  *   quick     tool@100k, recall@300k
  *   standard  tool@100k, recall@300k, recall@75%, recall@90%
  *
@@ -617,7 +617,8 @@ function resolveSize(
 	if (size.endsWith("%")) {
 		const window = contextLength ?? 131072;
 		const pct = Number(size.slice(0, -1)) / 100;
-		return Math.floor((window - maxTokens) * pct);
+		// Of the whole window, clamped only so prompt plus reply still fits.
+		return Math.min(Math.floor(window * pct), window - maxTokens);
 	}
 	const n = Number(size);
 	if (contextLength && n > contextLength - maxTokens) return undefined;

--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -552,8 +552,24 @@
 
 	// The pill is the mode's pre-task switch. Empty conversations only — the mode
 	// cannot be joined once a chat has started without it.
+	// With no set configured the send would fail; no switch is better than a
+	// dead end.
+	let mlModelSet = $derived(
+		ML_ASSISTANT_MODE
+			? ((page.data as { mlAssistantModels?: string[] }).mlAssistantModels ?? [])
+			: []
+	);
 	let mlPillVisible = $derived(
-		ML_ASSISTANT_MODE && !shared && !isReadOnly && !mlTaskRunning && messages.length === 0
+		ML_ASSISTANT_MODE &&
+			!shared &&
+			!isReadOnly &&
+			!mlTaskRunning &&
+			messages.length === 0 &&
+			mlModelSet.length > 0
+	);
+	// A mode conversation whose model left the set can only move within the set.
+	let switchableModels = $derived(
+		mlTaskRunning ? models.filter((m) => mlModelSet.includes(m.id)) : models
 	);
 
 	$effect(() => {
@@ -909,7 +925,7 @@
 							</div>
 						{/each}
 						{#if isReadOnly}
-							<ModelSwitch {models} {currentModel} />
+							<ModelSwitch models={switchableModels} {currentModel} />
 						{/if}
 					</div>
 				{:else if pending}

--- a/src/lib/components/chat/ModelSwitch.svelte
+++ b/src/lib/components/chat/ModelSwitch.svelte
@@ -5,6 +5,7 @@
 	import { page } from "$app/state";
 	import { base } from "$app/paths";
 	import type { Model } from "$lib/types/Model";
+	import { error } from "$lib/stores/errors";
 
 	interface Props {
 		models: Model[];
@@ -15,13 +16,11 @@
 
 	const convsStore = useConversationsStore();
 
-	let selectedModelId = $state("");
-
-	$effect.pre(() => {
-		selectedModelId = models.map((m) => m.id).includes(currentModel.id)
+	let selectedModelId = $derived(
+		models.some((m) => m.id === currentModel.id)
 			? currentModel.id
-			: models[0].id;
-	});
+			: (models[0]?.id ?? currentModel.id)
+	);
 
 	async function handleModelChange() {
 		if (!page.params.id) return;
@@ -36,12 +35,19 @@
 			});
 
 			if (!response.ok) {
-				throw new Error("Failed to update model");
+				let message = "Failed to update model";
+				try {
+					message = ((await response.json()) as { message?: string }).message ?? message;
+				} catch {
+					// not JSON
+				}
+				throw new Error(message);
 			}
 
 			await Promise.all([safeInvalidate(UrlDependency.Conversation), convsStore.refresh()]);
-		} catch (error) {
-			console.error(error);
+		} catch (err) {
+			console.error(err);
+			error.set((err as Error).message);
 		}
 	}
 </script>
@@ -57,7 +63,7 @@
 			bind:value={selectedModelId}
 			class="rounded-md bg-gray-100 px-2 py-1 max-sm:max-w-32 dark:bg-gray-900"
 		>
-			{#each models as model}
+			{#each models as model (model.id)}
 				<option value={model.id}>{model.name}</option>
 			{/each}
 		</select>

--- a/src/lib/server/__tests__/conversation-ml-assistant-models.spec.ts
+++ b/src/lib/server/__tests__/conversation-ml-assistant-models.spec.ts
@@ -33,6 +33,7 @@ import {
 } from "$lib/server/api/__tests__/testHelpers";
 import { POST as createConversation } from "../../../routes/conversation/+server";
 import { PATCH as patchConversation } from "../../../routes/conversation/[id]/+server";
+import { PATCH as patchConversationV2 } from "../../../routes/api/v2/conversations/[id]/+server";
 
 beforeAll(async () => {
 	await ready;
@@ -95,6 +96,30 @@ describe.sequential("ML Intern conversations run on the fixed model set", () => 
 				locals,
 				params: { id: conv._id.toString() },
 				request: new Request("http://localhost/conversation", {
+					method: "PATCH",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ model }),
+				}),
+			} as never);
+
+		await expect(patch("omni")).rejects.toMatchObject({ status: 400 });
+		expect((await collections.conversations.findOne({ _id: conv._id }))?.model).toBe(conv.model);
+
+		const ok = await patch("moonshotai/Kimi-K3");
+		expect(ok.status).toBe(200);
+		expect((await collections.conversations.findOne({ _id: conv._id }))?.model).toBe(
+			"moonshotai/Kimi-K3"
+		);
+	});
+
+	it("guards the v2 endpoint the same way", async () => {
+		const { locals } = await createTestUser();
+		const conv = await createTestConversation(locals, { mlAssistant: true });
+		const patch = (model: string) =>
+			patchConversationV2({
+				locals,
+				params: { id: conv._id.toString() },
+				request: new Request("http://localhost/api/v2/conversations/x", {
 					method: "PATCH",
 					headers: { "Content-Type": "application/json" },
 					body: JSON.stringify({ model }),

--- a/src/lib/server/__tests__/conversation-ml-assistant-models.spec.ts
+++ b/src/lib/server/__tests__/conversation-ml-assistant-models.spec.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+
+const { FAKE_MODELS, mlSet } = vi.hoisted(() => ({
+	FAKE_MODELS: ["zai-org/GLM-5.3-Flash", "moonshotai/Kimi-K3", "omni"].map((id) => ({
+		id,
+		name: id,
+		unlisted: false,
+		preprompt: "",
+	})),
+	mlSet: { ids: ["zai-org/GLM-5.3-Flash", "moonshotai/Kimi-K3"] },
+}));
+
+vi.mock("$lib/server/models", () => ({
+	models: FAKE_MODELS,
+	validateModel: () => z.string().refine((id) => FAKE_MODELS.some((m) => m.id === id)),
+	validModelIdSchema: z.string(),
+}));
+vi.mock("$lib/utils/mlAssistantFlag", () => ({ ML_ASSISTANT_MODE: true }));
+vi.mock("$lib/server/mlAssistantModels", () => ({
+	mlAssistantModelIds: () => mlSet.ids,
+	resolveMlAssistantModel: (requested: string | undefined) =>
+		mlSet.ids.length === 0 ? undefined : (mlSet.ids.find((id) => id === requested) ?? mlSet.ids[0]),
+	mlAssistantProviderFor: (_id: string, pref: string | undefined) => pref,
+	mlAssistantModelEntry: () => undefined,
+}));
+
+import { collections, ready } from "$lib/server/database";
+import {
+	cleanupTestData,
+	createTestConversation,
+	createTestUser,
+} from "$lib/server/api/__tests__/testHelpers";
+import { POST as createConversation } from "../../../routes/conversation/+server";
+import { PATCH as patchConversation } from "../../../routes/conversation/[id]/+server";
+
+beforeAll(async () => {
+	await ready;
+});
+
+async function create(locals: App.Locals, body: Record<string, unknown>) {
+	const response = await createConversation({
+		locals,
+		request: new Request("http://localhost/conversation", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(body),
+		}),
+	} as never);
+	const { conversationId } = (await response.json()) as { conversationId: string };
+	const { ObjectId } = await import("mongodb");
+	return collections.conversations.findOne({ _id: new ObjectId(conversationId) });
+}
+
+describe.sequential("ML Intern conversations run on the fixed model set", () => {
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		mlSet.ids = ["zai-org/GLM-5.3-Flash", "moonshotai/Kimi-K3"];
+		await cleanupTestData();
+	});
+
+	it("replaces an unlisted model (the router alias included) with the default", async () => {
+		const { locals } = await createTestUser();
+		const conv = await create(locals, { model: "omni", mlAssistant: true });
+		expect(conv?.model).toBe("zai-org/GLM-5.3-Flash");
+		expect(conv?.mlAssistant).toBe(true);
+	});
+
+	it("keeps a listed model", async () => {
+		const { locals } = await createTestUser();
+		const conv = await create(locals, { model: "moonshotai/Kimi-K3", mlAssistant: true });
+		expect(conv?.model).toBe("moonshotai/Kimi-K3");
+	});
+
+	it("leaves ordinary conversations alone", async () => {
+		const { locals } = await createTestUser();
+		const conv = await create(locals, { model: "omni" });
+		expect(conv?.model).toBe("omni");
+		expect(conv?.mlAssistant).toBeUndefined();
+	});
+
+	it("refuses to start the mode with no models configured", async () => {
+		mlSet.ids = [];
+		const { locals } = await createTestUser();
+		await expect(create(locals, { model: "omni", mlAssistant: true })).rejects.toMatchObject({
+			status: 400,
+		});
+	});
+
+	it("only switches a mode conversation to a listed model", async () => {
+		const { locals } = await createTestUser();
+		const conv = await createTestConversation(locals, { mlAssistant: true });
+		const patch = (model: string) =>
+			patchConversation({
+				locals,
+				params: { id: conv._id.toString() },
+				request: new Request("http://localhost/conversation", {
+					method: "PATCH",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ model }),
+				}),
+			} as never);
+
+		await expect(patch("omni")).rejects.toMatchObject({ status: 400 });
+		expect((await collections.conversations.findOne({ _id: conv._id }))?.model).toBe(conv.model);
+
+		const ok = await patch("moonshotai/Kimi-K3");
+		expect(ok.status).toBe(200);
+		expect((await collections.conversations.findOne({ _id: conv._id }))?.model).toBe(
+			"moonshotai/Kimi-K3"
+		);
+	});
+
+	it("lets an ordinary conversation switch to any model", async () => {
+		const { locals } = await createTestUser();
+		const conv = await createTestConversation(locals);
+		const ok = await patchConversation({
+			locals,
+			params: { id: conv._id.toString() },
+			request: new Request("http://localhost/conversation", {
+				method: "PATCH",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ model: "omni" }),
+			}),
+		} as never);
+		expect(ok.status).toBe(200);
+	});
+});

--- a/src/lib/server/api/types.ts
+++ b/src/lib/server/api/types.ts
@@ -44,4 +44,6 @@ export interface FeatureFlags {
 	transcriptionEnabled: boolean;
 	/** Fixed model used for background tasks (e.g. conversation titles); null when tasks follow the conversation's model */
 	taskModelId: string | null;
+	/** Models ML Intern conversations may use, in order; the first is the default. Empty when the mode is off. */
+	mlAssistantModels: string[];
 }

--- a/src/lib/server/conversationSettings.ts
+++ b/src/lib/server/conversationSettings.ts
@@ -1,6 +1,9 @@
 import type { Filter, UpdateResult } from "mongodb";
+import { error } from "@sveltejs/kit";
 import { collections } from "$lib/server/database";
 import type { Conversation } from "$lib/types/Conversation";
+import { isMlAssistantConversation } from "$lib/server/mlAssistant";
+import { mlAssistantModelIds } from "$lib/server/mlAssistantModels";
 
 /** The mutable conversation settings both PATCH endpoints expose. */
 export interface ConversationSettingsUpdate {
@@ -32,7 +35,7 @@ export interface ConversationSettingsUpdate {
  *
  * Callers own authorization: pass a filter that already scopes to the caller.
  */
-export function applyConversationSettings(
+export async function applyConversationSettings(
 	filter: Filter<Conversation>,
 	values: ConversationSettingsUpdate
 ): Promise<UpdateResult> {
@@ -46,6 +49,20 @@ export function applyConversationSettings(
 
 	if (values.model === undefined) {
 		return collections.conversations.updateOne(filter, { $set: updateValues });
+	}
+
+	// Here, not in the endpoints: an ML Intern conversation may only move within
+	// the mode's fixed set, and a guard that lives in one handler is exactly how
+	// the other one came to bypass it.
+	const current = await collections.conversations.findOne(filter, {
+		projection: { mlAssistant: 1 },
+	});
+	if (
+		current &&
+		isMlAssistantConversation(current) &&
+		!mlAssistantModelIds().includes(values.model)
+	) {
+		error(400, "This model is not available for ML Intern conversations");
 	}
 
 	const newModel = values.model;

--- a/src/lib/server/generation/parkedSweeper.ts
+++ b/src/lib/server/generation/parkedSweeper.ts
@@ -7,6 +7,7 @@ import { models } from "$lib/server/models";
 import { buildSubtree } from "$lib/utils/tree/buildSubtree";
 import { textGeneration } from "$lib/server/textGeneration";
 import { isMlAssistantConversation } from "$lib/server/mlAssistant";
+import { mlAssistantProviderFor } from "$lib/server/mlAssistantModels";
 import { ML_ASSISTANT_EFFORT } from "$lib/constants/mlAssistant";
 import { waitResumeResultText } from "$lib/server/textGeneration/builtinTools/waitTool";
 import { ToolResultStatus } from "$lib/types/Tool";
@@ -321,7 +322,9 @@ async function resumeParkedCallInner(park: ParkedCall): Promise<void> {
 			username: locals.user?.username,
 			provider:
 				config.isHuggingChat && !model.isRouter
-					? settings?.providerOverrides?.[model.id]
+					? isMlAssistantConversation(conv)
+						? mlAssistantProviderFor(model.id, settings?.providerOverrides?.[model.id])
+						: settings?.providerOverrides?.[model.id]
 					: undefined,
 			reasoningEffort: isMlAssistantConversation(conv)
 				? ML_ASSISTANT_EFFORT

--- a/src/lib/server/mlAssistantModels.spec.ts
+++ b/src/lib/server/mlAssistantModels.spec.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocked = vi.hoisted(() => ({ env: "" as string, mode: true }));
+vi.mock("./config", () => ({
+	config: new Proxy(
+		{},
+		{ get: (_t, key) => (key === "ML_ASSISTANT_MODELS" ? mocked.env : undefined) }
+	),
+}));
+vi.mock("$lib/utils/mlAssistantFlag", () => ({
+	get ML_ASSISTANT_MODE() {
+		return mocked.mode;
+	},
+}));
+vi.mock("./logger", () => ({ logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() } }));
+
+import {
+	mlAssistantModelEntries,
+	mlAssistantModelIds,
+	mlAssistantProviderFor,
+	parseMlAssistantModels,
+	resolveMlAssistantModel,
+	setMlAssistantKnownModelIds,
+} from "./mlAssistantModels";
+
+const CATALOG = ["zai-org/GLM-5.3-Flash", "moonshotai/Kimi-K3", "zai-org/GLM-5.3", "omni"];
+
+describe("parseMlAssistantModels", () => {
+	it("keeps entries in order, first is the default", () => {
+		const entries = parseMlAssistantModels(
+			`[{id:"zai-org/GLM-5.3-Flash", provider:"together"}, {id:"moonshotai/Kimi-K3"}]`,
+			CATALOG
+		);
+		expect(entries.map((e) => e.id)).toEqual(["zai-org/GLM-5.3-Flash", "moonshotai/Kimi-K3"]);
+		expect(entries[0].provider).toBe("together");
+		expect(entries[1].provider).toBeUndefined();
+	});
+
+	it("drops unknown models instead of failing, and dedupes", () => {
+		const entries = parseMlAssistantModels(
+			`[{id:"nope/missing"}, {id:"moonshotai/Kimi-K3"}, {id:"moonshotai/Kimi-K3", provider:"baseten"}]`,
+			CATALOG
+		);
+		expect(entries).toEqual([{ id: "moonshotai/Kimi-K3" }]);
+	});
+
+	it("returns nothing for empty or malformed input", () => {
+		expect(parseMlAssistantModels(undefined, CATALOG)).toEqual([]);
+		expect(parseMlAssistantModels("   ", CATALOG)).toEqual([]);
+		expect(parseMlAssistantModels("not json", CATALOG)).toEqual([]);
+		expect(parseMlAssistantModels(`[{provider:"together"}]`, CATALOG)).toEqual([]);
+	});
+
+	it("accepts the backtick-wrapped .env convention", () => {
+		expect(
+			parseMlAssistantModels('`[{id:"moonshotai/Kimi-K3"}]`', CATALOG).map((e) => e.id)
+		).toEqual(["moonshotai/Kimi-K3"]);
+	});
+
+	it("accepts any id when no catalog is given", () => {
+		expect(parseMlAssistantModels(`[{id:"anything"}]`).map((e) => e.id)).toEqual(["anything"]);
+	});
+});
+
+describe("configured set", () => {
+	beforeEach(() => {
+		mocked.mode = true;
+		mocked.env = `[
+			{id:"zai-org/GLM-5.3-Flash", provider:"together", parameters:{max_tokens: 49152}},
+			{id:"moonshotai/Kimi-K3", provider:"fireworks-ai"},
+		]`;
+		setMlAssistantKnownModelIds(() => CATALOG);
+	});
+
+	it("exposes ids in configured order", () => {
+		expect(mlAssistantModelIds()).toEqual(["zai-org/GLM-5.3-Flash", "moonshotai/Kimi-K3"]);
+		expect(mlAssistantModelEntries()[0].parameters).toEqual({ max_tokens: 49152 });
+	});
+
+	it("resolves a requested model to itself when listed, else to the default", () => {
+		expect(resolveMlAssistantModel("moonshotai/Kimi-K3")).toBe("moonshotai/Kimi-K3");
+		expect(resolveMlAssistantModel("omni")).toBe("zai-org/GLM-5.3-Flash");
+		expect(resolveMlAssistantModel(undefined)).toBe("zai-org/GLM-5.3-Flash");
+	});
+
+	it("pins the provider over the user's preference for listed models only", () => {
+		expect(mlAssistantProviderFor("zai-org/GLM-5.3-Flash", "baseten")).toBe("together");
+		expect(mlAssistantProviderFor("zai-org/GLM-5.3-Flash", "auto")).toBe("together");
+		expect(mlAssistantProviderFor("zai-org/GLM-5.3", "baseten")).toBe("baseten");
+		expect(mlAssistantProviderFor("zai-org/GLM-5.3", undefined)).toBeUndefined();
+	});
+
+	it("re-parses when the env value changes", () => {
+		expect(mlAssistantModelIds()).toHaveLength(2);
+		mocked.env = `[{id:"zai-org/GLM-5.3"}]`;
+		expect(mlAssistantModelIds()).toEqual(["zai-org/GLM-5.3"]);
+	});
+
+	it("is empty when the build does not ship the mode", () => {
+		mocked.mode = false;
+		setMlAssistantKnownModelIds(() => CATALOG);
+		expect(mlAssistantModelIds()).toEqual([]);
+		expect(resolveMlAssistantModel("zai-org/GLM-5.3-Flash")).toBeUndefined();
+	});
+});

--- a/src/lib/server/mlAssistantModels.spec.ts
+++ b/src/lib/server/mlAssistantModels.spec.ts
@@ -20,28 +20,51 @@ import {
 	mlAssistantProviderFor,
 	parseMlAssistantModels,
 	resolveMlAssistantModel,
-	setMlAssistantKnownModelIds,
+	setMlAssistantCatalog,
 } from "./mlAssistantModels";
 
-const CATALOG = ["zai-org/GLM-5.3-Flash", "moonshotai/Kimi-K3", "zai-org/GLM-5.3", "omni"];
+const CATALOG = [
+	{ id: "zai-org/GLM-5.3-Flash" },
+	{ id: "moonshotai/Kimi-K3" },
+	{ id: "zai-org/GLM-5.3" },
+	{ id: "omni", isRouter: true },
+];
 
 describe("parseMlAssistantModels", () => {
 	it("keeps entries in order, first is the default", () => {
 		const entries = parseMlAssistantModels(
-			`[{id:"zai-org/GLM-5.3-Flash", provider:"together"}, {id:"moonshotai/Kimi-K3"}]`,
+			`[{id:"zai-org/GLM-5.3-Flash", provider:"together"}, {id:"moonshotai/Kimi-K3", provider:"baseten"}]`,
 			CATALOG
 		);
 		expect(entries.map((e) => e.id)).toEqual(["zai-org/GLM-5.3-Flash", "moonshotai/Kimi-K3"]);
 		expect(entries[0].provider).toBe("together");
-		expect(entries[1].provider).toBeUndefined();
+		expect(entries[1].provider).toBe("baseten");
+	});
+
+	it("rejects the whole value when an entry has no provider", () => {
+		expect(
+			parseMlAssistantModels(
+				`[{id:"zai-org/GLM-5.3-Flash", provider:"together"}, {id:"moonshotai/Kimi-K3"}]`,
+				CATALOG
+			)
+		).toEqual([]);
+	});
+
+	it("drops the router alias even though it is in the catalog", () => {
+		expect(
+			parseMlAssistantModels(
+				`[{id:"omni", provider:"together"}, {id:"zai-org/GLM-5.3", provider:"novita"}]`,
+				CATALOG
+			).map((e) => e.id)
+		).toEqual(["zai-org/GLM-5.3"]);
 	});
 
 	it("drops unknown models instead of failing, and dedupes", () => {
 		const entries = parseMlAssistantModels(
-			`[{id:"nope/missing"}, {id:"moonshotai/Kimi-K3"}, {id:"moonshotai/Kimi-K3", provider:"baseten"}]`,
+			`[{id:"nope/missing", provider:"x"}, {id:"moonshotai/Kimi-K3", provider:"together"}, {id:"moonshotai/Kimi-K3", provider:"baseten"}]`,
 			CATALOG
 		);
-		expect(entries).toEqual([{ id: "moonshotai/Kimi-K3" }]);
+		expect(entries).toEqual([{ id: "moonshotai/Kimi-K3", provider: "together" }]);
 	});
 
 	it("returns nothing for empty or malformed input", () => {
@@ -53,12 +76,16 @@ describe("parseMlAssistantModels", () => {
 
 	it("accepts the backtick-wrapped .env convention", () => {
 		expect(
-			parseMlAssistantModels('`[{id:"moonshotai/Kimi-K3"}]`', CATALOG).map((e) => e.id)
+			parseMlAssistantModels('`[{id:"moonshotai/Kimi-K3", provider:"together"}]`', CATALOG).map(
+				(e) => e.id
+			)
 		).toEqual(["moonshotai/Kimi-K3"]);
 	});
 
 	it("accepts any id when no catalog is given", () => {
-		expect(parseMlAssistantModels(`[{id:"anything"}]`).map((e) => e.id)).toEqual(["anything"]);
+		expect(parseMlAssistantModels(`[{id:"anything", provider:"p"}]`).map((e) => e.id)).toEqual([
+			"anything",
+		]);
 	});
 });
 
@@ -69,7 +96,7 @@ describe("configured set", () => {
 			{id:"zai-org/GLM-5.3-Flash", provider:"together", parameters:{max_tokens: 49152}},
 			{id:"moonshotai/Kimi-K3", provider:"fireworks-ai"},
 		]`;
-		setMlAssistantKnownModelIds(() => CATALOG);
+		setMlAssistantCatalog(() => CATALOG);
 	});
 
 	it("exposes ids in configured order", () => {
@@ -92,13 +119,13 @@ describe("configured set", () => {
 
 	it("re-parses when the env value changes", () => {
 		expect(mlAssistantModelIds()).toHaveLength(2);
-		mocked.env = `[{id:"zai-org/GLM-5.3"}]`;
+		mocked.env = `[{id:"zai-org/GLM-5.3", provider:"novita"}]`;
 		expect(mlAssistantModelIds()).toEqual(["zai-org/GLM-5.3"]);
 	});
 
 	it("is empty when the build does not ship the mode", () => {
 		mocked.mode = false;
-		setMlAssistantKnownModelIds(() => CATALOG);
+		setMlAssistantCatalog(() => CATALOG);
 		expect(mlAssistantModelIds()).toEqual([]);
 		expect(resolveMlAssistantModel("zai-org/GLM-5.3-Flash")).toBeUndefined();
 	});

--- a/src/lib/server/mlAssistantModels.ts
+++ b/src/lib/server/mlAssistantModels.ts
@@ -1,0 +1,129 @@
+import JSON5 from "json5";
+import { z } from "zod";
+import { config } from "./config";
+import { logger } from "./logger";
+import { ML_ASSISTANT_MODE } from "$lib/utils/mlAssistantFlag";
+
+/**
+ * The fixed set of models ML Intern conversations may run on, from
+ * `ML_ASSISTANT_MODELS`. Separate from the catalog on purpose: the mode
+ * drives 1M-token tool loops, and the same model behaves very differently
+ * across inference providers at that size (see scripts/probe-model.ts), so
+ * each entry pins the provider the model was verified on. The router alias
+ * is excluded by construction — it can't be listed here.
+ *
+ * The first entry is the default. `parameters` merge over the catalog entry's
+ * for mode conversations only.
+ */
+const entrySchema = z.object({
+	id: z.string().trim().min(1),
+	provider: z.string().trim().min(1).optional(),
+	parameters: z.record(z.unknown()).optional(),
+});
+
+export type MlAssistantModelEntry = z.infer<typeof entrySchema>;
+
+/**
+ * Parse the env value. Entries whose id is not in `knownIds` are dropped with
+ * an error log rather than failing startup: a model leaving the router should
+ * not take the whole app down, and the mode still works with what remains.
+ */
+export function parseMlAssistantModels(
+	raw: string | undefined,
+	knownIds?: Iterable<string>
+): MlAssistantModelEntry[] {
+	// Backtick-wrapped like MODELS, so the same .env convention works here.
+	const trimmed = (raw ?? "").trim();
+	const unquoted =
+		trimmed.startsWith("`") && trimmed.endsWith("`") ? trimmed.slice(1, -1) : trimmed;
+	if (!unquoted.trim()) return [];
+	let entries: MlAssistantModelEntry[];
+	try {
+		entries = z.array(entrySchema).parse(JSON5.parse(unquoted));
+	} catch (error) {
+		logger.error(error, "[mlAssistant] Failed to parse ML_ASSISTANT_MODELS");
+		return [];
+	}
+	const known = knownIds ? new Set(knownIds) : undefined;
+	const seen = new Set<string>();
+	const kept: MlAssistantModelEntry[] = [];
+	for (const entry of entries) {
+		if (seen.has(entry.id)) continue;
+		if (known && !known.has(entry.id)) {
+			logger.error(
+				{ id: entry.id },
+				"[mlAssistant] ML_ASSISTANT_MODELS entry is not a known model"
+			);
+			continue;
+		}
+		seen.add(entry.id);
+		kept.push(entry);
+	}
+	return kept;
+}
+
+let cachedRaw: string | undefined;
+let cachedEntries: MlAssistantModelEntry[] = [];
+
+/**
+ * The configured entries, validated against the loaded catalog. Re-parsed
+ * only when the env value changes (the config manager can update it live).
+ */
+export function mlAssistantModelEntries(): MlAssistantModelEntry[] {
+	if (!ML_ASSISTANT_MODE) return [];
+	const raw = (Reflect.get(config, "ML_ASSISTANT_MODELS") as string | undefined) ?? "";
+	if (raw !== cachedRaw) {
+		cachedRaw = raw;
+		cachedEntries = parseMlAssistantModels(raw, knownModelIds());
+	}
+	return cachedEntries;
+}
+
+let knownIdsResolver: () => Iterable<string> | undefined = () => undefined;
+
+/**
+ * Installed by the models module once the catalog is loaded, so this module
+ * never imports it (the catalog is what the entries are validated against,
+ * and importing it here would tie parsing to catalog startup).
+ */
+export function setMlAssistantKnownModelIds(resolver: () => Iterable<string> | undefined): void {
+	knownIdsResolver = resolver;
+	cachedRaw = undefined;
+}
+
+function knownModelIds(): Iterable<string> | undefined {
+	return knownIdsResolver();
+}
+
+export function mlAssistantModelIds(): string[] {
+	return mlAssistantModelEntries().map((e) => e.id);
+}
+
+export function mlAssistantModelEntry(modelId: string): MlAssistantModelEntry | undefined {
+	return mlAssistantModelEntries().find((e) => e.id === modelId);
+}
+
+/**
+ * The model a new mode conversation runs on: the requested one when it is in
+ * the set, else the default. `undefined` when the set is empty, which callers
+ * treat as "the mode has no models configured".
+ */
+export function resolveMlAssistantModel(requested: string | undefined): string | undefined {
+	const entries = mlAssistantModelEntries();
+	if (entries.length === 0) return undefined;
+	return entries.find((e) => e.id === requested)?.id ?? entries[0].id;
+}
+
+/**
+ * Provider for a mode conversation's request. The pinned provider always wins
+ * over the user's per-model preference: "auto" and the policies can route to
+ * a provider the model was never verified on. A model outside the set keeps
+ * the user's preference, so a conversation on a since-removed entry still
+ * runs rather than silently changing behaviour.
+ */
+export function mlAssistantProviderFor(
+	modelId: string,
+	userPreference: string | undefined
+): string | undefined {
+	return mlAssistantModelEntry(modelId)?.provider ?? userPreference;
+}

--- a/src/lib/server/mlAssistantModels.ts
+++ b/src/lib/server/mlAssistantModels.ts
@@ -9,28 +9,36 @@ import { ML_ASSISTANT_MODE } from "$lib/utils/mlAssistantFlag";
  * `ML_ASSISTANT_MODELS`. Separate from the catalog on purpose: the mode
  * drives 1M-token tool loops, and the same model behaves very differently
  * across inference providers at that size (see scripts/probe-model.ts), so
- * each entry pins the provider the model was verified on. The router alias
- * is excluded by construction — it can't be listed here.
+ * each entry pins the provider the model was verified on, and an entry without
+ * one is rejected: the pin is the point. The router alias is dropped at parse
+ * time, since a pin on it would be discarded by the call sites' router gate
+ * and the mode would run unpinned.
  *
  * The first entry is the default. `parameters` merge over the catalog entry's
  * for mode conversations only.
  */
 const entrySchema = z.object({
 	id: z.string().trim().min(1),
-	provider: z.string().trim().min(1).optional(),
+	provider: z.string().trim().min(1),
 	parameters: z.record(z.unknown()).optional(),
 });
 
 export type MlAssistantModelEntry = z.infer<typeof entrySchema>;
 
+export interface MlAssistantCatalogEntry {
+	id: string;
+	isRouter?: boolean;
+}
+
 /**
- * Parse the env value. Entries whose id is not in `knownIds` are dropped with
- * an error log rather than failing startup: a model leaving the router should
- * not take the whole app down, and the mode still works with what remains.
+ * Parse the env value. Entries that are not in `catalog`, or that name the
+ * router alias, are dropped with an error log rather than failing startup: a
+ * model leaving the router should not take the whole app down, and the mode
+ * still works with what remains.
  */
 export function parseMlAssistantModels(
 	raw: string | undefined,
-	knownIds?: Iterable<string>
+	catalog?: Iterable<MlAssistantCatalogEntry>
 ): MlAssistantModelEntry[] {
 	// Backtick-wrapped like MODELS, so the same .env convention works here.
 	const trimmed = (raw ?? "").trim();
@@ -44,7 +52,7 @@ export function parseMlAssistantModels(
 		logger.error(error, "[mlAssistant] Failed to parse ML_ASSISTANT_MODELS");
 		return [];
 	}
-	const known = knownIds ? new Set(knownIds) : undefined;
+	const known = catalog ? new Map([...catalog].map((m) => [m.id, m])) : undefined;
 	const seen = new Set<string>();
 	const kept: MlAssistantModelEntry[] = [];
 	for (const entry of entries) {
@@ -53,6 +61,13 @@ export function parseMlAssistantModels(
 			logger.error(
 				{ id: entry.id },
 				"[mlAssistant] ML_ASSISTANT_MODELS entry is not a known model"
+			);
+			continue;
+		}
+		if (known?.get(entry.id)?.isRouter) {
+			logger.error(
+				{ id: entry.id },
+				"[mlAssistant] ML_ASSISTANT_MODELS entry is the router alias; the mode needs a concrete model"
 			);
 			continue;
 		}
@@ -74,25 +89,27 @@ export function mlAssistantModelEntries(): MlAssistantModelEntry[] {
 	const raw = (Reflect.get(config, "ML_ASSISTANT_MODELS") as string | undefined) ?? "";
 	if (raw !== cachedRaw) {
 		cachedRaw = raw;
-		cachedEntries = parseMlAssistantModels(raw, knownModelIds());
+		cachedEntries = parseMlAssistantModels(raw, catalog());
 	}
 	return cachedEntries;
 }
 
-let knownIdsResolver: () => Iterable<string> | undefined = () => undefined;
+let catalogResolver: () => Iterable<MlAssistantCatalogEntry> | undefined = () => undefined;
 
 /**
  * Installed by the models module once the catalog is loaded, so this module
  * never imports it (the catalog is what the entries are validated against,
  * and importing it here would tie parsing to catalog startup).
  */
-export function setMlAssistantKnownModelIds(resolver: () => Iterable<string> | undefined): void {
-	knownIdsResolver = resolver;
+export function setMlAssistantCatalog(
+	resolver: () => Iterable<MlAssistantCatalogEntry> | undefined
+): void {
+	catalogResolver = resolver;
 	cachedRaw = undefined;
 }
 
-function knownModelIds(): Iterable<string> | undefined {
-	return knownIdsResolver();
+function catalog(): Iterable<MlAssistantCatalogEntry> | undefined {
+	return catalogResolver();
 }
 
 export function mlAssistantModelIds(): string[] {
@@ -119,7 +136,9 @@ export function resolveMlAssistantModel(requested: string | undefined): string |
  * over the user's per-model preference: "auto" and the policies can route to
  * a provider the model was never verified on. A model outside the set keeps
  * the user's preference, so a conversation on a since-removed entry still
- * runs rather than silently changing behaviour.
+ * runs rather than silently changing behaviour. Only meaningful against the
+ * HF router (the `model:provider` suffix is its feature); the call sites gate
+ * on that, so self-hosted deployments get the model set without the pin.
  */
 export function mlAssistantProviderFor(
 	modelId: string,

--- a/src/lib/server/models.ts
+++ b/src/lib/server/models.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 import endpoints, { endpointSchema, type Endpoint } from "./endpoints/endpoints";
 
 import JSON5 from "json5";
-import { setMlAssistantKnownModelIds } from "./mlAssistantModels";
+import { setMlAssistantCatalog } from "./mlAssistantModels";
 import { logger } from "$lib/server/logger";
 import { preservesReasoningByDefault } from "$lib/server/reasoningPolicy";
 import { makeRouterEndpoint } from "$lib/server/router/endpoint";
@@ -439,7 +439,7 @@ if (!building) {
 	}
 
 	models = newModels;
-	setMlAssistantKnownModelIds(() => models.map((model) => model.id));
+	setMlAssistantCatalog(() => models.map((model) => ({ id: model.id, isRouter: model.isRouter })));
 	defaultModel = models[0];
 	taskModel = resolveTaskModel(models);
 	validModelIdSchema = createValidModelIdSchema(models);

--- a/src/lib/server/models.ts
+++ b/src/lib/server/models.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 import endpoints, { endpointSchema, type Endpoint } from "./endpoints/endpoints";
 
 import JSON5 from "json5";
+import { setMlAssistantKnownModelIds } from "./mlAssistantModels";
 import { logger } from "$lib/server/logger";
 import { preservesReasoningByDefault } from "$lib/server/reasoningPolicy";
 import { makeRouterEndpoint } from "$lib/server/router/endpoint";
@@ -438,6 +439,7 @@ if (!building) {
 	}
 
 	models = newModels;
+	setMlAssistantKnownModelIds(() => models.map((model) => model.id));
 	defaultModel = models[0];
 	taskModel = resolveTaskModel(models);
 	validModelIdSchema = createValidModelIdSchema(models);

--- a/src/lib/server/textGeneration/mcp/runMcpFlow.ts
+++ b/src/lib/server/textGeneration/mcp/runMcpFlow.ts
@@ -466,7 +466,7 @@ export async function* runMcpFlow({
 		// reply allowance this request will actually ask for.
 		const parameters = {
 			...targetModel.parameters,
-			...(mlAssistant ? mlAssistantModelEntry(targetModel.id ?? targetModel.name)?.parameters : {}),
+			...(mlAssistant ? mlAssistantModelEntry(targetModel.id || targetModel.name)?.parameters : {}),
 			...assistant?.generateSettings,
 		} as Record<string, unknown>;
 		const catalogMaxTokens =

--- a/src/lib/server/textGeneration/mcp/runMcpFlow.ts
+++ b/src/lib/server/textGeneration/mcp/runMcpFlow.ts
@@ -29,6 +29,7 @@ import { logger } from "$lib/server/logger";
 import { AbortedGenerations } from "$lib/server/abortedGenerations";
 import { withoutContentLength } from "$lib/server/undiciCompat";
 import { isMlAssistantConversation, withMlAssistantServers } from "$lib/server/mlAssistant";
+import { mlAssistantModelEntry } from "$lib/server/mlAssistantModels";
 import { createMlBudgetGuard, withRequiredDiscriminators } from "$lib/server/mlBudget/guard";
 import { ML_ASSISTANT_MIN_COMPLETION_TOKENS } from "$lib/constants/mlAssistant";
 import { withRateLimitRetry } from "../utils/rateLimitRetry";
@@ -463,10 +464,11 @@ export async function* runMcpFlow({
 
 		// Hoisted above the message prep so the history budget can reserve the
 		// reply allowance this request will actually ask for.
-		const parameters = { ...targetModel.parameters, ...assistant?.generateSettings } as Record<
-			string,
-			unknown
-		>;
+		const parameters = {
+			...targetModel.parameters,
+			...(mlAssistant ? mlAssistantModelEntry(targetModel.id ?? targetModel.name)?.parameters : {}),
+			...assistant?.generateSettings,
+		} as Record<string, unknown>;
 		const catalogMaxTokens =
 			(parameters?.max_tokens as number | undefined) ??
 			(parameters?.max_new_tokens as number | undefined) ??

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -47,6 +47,10 @@
 			} else {
 				model = data.models[0].id;
 			}
+			// The mode runs on its own fixed set; the server enforces this too.
+			if (mlAssistant.taskStarted && data.mlAssistantModels.length > 0) {
+				model = data.mlAssistantModels.includes(model) ? model : data.mlAssistantModels[0];
+			}
 			const res = await fetch(`${base}/conversation`, {
 				method: "POST",
 				headers: {

--- a/src/routes/api/v2/feature-flags/+server.ts
+++ b/src/routes/api/v2/feature-flags/+server.ts
@@ -3,6 +3,7 @@ import { superjsonResponse } from "$lib/server/api/utils/superjsonResponse";
 import { loginEnabled } from "$lib/server/auth";
 import { config } from "$lib/server/config";
 import type { FeatureFlags } from "$lib/server/api/types";
+import { mlAssistantModelIds } from "$lib/server/mlAssistantModels";
 
 export const GET: RequestHandler = async ({ locals }) => {
 	// Mirror the title-generation resolution (generateFromDefaultEndpoint): the
@@ -26,5 +27,6 @@ export const GET: RequestHandler = async ({ locals }) => {
 		isAdmin: locals.isAdmin,
 		transcriptionEnabled: !!config.get("TRANSCRIPTION_MODEL"),
 		taskModelId,
+		mlAssistantModels: mlAssistantModelIds(),
 	} satisfies FeatureFlags);
 };

--- a/src/routes/conversation/+server.ts
+++ b/src/routes/conversation/+server.ts
@@ -43,19 +43,8 @@ export const POST: RequestHandler = async ({ locals, request }) => {
 
 	// Only builds that ship ML Assistant mode can start a conversation in it.
 	const isMlAssistant = ML_ASSISTANT_MODE && values.mlAssistant === true;
-	// The mode runs on its own fixed set (ML_ASSISTANT_MODELS): whatever the
-	// composer had selected — the router alias included — is replaced by the
-	// set's default when it isn't listed, so a stale client can't route the
-	// mode onto an unverified model.
-	if (isMlAssistant) {
-		const resolved = resolveMlAssistantModel(values.model);
-		if (!resolved) {
-			error(400, "ML Intern has no models configured");
-		}
-		values.model = resolved;
-	}
 
-	const model = models.find((m) => (m.id || m.name) === values.model);
+	let model = models.find((m) => (m.id || m.name) === values.model);
 
 	if (!model) {
 		error(400, "Invalid model");
@@ -90,6 +79,20 @@ export const POST: RequestHandler = async ({ locals, request }) => {
 		rootMessageId = conversation.rootMessageId ?? rootMessageId;
 		values.model = conversation.model;
 		values.preprompt = conversation.preprompt;
+	}
+
+	// The mode runs on its own fixed set (ML_ASSISTANT_MODELS): whatever was
+	// requested — the router alias, or a shared conversation's model — is
+	// replaced by the set's default when it isn't listed, so neither a stale
+	// client nor an import can route the mode onto an unverified model. After
+	// the share import, which is the last thing that can change the model.
+	if (isMlAssistant) {
+		const resolved = resolveMlAssistantModel(values.model);
+		if (!resolved) {
+			error(400, "ML Intern has no models configured");
+		}
+		values.model = resolved;
+		model = models.find((m) => (m.id || m.name) === resolved) ?? model;
 	}
 
 	if (model.unlisted) {

--- a/src/routes/conversation/+server.ts
+++ b/src/routes/conversation/+server.ts
@@ -12,6 +12,7 @@ import { usageLimits } from "$lib/server/usageLimits";
 import { MetricsServer } from "$lib/server/metrics";
 import superjson from "superjson";
 import { ML_ASSISTANT_MODE } from "$lib/utils/mlAssistantFlag";
+import { resolveMlAssistantModel } from "$lib/server/mlAssistantModels";
 import { usdToMicroUsd } from "$lib/utils/mlBudget";
 
 export const POST: RequestHandler = async ({ locals, request }) => {
@@ -38,6 +39,20 @@ export const POST: RequestHandler = async ({ locals, request }) => {
 
 	if (usageLimits?.conversations && convCount > usageLimits?.conversations) {
 		error(429, "You have reached the maximum number of conversations. Delete some to continue.");
+	}
+
+	// Only builds that ship ML Assistant mode can start a conversation in it.
+	const isMlAssistant = ML_ASSISTANT_MODE && values.mlAssistant === true;
+	// The mode runs on its own fixed set (ML_ASSISTANT_MODELS): whatever the
+	// composer had selected — the router alias included — is replaced by the
+	// set's default when it isn't listed, so a stale client can't route the
+	// mode onto an unverified model.
+	if (isMlAssistant) {
+		const resolved = resolveMlAssistantModel(values.model);
+		if (!resolved) {
+			error(400, "ML Intern has no models configured");
+		}
+		values.model = resolved;
 	}
 
 	const model = models.find((m) => (m.id || m.name) === values.model);
@@ -81,8 +96,6 @@ export const POST: RequestHandler = async ({ locals, request }) => {
 		error(400, "Can't start a conversation with an unlisted model");
 	}
 
-	// Only builds that ship ML Assistant mode can start a conversation in it.
-	const isMlAssistant = ML_ASSISTANT_MODE && values.mlAssistant === true;
 	// Every mode conversation carries a budget, and it is what the user granted
 	// in the composer — nothing more. No grant means $0: the gate refuses every
 	// submission until the user sets one, so spend authority is never implicit.

--- a/src/routes/conversation/[id]/+server.ts
+++ b/src/routes/conversation/[id]/+server.ts
@@ -25,6 +25,7 @@ import { textGeneration } from "$lib/server/textGeneration";
 import type { TextGenerationContext } from "$lib/server/textGeneration/types";
 import type { McpServerConfig } from "$lib/server/mcp/httpClient";
 import { isMlAssistantConversation } from "$lib/server/mlAssistant";
+import { mlAssistantModelIds, mlAssistantProviderFor } from "$lib/server/mlAssistantModels";
 import { ML_ASSISTANT_EFFORT } from "$lib/constants/mlAssistant";
 import { logger } from "$lib/server/logger.js";
 import { compressUpdatesForStorage } from "$lib/server/generation/compressUpdates";
@@ -670,7 +671,9 @@ export async function POST({ request, locals, params, getClientAddress }) {
 					// Inference provider preference (HuggingChat only, skip for router models)
 					provider:
 						config.isHuggingChat && !model.isRouter
-							? userSettings?.providerOverrides?.[model.id]
+							? isMlAssistantConversation(conv)
+								? mlAssistantProviderFor(model.id, userSettings?.providerOverrides?.[model.id])
+								: userSettings?.providerOverrides?.[model.id]
 							: undefined,
 					// Thinking-effort override (only forwarded for reasoning-capable models;
 					// per-user override can force-enable on self-hosted). The ML Assistant
@@ -854,6 +857,14 @@ export async function PATCH({ request, locals, params }) {
 
 	if (!conv) {
 		error(404, "Conversation not found");
+	}
+
+	if (
+		values.model !== undefined &&
+		isMlAssistantConversation(conv) &&
+		!mlAssistantModelIds().includes(values.model)
+	) {
+		error(400, "This model is not available for ML Intern conversations");
 	}
 
 	await applyConversationSettings({ _id: convId }, values);

--- a/src/routes/conversation/[id]/+server.ts
+++ b/src/routes/conversation/[id]/+server.ts
@@ -25,7 +25,7 @@ import { textGeneration } from "$lib/server/textGeneration";
 import type { TextGenerationContext } from "$lib/server/textGeneration/types";
 import type { McpServerConfig } from "$lib/server/mcp/httpClient";
 import { isMlAssistantConversation } from "$lib/server/mlAssistant";
-import { mlAssistantModelIds, mlAssistantProviderFor } from "$lib/server/mlAssistantModels";
+import { mlAssistantProviderFor } from "$lib/server/mlAssistantModels";
 import { ML_ASSISTANT_EFFORT } from "$lib/constants/mlAssistant";
 import { logger } from "$lib/server/logger.js";
 import { compressUpdatesForStorage } from "$lib/server/generation/compressUpdates";
@@ -857,14 +857,6 @@ export async function PATCH({ request, locals, params }) {
 
 	if (!conv) {
 		error(404, "Conversation not found");
-	}
-
-	if (
-		values.model !== undefined &&
-		isMlAssistantConversation(conv) &&
-		!mlAssistantModelIds().includes(values.model)
-	) {
-		error(400, "This model is not available for ML Intern conversations");
 	}
 
 	await applyConversationSettings({ _id: convId }, values);

--- a/src/routes/models/+page.svelte
+++ b/src/routes/models/+page.svelte
@@ -14,6 +14,8 @@
 	import { PROVIDERS_HUB_ORGS } from "@huggingface/inference";
 	import { useSettingsStore } from "$lib/stores/settings";
 	import { goto } from "$app/navigation";
+	import { mlAssistant } from "$lib/stores/mlAssistant.svelte";
+	import { ML_ASSISTANT_MODE } from "$lib/utils/mlAssistantFlag";
 	interface Props {
 		data: PageData;
 	}
@@ -29,9 +31,20 @@
 	const normalize = (s: string) => s.toLowerCase().replace(/[^a-z0-9]+/g, " ");
 	let queryTokens = $derived(normalize(modelFilter).trim().split(/\s+/).filter(Boolean));
 
+	// With the ML Intern switch on, only the mode's fixed set is offered, in its
+	// configured order — anything else would be swapped for the default on send.
+	let mlModelsOnly = $derived(ML_ASSISTANT_MODE && mlAssistant.enabled);
+	let browsableModels = $derived(
+		mlModelsOnly
+			? data.mlAssistantModels
+					.map((id) => data.models.find((el) => el.id === id))
+					.filter((el): el is (typeof data.models)[number] => el !== undefined)
+			: data.models
+	);
+
 	// Filtered models list
 	let filteredModels = $derived(
-		data.models
+		browsableModels
 			.filter((el) => !el.unlisted)
 			.filter((el) => {
 				const haystack = normalize(`${el.id} ${el.name ?? ""} ${el.displayName ?? ""}`);
@@ -79,12 +92,16 @@
 			{/if}
 		</div>
 		<h2 class="text-gray-500">
-			All models available{#if publicConfig.isHuggingChat}&nbsp;via <a
-					target="_blank"
-					href="https://huggingface.co/inference/models"
-					class="underline decoration-gray-300 hover:decoration-gray-500 dark:decoration-gray-600 dark:hover:decoration-gray-500"
-					>Inference Providers</a
-				>{/if}
+			{#if mlModelsOnly}
+				Models available in ML Intern mode. Turn the mode off in the composer to browse every model.
+			{:else}
+				All models available{#if publicConfig.isHuggingChat}&nbsp;via <a
+						target="_blank"
+						href="https://huggingface.co/inference/models"
+						class="underline decoration-gray-300 hover:decoration-gray-500 dark:decoration-gray-600 dark:hover:decoration-gray-500"
+						>Inference Providers</a
+					>{/if}
+			{/if}
 		</h2>
 
 		<!-- Filter input -->
@@ -134,7 +151,7 @@
 								>
 									{model.displayName}
 								</h3>
-								{#if index === 0 && model.isRouter && !isActive}
+								{#if index === 0 && (model.isRouter || mlModelsOnly) && !isActive}
 									<span
 										class="rounded-sm border border-gray-200 px-1.5 py-0.5 text-[10px] font-semibold text-gray-500 uppercase dark:border-gray-700 dark:text-gray-400"
 									>

--- a/src/routes/models/+page.svelte
+++ b/src/routes/models/+page.svelte
@@ -151,7 +151,7 @@
 								>
 									{model.displayName}
 								</h3>
-								{#if index === 0 && (model.isRouter || mlModelsOnly) && !isActive}
+								{#if ((index === 0 && model.isRouter) || (mlModelsOnly && model.id === data.mlAssistantModels[0])) && !isActive}
 									<span
 										class="rounded-sm border border-gray-200 px-1.5 py-0.5 text-[10px] font-semibold text-gray-500 uppercase dark:border-gray-700 dark:text-gray-400"
 									>

--- a/src/routes/models/[...model]/+page.svelte
+++ b/src/routes/models/[...model]/+page.svelte
@@ -38,13 +38,20 @@
 		try {
 			loading = true;
 
+			// The mode runs on its own fixed set; the server enforces this too.
+			const model =
+				mlAssistant.taskStarted &&
+				data.mlAssistantModels.length > 0 &&
+				!data.mlAssistantModels.includes(modelId)
+					? data.mlAssistantModels[0]
+					: modelId;
 			const res = await fetch(`${base}/conversation`, {
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",
 				},
 				body: JSON.stringify({
-					model: modelId,
+					model,
 					preprompt:
 						($settings.customPromptsEnabled?.[modelId] ?? true)
 							? $settings.customPrompts[modelId]
@@ -78,7 +85,7 @@
 			convsStore.prepend({
 				id: conversationId,
 				title: "New Chat",
-				model: modelId,
+				model,
 				updatedAt: new Date(),
 				// Latched before the create request, so the sidebar row carries the
 				// mode's designation from the moment it appears.

--- a/src/routes/settings/(nav)/+layout.svelte
+++ b/src/routes/settings/(nav)/+layout.svelte
@@ -23,6 +23,8 @@
 	import { browser } from "$app/environment";
 	import { isDesktop } from "$lib/utils/isDesktop";
 	import { debounce } from "$lib/utils/debounce";
+	import { mlAssistant } from "$lib/stores/mlAssistant.svelte";
+	import { ML_ASSISTANT_MODE } from "$lib/utils/mlAssistantFlag";
 
 	interface Props {
 		data: LayoutData;
@@ -101,6 +103,17 @@
 	let modelFilter = $state("");
 	const normalize = (s: string) => s.toLowerCase().replace(/[^a-z0-9]+/g, " ");
 	let queryTokens = $derived(normalize(modelFilter).trim().split(/\s+/).filter(Boolean));
+
+	// With the ML Intern switch on, only the mode's fixed set is offered, in its
+	// configured order — anything else would be swapped for the default on send.
+	let mlModelsOnly = $derived(ML_ASSISTANT_MODE && mlAssistant.enabled);
+	let browsableModels = $derived(
+		mlModelsOnly
+			? data.mlAssistantModels
+					.map((id) => data.models.find((el) => el.id === id))
+					.filter((el): el is (typeof data.models)[number] => el !== undefined)
+			: data.models
+	);
 </script>
 
 <div
@@ -161,12 +174,17 @@
 				/>
 			</div>
 
-			{#each data.models
+			{#if mlModelsOnly}
+				<p class="px-3 pb-2 text-xs text-gray-500 dark:text-gray-400">
+					ML Intern mode is on, so only its models are listed.
+				</p>
+			{/if}
+			{#each browsableModels
 				.filter((el) => !el.unlisted)
 				.filter((el) => {
 					const haystack = normalize(`${el.id} ${el.name ?? ""} ${el.displayName ?? ""}`);
 					return queryTokens.every((q) => haystack.includes(q));
-				}) as model}
+				}) as model (model.id)}
 				<button
 					type="button"
 					onclick={() => goto(`${base}/settings/${model.id}`)}


### PR DESCRIPTION
## What

- `ML_ASSISTANT_MODELS`: a JSON5 list of the models ML Intern conversations may run on, each pinning the inference provider it was verified on. First entry is the default; `parameters` merge over the catalog entry for mode conversations.
- Creating a mode conversation swaps any unlisted model (omni included) for the default. Switching a mode conversation to an unlisted model returns 400. The pinned provider overrides the user's per-model preference and `auto` at request time, in the conversation route and the parked-turn sweeper.
- With the ML Intern pill on, the Models page and the settings sidebar list only the set, in order, with the default marked.
- `scripts/probe-model.ts` (`npm run probe-model -- --model <id>`): sends the tool loop's exact request shape with a generated ML Intern history at 100k to 1M tokens, grades recall of verbatim log lines, and gives each model/provider run a verdict (OK, DEGRADED, SWALLOWED, TRUNCATED, ERROR).
- Chart pins for prod and dev, docs, `.env` reference.

## Why

Users saw ML Intern turns "stop mid-flow" on very long contexts. Probing GLM-5.3-Flash on the router showed it is provider-specific: on baseten the model intermittently fabricated, looped ("I I I I…"), or emitted garbage above ~150k prompt tokens and then ended with a normal `finish_reason: "stop"`, which chat-ui finalizes as a completed answer. The same requests on together and novita answered verbatim at 1,034k tokens. Baseten also silently discards a tool call whose name is not in the `tools` array (finish "stop", no delta, tokens still billed). The router's `auto` choice landed on baseten, so pinning the provider per model is the only reliable guard.

Matrix used for the chart pins (recall of verbatim log lines):

| model | pinned | evidence | notes |
|---|---|---|---|
| GLM-5.3-Flash | together | 5/5 at 924k | novita 4/5; fireworks 504 at 924k; baseten inconsistent |
| Kimi-K3 | baseten | 6/6 at 1,046k, 5/5 at 892k | fireworks 6/6 (slow prefill); together reasons to the cap near 1M; deepinfra's real window is 262k; featherless drops streams |
| GLM-5.3 | novita | 3/4 at 827k, 2/5 at 924k | degrades above ~800k on every provider |
| DeepSeek-V4-Pro-0813 | together | 4/4 at 761k, 5/5 at 911k | fireworks equal; novita and baseten 0/4 at 761k; deepinfra 1/5 at 910k; baseten 529 at 911k |
| DeepSeek-V4-Flash-0731 | novita | 3/4 at 761k, 5/5 at 911k | fireworks 4/5 at 911k; together and baseten 0/4 at 761k; deepinfra 0/5 at 910k |

## Tests

- Unit tests for the model set module; route tests for creation substitution and the switch guard.
- `npm run test`: 96 files, 1190 tests pass. `npm run check`: 0 errors.
