### PR TITLE
ML Intern: bill jobs and sandboxes to the user's billing organisation

### DIFF
--- a/.env
+++ b/.env
@@ -43,10 +43,12 @@ COUPLE_SESSION_WITH_COOKIE_NAME=
 # when OPEN_ID is configured, users are required to login after the welcome modal
 OPENID_CLIENT_ID="" # You can set to "__CIMD__" for automatic oauth app creation when deployed, see https://datatracker.ietf.org/doc/draft-ietf-oauth-client-id-metadata-document/
 OPENID_CLIENT_SECRET=
-# Add the "contribute-repos" scope to let users deploy artifacts to a Hugging Face Space
-# (the app can create Spaces and update only the ones it created). Requires the OAuth app to
-# permit that scope; only add it for Hugging Face OIDC, not generic providers that lack it.
-OPENID_SCOPES="openid profile inference-api read-mcp read-billing"
+# "jobs" lets the app start Hugging Face Jobs as the user, which ML Intern and any Hub MCP job
+# tool need; without it every submission returns 403. Add "contribute-repos" to let users deploy
+# artifacts to a Space (the app can create Spaces and update only the ones it created). Both
+# require the OAuth app to permit the scope, and both are Hugging Face OIDC scopes: drop them for
+# a generic provider that lacks them.
+OPENID_SCOPES="openid profile inference-api read-mcp read-billing jobs"
 USE_USER_TOKEN=
 AUTOMATIC_LOGIN=# if true authentication is required on all routes
 

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -13,7 +13,7 @@ declare global {
 			user?: User;
 			isAdmin: boolean;
 			token?: string;
-			/** Organization to bill inference requests to (from settings) */
+			/** Organization to bill inference, and ML Intern's Hub compute, to (from settings) */
 			billingOrganization?: string;
 		}
 

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -13,7 +13,7 @@ declare global {
 			user?: User;
 			isAdmin: boolean;
 			token?: string;
-			/** Organization to bill inference, and ML Intern's Hub compute, to (from settings) */
+			/** Organization to bill inference, and ML Intern's Jobs and sandboxes, to (from settings) */
 			billingOrganization?: string;
 		}
 

--- a/src/lib/components/chat/MlInternOnboardingModal.svelte
+++ b/src/lib/components/chat/MlInternOnboardingModal.svelte
@@ -85,7 +85,7 @@
 						own or use other Hugging Face products. To make sure you never overspend, set a budget
 						in your billing settings too. Jobs and sandboxes are charged to the organization you
 						bill in HuggingChat's settings if you have picked one, and to your own account
-						otherwise.
+						otherwise; Spaces, dashboards and repositories stay under your own account either way.
 					</p>
 					<a
 						href={BILLING_SETTINGS_URL}

--- a/src/lib/components/chat/MlInternOnboardingModal.svelte
+++ b/src/lib/components/chat/MlInternOnboardingModal.svelte
@@ -83,7 +83,9 @@
 						A budget you give ML Intern in the chat is strictly enforced on the Jobs it launches
 						from here, but it is not a complete guarantee: a Job it starts could launch Jobs of its
 						own or use other Hugging Face products. To make sure you never overspend, set a budget
-						in your billing settings too.
+						in your billing settings too. Jobs and sandboxes are charged to the organization you
+						bill in HuggingChat's settings if you have picked one, and to your own account
+						otherwise.
 					</p>
 					<a
 						href={BILLING_SETTINGS_URL}

--- a/src/lib/server/billingOrganizations.spec.ts
+++ b/src/lib/server/billingOrganizations.spec.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { assertBillableOrganization, fetchBillableOrganizations } from "./billingOrganizations";
+
+const userinfo = (body: unknown, status = 200) =>
+	vi.fn(async () => new Response(JSON.stringify(body), { status }));
+
+afterEach(() => vi.unstubAllGlobals());
+
+const ORGS = [
+	{ sub: "1", name: "Acme", preferred_username: "acme", plan: "team" },
+	{ sub: "2", name: "Payer", preferred_username: "payer", canPay: true },
+	{ sub: "3", name: "Free", preferred_username: "free", canPay: false },
+];
+
+describe("fetchBillableOrganizations", () => {
+	it("keeps the organisations with a plan or a payment method", async () => {
+		vi.stubGlobal("fetch", userinfo({ canPay: true, orgs: ORGS }));
+		const billable = await fetchBillableOrganizations("tok");
+
+		expect(billable?.userCanPay).toBe(true);
+		expect(billable?.organizations.map((org) => org.preferred_username)).toEqual(["acme", "payer"]);
+		// Only the three fields the client needs; the rest of userinfo stays server-side.
+		expect(Object.keys(billable?.organizations[0] ?? {}).sort()).toEqual([
+			"name",
+			"preferred_username",
+			"sub",
+		]);
+	});
+
+	it("says so when the Hub could not be asked", async () => {
+		vi.stubGlobal("fetch", userinfo({}, 503));
+		expect(await fetchBillableOrganizations("tok")).toBeUndefined();
+	});
+});
+
+describe("assertBillableOrganization", () => {
+	const status = async (promise: Promise<unknown>) => {
+		try {
+			await promise;
+			return undefined;
+		} catch (err) {
+			return (err as { status?: number }).status;
+		}
+	};
+
+	it("lets a billable organisation through", async () => {
+		vi.stubGlobal("fetch", userinfo({ orgs: ORGS }));
+		await expect(assertBillableOrganization({ token: "tok" }, "acme")).resolves.toBeUndefined();
+	});
+
+	it("refuses one the user cannot bill", async () => {
+		vi.stubGlobal("fetch", userinfo({ orgs: ORGS }));
+		expect(await status(assertBillableOrganization({ token: "tok" }, "free"))).toBe(400);
+		expect(await status(assertBillableOrganization({ token: "tok" }, "stranger"))).toBe(400);
+	});
+
+	it("needs a login to check against, and the Hub to answer", async () => {
+		vi.stubGlobal("fetch", userinfo({ orgs: ORGS }));
+		expect(await status(assertBillableOrganization({}, "acme"))).toBe(401);
+		vi.stubGlobal("fetch", userinfo({}, 500));
+		expect(await status(assertBillableOrganization({ token: "tok" }, "acme"))).toBe(502);
+	});
+});

--- a/src/lib/server/billingOrganizations.ts
+++ b/src/lib/server/billingOrganizations.ts
@@ -1,0 +1,57 @@
+import { error } from "@sveltejs/kit";
+import { logger } from "$lib/server/logger";
+
+export interface BillingOrganization {
+	sub: string;
+	name: string;
+	preferred_username: string;
+}
+
+interface UserInfoOrganization extends BillingOrganization {
+	canPay?: boolean;
+	plan?: string;
+}
+
+/**
+ * The organisations this user may bill through the app, and whether they may
+ * bill themselves, from the Hub's OAuth userinfo. `undefined` when the Hub
+ * could not be asked.
+ */
+export async function fetchBillableOrganizations(
+	token: string
+): Promise<{ userCanPay: boolean; organizations: BillingOrganization[] } | undefined> {
+	const response = await fetch("https://huggingface.co/oauth/userinfo", {
+		headers: { Authorization: `Bearer ${token}` },
+	});
+	if (!response.ok) {
+		logger.error(`Failed to fetch billing orgs: ${response.status}`);
+		return undefined;
+	}
+	const data = (await response.json()) as { canPay?: boolean; orgs?: UserInfoOrganization[] };
+	return {
+		userCanPay: data.canPay ?? false,
+		organizations: (data.orgs ?? [])
+			.filter((org) => org.plan || org.canPay === true)
+			.map(({ sub, name, preferred_username }) => ({ sub, name, preferred_username })),
+	};
+}
+
+/**
+ * Refuses a billing target the user cannot bill through this app.
+ *
+ * A financial setting is checked when it changes, not when it is read back:
+ * the org list the settings page fetches only cleans up after the fact, and an
+ * API client never fetches it. Asks the Hub, so callers run it on a change of
+ * value only. Personal (empty) needs no check.
+ */
+export async function assertBillableOrganization(
+	locals: Pick<App.Locals, "token">,
+	organization: string
+): Promise<void> {
+	if (!locals.token) error(401, "Log in again to change who is billed.");
+	const billable = await fetchBillableOrganizations(locals.token);
+	if (!billable) error(502, "Could not verify billing eligibility with Hugging Face.");
+	if (!billable.organizations.some((org) => org.preferred_username === organization)) {
+		error(400, `Organization "${organization}" cannot be billed from this account.`);
+	}
+}

