### PR TITLE
ML Intern launch card on the HuggingChat home screen

### DIFF
--- a/src/lib/components/WelcomeModal.svelte
+++ b/src/lib/components/WelcomeModal.svelte
@@ -2,6 +2,7 @@
 	import Modal from "$lib/components/Modal.svelte";
 	import IconOmni from "$lib/components/icons/IconOmni.svelte";
 	import { usePublicConfig } from "$lib/utils/PublicConfig.svelte";
+	import { ML_ASSISTANT_MODE } from "$lib/utils/mlAssistantFlag";
 
 	const publicConfig = usePublicConfig();
 
@@ -30,6 +31,14 @@
 				<Logo classNames="mr-2 size-12 dark:invert" />
 				{publicConfig.PUBLIC_APP_NAME}
 			</h2> -->
+			{#if ML_ASSISTANT_MODE && publicConfig.isHuggingChat}
+				<!-- Launch label, in the corner the "Now with MCP!" badge used to take. -->
+				<div
+					class="absolute right-3 bottom-3 rounded-lg border border-[#ea580c]/30 bg-[#ea580c]/20 px-2 py-0.5 text-sm font-semibold text-[#fdba74]"
+				>
+					Now with ML Intern!
+				</div>
+			{/if}
 		</div>
 
 		<div class="text-gray-700 dark:text-gray-200">

--- a/src/lib/components/chat/ChatInput.svelte
+++ b/src/lib/components/chat/ChatInput.svelte
@@ -415,11 +415,12 @@
 	{#if !showNoTools || showMlPill}
 		<div
 			class={[
-				"-ml-0.5 scrollbar-custom flex max-w-[calc(100%-40px)] flex-wrap items-center justify-start gap-1.5 px-3 pt-1.5 pb-2.5 text-gray-500 max-md:flex-nowrap max-md:overflow-x-auto dark:text-gray-400",
+				// Stops short of the trailing action buttons; ChatWindow reports their width.
+				"-ml-0.5 scrollbar-custom flex max-w-[calc(100%-var(--composer-actions-width,40px))] flex-wrap items-center justify-start gap-1.5 px-3 pt-1.5 pb-2.5 text-gray-500 max-md:flex-nowrap max-md:overflow-x-auto max-md:mask-r-from-85% dark:text-gray-400",
 			]}
 		>
 			{#if showFileUpload}
-				<div class="flex items-center">
+				<div class="flex shrink-0 items-center">
 					<input
 						bind:this={fileInputEl}
 						disabled={loading}
@@ -580,7 +581,7 @@
 
 					{#if $enabledServersCount > 0}
 						<div
-							class="ml-1.5 inline-flex h-8 items-center gap-1.5 rounded-full bg-blue-600/10 pr-1 pl-2 text-xs font-semibold text-blue-700 sm:h-7 dark:bg-blue-600/20 dark:text-blue-400"
+							class="ml-1.5 inline-flex h-8 shrink-0 items-center gap-1.5 rounded-full bg-blue-600/10 pr-1 pl-2 text-xs font-semibold text-blue-700 sm:h-7 dark:bg-blue-600/20 dark:text-blue-400"
 							class:grayscale={!modelSupportsTools}
 							class:opacity-60={!modelSupportsTools}
 							class:cursor-help={!modelSupportsTools}
@@ -601,7 +602,7 @@
 											<img
 												src={getMcpServerFaviconUrl(server.url)}
 												alt=""
-												class="size-4 rounded-sm bg-white p-px shadow-xs ring-1 ring-black/5 dark:bg-gray-900 dark:ring-white/10"
+												class="size-4 shrink-0 rounded-sm bg-white p-px shadow-xs ring-1 ring-black/5 dark:bg-gray-900 dark:ring-white/10"
 											/>
 										{/each}
 										{#if selectedServers.length > 3}

--- a/src/lib/components/chat/ChatIntroduction.svelte
+++ b/src/lib/components/chat/ChatIntroduction.svelte
@@ -8,9 +8,10 @@
 	interface Props {
 		currentModel: Model;
 		onmessage?: (content: string) => void;
+		children?: import("svelte").Snippet;
 	}
 
-	let { currentModel: _currentModel, onmessage }: Props = $props();
+	let { currentModel: _currentModel, onmessage, children }: Props = $props();
 
 	$effect(() => {
 		// referenced to appease linter while UI blocks are commented out
@@ -19,13 +20,16 @@
 	});
 </script>
 
-<div class="my-auto grid items-center justify-center gap-8 text-center">
+<div
+	class="my-auto grid -translate-y-16 items-center justify-center gap-8 text-center md:-translate-y-12"
+>
 	<div
-		class="flex -translate-y-16 items-center rounded-xl text-[1.6rem] font-semibold select-none md:-translate-y-12 md:text-[2.55rem]"
+		class="flex items-center justify-center rounded-xl text-[1.6rem] font-semibold select-none md:text-[2.55rem]"
 	>
 		<Logo classNames="size-[2.55rem] md:size-[4.25rem] dark:invert mr-0.5" />
 		{publicConfig.PUBLIC_APP_NAME}
 	</div>
+	{@render children?.()}
 	<!-- <div class="lg:col-span-1">
 		<div>
 			<div class="mb-3 flex items-center text-2xl font-semibold">

--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -68,6 +68,9 @@
 	import MlAssistantStrip from "./MlAssistantStrip.svelte";
 	import { ML_ASSISTANT_MODE } from "$lib/utils/mlAssistantFlag";
 	import { mlAssistant } from "$lib/stores/mlAssistant.svelte";
+	import MlInternSpotlight from "./MlInternSpotlight.svelte";
+	import { useConversationsStore } from "$lib/stores/conversations.svelte";
+	import { MediaQuery } from "svelte/reactivity";
 	import { planStepsToMlSteps } from "$lib/utils/planProgress";
 	import type { PlanState } from "$lib/types/Plan";
 	import type { MlBudget } from "$lib/types/Conversation";
@@ -571,6 +574,42 @@
 			messages.length === 0 &&
 			mlModelSet.length > 0
 	);
+
+	// ML Intern launch card under the home-screen logo (HuggingChat only). Temporary,
+	// so its dismissal lives in localStorage rather than in a settings field. Off on
+	// short viewports, and while the recorder replaces the composer: the pill (and
+	// with it the first-run onboarding its CTA relies on) is unmounted then.
+	const convsStore = useConversationsStore();
+	const shortViewport = new MediaQuery("(max-height: 560px)");
+	const ML_SPOTLIGHT_KEY = "mlInternSpotlightDismissed";
+	// Hidden until the browser has been asked, so SSR and hydration agree.
+	let mlSpotlightDismissed = $state(true);
+	$effect(() => {
+		mlSpotlightDismissed = localStorage.getItem(ML_SPOTLIGHT_KEY) === "1";
+	});
+	let mlSpotlightVisible = $derived(
+		publicConfig.isHuggingChat &&
+			mlPillVisible &&
+			page.route.id === "/" &&
+			!mlAssistant.enabled &&
+			!mlSpotlightDismissed &&
+			!shortViewport.current &&
+			!isRecording &&
+			!isTranscribing &&
+			!convsStore.list.some((conv) => conv.mlAssistant)
+	);
+
+	function dismissMlSpotlight() {
+		mlSpotlightDismissed = true;
+		localStorage.setItem(ML_SPOTLIGHT_KEY, "1");
+	}
+
+	/** The card's CTA: switches the mode on, as the pill would, and retires the card. */
+	function tryMlIntern() {
+		if (requireAuthUser()) return;
+		mlAssistant.toggle(true);
+		dismissMlSpotlight();
+	}
 	// A mode conversation whose model left the set can only move within the set.
 	let switchableModels = $derived(
 		mlTaskRunning ? models.filter((m) => mlModelSet.includes(m.id)) : models
@@ -842,7 +881,7 @@
 				<IconShare />
 			</button>
 		{/if}
-		{#if featureAnnouncement && showFeatureAnnouncement}
+		{#if featureAnnouncement && showFeatureAnnouncement && !mlSpotlightVisible}
 			<FeatureAnnouncementToast announcement={featureAnnouncement} />
 		{/if}
 		<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
@@ -955,7 +994,11 @@
 						onmessage={(content) => {
 							onmessage?.(content);
 						}}
-					/>
+					>
+						{#if mlSpotlightVisible}
+							<MlInternSpotlight ontry={tryMlIntern} ondismiss={dismissMlSpotlight} />
+						{/if}
+					</ChatIntroduction>
 				{/if}
 			</div>
 
@@ -1075,6 +1118,7 @@
 						"opacity-30": isReadOnly,
 						"max-sm:mb-4": focused && isVirtualKeyboard(),
 					}}
+					style:--composer-actions-width={transcriptionEnabled && !loading ? "84px" : "44px"}
 				>
 					{#if ML_ASSISTANT_MODE}
 						<MlAssistantStrip

--- a/src/lib/components/chat/MlInternPill.svelte
+++ b/src/lib/components/chat/MlInternPill.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { Switch } from "bits-ui";
+	import { untrack } from "svelte";
 	import { requireAuthUser } from "$lib/utils/auth";
 	import { useSettingsStore } from "$lib/stores/settings";
 	import { mlAssistant } from "$lib/stores/mlAssistant.svelte";
@@ -13,9 +14,19 @@
 	function ontoggle(next: boolean) {
 		if (requireAuthUser()) return;
 		mlAssistant.toggle(next);
-		// The mode stays on underneath: the modal is advice, not a confirmation step.
-		if (next && !$settings.mlInternOnboardingSeen) onboardingOpen = true;
 	}
+
+	// First time the mode goes on (from the switch or the home-screen card), open the
+	// onboarding. Edge-triggered, so a pill mounted with the mode already on stays quiet.
+	let wasEnabled: boolean | undefined;
+	$effect(() => {
+		const on = enabled;
+		const seen = $settings.mlInternOnboardingSeen;
+		untrack(() => {
+			if (on && wasEnabled === false && !seen) onboardingOpen = true;
+			wasEnabled = on;
+		});
+	});
 
 	function closeOnboarding() {
 		// Escape reaches Modal's window and dialog handlers before the unmount

--- a/src/lib/components/chat/MlInternPill.svelte.test.ts
+++ b/src/lib/components/chat/MlInternPill.svelte.test.ts
@@ -118,6 +118,19 @@ describe("MlInternPill", () => {
 			expect(mlAssistant.enabled).toBe(true);
 		});
 
+		it("opens the onboarding when the mode is switched on from outside the pill", async () => {
+			const { set, context } = settingsContext(false);
+			renderWithApp(MlInternPill, {}, { context });
+			expect(dialog()).toBeNull();
+
+			// The home-screen spotlight's CTA flips the store directly.
+			mlAssistant.toggle(true);
+
+			await vi.waitFor(() => expect(dialog()).not.toBeNull());
+			expect(dialog()?.textContent).toContain("ML Intern is experimental");
+			expect(set).not.toHaveBeenCalled();
+		});
+
 		it("records Escape once, though the key reaches the modal twice", async () => {
 			const { set, context } = settingsContext(false);
 			const { container } = renderWithApp(MlInternPill, {}, { context });

--- a/src/lib/components/chat/MlInternSpotlight.svelte
+++ b/src/lib/components/chat/MlInternSpotlight.svelte
@@ -1,0 +1,115 @@
+<script lang="ts">
+	import { fade, scale } from "svelte/transition";
+	import { backOut } from "svelte/easing";
+	import MlInternFlask from "$lib/components/icons/MlInternFlask.svelte";
+	import LucideX from "~icons/lucide/x";
+
+	interface Props {
+		ontry: () => void;
+		ondismiss: () => void;
+	}
+
+	let { ontry, ondismiss }: Props = $props();
+</script>
+
+<!-- HuggingChat launch card for ML Intern: the CTA hands over to the composer pill. -->
+<section
+	in:scale={{ start: 0.94, duration: 450, delay: 150, easing: backOut }}
+	out:fade={{ duration: 150 }}
+	aria-labelledby="ml-intern-spotlight-title"
+	class="ml-intern-spotlight relative isolate mx-auto flex w-full max-w-[22.5rem] items-center gap-3 rounded-2xl border border-gray-200/80 bg-white py-3 pr-3 pl-3.5 text-left shadow-sm shadow-black/5 dark:border-gray-700/60 dark:bg-[#141414] dark:shadow-black/20"
+>
+	<span class="spotlight-light" aria-hidden="true"></span>
+	<span class="mr-2 grid w-9 flex-none place-items-center">
+		<MlInternFlask />
+	</span>
+
+	<div class="min-w-0 flex-1">
+		<h2
+			id="ml-intern-spotlight-title"
+			class="flex items-center gap-1.5 text-sm font-semibold text-gray-900 dark:text-gray-100"
+		>
+			Have an ML idea?
+			<span
+				class="rounded-md bg-[#ea580c]/20 px-[5px] py-[3px] text-[10px] leading-none font-bold text-[#c2410c] dark:bg-[#ea580c]/25 dark:text-[#fdba74]"
+			>
+				NEW
+			</span>
+		</h2>
+		<p class="mt-0.5 text-[13px] leading-snug text-pretty text-gray-500 dark:text-gray-400">
+			ML Intern plans and runs it for you. No PhD required.
+		</p>
+	</div>
+
+	<button
+		type="button"
+		onclick={ontry}
+		class="flex-none rounded-lg bg-[#ea580c] px-3 py-1.5 text-[13px] font-medium text-white transition-colors hover:bg-[#c2410c] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#ea580c]/60"
+	>
+		Try it
+	</button>
+
+	<button
+		type="button"
+		class="absolute -top-2 -right-2 grid size-6 place-items-center rounded-full border border-gray-200 bg-white text-gray-400 shadow-sm hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-blue-500/60 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-400 dark:hover:text-gray-100"
+		aria-label="Dismiss"
+		onclick={ondismiss}
+	>
+		<LucideX class="size-3" />
+	</button>
+</section>
+
+<style>
+	.spotlight-light {
+		position: absolute;
+		inset: 0;
+		z-index: -1;
+		overflow: hidden;
+		border-radius: inherit;
+		pointer-events: none;
+		background:
+			radial-gradient(ellipse 95px 100px at 16px 0, #ffad4724, #ff98000d 55%, transparent 80%),
+			radial-gradient(ellipse 58px 45px at 35px 61%, #ff980018, transparent);
+	}
+
+	.spotlight-light::before {
+		position: absolute;
+		inset: 0;
+		content: "";
+		background: conic-gradient(
+			from 106deg at 16px 0,
+			transparent 0deg,
+			#ffbf632b 5deg,
+			#ffb84d12 18deg,
+			transparent 19deg,
+			#ffb84d1f 31deg,
+			transparent 32deg 360deg
+		);
+		mask-image: radial-gradient(ellipse 155px 110px at 16px 0, #000, transparent 85%);
+	}
+
+	:global(.dark) .spotlight-light {
+		background:
+			radial-gradient(
+				ellipse 90px 100px at 16px 0,
+				#ff8800b3,
+				#d15d0040 40%,
+				#b84b0010 65%,
+				transparent 90%
+			),
+			radial-gradient(ellipse 65px 65px at 30px 60%, #fb720021, transparent);
+	}
+
+	:global(.dark) .spotlight-light::before {
+		opacity: 1;
+		background: conic-gradient(
+			from 106deg at 16px 0,
+			transparent 0deg,
+			#ffb84d26 5deg,
+			#ffb84d0a 18deg,
+			transparent 19deg,
+			#ffb84d12 31deg,
+			transparent 32deg 360deg
+		);
+	}
+</style>

--- a/src/lib/components/chat/MlInternSpotlight.svelte.test.ts
+++ b/src/lib/components/chat/MlInternSpotlight.svelte.test.ts
@@ -1,0 +1,34 @@
+import MlInternSpotlight from "./MlInternSpotlight.svelte";
+import { renderWithApp } from "$lib/components/__tests__/renderWithApp";
+import { describe, expect, it, vi } from "vitest";
+
+const buttonNamed = (root: ParentNode, name: string): HTMLButtonElement => {
+	const el = [...root.querySelectorAll("button")].find(
+		(b) => b.textContent?.trim() === name || b.getAttribute("aria-label") === name
+	);
+	if (!el) throw new Error(`no button named ${name}`);
+	return el;
+};
+
+describe("MlInternSpotlight", () => {
+	it("is a labelled region carrying the launch line and the NEW badge", () => {
+		const { container } = renderWithApp(MlInternSpotlight, { ontry: vi.fn(), ondismiss: vi.fn() });
+
+		const id = container.querySelector("section")?.getAttribute("aria-labelledby") ?? "";
+		expect(document.getElementById(id)?.textContent).toContain("Have an ML idea?");
+		expect(container.textContent).toContain("No PhD required");
+		expect(container.textContent).toContain("NEW");
+	});
+
+	it("offers exactly two actions: try the mode, or put the card away", () => {
+		const ontry = vi.fn();
+		const ondismiss = vi.fn();
+		const { container } = renderWithApp(MlInternSpotlight, { ontry, ondismiss });
+
+		expect(container.querySelectorAll("button").length).toBe(2);
+		buttonNamed(container, "Try it").click();
+		buttonNamed(container, "Dismiss").click();
+		expect(ontry).toHaveBeenCalledTimes(1);
+		expect(ondismiss).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/lib/components/icons/MlInternFlask.svelte
+++ b/src/lib/components/icons/MlInternFlask.svelte
@@ -1,0 +1,200 @@
+<script lang="ts">
+	const id = $props.id();
+</script>
+
+<svg viewBox="0 0 96 112" fill="none" class="ml-intern-flask" aria-hidden="true" focusable="false">
+	<defs>
+		<linearGradient id="{id}-glass" x1="30" y1="12" x2="65" y2="100" gradientUnits="userSpaceOnUse">
+			<stop stop-color="#ff9b26" stop-opacity=".25" />
+			<stop offset=".48" stop-color="#f47708" stop-opacity=".12" />
+			<stop offset="1" stop-color="#ff8a00" stop-opacity=".4" />
+		</linearGradient>
+		<linearGradient id="{id}-rim" x1="32" y1="9" x2="67" y2="102" gradientUnits="userSpaceOnUse">
+			<stop stop-color="var(--flask-rim-top)" />
+			<stop offset=".25" stop-color="var(--flask-rim-upper)" />
+			<stop offset=".64" stop-color="var(--flask-rim-lower)" />
+			<stop offset="1" stop-color="var(--flask-rim-bottom)" />
+		</linearGradient>
+		<linearGradient id="{id}-liquid" x1="48" y1="69" x2="48" y2="98" gradientUnits="userSpaceOnUse">
+			<stop stop-color="var(--flask-liquid-top)" />
+			<stop offset=".34" stop-color="var(--flask-liquid-middle)" />
+			<stop offset="1" stop-color="#ff7800" />
+		</linearGradient>
+		<linearGradient
+			id="{id}-back-wave"
+			x1="25"
+			y1="70"
+			x2="62"
+			y2="89"
+			gradientUnits="userSpaceOnUse"
+		>
+			<stop stop-color="#ffb33b" />
+			<stop offset="1" stop-color="#f77906" />
+		</linearGradient>
+		<linearGradient id="{id}-lip" x1="48" y1="8" x2="48" y2="16" gradientUnits="userSpaceOnUse">
+			<stop stop-color="var(--flask-lip-top)" />
+			<stop offset=".5" stop-color="var(--flask-lip-middle)" />
+			<stop offset="1" stop-color="var(--flask-lip-bottom)" />
+		</linearGradient>
+		<radialGradient id="{id}-halo">
+			<stop stop-color="#ff8a00" stop-opacity=".7" />
+			<stop offset=".45" stop-color="#ff6a00" stop-opacity=".3" />
+			<stop offset="1" stop-color="#ff6a00" stop-opacity="0" />
+		</radialGradient>
+		<filter
+			id="{id}-glow"
+			x="-70%"
+			y="-50%"
+			width="240%"
+			height="210%"
+			color-interpolation-filters="sRGB"
+		>
+			<feGaussianBlur stdDeviation="6" />
+		</filter>
+		<filter
+			id="{id}-soft-glow"
+			x="-30%"
+			y="-25%"
+			width="160%"
+			height="150%"
+			color-interpolation-filters="sRGB"
+		>
+			<feGaussianBlur stdDeviation="1.5" />
+		</filter>
+		<path
+			id="{id}-bottle"
+			d="M37 13H59V36C59 38 60 40 61 42L82 81C87 90 81 100 71 100H25C15 100 9 90 14 81L35 42C36 40 37 38 37 36Z"
+		/>
+		<clipPath id="{id}-inside">
+			<use href="#{id}-bottle" />
+		</clipPath>
+	</defs>
+
+	<ellipse class="flask-halo" cx="47" cy="86" rx="62" ry="46" fill="url(#{id}-halo)" />
+	<use
+		class="flask-glow"
+		href="#{id}-bottle"
+		stroke="#ff8a00"
+		stroke-width="7"
+		filter="url(#{id}-glow)"
+		opacity=".7"
+	/>
+	<use class="flask-glass" href="#{id}-bottle" fill="url(#{id}-glass)" />
+	<g clip-path="url(#{id}-inside)">
+		<path d="M13 77C24 61 38 74 50 76S70 75 83 82V103H13Z" fill="url(#{id}-back-wave)" />
+		<path d="M12 74C28 86 40 75 54 71S74 67 85 79V103H12Z" fill="url(#{id}-liquid)" />
+		<path d="M12 74C28 86 40 75 54 71S74 67 85 79" stroke="#ffdf76" stroke-opacity=".25" />
+	</g>
+	<use
+		class="flask-inner-rim"
+		href="#{id}-bottle"
+		clip-path="url(#{id}-inside)"
+		stroke="#ffe9aa"
+		stroke-width="12"
+		stroke-linejoin="round"
+	/>
+	<use href="#{id}-bottle" stroke="url(#{id}-rim)" stroke-width="5" stroke-linejoin="round" />
+	<!-- A narrow reflection keeps the glass edge bright without flattening its gold gradient. -->
+	<path
+		d="M36 17V36C36 39 35 41 34 43L13 82C9 91 16 101 25 101"
+		stroke="#fff0ae"
+		stroke-opacity=".45"
+		stroke-width="1"
+		stroke-linecap="round"
+	/>
+	<path
+		class="flask-lip-glow"
+		d="M34 12H62"
+		stroke="#ffc544"
+		stroke-width="10"
+		stroke-linecap="round"
+		filter="url(#{id}-soft-glow)"
+		opacity=".6"
+	/>
+	<path d="M34 12H62" stroke="url(#{id}-lip)" stroke-width="7.5" stroke-linecap="round" />
+	<path
+		class="flask-lip-inset"
+		d="M34 12H62"
+		stroke="#fff0c5"
+		stroke-width="2.5"
+		stroke-linecap="round"
+	/>
+	<path
+		class="flask-lip-highlight"
+		d="M35 9H61"
+		stroke="#fff1b0"
+		stroke-opacity=".55"
+		stroke-width="1"
+		stroke-linecap="round"
+	/>
+	<circle cx="44" cy="56" r="3.25" fill="var(--flask-bubble, url(#{id}-lip))" />
+	<circle cx="53" cy="64" r="2.75" fill="var(--flask-bubble, url(#{id}-liquid))" />
+</svg>
+
+<style>
+	.ml-intern-flask {
+		--flask-rim-top: #e49300;
+		--flask-rim-upper: #ed9900;
+		--flask-rim-lower: #ff9800;
+		--flask-rim-bottom: #ff9d0a;
+		--flask-liquid-top: #ffa800;
+		--flask-liquid-middle: #ff9500;
+		--flask-lip-top: #e59400;
+		--flask-lip-middle: #ee9b00;
+		--flask-lip-bottom: #f4a20a;
+		--flask-bubble: #ec9600;
+		display: block;
+		width: 36px;
+		height: 44px;
+		overflow: visible;
+	}
+
+	.flask-halo,
+	.flask-glass {
+		opacity: 0.55;
+	}
+
+	.flask-glow {
+		opacity: 0.25;
+	}
+
+	.flask-lip-glow {
+		opacity: 0.12;
+	}
+
+	.flask-lip-highlight {
+		opacity: 0;
+	}
+
+	:global(.dark) .ml-intern-flask {
+		--flask-rim-top: #ffe58a;
+		--flask-rim-upper: #ffc04b;
+		--flask-rim-lower: #ffc043;
+		--flask-rim-bottom: #ffb719;
+		--flask-liquid-top: #ffd34d;
+		--flask-liquid-middle: #ffa813;
+		--flask-lip-top: #ffea97;
+		--flask-lip-middle: #ffd05e;
+		--flask-lip-bottom: #ffb32a;
+		--flask-bubble: initial;
+	}
+
+	:global(.dark) .flask-halo,
+	:global(.dark) .flask-glass,
+	:global(.dark) .flask-lip-highlight {
+		opacity: 1;
+	}
+
+	:global(.dark) .flask-glow {
+		opacity: 0.7;
+	}
+
+	:global(.dark) .flask-lip-glow {
+		opacity: 0.6;
+	}
+
+	:global(.dark) .flask-inner-rim,
+	:global(.dark) .flask-lip-inset {
+		opacity: 0;
+	}
+</style>


### PR DESCRIPTION
Pete is launching ML Intern mode today and asked for a CTA on HuggingChat that points people at it. This adds a small launch card under the home-screen logo and a label on the welcome modal, and fixes two composer issues found along the way.

## What changed

- New `MlInternSpotlight` card under the logo, HuggingChat only: "Have an ML idea? ML Intern plans and runs it for you. No PhD required." Its CTA switches the mode on, the same as the composer pill; the composer then swaps its placeholder and example chips to the ML Intern set. A corner dismiss button puts the card away. Dismissal is stored in localStorage (this is a temporary launch aid, not a setting). The card also stops showing once the user has an ML Intern conversation, while the voice recorder replaces the composer, and on viewports 560px tall or less.
- The model-announcement toast is hidden while the card is showing, so the home screen never has two "NEW" callouts at once.
- The welcome modal gets a "Now with ML Intern!" corner label, in the spot the "Now with MCP!" badge used to take. HuggingChat only, behind the ML Intern build flag.
- The ML Intern pill now opens its first-run onboarding modal whenever the mode goes on for the first time, not only on its own click, so people who come in through the card still get the MCP tools and spending-cap guidance. Edge-triggered, so a pill mounted with the mode already on stays quiet. Covered by a new test.
- Composer fix: the pill row reserved 40px on the right regardless of the mic button, and its children were allowed to shrink, which squashed the MCP pill and its favicons on mobile. The row now reserves the width of whatever action buttons are present (ChatWindow reports it through a CSS variable), every pill is `shrink-0`, and on mobile the row scrolls with a right-edge fade instead of compressing.
- New `MlInternFlask` icon used by the card.

## Notes for review

- No expiry date on purpose. Removing the card later means deleting `MlInternSpotlight.svelte` and its icon, the block in `ChatWindow.svelte`, and the welcome-modal label.
- The card only renders where the pill does: `ML_ASSISTANT_MODE` build flag plus a non-empty `ML_ASSISTANT_MODELS`. Prod needs #2551 merged and redeployed before either shows up.
- Checked in the browser at desktop and 375px widths, light and dark. `npm run check`, `npm run lint`, and the card and pill browser tests pass.