--- a/src/lib/server/mcp/hubBilling.spec.ts
+++ b/src/lib/server/mcp/hubBilling.spec.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+import { createHubBillingRewrite } from "./hubBilling";
+
+const HF_URL = "https://hf.co/mcp?login";
+const rewrite = createHubBillingRewrite("acme");
+const apply = (tool: string, args: Record<string, unknown>, serverUrl = HF_URL) =>
+	rewrite({ serverUrl, tool, args });
+
+describe("hub billing rewrite: jobs", () => {
+	it("runs a submission under the billing organisation", () => {
+		const args = {
+			operation: "run",
+			args: { image: "python:3.12", command: ["python", "-c", "1"] },
+		};
+		expect(apply("hf_jobs", args)).toEqual({
+			operation: "run",
+			args: { image: "python:3.12", command: ["python", "-c", "1"], namespace: "acme" },
+		});
+	});
+
+	it("overrides a namespace the model wrote on a submission", () => {
+		// Who pays is the user's setting; the model cannot opt a run out of it.
+		for (const operation of ["run", "uv", "scheduled run", "scheduled uv"]) {
+			const out = apply("hf_jobs", { operation, args: { script: "print(1)", namespace: "pngwn" } });
+			expect((out.args as Record<string, unknown>).namespace).toBe("acme");
+		}
+	});
+
+	it("fills in the namespace on a read that names none", () => {
+		// The org's jobs live in the org's namespace; a bare id would 404 under the user.
+		for (const operation of ["ps", "logs", "inspect", "cancel"]) {
+			const out = apply("hf_jobs", { operation, args: { job_id: "abc" } });
+			expect(out.args).toEqual({ job_id: "abc", namespace: "acme" });
+		}
+	});
+
+	it("keeps a namespace the model named on a read", () => {
+		// A job launched before the setting changed lives elsewhere, and its URL says where.
+		const args = { operation: "logs", args: { job_id: "abc", namespace: "pngwn" } };
+		expect(apply("hf_jobs", args)).toBe(args);
+	});
+
+	it("treats missing args as an empty object", () => {
+		expect(apply("hf_jobs", { operation: "ps" })).toEqual({
+			operation: "ps",
+			args: { namespace: "acme" },
+		});
+	});
+
+	it("leaves a call without an operation for the gate to refuse", () => {
+		const args = { args: { image: "python:3.12" } };
+		expect(apply("hf_jobs", args)).toBe(args);
+	});
+
+	it("leaves args that are not an object for the preflight to reject", () => {
+		const args = { operation: "run", args: "python:3.12" };
+		expect(apply("hf_jobs", args)).toBe(args);
+	});
+
+	it("does not mutate what the model sent", () => {
+		const inner = { image: "python:3.12" };
+		const args = { operation: "run", args: inner };
+		apply("hf_jobs", args);
+		expect(inner).toEqual({ image: "python:3.12" });
+		expect(args.args).toBe(inner);
+	});
+});
+
+describe("hub billing rewrite: sandboxes", () => {
+	it("creates under the billing organisation", () => {
+		const args = { cmd: "create", args: ["create", "--flavor", "cpu-basic", "--timeout", "1h"] };
+		expect(apply("hf_sandbox", args)).toEqual({
+			cmd: "create",
+			args: ["create", "--flavor", "cpu-basic", "--timeout", "1h", "--namespace", "acme"],
+		});
+		expect(args.args).toHaveLength(5);
+	});
+
+	it("replaces the value of a --namespace the model wrote", () => {
+		const args = {
+			cmd: "create",
+			args: ["create", "--namespace", "pngwn", "--flavor", "cpu-basic"],
+		};
+		expect(apply("hf_sandbox", args).args).toEqual([
+			"create",
+			"--namespace",
+			"acme",
+			"--flavor",
+			"cpu-basic",
+		]);
+	});
+
+	it("supplies the value when --namespace is the last token", () => {
+		const args = { cmd: "create", args: ["create", "--flavor", "cpu-basic", "--namespace"] };
+		expect(apply("hf_sandbox", args).args).toEqual([
+			"create",
+			"--flavor",
+			"cpu-basic",
+			"--namespace",
+			"acme",
+		]);
+	});
+
+	it("leaves every other command alone", () => {
+		// The handle already names the namespace.
+		for (const cmd of ["status", "terminate", "ps", "kill"]) {
+			const args = { cmd, args: [cmd, "hfsb2:acme:0123456789abcdef01234567"] };
+			expect(apply("hf_sandbox", args)).toBe(args);
+		}
+	});
+
+	it("leaves args that are not a token list for the preflight to reject", () => {
+		const args = { cmd: "create", args: "create --flavor cpu-basic" };
+		expect(apply("hf_sandbox", args)).toBe(args);
+	});
+});
+
+describe("hub billing rewrite: scope", () => {
+	it("ignores servers other than the Hub's", () => {
+		// A custom server is free to export its own hf_jobs; its namespace is not ours to set.
+		const args = { operation: "run", args: { image: "python:3.12" } };
+		expect(apply("hf_jobs", args, "https://mcp.exa.ai/mcp")).toBe(args);
+		expect(apply("hf_jobs", args, "https://evil.example/hf.co/mcp")).toBe(args);
+	});
+
+	it("covers the bare Hub endpoint as well as the login one", () => {
+		const args = { operation: "run", args: { image: "python:3.12" } };
+		expect(apply("hf_jobs", args, "https://huggingface.co/mcp").args).toEqual({
+			image: "python:3.12",
+			namespace: "acme",
+		});
+	});
+
+	it("ignores Hub tools that spend nothing", () => {
+		const args = { operations: [{ cmd: "ls", args: ["hf://models/trending"] }] };
+		expect(apply("hf_fs", args)).toBe(args);
+	});
+});

--- a/src/lib/server/mcp/hubBilling.spec.ts
+++ b/src/lib/server/mcp/hubBilling.spec.ts
@@ -76,17 +76,32 @@ describe("hub billing rewrite: sandboxes", () => {
 		expect(args.args).toHaveLength(5);
 	});
 
-	it("replaces the value of a --namespace the model wrote", () => {
+	it("replaces a --namespace the model wrote", () => {
 		const args = {
 			cmd: "create",
 			args: ["create", "--namespace", "pngwn", "--flavor", "cpu-basic"],
 		};
 		expect(apply("hf_sandbox", args).args).toEqual([
 			"create",
-			"--namespace",
-			"acme",
 			"--flavor",
 			"cpu-basic",
+			"--namespace",
+			"acme",
+		]);
+	});
+
+	it("collapses repeated --namespace flags to one", () => {
+		// The Hub's parser takes the option once; a duplicate is rejected outright.
+		const args = {
+			cmd: "create",
+			args: ["create", "--namespace", "pngwn", "--flavor", "cpu-basic", "--namespace", "acme"],
+		};
+		expect(apply("hf_sandbox", args).args).toEqual([
+			"create",
+			"--flavor",
+			"cpu-basic",
+			"--namespace",
+			"acme",
 		]);
 	});
 

--- a/src/lib/server/mcp/hubBilling.ts
+++ b/src/lib/server/mcp/hubBilling.ts
@@ -1,0 +1,83 @@
+import { logger } from "$lib/server/logger";
+import { isHfMcpServer } from "./hf";
+import type { ToolArgsRewrite } from "$lib/server/textGeneration/mcp/toolInvocation";
+
+/**
+ * Bills the Hub compute a conversation launches to the user's billing
+ * organisation.
+ *
+ * Not a header: inference takes `X-HF-Bill-To`, but a job is charged to the
+ * namespace it is created under, and the Hub MCP server forwards nothing from
+ * the transport to the Jobs API. The namespace is an argument — `namespace` on
+ * every hf_jobs operation, `--namespace` on hf_sandbox create — defaulting to
+ * the signed-in user when absent.
+ *
+ * Submissions are overwritten, reads are filled in. Who pays is the user's
+ * setting, not the model's call. A read may legitimately name somewhere else:
+ * a job launched before the setting changed lives under the user, and its URL
+ * says so. Filling in a read that names none is also what lets `check_job` find
+ * the org's jobs from a bare id.
+ */
+
+/** hf_jobs operations that create a job, and so decide who is charged for it. */
+const SUBMITTING_OPERATIONS = new Set(["run", "uv", "scheduled run", "scheduled uv"]);
+
+const asRecord = (value: unknown): Record<string, unknown> | undefined =>
+	typeof value === "object" && value !== null && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: undefined;
+
+const namesNamespace = (value: unknown): value is string =>
+	typeof value === "string" && value.trim().length > 0;
+
+function withJobsNamespace(
+	args: Record<string, unknown>,
+	namespace: string
+): Record<string, unknown> {
+	// Without an operation the budget gate refuses the call; leave it whole so
+	// the refusal describes what the model actually sent.
+	if (typeof args.operation !== "string") return args;
+	// An absent `args` is an empty object to the server. Anything else that is
+	// not an object fails the tool's own schema, and the preflight should say so.
+	const inner = args.args === undefined ? {} : asRecord(args.args);
+	if (!inner) return args;
+	const submitting = SUBMITTING_OPERATIONS.has(args.operation);
+	if (!submitting && namesNamespace(inner.namespace)) return args;
+	if (submitting && namesNamespace(inner.namespace) && inner.namespace !== namespace) {
+		logger.debug(
+			{ tool: "hf_jobs", wanted: inner.namespace, namespace },
+			"[mcp] billing namespace replaces the model's"
+		);
+	}
+	return { ...args, args: { ...inner, namespace } };
+}
+
+function withSandboxNamespace(
+	args: Record<string, unknown>,
+	namespace: string
+): Record<string, unknown> {
+	// Only create decides who pays: every later command carries a handle that
+	// already names the namespace (hfsb2:<namespace>:<id>).
+	if (args.cmd !== "create" || !Array.isArray(args.args)) return args;
+	const tokens = [...(args.args as unknown[])];
+	const at = tokens.indexOf("--namespace");
+	if (at < 0) return { ...args, args: [...tokens, "--namespace", namespace] };
+	if (namesNamespace(tokens[at + 1]) && tokens[at + 1] !== namespace) {
+		logger.debug(
+			{ tool: "hf_sandbox", wanted: tokens[at + 1], namespace },
+			"[mcp] billing namespace replaces the model's"
+		);
+	}
+	tokens[at + 1] = namespace;
+	return { ...args, args: tokens };
+}
+
+/** Hub servers only: a custom server may export its own `hf_jobs`, whose namespace is not ours. */
+export function createHubBillingRewrite(namespace: string): ToolArgsRewrite {
+	return ({ serverUrl, tool, args }) => {
+		if (!isHfMcpServer(serverUrl)) return args;
+		if (tool === "hf_jobs") return withJobsNamespace(args, namespace);
+		if (tool === "hf_sandbox") return withSandboxNamespace(args, namespace);
+		return args;
+	};
+}

--- a/src/lib/server/mcp/hubBilling.ts
+++ b/src/lib/server/mcp/hubBilling.ts
@@ -59,17 +59,25 @@ function withSandboxNamespace(
 	// Only create decides who pays: every later command carries a handle that
 	// already names the namespace (hfsb2:<namespace>:<id>).
 	if (args.cmd !== "create" || !Array.isArray(args.args)) return args;
-	const tokens = [...(args.args as unknown[])];
-	const at = tokens.indexOf("--namespace");
-	if (at < 0) return { ...args, args: [...tokens, "--namespace", namespace] };
-	if (namesNamespace(tokens[at + 1]) && tokens[at + 1] !== namespace) {
+	// The server's parser takes this option once and rejects a repeat, so every
+	// occurrence goes and exactly one comes back.
+	const given = args.args as unknown[];
+	const tokens: unknown[] = [];
+	const wanted: unknown[] = [];
+	for (let i = 0; i < given.length; i++) {
+		if (given[i] !== "--namespace") {
+			tokens.push(given[i]);
+			continue;
+		}
+		if (i + 1 < given.length) wanted.push(given[++i]);
+	}
+	if (wanted.some((value) => namesNamespace(value) && value !== namespace)) {
 		logger.debug(
-			{ tool: "hf_sandbox", wanted: tokens[at + 1], namespace },
+			{ tool: "hf_sandbox", wanted, namespace },
 			"[mcp] billing namespace replaces the model's"
 		);
 	}
-	tokens[at + 1] = namespace;
-	return { ...args, args: tokens };
+	return { ...args, args: [...tokens, "--namespace", namespace] };
 }
 
 /** Hub servers only: a custom server may export its own `hf_jobs`, whose namespace is not ours. */

--- a/src/lib/server/mlAssistant.spec.ts
+++ b/src/lib/server/mlAssistant.spec.ts
@@ -8,6 +8,7 @@ vi.mock("./mcp/registry", () => ({ getMcpServers: () => mockedServers.value }));
 import {
 	ML_ASSISTANT_MCP_SERVERS,
 	isMlAssistantConversation,
+	mlAssistantBillingNamespace,
 	pinnedHubToken,
 	withMlAssistantServers,
 } from "./mlAssistant";
@@ -127,5 +128,33 @@ describe("pinnedHubToken", () => {
 			{ name: "Hugging Face", url: "https://hf.co/mcp", headers: { Authorization: "Basic abc" } },
 		];
 		expect(pinnedHubToken()).toBeUndefined();
+	});
+});
+
+describe("mlAssistantBillingNamespace", () => {
+	it("is the user's billing organisation, trimmed", () => {
+		mockedServers.value = [{ name: "Hugging Face", url: "https://hf.co/mcp?login" }];
+		expect(mlAssistantBillingNamespace({ billingOrganization: " acme " })).toBe("acme");
+	});
+
+	it("is nothing when the user bills their own account", () => {
+		mockedServers.value = [];
+		expect(mlAssistantBillingNamespace({ billingOrganization: "" })).toBeUndefined();
+		expect(mlAssistantBillingNamespace({ billingOrganization: "   " })).toBeUndefined();
+		expect(mlAssistantBillingNamespace({})).toBeUndefined();
+		expect(mlAssistantBillingNamespace(undefined)).toBeUndefined();
+	});
+
+	it("stands down when an operator-pinned Hub entry launches the work", () => {
+		// Jobs then run as the operator's account, which cannot write to the
+		// user's organisations; a namespace it lacks would 403 every submission.
+		mockedServers.value = [
+			{
+				name: "Hugging Face",
+				url: "https://hf.co/mcp",
+				headers: { Authorization: "Bearer hf_pinned" },
+			},
+		];
+		expect(mlAssistantBillingNamespace({ billingOrganization: "acme" })).toBeUndefined();
 	});
 });

--- a/src/lib/server/mlAssistant.spec.ts
+++ b/src/lib/server/mlAssistant.spec.ts
@@ -9,6 +9,7 @@ import {
 	ML_ASSISTANT_MCP_SERVERS,
 	isMlAssistantConversation,
 	mlAssistantBillingNamespace,
+	mlAssistantPayerNamespace,
 	pinnedHubToken,
 	withMlAssistantServers,
 } from "./mlAssistant";
@@ -156,5 +157,27 @@ describe("mlAssistantBillingNamespace", () => {
 			},
 		];
 		expect(mlAssistantBillingNamespace({ billingOrganization: "acme" })).toBe("acme");
+	});
+});
+
+describe("mlAssistantPayerNamespace", () => {
+	it("is the billing organisation when there is one", () => {
+		expect(
+			mlAssistantPayerNamespace({ billingOrganization: "acme", user: { username: "pngwn" } })
+		).toBe("acme");
+	});
+
+	it("is the user's own account under Personal", () => {
+		// Enforced, not defaulted: a run the model addressed to some organisation
+		// must not charge an account the user never picked.
+		expect(
+			mlAssistantPayerNamespace({ billingOrganization: "", user: { username: "pngwn" } })
+		).toBe("pngwn");
+		expect(mlAssistantPayerNamespace({ user: { username: " pngwn " } })).toBe("pngwn");
+	});
+
+	it("is nothing when neither is known", () => {
+		expect(mlAssistantPayerNamespace({ user: {} })).toBeUndefined();
+		expect(mlAssistantPayerNamespace(undefined)).toBeUndefined();
 	});
 });

--- a/src/lib/server/mlAssistant.spec.ts
+++ b/src/lib/server/mlAssistant.spec.ts
@@ -145,9 +145,9 @@ describe("mlAssistantBillingNamespace", () => {
 		expect(mlAssistantBillingNamespace(undefined)).toBeUndefined();
 	});
 
-	it("stands down when an operator-pinned Hub entry launches the work", () => {
-		// Jobs then run as the operator's account, which cannot write to the
-		// user's organisations; a namespace it lacks would 403 every submission.
+	it("holds when an operator-pinned Hub entry is configured", () => {
+		// Whether that credential may bill the organisation is the Hub's call: a
+		// refused submission is loud, a silently redirected charge is not.
 		mockedServers.value = [
 			{
 				name: "Hugging Face",
@@ -155,6 +155,6 @@ describe("mlAssistantBillingNamespace", () => {
 				headers: { Authorization: "Bearer hf_pinned" },
 			},
 		];
-		expect(mlAssistantBillingNamespace({ billingOrganization: "acme" })).toBeUndefined();
+		expect(mlAssistantBillingNamespace({ billingOrganization: "acme" })).toBe("acme");
 	});
 });

--- a/src/lib/server/mlAssistant.ts
+++ b/src/lib/server/mlAssistant.ts
@@ -77,6 +77,20 @@ export function mlAssistantBillingNamespace(
 }
 
 /**
+ * The namespace this request's Hub compute runs under and is charged to: the
+ * billing organisation, else the user's own account.
+ *
+ * Personal is a choice too. Without a namespace of its own to enforce, a run
+ * the model addressed to some organisation would go through and charge an
+ * account the user never picked.
+ */
+export function mlAssistantPayerNamespace(
+	locals: { billingOrganization?: string; user?: { username?: string } } | undefined
+): string | undefined {
+	return mlAssistantBillingNamespace(locals) ?? (locals?.user?.username?.trim() || undefined);
+}
+
+/**
  * The preset's servers plus the ones already resolved for this request, preset
  * first. Deduplicated by name with the preset winning.
  */

--- a/src/lib/server/mlAssistant.ts
+++ b/src/lib/server/mlAssistant.ts
@@ -63,17 +63,17 @@ export function pinnedHubToken(): string | undefined {
 /**
  * The organisation this request's Hub compute is billed to, if any.
  *
- * The user's billing setting — the one inference sends as X-HF-Bill-To — unless
- * an operator-pinned Hub entry is what launches the work. Jobs then run as the
- * operator's account, which has no standing in the user's organisations, and a
- * namespace it cannot write to would turn every submission into a 403.
+ * Deliberately blind to how the Hub server authenticates. An operator-pinned
+ * token may or may not belong to the organisation the user picked, and a guess
+ * is wrong in one direction or the other: a namespace the credential cannot
+ * write to fails loudly at submission, where a suppressed setting bills the
+ * wrong account in silence. The Hub is the authority on the first; only the
+ * setting can prevent the second.
  */
 export function mlAssistantBillingNamespace(
 	locals: { billingOrganization?: string } | undefined
 ): string | undefined {
-	const organization = locals?.billingOrganization?.trim();
-	if (!organization) return undefined;
-	return pinnedHubToken() === undefined ? organization : undefined;
+	return locals?.billingOrganization?.trim() || undefined;
 }
 
 /**

--- a/src/lib/server/mlAssistant.ts
+++ b/src/lib/server/mlAssistant.ts
@@ -61,6 +61,22 @@ export function pinnedHubToken(): string | undefined {
 }
 
 /**
+ * The organisation this request's Hub compute is billed to, if any.
+ *
+ * The user's billing setting — the one inference sends as X-HF-Bill-To — unless
+ * an operator-pinned Hub entry is what launches the work. Jobs then run as the
+ * operator's account, which has no standing in the user's organisations, and a
+ * namespace it cannot write to would turn every submission into a 403.
+ */
+export function mlAssistantBillingNamespace(
+	locals: { billingOrganization?: string } | undefined
+): string | undefined {
+	const organization = locals?.billingOrganization?.trim();
+	if (!organization) return undefined;
+	return pinnedHubToken() === undefined ? organization : undefined;
+}
+
+/**
  * The preset's servers plus the ones already resolved for this request, preset
  * first. Deduplicated by name with the preset winning.
  */

--- a/src/lib/server/mlAssistantPrompt.spec.ts
+++ b/src/lib/server/mlAssistantPrompt.spec.ts
@@ -422,3 +422,43 @@ describe("ML Assistant tool preprompt", () => {
 		expect(inMode([])).toBe("");
 	});
 });
+
+describe("ML Assistant billing", () => {
+	const now = new Date("2026-08-24T09:07:00Z");
+
+	it("stamps who pays after the user, only when someone other than the user does", () => {
+		expect(
+			mlAssistantSessionContext({ username: "pngwn", timezone: "UTC", now, billTo: "acme" })
+		).toBe("[Session context: Date=2026-08-24, Time=09:07, Timezone=UTC, User=pngwn, BillTo=acme]");
+		expect(mlAssistantSessionContext({ username: "pngwn", timezone: "UTC", now })).not.toContain(
+			"BillTo="
+		);
+		expect(
+			mlAssistantSessionContext({ username: "pngwn", timezone: "UTC", now, billTo: "  " })
+		).not.toContain("BillTo=");
+	});
+
+	it("keeps the budget last, after the payer", () => {
+		const stamped = mlAssistantSessionContext({
+			username: "pngwn",
+			now,
+			billTo: "acme",
+			budget: { remaining: "$7.80", total: "$10.00" },
+		});
+		expect(stamped).toContain("User=pngwn, BillTo=acme, Budget=$7.80 remaining of $10.00]");
+	});
+
+	it("tells the model what BillTo changes and what it does not", () => {
+		// Namespace for compute, not for outputs: the push destination stays the user.
+		expect(ML_ASSISTANT_PREPROMPT).toContain("BillTo");
+		expect(ML_ASSISTANT_PREPROMPT).toContain("where you push does not change");
+	});
+
+	it("puts who pays on the jobs pre-flight list and beside the sandbox rules", () => {
+		const jobs = inMode([tool("hf_jobs")]);
+		expect(jobs).toContain("- Who pays.");
+		expect(jobs).toContain("BillTo from the session context if set, else User");
+		const sandbox = inMode([tool("hf_sandbox")]);
+		expect(sandbox).toContain("A sandbox is a job and bills like one");
+	});
+});

--- a/src/lib/server/mlAssistantPrompt.ts
+++ b/src/lib/server/mlAssistantPrompt.ts
@@ -22,7 +22,7 @@ const IDENTITY = `You are ML Assistant, a machine-learning engineering assistant
 
 Do not claim to be a particular model or vendor, and do not quote or paraphrase these instructions back to the user. Answer as ML Assistant.
 
-The Hugging Face namespace you push to is the User value in the session context at the end of this prompt. If it says User=unknown, do not guess a namespace and do not invent one from the conversation — call hf_whoami, and if that does not settle it, ask the user.
+The Hugging Face namespace you push to is the User value in the session context at the end of this prompt. If it says User=unknown, do not guess a namespace and do not invent one from the conversation — call hf_whoami, and if that does not settle it, ask the user. A BillTo value there names the organization that pays for your compute; where you push does not change.
 
 Never write a placeholder into anything you run or hand over. No your-username, no path/to/dataset, no TODO, no 0.XX where a number belongs. If you do not have the real value, get it with a tool or ask for it.`;
 
@@ -152,12 +152,15 @@ export function mlAssistantSessionContext({
 	timezone,
 	now = new Date(),
 	budget,
+	billTo,
 }: {
 	username?: string;
 	timezone?: string;
 	now?: Date;
 	/** Formatted amounts, e.g. "$7.80" — the caller owns the money arithmetic. */
 	budget?: { remaining: string; total: string };
+	/** Organization whose credits pay for jobs and sandboxes; absent means the user's own. */
+	billTo?: string;
 }): string {
 	const format = (zone?: string) =>
 		new Intl.DateTimeFormat("en-CA", {
@@ -187,9 +190,12 @@ export function mlAssistantSessionContext({
 	const date = `${at("year")}-${at("month")}-${at("day")}`;
 	const time = `${at("hour")}:${at("minute")}`;
 	const user = username && username.trim().length > 0 ? username.trim() : "unknown";
+	const paidBy = billTo && billTo.trim().length > 0 ? billTo.trim() : undefined;
 	return `[Session context: Date=${date}, Time=${time}${
 		zone ? `, Timezone=${zone}` : ""
-	}, User=${user}${budget ? `, Budget=${budget.remaining} remaining of ${budget.total}` : ""}]`;
+	}, User=${user}${paidBy ? `, BillTo=${paidBy}` : ""}${
+		budget ? `, Budget=${budget.remaining} remaining of ${budget.total}` : ""
+	}]`;
 }
 
 /**
@@ -231,6 +237,7 @@ const HF_JOBS_CONTRACT = `RUNNING JOBS (hf_jobs): a job is remote compute with e
 - Name. Every submission carries a name saying what the run is — method, model, dataset, and whether it is the smoke test or the real thing (sft-qwen3-0.6b-capybara-smoke). Skip it and the job lands in the user's dashboard as an image tag plus a hash, indistinguishable from every other unnamed run. Add further labels where they would help the user filter — the dataset, the base model, the experiment they belong to.
 - Token. Pushing to the Hub from inside a job needs the token passed in explicitly as a secret (HF_TOKEN). Leave it out and the run trains for an hour and then fails at the push, which is the most expensive mistake available here.
 - Hardware. The default flavor is cpu-basic: two CPU cores. A training job that does not name a GPU flavor does not fail, it crawls. Name the flavor, what it costs per hour, and how long you expect the run to take.
+- Who pays. A job bills the namespace it runs under — BillTo from the session context if set, else User — and the server sets it on every hf_jobs call. A job living elsewhere (its URL says where) needs its namespace passed to read it.
 - Timeout. Set it above your estimate of the run, not at it. A timeout shorter than the run loses the run at the end.
 - Dependencies. Pin every one explicitly — the uv --with arguments, or an image that already has them — and pin to the CURRENT release, never the version you remember: your memory of these libraries is stale, and a pin written from it is how a run dies at import. Resolve the real number instead of recalling it — \`pip index versions <package>\`, or what uv resolves — in the sandbox or a one-line job, and pin what it returns. Anything older needs a reason you have actually validated, a breaking change you hit or a pin the image forces, and it goes on the pre-flight list. Unpinned is not the safe middle: it drifts between the smoke test and the real run, and away from anything that has to match it. Never build flash-attention from source in a job; it eats the budget and usually fails.
 - Destination. push_to_hub with an explicit hub_model_id in the namespace from the session context, or a mounted bucket volume for checkpoints. Nothing written to the container's own disk survives the job.
@@ -246,7 +253,7 @@ Estimate before you submit. The smoke test on the real flavor gives you measured
 
 After submitting, report the job id and its URL, then wait and delegate the reading rather than pulling logs into this conversation — every tail you read here stays in it for the rest of the run, and a smoke job's tracebacks are the ones you least want in it. Make the first check soon, with a SHORT wait, because failures cluster at the start: a wrong dependency or a bad column name shows up in the first minute, and a twenty-minute wait over it is twenty minutes lost. That first check is also where you confirm the dashboard has rows in it, not merely that the job is running. Once the run has proven itself, lengthen the waits to match the time remaining. A submitted job is not a finished one, and a job that failed says why in its logs — read them before you change anything.`;
 
-const HF_SANDBOX_RULES = `SANDBOXES (hf_sandbox): a sandbox is a machine you run commands in directly, which makes it the right place for the fast checks — does the script import, does the dataset load, are the shapes what you think. A job queues, pulls an image, and only then tells you about a typo; a sandbox tells you in seconds. When you have this tool, the fast checks go here FIRST, every time — not in a smoke job out of habit. A job's queue time is the wrong price for finding a typo. What it cannot do is stand in for the GPU smoke test: it has no GPU, so it tells you the script imports and the columns are right, and nothing at all about whether the batch fits in memory or how fast a step is.
+const HF_SANDBOX_RULES = `SANDBOXES (hf_sandbox): a sandbox is a machine you run commands in directly, which makes it the right place for the fast checks — does the script import, does the dataset load, are the shapes what you think. A job queues, pulls an image, and only then tells you about a typo; a sandbox tells you in seconds. When you have this tool, the fast checks go here FIRST, every time — not in a smoke job out of habit. A job's queue time is the wrong price for finding a typo. What it cannot do is stand in for the GPU smoke test: it has no GPU, so it tells you the script imports and the columns are right, and nothing at all about whether the batch fits in memory or how fast a step is. A sandbox is a job and bills like one, under BillTo when set; its handle, hfsb2:<namespace>:<id>, says where.
 
 These tools and hf_jobs take different argument shapes, and mixing them is the most common rejected call. Here \`cmd\` only selects the operation and everything else is a token in the \`args\` array — the timeout among them, as the pair \`--timeout 55\` — while hf_jobs takes an object with \`timeout\` as a key inside it. Each tool's own parameter descriptions carry its exact grammar; read those rather than reasoning across from the sibling.
 

--- a/src/lib/server/textGeneration/builtinTools/nestedAgent.ts
+++ b/src/lib/server/textGeneration/builtinTools/nestedAgent.ts
@@ -11,6 +11,7 @@ import { MessageToolUpdateType, MessageUpdateType } from "$lib/types/MessageUpda
 import { recordNestedAgentCalls, type LoggedCall } from "./nestedAgentCallLog";
 import {
 	executeToolCalls,
+	withRewrittenArguments,
 	type NormalizedToolCall,
 	type ToolArgsRewrite,
 } from "../mcp/toolInvocation";
@@ -142,6 +143,19 @@ export function makeTruncator(maxChars: number, head: number, tail: number) {
 			output.slice(0, head) + "\n...(truncated)...\n" + output.slice(-tail)
 		);
 	};
+}
+
+/** The model's calls carrying the arguments the executor was handed, where those differ. */
+function withDispatchedArguments<T extends { id: string; function?: { arguments?: string } }>(
+	calls: T[],
+	dispatched: NormalizedToolCall[]
+): T[] {
+	const byId = new Map(dispatched.map((call) => [call.id, call.arguments]));
+	return calls.map((call) => {
+		const rewritten = byId.get(call.id);
+		if (rewritten === undefined || rewritten === call.function?.arguments) return call;
+		return { ...call, function: { ...call.function, arguments: rewritten } };
+	});
 }
 
 /** JSON with object keys sorted at every depth, so arg order can't defeat the repetition check. */
@@ -342,25 +356,7 @@ export async function runNestedAgent(
 			return content ? { resultText: content } : { error: spec.failure.noSummary };
 		}
 
-		// Wire-safe rebuild: only role/content/tool_calls go back. The raw
-		// message can carry provider fields (reasoning_content and friends)
-		// that OpenAI-compatible backends reject when echoed; content is
-		// omitted when empty because some backends 400 on empty text next to
-		// tool_calls.
-		messages = [
-			...messages,
-			{
-				role: "assistant",
-				// Same guard as the parent loop: an unparseable payload echoed back
-				// 400s every later request of the run. See withParseableArguments.
-				tool_calls: withParseableArguments(toolCalls),
-				...(typeof msg.content === "string" && msg.content.trim().length > 0
-					? { content: msg.content }
-					: {}),
-			},
-		];
-
-		const allowedCalls: NormalizedToolCall[] = [];
+		let allowedCalls: NormalizedToolCall[] = [];
 		const refusedCalls: LoggedCall[] = [];
 		const refusals: ChatCompletionMessageParam[] = [];
 		const repeatCounts = new Map<string, number>();
@@ -388,6 +384,30 @@ export async function runNestedAgent(
 			}
 			allowedCalls.push({ id: call.id, name, arguments: rawArguments });
 		}
+		if (deps.rewriteArgs) {
+			allowedCalls = withRewrittenArguments(allowedCalls, {
+				mapping: deps.mapping,
+				servers: deps.servers,
+				builtinTools: allowedBuiltins,
+				parseArgs: parseToolArguments,
+				rewrite: deps.rewriteArgs,
+			});
+		}
+
+		// Wire-safe rebuild: only role/content/tool_calls go back. The raw
+		// message can carry provider fields (reasoning_content and friends)
+		// that OpenAI-compatible backends reject when echoed; content is
+		// omitted when empty because some backends 400 on empty text next to
+		// tool_calls. Allowed calls echo the arguments the executor was handed.
+		const assistantTurn: ChatCompletionMessageParam = {
+			role: "assistant",
+			// Same guard as the parent loop: an unparseable payload echoed back
+			// 400s every later request of the run. See withParseableArguments.
+			tool_calls: withParseableArguments(withDispatchedArguments(toolCalls, allowedCalls)),
+			...(typeof msg.content === "string" && msg.content.trim().length > 0
+				? { content: msg.content }
+				: {}),
+		};
 
 		let toolMessages: ChatCompletionMessageParam[] = [];
 		if (allowedCalls.length > 0) {
@@ -429,6 +449,7 @@ export async function runNestedAgent(
 
 		messages = [
 			...messages,
+			assistantTurn,
 			...refusals,
 			...toolMessages.map((message) =>
 				message.role === "tool" && typeof message.content === "string"

--- a/src/lib/server/textGeneration/builtinTools/nestedAgent.ts
+++ b/src/lib/server/textGeneration/builtinTools/nestedAgent.ts
@@ -9,7 +9,11 @@ import type { McpToolMapping, OpenAiTool } from "$lib/server/mcp/tools";
 import type { McpServerConfig } from "$lib/server/mcp/httpClient";
 import { MessageToolUpdateType, MessageUpdateType } from "$lib/types/MessageUpdate";
 import { recordNestedAgentCalls, type LoggedCall } from "./nestedAgentCallLog";
-import { executeToolCalls, type NormalizedToolCall } from "../mcp/toolInvocation";
+import {
+	executeToolCalls,
+	type NormalizedToolCall,
+	type ToolArgsRewrite,
+} from "../mcp/toolInvocation";
 import { createSchemaPreflightGuard } from "$lib/server/mcp/preflightGuard";
 import { composeGuards, type ToolCallGuard } from "../mcp/toolGuard";
 import { parseToolArguments, withParseableArguments } from "../mcp/toolArgs";
@@ -61,6 +65,12 @@ export interface NestedAgentDeps {
 	/** Every builtin offered this turn; filtered by the spec's allowlist here. */
 	hostBuiltinTools: BuiltinTool[];
 	contextLengthTokens?: number;
+	/**
+	 * The parent's argument rewrite. Unlike the budget guard it is not withheld
+	 * here: it decides which namespace a job lives in, and a sub-agent reading
+	 * the parent's jobs has to look where they were put.
+	 */
+	rewriteArgs?: ToolArgsRewrite;
 }
 
 export interface NestedAgentSpec {
@@ -403,6 +413,7 @@ export async function runNestedAgent(
 				// a call against its own schema is not a policy, it is the round
 				// trip and the iteration this run would otherwise lose.
 				guard: preflightGuard,
+				...(deps.rewriteArgs ? { rewriteArgs: deps.rewriteArgs } : {}),
 				// No `elicitation`: the sub-agent has no chat to ask, so an
 				// input-required response comes back as an ordinary tool error.
 			});

--- a/src/lib/server/textGeneration/index.ts
+++ b/src/lib/server/textGeneration/index.ts
@@ -10,7 +10,11 @@ import { generate } from "./generate";
 import { runMcpFlow } from "./mcp/runMcpFlow";
 import { mergeAsyncGenerators } from "$lib/utils/mergeAsyncGenerators";
 import type { TextGenerationContext } from "./types";
-import { isMlAssistantConversation, pinnedHubToken } from "$lib/server/mlAssistant";
+import {
+	isMlAssistantConversation,
+	mlAssistantBillingNamespace,
+	pinnedHubToken,
+} from "$lib/server/mlAssistant";
 import { settleMlBudget } from "$lib/server/mlBudget/settle";
 import { reservedMicroUsd } from "$lib/utils/mlBudget";
 import { logger } from "$lib/server/logger";
@@ -108,6 +112,9 @@ async function* textGenerationWithoutTitle(
 		username: ctx.username,
 		timezone: (ctx.locals as unknown as { timezone?: string } | undefined)?.timezone,
 		budget: conv.mlBudget,
+		// The same resolution the dispatch rewrite uses, so the prompt never
+		// names a payer the calls will not carry.
+		billTo: mlAssistant ? mlAssistantBillingNamespace(ctx.locals) : undefined,
 	});
 
 	const processedMessages = await preprocessMessages(messages, convId);

--- a/src/lib/server/textGeneration/mcp/runMcpFlow.ts
+++ b/src/lib/server/textGeneration/mcp/runMcpFlow.ts
@@ -30,9 +30,11 @@ import { AbortedGenerations } from "$lib/server/abortedGenerations";
 import { withoutContentLength } from "$lib/server/undiciCompat";
 import {
 	isMlAssistantConversation,
+	mlAssistantBillingNamespace,
 	pinnedHubToken,
 	withMlAssistantServers,
 } from "$lib/server/mlAssistant";
+import { createHubBillingRewrite } from "$lib/server/mcp/hubBilling";
 import { mlAssistantModelEntry } from "$lib/server/mlAssistantModels";
 import { createMlBudgetGuard, withRequiredDiscriminators } from "$lib/server/mlBudget/guard";
 import { createRepeatedCallGuard } from "./repeatedCallGuard";
@@ -170,6 +172,11 @@ export async function* runMcpFlow({
 					(locals as unknown as { token?: string } | undefined)?.token,
 			})
 		: undefined;
+
+	// A job bills the namespace it runs under, so the billing setting travels as
+	// an argument rather than a header — see mcp/hubBilling.ts.
+	const billingNamespace = mlAssistant ? mlAssistantBillingNamespace(locals) : undefined;
+	const rewriteArgs = billingNamespace ? createHubBillingRewrite(billingNamespace) : undefined;
 
 	// Built here so it spans the turn's rounds; chained below, once the tool
 	// mapping the schema check reads exists.
@@ -655,6 +662,7 @@ export async function* runMcpFlow({
 			mcpTools: shapedMcpTools,
 			hostBuiltinTools: builtinTools,
 			contextLengthTokens: targetContextLength,
+			...(rewriteArgs ? { rewriteArgs } : {}),
 		};
 		for (const tool of builtinTools) {
 			if (isNestedAgentTool(tool)) tool.bind(nestedAgentDeps);
@@ -1082,6 +1090,7 @@ export async function* runMcpFlow({
 					},
 					builtinTools,
 					guard,
+					...(rewriteArgs ? { rewriteArgs } : {}),
 					// So a server operator can tell autonomous, job-shaped mode traffic
 					// from ordinary chat: the name is sent once, at initialize.
 					...(mlAssistant ? { clientKind: "intern" as const } : {}),

--- a/src/lib/server/textGeneration/mcp/runMcpFlow.ts
+++ b/src/lib/server/textGeneration/mcp/runMcpFlow.ts
@@ -34,7 +34,7 @@ import { AbortedGenerations } from "$lib/server/abortedGenerations";
 import { withoutContentLength } from "$lib/server/undiciCompat";
 import {
 	isMlAssistantConversation,
-	mlAssistantBillingNamespace,
+	mlAssistantPayerNamespace,
 	pinnedHubToken,
 	withMlAssistantServers,
 } from "$lib/server/mlAssistant";
@@ -179,8 +179,14 @@ export async function* runMcpFlow({
 
 	// A job bills the namespace it runs under, so the billing setting travels as
 	// an argument rather than a header — see mcp/hubBilling.ts.
-	const billingNamespace = mlAssistant ? mlAssistantBillingNamespace(locals) : undefined;
-	const rewriteArgs = billingNamespace ? createHubBillingRewrite(billingNamespace) : undefined;
+	const payer = mlAssistant ? mlAssistantPayerNamespace(locals) : undefined;
+	const rewriteArgs = payer ? createHubBillingRewrite(payer) : undefined;
+	if (mlAssistant) {
+		logger.info(
+			{ conversationId: conv._id.toString(), payer: payer ?? null },
+			"[mcp] Hub compute for this run bills to"
+		);
+	}
 
 	// Built here so it spans the turn's rounds; chained below, once the tool
 	// mapping the schema check reads exists.

--- a/src/lib/server/textGeneration/mcp/runMcpFlow.ts
+++ b/src/lib/server/textGeneration/mcp/runMcpFlow.ts
@@ -13,7 +13,11 @@ import type { Stream } from "openai/streaming";
 import { buildToolPreprompt } from "../utils/toolPrompt";
 import type { EndpointMessage } from "../../endpoints/endpoints";
 import { resolveRouterTarget } from "./routerResolution";
-import { executeToolCalls, type NormalizedToolCall } from "./toolInvocation";
+import {
+	executeToolCalls,
+	withRewrittenArguments,
+	type NormalizedToolCall,
+} from "./toolInvocation";
 import { hasTruncatedToolCall, parseToolArguments, withParseableArguments } from "./toolArgs";
 import type { TextGenerationContext } from "../types";
 import {
@@ -1021,6 +1025,16 @@ export async function* runMcpFlow({
 						})) as NormalizedToolCall[];
 				}
 
+				if (rewriteArgs) {
+					calls = withRewrittenArguments(calls, {
+						mapping,
+						servers,
+						builtinTools,
+						parseArgs,
+						rewrite: rewriteArgs,
+					});
+				}
+
 				// Include the assistant message with tool_calls so the next round
 				// sees both the calls and their outputs, matching MCP branch behavior.
 				const toolCalls: ChatCompletionMessageToolCall[] = calls.map((call) => ({
@@ -1090,7 +1104,6 @@ export async function* runMcpFlow({
 					},
 					builtinTools,
 					guard,
-					...(rewriteArgs ? { rewriteArgs } : {}),
 					// So a server operator can tell autonomous, job-shaped mode traffic
 					// from ordinary chat: the name is sent once, at initialize.
 					...(mlAssistant ? { clientKind: "intern" as const } : {}),

--- a/src/lib/server/textGeneration/mcp/toolInvocation.spec.ts
+++ b/src/lib/server/textGeneration/mcp/toolInvocation.spec.ts
@@ -26,7 +26,8 @@ vi.mock("../../logger", () => ({
 	logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
 
-const { executeToolCalls, isValidJsonObject } = await import("./toolInvocation");
+const { executeToolCalls, isValidJsonObject, withRewrittenArguments } =
+	await import("./toolInvocation");
 
 const SERVERS = [{ name: "hf", url: "https://example.test/mcp" }];
 const MAPPING = { do_thing: { fnName: "do_thing", server: "hf", tool: "do_thing" } };
@@ -43,8 +44,7 @@ async function drain(
 	calls: NormalizedToolCall[],
 	elicitation?: { conversationId: ObjectId; generationId?: string; messageId?: string },
 	builtinTools?: BuiltinTool[],
-	guard?: import("./toolGuard").ToolCallGuard,
-	rewriteArgs?: ToolArgsRewrite
+	guard?: import("./toolGuard").ToolCallGuard
 ) {
 	const events = [];
 	for await (const event of executeToolCalls({
@@ -57,7 +57,6 @@ async function drain(
 		...(elicitation ? { elicitation } : {}),
 		...(builtinTools ? { builtinTools } : {}),
 		...(guard ? { guard } : {}),
-		...(rewriteArgs ? { rewriteArgs } : {}),
 	})) {
 		events.push(event);
 	}
@@ -540,52 +539,66 @@ describe("executeToolCalls with a guard", () => {
 	});
 });
 
-describe("executeToolCalls: argument rewrite", () => {
+describe("withRewrittenArguments", () => {
 	const stamp: ToolArgsRewrite = ({ serverUrl, tool, args }) => ({
 		...args,
 		via: `${tool}@${serverUrl}`,
 	});
+	const options = {
+		mapping: MAPPING,
+		servers: SERVERS,
+		parseArgs: parseToolArguments,
+	};
 
-	it("rewrites before the guard, the server and the Call update see the arguments", async () => {
-		// One set of arguments everywhere: a guard pricing what the server will
-		// not receive, or a UI showing what the server did not, is the bug this
-		// ordering prevents.
-		const seen: Array<Record<string, unknown>> = [];
-		const guard: import("./toolGuard").ToolCallGuard = {
-			allowParking: true,
-			async before(call) {
-				seen.push(call.args);
-				return { allow: true };
-			},
-			async after() {
-				return undefined;
-			},
-		};
-		const events = await drain([CALL], undefined, undefined, guard, stamp);
+	it("re-serialises a call the rewrite changed", () => {
+		const [call] = withRewrittenArguments([CALL], { ...options, rewrite: stamp });
 
-		const expected = { a: 1, via: "do_thing@https://example.test/mcp" };
-		expect(seen).toEqual([expected]);
-		expect(mcpMock.callMcpTool.mock.calls[0][2]).toEqual(expected);
-		const call = toolUpdatesOf(events).find((u) => u.subtype === MessageToolUpdateType.Call);
-		expect(call?.subtype === MessageToolUpdateType.Call && call.call.parameters).toEqual(expected);
+		expect(call.id).toBe(CALL.id);
+		expect(call.name).toBe(CALL.name);
+		expect(JSON.parse(call.arguments)).toEqual({ a: 1, via: "do_thing@https://example.test/mcp" });
 	});
 
-	it("leaves builtins alone", async () => {
-		// A builtin runs in this process; the rewrite is for what a server reads.
-		const received: Array<Record<string, unknown>> = [];
+	it("keeps a call the rewrite left alone, string and all", () => {
+		// Identity is the no-change signal; the original string stays byte for byte.
+		const spaced: NormalizedToolCall = { ...CALL, arguments: '{ "a" : 1 }' };
+		const [call] = withRewrittenArguments([spaced], { ...options, rewrite: ({ args }) => args });
+
+		expect(call).toBe(spaced);
+	});
+
+	it("skips builtins, unmapped tools and undecodable arguments", () => {
+		const rewrite = vi.fn(stamp);
 		const builtin: BuiltinTool = {
 			name: "do_thing",
 			definition: { type: "function", function: { name: "do_thing" } },
-			execute: async (args) => {
-				received.push(args);
-				return { resultText: "done" };
-			},
+			execute: async () => ({ resultText: "done" }),
 		};
-		const rewrite = vi.fn(stamp);
-		await drain([CALL], undefined, [builtin], undefined, rewrite);
+		const unmapped: NormalizedToolCall = { id: "call_2", name: "nope", arguments: "{}" };
+		const broken: NormalizedToolCall = { id: "call_3", name: "do_thing", arguments: '{"broken":' };
 
+		expect(
+			withRewrittenArguments([CALL], { ...options, builtinTools: [builtin], rewrite })
+		).toEqual([CALL]);
+		expect(withRewrittenArguments([unmapped, broken], { ...options, rewrite })).toEqual([
+			unmapped,
+			broken,
+		]);
 		expect(rewrite).not.toHaveBeenCalled();
-		expect(received).toEqual([{ a: 1 }]);
-		expect(mcpMock.callMcpTool).not.toHaveBeenCalled();
+	});
+
+	it("is what the executor persists and dispatches", async () => {
+		// The point of rewriting the call rather than the dispatch: history,
+		// the persisted Call update and the server all carry the same arguments.
+		const calls = withRewrittenArguments([CALL], { ...options, rewrite: stamp });
+		const events = await drain(calls);
+
+		const expected = { a: 1, via: "do_thing@https://example.test/mcp" };
+		expect(mcpMock.callMcpTool.mock.calls[0][2]).toEqual(expected);
+		const call = toolUpdatesOf(events).find((u) => u.subtype === MessageToolUpdateType.Call);
+		expect(
+			call?.subtype === MessageToolUpdateType.Call && call.argumentsRaw
+				? JSON.parse(call.argumentsRaw)
+				: undefined
+		).toEqual(expected);
 	});
 });

--- a/src/lib/server/textGeneration/mcp/toolInvocation.spec.ts
+++ b/src/lib/server/textGeneration/mcp/toolInvocation.spec.ts
@@ -4,7 +4,7 @@ import { collections, ready } from "$lib/server/database";
 import { MessageToolUpdateType, MessageUpdateType } from "$lib/types/MessageUpdate";
 import { ToolResultStatus } from "$lib/types/Tool";
 import { parseToolArguments } from "./toolArgs";
-import type { NormalizedToolCall } from "./toolInvocation";
+import type { NormalizedToolCall, ToolArgsRewrite } from "./toolInvocation";
 import type { BuiltinTool } from "../builtinTools/types";
 import type { McpToolTextResponse } from "$lib/server/mcp/httpClient";
 import type { ChatCompletionToolMessageParam } from "openai/resources/chat/completions";
@@ -43,7 +43,8 @@ async function drain(
 	calls: NormalizedToolCall[],
 	elicitation?: { conversationId: ObjectId; generationId?: string; messageId?: string },
 	builtinTools?: BuiltinTool[],
-	guard?: import("./toolGuard").ToolCallGuard
+	guard?: import("./toolGuard").ToolCallGuard,
+	rewriteArgs?: ToolArgsRewrite
 ) {
 	const events = [];
 	for await (const event of executeToolCalls({
@@ -56,6 +57,7 @@ async function drain(
 		...(elicitation ? { elicitation } : {}),
 		...(builtinTools ? { builtinTools } : {}),
 		...(guard ? { guard } : {}),
+		...(rewriteArgs ? { rewriteArgs } : {}),
 	})) {
 		events.push(event);
 	}
@@ -535,5 +537,55 @@ describe("executeToolCalls with a guard", () => {
 			(e) => e.type === "update" && e.update.type === MessageUpdateType.Budget
 		);
 		expect(budgets).toHaveLength(2);
+	});
+});
+
+describe("executeToolCalls: argument rewrite", () => {
+	const stamp: ToolArgsRewrite = ({ serverUrl, tool, args }) => ({
+		...args,
+		via: `${tool}@${serverUrl}`,
+	});
+
+	it("rewrites before the guard, the server and the Call update see the arguments", async () => {
+		// One set of arguments everywhere: a guard pricing what the server will
+		// not receive, or a UI showing what the server did not, is the bug this
+		// ordering prevents.
+		const seen: Array<Record<string, unknown>> = [];
+		const guard: import("./toolGuard").ToolCallGuard = {
+			allowParking: true,
+			async before(call) {
+				seen.push(call.args);
+				return { allow: true };
+			},
+			async after() {
+				return undefined;
+			},
+		};
+		const events = await drain([CALL], undefined, undefined, guard, stamp);
+
+		const expected = { a: 1, via: "do_thing@https://example.test/mcp" };
+		expect(seen).toEqual([expected]);
+		expect(mcpMock.callMcpTool.mock.calls[0][2]).toEqual(expected);
+		const call = toolUpdatesOf(events).find((u) => u.subtype === MessageToolUpdateType.Call);
+		expect(call?.subtype === MessageToolUpdateType.Call && call.call.parameters).toEqual(expected);
+	});
+
+	it("leaves builtins alone", async () => {
+		// A builtin runs in this process; the rewrite is for what a server reads.
+		const received: Array<Record<string, unknown>> = [];
+		const builtin: BuiltinTool = {
+			name: "do_thing",
+			definition: { type: "function", function: { name: "do_thing" } },
+			execute: async (args) => {
+				received.push(args);
+				return { resultText: "done" };
+			},
+		};
+		const rewrite = vi.fn(stamp);
+		await drain([CALL], undefined, [builtin], undefined, rewrite);
+
+		expect(rewrite).not.toHaveBeenCalled();
+		expect(received).toEqual([{ a: 1 }]);
+		expect(mcpMock.callMcpTool).not.toHaveBeenCalled();
 	});
 });

--- a/src/lib/server/textGeneration/mcp/toolInvocation.ts
+++ b/src/lib/server/textGeneration/mcp/toolInvocation.ts
@@ -35,6 +35,17 @@ export interface NormalizedToolCall {
 	arguments: string;
 }
 
+/**
+ * Rewrites a call's arguments before the guards, the server and the UI's Call
+ * update see them, for policy the server can only read from the arguments (see
+ * mcp/hubBilling.ts). Returning the same object means no change.
+ */
+export type ToolArgsRewrite = (call: {
+	serverUrl: string;
+	tool: string;
+	args: Record<string, unknown>;
+}) => Record<string, unknown>;
+
 export interface ExecuteToolCallsParams {
 	calls: NormalizedToolCall[];
 	mapping: Record<string, McpToolMapping>;
@@ -61,6 +72,8 @@ export interface ExecuteToolCallsParams {
 	builtinTools?: BuiltinTool[];
 	/** Policy gate consulted around every MCP dispatch (not builtins) — see toolGuard.ts. */
 	guard?: ToolCallGuard;
+	/** Applied to every MCP dispatch (not builtins) before the guard sees it. */
+	rewriteArgs?: ToolArgsRewrite;
 	/** Identity these calls introduce themselves to the server with. */
 	clientKind?: McpClientKind;
 }
@@ -121,12 +134,14 @@ export async function* executeToolCalls({
 	owner,
 	builtinTools,
 	guard,
+	rewriteArgs,
 	clientKind,
 }: ExecuteToolCallsParams): AsyncGenerator<ToolExecutionEvent, void, undefined> {
 	const effectiveTimeoutMs = toolTimeoutMs ?? getMcpToolTimeoutMs();
 	const toolMessages: ChatCompletionMessageParam[] = [];
 	const toolRuns: ToolRun[] = [];
 	const serverLookup = serverMap(servers);
+	const builtinByName = new Map((builtinTools ?? []).map((tool) => [tool.name, tool]));
 	// Pre-emit call + ETA updates and prepare tasks
 	type TaskResult = {
 		index: number;
@@ -140,7 +155,13 @@ export async function* executeToolCalls({
 	};
 
 	const prepared = calls.map((call) => {
-		const argsObj = parseArgs(call.arguments);
+		let argsObj = parseArgs(call.arguments);
+		// Before paramsClean, so the Call update shows what the server receives.
+		const mappingEntry = builtinByName.has(call.name) ? undefined : mapping[call.name];
+		const serverCfg = mappingEntry ? serverLookup.get(mappingEntry.server) : undefined;
+		if (rewriteArgs && argsObj && mappingEntry && serverCfg) {
+			argsObj = rewriteArgs({ serverUrl: serverCfg.url, tool: mappingEntry.tool, args: argsObj });
+		}
 		const paramsClean: Record<string, Primitive> = {};
 		for (const [k, v] of Object.entries(argsObj ?? {})) {
 			const prim = toPrimitive(v);
@@ -248,7 +269,6 @@ export async function* executeToolCalls({
 		emit: (update) => updatesQueue.push(update),
 	};
 
-	const builtinByName = new Map((builtinTools ?? []).map((tool) => [tool.name, tool]));
 	// Positional, not success-conditional: which parking call survives must not depend
 	// on a race between concurrent tasks.
 	const parkingCalls = prepared.filter((p) => builtinByName.get(p.call.name)?.mayPark);

--- a/src/lib/server/textGeneration/mcp/toolInvocation.ts
+++ b/src/lib/server/textGeneration/mcp/toolInvocation.ts
@@ -36,15 +36,50 @@ export interface NormalizedToolCall {
 }
 
 /**
- * Rewrites a call's arguments before the guards, the server and the UI's Call
- * update see them, for policy the server can only read from the arguments (see
- * mcp/hubBilling.ts). Returning the same object means no change.
+ * Rewrites a call's arguments for policy the server can only read from the
+ * arguments (see mcp/hubBilling.ts). Returning the same object means no change.
  */
 export type ToolArgsRewrite = (call: {
 	serverUrl: string;
 	tool: string;
 	args: Record<string, unknown>;
 }) => Record<string, unknown>;
+
+/**
+ * The calls with `rewrite` applied to each one bound for an MCP server.
+ *
+ * Applied to the calls themselves, ahead of everything that reads them — the
+ * assistant tool_calls message the model sees next round, the `argumentsRaw`
+ * the Call update persists and replay prefers, the guards, the dispatch — so no
+ * consumer describes arguments the server never received. A call the rewrite
+ * leaves alone keeps its argument string byte for byte; undecodable arguments
+ * are left for the executor to refuse.
+ */
+export function withRewrittenArguments(
+	calls: NormalizedToolCall[],
+	{
+		mapping,
+		servers,
+		builtinTools,
+		parseArgs,
+		rewrite,
+	}: Pick<ExecuteToolCallsParams, "mapping" | "servers" | "builtinTools" | "parseArgs"> & {
+		rewrite: ToolArgsRewrite;
+	}
+): NormalizedToolCall[] {
+	const serverLookup = serverMap(servers);
+	const builtinNames = new Set((builtinTools ?? []).map((tool) => tool.name));
+	return calls.map((call) => {
+		if (builtinNames.has(call.name)) return call;
+		const entry = mapping[call.name];
+		const server = entry ? serverLookup.get(entry.server) : undefined;
+		if (!entry || !server) return call;
+		const args = parseArgs(call.arguments);
+		if (!args) return call;
+		const rewritten = rewrite({ serverUrl: server.url, tool: entry.tool, args });
+		return rewritten === args ? call : { ...call, arguments: JSON.stringify(rewritten) };
+	});
+}
 
 export interface ExecuteToolCallsParams {
 	calls: NormalizedToolCall[];
@@ -72,8 +107,6 @@ export interface ExecuteToolCallsParams {
 	builtinTools?: BuiltinTool[];
 	/** Policy gate consulted around every MCP dispatch (not builtins) — see toolGuard.ts. */
 	guard?: ToolCallGuard;
-	/** Applied to every MCP dispatch (not builtins) before the guard sees it. */
-	rewriteArgs?: ToolArgsRewrite;
 	/** Identity these calls introduce themselves to the server with. */
 	clientKind?: McpClientKind;
 }
@@ -134,14 +167,12 @@ export async function* executeToolCalls({
 	owner,
 	builtinTools,
 	guard,
-	rewriteArgs,
 	clientKind,
 }: ExecuteToolCallsParams): AsyncGenerator<ToolExecutionEvent, void, undefined> {
 	const effectiveTimeoutMs = toolTimeoutMs ?? getMcpToolTimeoutMs();
 	const toolMessages: ChatCompletionMessageParam[] = [];
 	const toolRuns: ToolRun[] = [];
 	const serverLookup = serverMap(servers);
-	const builtinByName = new Map((builtinTools ?? []).map((tool) => [tool.name, tool]));
 	// Pre-emit call + ETA updates and prepare tasks
 	type TaskResult = {
 		index: number;
@@ -155,13 +186,7 @@ export async function* executeToolCalls({
 	};
 
 	const prepared = calls.map((call) => {
-		let argsObj = parseArgs(call.arguments);
-		// Before paramsClean, so the Call update shows what the server receives.
-		const mappingEntry = builtinByName.has(call.name) ? undefined : mapping[call.name];
-		const serverCfg = mappingEntry ? serverLookup.get(mappingEntry.server) : undefined;
-		if (rewriteArgs && argsObj && mappingEntry && serverCfg) {
-			argsObj = rewriteArgs({ serverUrl: serverCfg.url, tool: mappingEntry.tool, args: argsObj });
-		}
+		const argsObj = parseArgs(call.arguments);
 		const paramsClean: Record<string, Primitive> = {};
 		for (const [k, v] of Object.entries(argsObj ?? {})) {
 			const prim = toPrimitive(v);
@@ -269,6 +294,7 @@ export async function* executeToolCalls({
 		emit: (update) => updatesQueue.push(update),
 	};
 
+	const builtinByName = new Map((builtinTools ?? []).map((tool) => [tool.name, tool]));
 	// Positional, not success-conditional: which parking call survives must not depend
 	// on a race between concurrent tasks.
 	const parkingCalls = prepared.filter((p) => builtinByName.get(p.call.name)?.mayPark);

--- a/src/lib/server/textGeneration/preprompt.spec.ts
+++ b/src/lib/server/textGeneration/preprompt.spec.ts
@@ -196,3 +196,24 @@ describe("resolvePreprompt", () => {
 		expect(outsideMode).not.toContain("Budget=");
 	});
 });
+
+describe("resolvePreprompt: who pays", () => {
+	it("stamps the billing organisation into the session context, in the mode only", () => {
+		const inMode = resolvePreprompt({
+			conversationPreprompt: undefined,
+			mlAssistant: true,
+			username: "pngwn",
+			billTo: "acme",
+		});
+		expect(inMode?.trimEnd().split("\n").at(-1)).toContain("User=pngwn, BillTo=acme");
+
+		expect(
+			resolvePreprompt({
+				conversationPreprompt: "You are a pirate.",
+				mlAssistant: false,
+				username: "pngwn",
+				billTo: "acme",
+			})
+		).toBe("You are a pirate.");
+	});
+});

--- a/src/lib/server/textGeneration/preprompt.ts
+++ b/src/lib/server/textGeneration/preprompt.ts
@@ -24,6 +24,8 @@ export interface PrepromptInput {
 	now?: Date;
 	/** The conversation's compute budget; presence turns on the budget rules. */
 	budget?: MlBudget;
+	/** Organization the mode's jobs and sandboxes are billed to; stamped as BillTo. */
+	billTo?: string;
 }
 
 /**
@@ -43,6 +45,7 @@ export function resolvePreprompt({
 	timezone,
 	now,
 	budget,
+	billTo,
 }: PrepromptInput): string | undefined {
 	const base = mlAssistant ? ML_ASSISTANT_PREPROMPT : conversationPreprompt;
 	const artifacts = mlAssistant || (artifactsOverride ?? supportsArtifacts);
@@ -63,5 +66,6 @@ export function resolvePreprompt({
 			remaining: formatMicroUsd(remainingMicroUsd(effective)),
 			total: formatMicroUsd(effective.totalMicroUsd),
 		},
+		billTo,
 	})}`;
 }

--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -27,7 +27,8 @@ type SettingsStore = {
 };
 
 type SettingsStoreWritable = Writable<SettingsStore> & {
-	instantSet: (settings: Partial<SettingsStore>) => Promise<void>;
+	/** Saves now, unlike `set`; resolves to whether the server accepted the change. */
+	instantSet: (settings: Partial<SettingsStore>) => Promise<boolean>;
 	initValue: <K extends keyof SettingsStore>(
 		key: K,
 		nestedKey: string,
@@ -136,14 +137,15 @@ export function createSettingsStore(initialValue: Omit<SettingsStore, "recentlyS
 			}, 300);
 		}
 	}
-	async function instantSet(settings: Partial<SettingsStore>) {
+	async function instantSet(settings: Partial<SettingsStore>): Promise<boolean> {
 		baseStore.update((s) => ({
 			...s,
 			...settings,
 		}));
 
-		if (browser) {
-			await fetch(`${base}/settings`, {
+		if (!browser) return true;
+		try {
+			const response = await fetch(`${base}/settings`, {
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",
@@ -153,6 +155,9 @@ export function createSettingsStore(initialValue: Omit<SettingsStore, "recentlyS
 					...settings,
 				}),
 			});
+			return response.ok;
+		} catch {
+			return false;
 		}
 	}
 

--- a/src/lib/types/Settings.ts
+++ b/src/lib/types/Settings.ts
@@ -85,9 +85,10 @@ export interface Settings extends Timestamps {
 	hapticsEnabled: boolean;
 
 	/**
-	 * Organization to bill inference requests, and the jobs and sandboxes ML Intern
-	 * launches, to (HuggingChat only). Stores the org's preferred_username. If
-	 * empty/undefined, bills to personal account.
+	 * Organization to bill inference requests, and the Jobs and sandboxes ML Intern
+	 * launches, to (HuggingChat only). Nothing else on the Hub follows it: Spaces,
+	 * repositories and Endpoints bill their own owner. Stores the org's
+	 * preferred_username. If empty/undefined, bills to personal account.
 	 */
 	billingOrganization?: string;
 }

--- a/src/lib/types/Settings.ts
+++ b/src/lib/types/Settings.ts
@@ -85,8 +85,9 @@ export interface Settings extends Timestamps {
 	hapticsEnabled: boolean;
 
 	/**
-	 * Organization to bill inference requests to (HuggingChat only).
-	 * Stores the org's preferred_username. If empty/undefined, bills to personal account.
+	 * Organization to bill inference requests, and the jobs and sandboxes ML Intern
+	 * launches, to (HuggingChat only). Stores the org's preferred_username. If
+	 * empty/undefined, bills to personal account.
 	 */
 	billingOrganization?: string;
 }

--- a/src/routes/api/v2/user/billing-orgs/+server.ts
+++ b/src/routes/api/v2/user/billing-orgs/+server.ts
@@ -4,6 +4,7 @@ import { config } from "$lib/server/config";
 import { collections } from "$lib/server/database";
 import { authCondition } from "$lib/server/auth";
 import { logger } from "$lib/server/logger";
+import { fetchBillableOrganizations } from "$lib/server/billingOrganizations";
 
 export const GET: RequestHandler = async ({ locals }) => {
 	if (!config.isHuggingChat) {
@@ -19,33 +20,17 @@ export const GET: RequestHandler = async ({ locals }) => {
 	}
 
 	try {
-		const response = await fetch("https://huggingface.co/oauth/userinfo", {
-			headers: { Authorization: `Bearer ${locals.token}` },
-		});
-
-		if (!response.ok) {
-			logger.error(`Failed to fetch billing orgs: ${response.status}`);
+		const billable = await fetchBillableOrganizations(locals.token);
+		if (!billable) {
 			error(502, "Failed to fetch billing information");
 		}
-
-		const data = await response.json();
 
 		const settings = await collections.settings.findOne(authCondition(locals));
 		const currentBillingOrg = settings?.billingOrganization;
 
-		const billingOrgs = (data.orgs ?? [])
-			.filter((org: { canPay?: boolean; plan?: string }) => org.plan || org.canPay === true)
-			.map((org: { sub: string; name: string; preferred_username: string }) => ({
-				sub: org.sub,
-				name: org.name,
-				preferred_username: org.preferred_username,
-			}));
-
 		const isCurrentOrgValid =
 			!currentBillingOrg ||
-			billingOrgs.some(
-				(org: { preferred_username: string }) => org.preferred_username === currentBillingOrg
-			);
+			billable.organizations.some((org) => org.preferred_username === currentBillingOrg);
 
 		if (!isCurrentOrgValid && currentBillingOrg) {
 			logger.info(
@@ -58,8 +43,8 @@ export const GET: RequestHandler = async ({ locals }) => {
 		}
 
 		return superjsonResponse({
-			userCanPay: data.canPay ?? false,
-			organizations: billingOrgs,
+			userCanPay: billable.userCanPay,
+			organizations: billable.organizations,
 			currentBillingOrg: isCurrentOrgValid ? currentBillingOrg : undefined,
 		});
 	} catch (err) {

--- a/src/routes/api/v2/user/settings/+server.ts
+++ b/src/routes/api/v2/user/settings/+server.ts
@@ -7,6 +7,7 @@ import { requireAuth } from "$lib/server/api/utils/requireAuth";
 import { defaultModel, models, validateModel } from "$lib/server/models";
 import { DEFAULT_SETTINGS, type SettingsEditable } from "$lib/types/Settings";
 import { resolveStreamingMode } from "$lib/utils/messageUpdates";
+import { assertBillableOrganization } from "$lib/server/billingOrganizations";
 import { z } from "zod";
 
 const settingsSchema = z.object({
@@ -96,6 +97,17 @@ export const POST: RequestHandler = async ({ locals, request }) => {
 		parsedSettings.multimodalOverrides = {};
 		parsedSettings.toolsOverrides = {};
 		parsedSettings.reasoningOverrides = {};
+	}
+
+	// A change of billing target is checked with the Hub; a resave of the same
+	// value is not, so ordinary settings edits never wait on it.
+	if (config.isHuggingChat && parsedSettings.billingOrganization) {
+		const current = await collections.settings.findOne(authCondition(locals), {
+			projection: { billingOrganization: 1 },
+		});
+		if (current?.billingOrganization !== parsedSettings.billingOrganization) {
+			await assertBillableOrganization(locals, parsedSettings.billingOrganization);
+		}
 	}
 
 	const settings = {

--- a/src/routes/settings/(nav)/+server.ts
+++ b/src/routes/settings/(nav)/+server.ts
@@ -4,6 +4,7 @@ import { authCondition } from "$lib/server/auth";
 import { config } from "$lib/server/config";
 import { DEFAULT_SETTINGS, type SettingsEditable } from "$lib/types/Settings";
 import { resolveStreamingMode } from "$lib/utils/messageUpdates";
+import { assertBillableOrganization } from "$lib/server/billingOrganizations";
 
 const settingsSchema = z.object({
 	shareConversationsWithModelAuthors: z
@@ -38,6 +39,17 @@ export async function POST({ request, locals }) {
 		parsedSettings.multimodalOverrides = {};
 		parsedSettings.toolsOverrides = {};
 		parsedSettings.reasoningOverrides = {};
+	}
+
+	// A change of billing target is checked with the Hub; a resave of the same
+	// value is not, so ordinary settings edits never wait on it.
+	if (config.isHuggingChat && parsedSettings.billingOrganization) {
+		const current = await collections.settings.findOne(authCondition(locals), {
+			projection: { billingOrganization: 1 },
+		});
+		if (current?.billingOrganization !== parsedSettings.billingOrganization) {
+			await assertBillableOrganization(locals, parsedSettings.billingOrganization);
+		}
 	}
 
 	const settings = {

--- a/src/routes/settings/(nav)/application/+page.svelte
+++ b/src/routes/settings/(nav)/application/+page.svelte
@@ -17,6 +17,7 @@
 	import { browser } from "$app/environment";
 	import { getThemePreference, setTheme, type ThemePreference } from "$lib/switchTheme";
 	import { supportsHaptics } from "$lib/utils/haptics";
+	import { ML_ASSISTANT_MODE } from "$lib/utils/mlAssistantFlag";
 
 	const publicConfig = usePublicConfig();
 	let settings = useSettingsStore();
@@ -269,8 +270,9 @@
 						<div>
 							<div class="text-[13px] font-medium text-gray-800 dark:text-gray-200">Billing</div>
 							<p class="text-[12px] text-gray-500 dark:text-gray-400">
-								Select between personal or organization billing for inference (for eligible
-								organizations).
+								Select between personal or organization billing for inference{ML_ASSISTANT_MODE
+									? " and for the jobs and sandboxes ML Intern runs"
+									: ""} (for eligible organizations).
 							</p>
 						</div>
 						<div class="flex items-center">

--- a/src/routes/settings/(nav)/application/+page.svelte
+++ b/src/routes/settings/(nav)/application/+page.svelte
@@ -57,12 +57,26 @@
 	let billingOrgs = $state<BillingOrg[]>([]);
 	let billingOrgsLoading = $state(false);
 	let billingOrgsError = $state<string | null>(null);
+	let billingOrgSaving = $state(false);
 
 	function getBillingOrganization() {
 		return $settings.billingOrganization ?? "";
 	}
-	function setBillingOrganization(v: string) {
-		settings.update((s) => ({ ...s, billingOrganization: v }));
+	// Saved at once and awaited, not debounced with the rest: who gets charged
+	// is not a preference to coalesce, and the server may refuse the target.
+	async function setBillingOrganization(v: string) {
+		const previous = getBillingOrganization();
+		if (v === previous) return;
+		billingOrgSaving = true;
+		billingOrgsError = null;
+		try {
+			if (!(await settings.instantSet({ billingOrganization: v }))) {
+				billingOrgsError = "Could not save this billing choice";
+				await settings.instantSet({ billingOrganization: previous });
+			}
+		} finally {
+			billingOrgSaving = false;
+		}
 	}
 
 	onMount(async () => {
@@ -86,7 +100,7 @@
 				billingOrgs = data.organizations ?? [];
 				// Update settings if current billing org was cleared by server
 				if (data.currentBillingOrg !== getBillingOrganization()) {
-					setBillingOrganization(data.currentBillingOrg ?? "");
+					await setBillingOrganization(data.currentBillingOrg ?? "");
 				}
 			} catch {
 				billingOrgsError = "Failed to load billing options";
@@ -270,20 +284,23 @@
 						<div>
 							<div class="text-[13px] font-medium text-gray-800 dark:text-gray-200">Billing</div>
 							<p class="text-[12px] text-gray-500 dark:text-gray-400">
-								Select between personal or organization billing for inference{ML_ASSISTANT_MODE
-									? " and for the jobs and sandboxes ML Intern runs"
-									: ""} (for eligible organizations).
+								Bill inference{ML_ASSISTANT_MODE
+									? ", and the Jobs and sandboxes ML Intern launches,"
+									: ""} to your personal account or to an eligible organization. Other Hub products, such
+								as Spaces and repositories, are not affected.
 							</p>
 						</div>
 						<div class="flex items-center">
 							{#if billingOrgsLoading}
 								<span class="text-xs text-gray-500 dark:text-gray-400">Loading...</span>
-							{:else if billingOrgsError}
-								<span class="text-xs text-red-500">{billingOrgsError}</span>
 							{:else}
+								{#if billingOrgsError}
+									<span class="mr-2 text-xs text-red-500">{billingOrgsError}</span>
+								{/if}
 								<select
-									class="rounded-md border border-gray-300 bg-white px-1 py-1 text-xs text-gray-800 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200"
+									class="rounded-md border border-gray-300 bg-white px-1 py-1 text-xs text-gray-800 disabled:opacity-60 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200"
 									value={getBillingOrganization()}
+									disabled={billingOrgSaving}
 									onchange={(e) => setBillingOrganization(e.currentTarget.value)}
 								>
 									<option value="">Personal</option>


### PR DESCRIPTION
## Summary

In ML Intern mode, jobs and sandboxes now run under, and are charged to, the organization the user picked in Settings → Application → Billing. Until now that setting redirected inference spend only (#2559 narrowed the copy for exactly that reason); everything launched through the Hub MCP server billed the user's own account.

## Why an argument, not a header

The Hub has no bill-to header for Jobs. A job is charged to the namespace it is created under, a sandbox is a job, and the hosted MCP server takes that namespace as an argument: `namespace` on every `hf_jobs` operation and `--namespace` on `hf_sandbox create`, defaulting to the signed-in user when absent. The server forwards nothing from the MCP transport to the Jobs API, so an `X-HF-Bill-To` header there would be a no-op.

## How it works

- **Argument rewrite before dispatch.** `executeToolCalls` gains an optional `rewriteArgs` hook, applied at parse time so the guards, the server and the UI's Call update all see the same arguments. Builtins are skipped. (`toolInvocation.ts`)
- **The Hub billing rewrite.** For Hub servers only: sets `namespace` on every `hf_jobs` call and `--namespace` on `hf_sandbox create`. Submissions are overwritten, because who pays is the user's setting and not the model's call. Reads are filled in only when the model named no namespace, so a job that lives elsewhere can still be inspected by its URL. (`mcp/hubBilling.ts`)
- **Nested sub-agents get the same rewrite.** Their guard chain is deliberately absent, but this is not a guard: it decides where a job lives, and `check_job` is handed a bare id, so without it org-owned jobs would 404 on read. (`nestedAgent.ts`)
- **One source of truth for who pays.** `mlAssistantBillingNamespace` returns the setting, but stands down when an operator-pinned Hub token launches the work, since that account cannot write to the user's organizations. Both the rewrite and the prompt use it, so the prompt never names a payer the calls will not carry. (`mlAssistant.ts`)
- **Prompt.** The session context stamps `BillTo=<org>` after `User`. The identity section says it changes who pays, not where outputs go. The jobs contract gains a "Who pays" pre-flight bullet; the sandbox rules say a sandbox bills like a job. Kept tight to stay under the existing 32k system-message ceiling.
- **Copy.** The settings description says the setting covers ML Intern's jobs and sandboxes (only in builds that ship the mode); the onboarding modal mentions it too.

The budget guard already recorded `namespace` from job and sandbox arguments onto reservations, and settlement already queries the Jobs API with it, so budget accounting follows the org-namespaced jobs without changes.

## Verification

- New `hubBilling.spec.ts` covers overwrite-on-submit, fill-in-on-read, explicit-read-namespace preserved, sandbox token handling, non-Hub servers and non-spending tools left alone, and no mutation of the model's arguments.
- `toolInvocation.spec.ts` checks the rewrite runs before the guard, the dispatch and the Call update, and that builtins are untouched.
- Prompt, preprompt and helper specs cover the `BillTo` stamp and the pinned-token exception.
- 137 tests pass across the affected files; `npm run check` reports 0 errors; ESLint and Prettier are clean on the touched files.

## Scope and open points

- Scoped to ML Intern conversations. Widening it to any conversation with the Hub MCP server is a one-line change in `runMcpFlow.ts`.
- Resource-group attribution is not possible: the Hub MCP server has no `resource_group_id` argument.
- Permission failures (no write role in the org, or an Enterprise restriction on who may bill the org) surface as ordinary tool errors from the Hub, as before. The billing-orgs picker still filters by plan or `canPay`, not by role.
