### PR TITLE
Recover when a question's answer was recorded but never continued

### DIFF
--- a/src/lib/components/chat/AskQuestion.svelte
+++ b/src/lib/components/chat/AskQuestion.svelte
@@ -104,7 +104,10 @@
 		});
 		submitting = false;
 		if (!result.ok) {
-			error = result.error;
+			// The answer that stands is the earlier one, so there is nothing left to ask; the
+			// transcript row settles when the continuation reports it.
+			if (result.answered) unregisterQuestion(request.elicitationId);
+			else error = result.error;
 			return;
 		}
 		// Mirror a budget grant into the strip right away — the server applied it

--- a/src/lib/components/chat/AskQuestion.svelte.test.ts
+++ b/src/lib/components/chat/AskQuestion.svelte.test.ts
@@ -2,6 +2,13 @@ import AskQuestion from "./AskQuestion.svelte";
 import { render } from "vitest-browser-svelte";
 import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
 import type { ElicitationField, ElicitationRequestPayload } from "$lib/types/McpElicitation";
+import {
+	pendingQuestions,
+	registerQuestion,
+	unregisterQuestion,
+} from "$lib/stores/pendingQuestion";
+import { elicitationToResume } from "$lib/stores/elicitationResume";
+import { get } from "svelte/store";
 
 let sent: Array<Record<string, unknown>>;
 
@@ -31,17 +38,19 @@ const ask = (name: string, question: string, over: Partial<ElicitationField> = {
 		...over,
 	}) as ElicitationField;
 
-const mount = (fields: ElicitationField[]) => {
-	const request: ElicitationRequestPayload = {
-		elicitationId: "11111111-1111-4111-8111-111111111111",
-		source: "assistant",
-		server: "",
-		mode: "form",
-		message: "",
-		fields,
-	};
-	return render(AskQuestion, { conversationId: "abc", request });
-};
+const ELICITATION_ID = "11111111-1111-4111-8111-111111111111";
+
+const requestFor = (fields: ElicitationField[]): ElicitationRequestPayload => ({
+	elicitationId: ELICITATION_ID,
+	source: "assistant",
+	server: "",
+	mode: "form",
+	message: "",
+	fields,
+});
+
+const mount = (fields: ElicitationField[]) =>
+	render(AskQuestion, { conversationId: "abc", request: requestFor(fields) });
 
 const rows = (el: HTMLElement) => [
 	...el.querySelectorAll<HTMLButtonElement>("button[aria-pressed]"),
@@ -201,5 +210,62 @@ describe("a question from the assistant", () => {
 		await vi.waitFor(() => expect(sent).toHaveLength(1));
 		expect(sent[0]).toMatchObject({ action: "decline" });
 		expect(sent[0]).not.toHaveProperty("content");
+	});
+});
+
+describe("a question that was answered before", () => {
+	const refuse = (body: Record<string, unknown>) =>
+		vi.stubGlobal("fetch", async () => new Response(JSON.stringify(body), { status: 409 }));
+
+	/** As the transcript form does when it re-opens the question after a reload. */
+	const mountRegistered = (fields: ElicitationField[]) => {
+		const request = requestFor(fields);
+		registerQuestion("abc", request);
+		return render(AskQuestion, { conversationId: "abc", request });
+	};
+
+	afterEach(() => {
+		unregisterQuestion(ELICITATION_ID);
+		elicitationToResume.set(null);
+	});
+
+	it("stops asking and continues the call the earlier answer never did", async () => {
+		// The row was resolved by an answer whose page lost its cue, so the transcript shows
+		// the question open again; a second answer is refused, but it must not dead-end.
+		refuse({
+			message: "Already answered. Continuing with that answer.",
+			answered: { action: "accept", resume: true, messageId: "m1" },
+		});
+		const { baseElement } = mountRegistered([ask("q1", "Which database?")]);
+		rowFor(baseElement, "Postgres")?.click();
+		button(baseElement, "Send")?.click();
+
+		await vi.waitFor(() => expect(get(pendingQuestions)).toHaveLength(0));
+		expect(get(elicitationToResume)).toEqual({
+			conversationId: "abc",
+			elicitationId: ELICITATION_ID,
+			messageId: "m1",
+		});
+		expect(baseElement.textContent).not.toContain("Already answered");
+	});
+
+	it("stops asking, and nothing more, when the call was already continued", async () => {
+		refuse({ message: "Already answered.", answered: { action: "accept", resume: false } });
+		const { baseElement } = mountRegistered([ask("q1", "Which database?")]);
+		button(baseElement, "Skip")?.click();
+
+		await vi.waitFor(() => expect(get(pendingQuestions)).toHaveLength(0));
+		expect(get(elicitationToResume)).toBeNull();
+	});
+
+	it("shows any other refusal and keeps the question open", async () => {
+		refuse({ message: "This request has expired." });
+		const { baseElement } = mountRegistered([ask("q1", "Which database?")]);
+		rowFor(baseElement, "Postgres")?.click();
+		button(baseElement, "Send")?.click();
+
+		await vi.waitFor(() => expect(baseElement.textContent).toContain("This request has expired."));
+		expect(get(pendingQuestions)).toHaveLength(1);
+		expect(get(elicitationToResume)).toBeNull();
 	});
 });

--- a/src/lib/server/generation/__tests__/finalize.spec.ts
+++ b/src/lib/server/generation/__tests__/finalize.spec.ts
@@ -54,8 +54,38 @@ describe.sequential("markGenerationInterrupted", () => {
 		await Promise.all([
 			collections.conversations.deleteMany({}),
 			collections.generations.deleteMany({}),
+			collections.mcpElicitations.deleteMany({}),
 		]);
 	});
+
+	const prompt = async ({
+		generationId,
+		conversationId,
+		messageId,
+		durable,
+	}: {
+		generationId: string;
+		conversationId: ObjectId;
+		messageId: string;
+		durable: boolean;
+	}) => {
+		const elicitationId = randomUUID();
+		const now = new Date();
+		await collections.mcpElicitations.insertOne({
+			_id: new ObjectId(),
+			elicitationId,
+			conversationId,
+			generationId,
+			status: "pending",
+			request: { elicitationId, server: "Test", mode: "form", message: "?", fields: [] },
+			...(durable
+				? { pending: { kind: "ask", messageId, toolCallId: "call-1", toolUuid: "tool-1" } }
+				: { expiresAt: new Date(now.getTime() + 60_000) }),
+			createdAt: now,
+			updatedAt: now,
+		});
+		return elicitationId;
+	};
 
 	it("marks the message when it wins the claim on a running run", async () => {
 		const { conversationId, messageId, generationId } = await seed({ status: "running" });
@@ -90,5 +120,24 @@ describe.sequential("markGenerationInterrupted", () => {
 		const gen = await collections.generations.findOne({ generationId });
 		expect(gen?.status).toBe("error");
 		expect(await messageInterrupted(conversationId, messageId)).toBe(false);
+	});
+
+	it("closes the prompts the dead run was polling, and only those", async () => {
+		const { conversationId, messageId, generationId } = await seed({ status: "running" });
+		const blocking = await prompt({ generationId, conversationId, messageId, durable: false });
+		// Nothing polls a durable prompt: its answer continues the turn whenever it comes, and
+		// closing it here would turn that answer into a refusal.
+		const durable = await prompt({ generationId, conversationId, messageId, durable: true });
+
+		await markGenerationInterrupted(generationId, { conversationId, messageId });
+
+		expect(await collections.mcpElicitations.findOne({ elicitationId: blocking })).toMatchObject({
+			status: "resolved",
+			action: "cancel",
+			resolution: "aborted",
+		});
+		expect(await collections.mcpElicitations.findOne({ elicitationId: durable })).toMatchObject({
+			status: "pending",
+		});
 	});
 });

--- a/src/lib/server/generation/finalize.ts
+++ b/src/lib/server/generation/finalize.ts
@@ -44,12 +44,27 @@ export async function markGenerationInterrupted(
 		{ $set: { "messages.$.interrupted": true, "messages.$.updatedAt": now, updatedAt: now } }
 	);
 	// Nothing is left to poll these, so leaving them pending invites an answer into the void.
+	// Only the blocking kind: a durable prompt is not polled, and its answer continues the
+	// turn whenever it comes, so closing it would turn that answer into a refusal.
 	// Scoped by conversation as well: `generationId` is client-chosen, so on its own it would
 	// let a caller close a prompt belonging to a chat this run has nothing to do with.
 	await collections.mcpElicitations
 		.updateMany(
-			{ generationId, conversationId: run.conversationId, status: "pending" },
-			{ $set: { status: "resolved", action: "cancel", resolvedAt: now, updatedAt: now } }
+			{
+				generationId,
+				conversationId: run.conversationId,
+				status: "pending",
+				pending: { $exists: false },
+			},
+			{
+				$set: {
+					status: "resolved",
+					action: "cancel",
+					resolution: "aborted",
+					resolvedAt: now,
+					updatedAt: now,
+				},
+			}
 		)
 		.catch((err) =>
 			logger.error({ err, generationId }, "[generation] failed to close pending elicitations")

--- a/src/lib/server/mcp/elicitation.spec.ts
+++ b/src/lib/server/mcp/elicitation.spec.ts
@@ -353,8 +353,51 @@ describe("submitElicitationAnswer", () => {
 		return elicitationId;
 	};
 
+	/** A 2026-era prompt: nothing waits on it, so the answer must start the continuation. */
+	const durableRow = async (turn: "awaiting_input" | "running") => {
+		const elicitationId = crypto.randomUUID();
+		const messageId = crypto.randomUUID();
+		const now = new Date();
+		await collections.mcpElicitations.insertOne({
+			_id: new ObjectId(),
+			elicitationId,
+			conversationId,
+			status: "pending",
+			request: {
+				elicitationId,
+				source: "assistant",
+				server: "",
+				mode: "form",
+				message: "",
+				fields: [
+					{
+						kind: "select",
+						name: "q1",
+						required: true,
+						multiple: false,
+						options: [{ value: "a", label: "A" }],
+					},
+				],
+			},
+			pending: { kind: "ask", messageId, toolCallId: "call-1", toolUuid: "tool-1" },
+			createdAt: now,
+			updatedAt: now,
+		});
+		await collections.turnStates.insertOne({
+			_id: new ObjectId(),
+			conversationId,
+			messageId,
+			status: turn,
+			producerId: "gen-1",
+			createdAt: now,
+			updatedAt: now,
+		});
+		return { elicitationId, messageId };
+	};
+
 	beforeEach(async () => {
 		await collections.mcpElicitations.deleteMany({});
+		await collections.turnStates.deleteMany({});
 	});
 
 	it("records a validated answer", async () => {
@@ -418,7 +461,69 @@ describe("submitElicitationAnswer", () => {
 			action: "decline",
 		});
 
-		expect(second).toMatchObject({ ok: false, status: 409 });
+		// A blocking prompt was unblocked by the first write; there is nothing to continue.
+		expect(second).toMatchObject({
+			ok: false,
+			status: 409,
+			answered: { action: "accept", resume: false },
+		});
+	});
+
+	it("tells a repeat answer to continue a call the first one never did", async () => {
+		// The page that answered lost its cue (reloaded, closed, or its run died before it
+		// persisted), so the transcript shows the question open again and the user answers
+		// it a second time. The turn is still parked on the question: nobody picked up
+		// the answer, and the repeat is the only thing that can.
+		const { elicitationId, messageId } = await durableRow("awaiting_input");
+
+		const first = await submitElicitationAnswer({
+			elicitationId,
+			conversationId,
+			action: "accept",
+			content: { q1: "a" },
+		});
+		expect(first).toEqual({ ok: true, resume: true, messageId });
+
+		const repeat = await submitElicitationAnswer({
+			elicitationId,
+			conversationId,
+			action: "decline",
+		});
+
+		expect(repeat).toMatchObject({
+			ok: false,
+			status: 409,
+			answered: { action: "accept", resume: true, messageId },
+		});
+		// The earlier answer stands: the repeat continues it, it does not replace it.
+		expect(await collections.mcpElicitations.findOne({ elicitationId })).toMatchObject({
+			action: "accept",
+			content: { q1: "a" },
+		});
+	});
+
+	it("leaves a continuation that already started alone", async () => {
+		const { elicitationId, messageId } = await durableRow("awaiting_input");
+		await submitElicitationAnswer({
+			elicitationId,
+			conversationId,
+			action: "accept",
+			content: { q1: "a" },
+		});
+		// Every continuation claims the turn as running first.
+		await collections.turnStates.updateOne({ messageId }, { $set: { status: "running" } });
+
+		const repeat = await submitElicitationAnswer({
+			elicitationId,
+			conversationId,
+			action: "decline",
+		});
+
+		expect(repeat).toMatchObject({
+			ok: false,
+			status: 409,
+			answered: { action: "accept", resume: false, messageId },
+		});
 	});
 
 	it("refuses an answer after the server stopped waiting", async () => {

--- a/src/lib/server/mcp/elicitation.spec.ts
+++ b/src/lib/server/mcp/elicitation.spec.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import { ObjectId } from "mongodb";
 import type { Client } from "@modelcontextprotocol/client";
 import { collections, ready } from "$lib/server/database";
+import type { McpElicitation } from "$lib/types/McpElicitation";
+import type { TurnStatus } from "$lib/types/TurnState";
 import {
 	handleElicitationRequest,
 	submitElicitationAnswer,
@@ -354,15 +356,33 @@ describe("submitElicitationAnswer", () => {
 	};
 
 	/** A 2026-era prompt: nothing waits on it, so the answer must start the continuation. */
-	const durableRow = async (turn: "awaiting_input" | "running") => {
+	const durableRow = async ({
+		turn = "awaiting_input",
+		settled = false,
+		closedBy,
+	}: {
+		turn?: TurnStatus;
+		/** The parked message already carries the Resolved update a continuation writes. */
+		settled?: boolean;
+		/** Seed the row already closed by the system instead of pending. */
+		closedBy?: "aborted" | "legacy";
+	} = {}) => {
 		const elicitationId = crypto.randomUUID();
 		const messageId = crypto.randomUUID();
 		const now = new Date();
+		const closed: Pick<McpElicitation, "status" | "action" | "resolvedAt" | "resolution"> = closedBy
+			? {
+					status: "resolved",
+					action: "cancel",
+					resolvedAt: now,
+					...(closedBy === "aborted" ? { resolution: "aborted" } : {}),
+				}
+			: { status: "pending" };
 		await collections.mcpElicitations.insertOne({
 			_id: new ObjectId(),
 			elicitationId,
 			conversationId,
-			status: "pending",
+			...closed,
 			request: {
 				elicitationId,
 				source: "assistant",
@@ -392,12 +412,47 @@ describe("submitElicitationAnswer", () => {
 			createdAt: now,
 			updatedAt: now,
 		});
+		await collections.conversations.insertOne({
+			_id: conversationId,
+			messages: [
+				{
+					id: messageId,
+					from: "assistant",
+					content: "",
+					updates: settled
+						? [
+								{
+									type: MessageUpdateType.Elicitation,
+									subtype: MessageElicitationUpdateType.Resolved,
+									elicitationId,
+									action: "cancel",
+									resolution: "user",
+								},
+							]
+						: [],
+				},
+			],
+			createdAt: now,
+			updatedAt: now,
+		} as never);
 		return { elicitationId, messageId };
 	};
 
+	const answer = (elicitationId: string) =>
+		submitElicitationAnswer({
+			elicitationId,
+			conversationId,
+			action: "accept",
+			content: { q1: "a" },
+		});
+
 	beforeEach(async () => {
-		await collections.mcpElicitations.deleteMany({});
-		await collections.turnStates.deleteMany({});
+		await Promise.all([
+			collections.mcpElicitations.deleteMany({}),
+			collections.turnStates.deleteMany({}),
+			collections.generations.deleteMany({ conversationId }),
+			collections.conversations.deleteMany({ _id: conversationId }),
+		]);
 	});
 
 	it("records a validated answer", async () => {
@@ -413,7 +468,12 @@ describe("submitElicitationAnswer", () => {
 		// `resume: false` — a blocking prompt is already unblocked by the write itself.
 		expect(result).toEqual({ ok: true, resume: false });
 		const row = await collections.mcpElicitations.findOne({ elicitationId });
-		expect(row).toMatchObject({ status: "resolved", action: "accept", content: { name: "Ada" } });
+		expect(row).toMatchObject({
+			status: "resolved",
+			action: "accept",
+			resolution: "user",
+			content: { name: "Ada" },
+		});
 	});
 
 	it("refuses an answer from another conversation", async () => {
@@ -461,69 +521,9 @@ describe("submitElicitationAnswer", () => {
 			action: "decline",
 		});
 
-		// A blocking prompt was unblocked by the first write; there is nothing to continue.
-		expect(second).toMatchObject({
-			ok: false,
-			status: 409,
-			answered: { action: "accept", resume: false },
-		});
-	});
-
-	it("tells a repeat answer to continue a call the first one never did", async () => {
-		// The page that answered lost its cue (reloaded, closed, or its run died before it
-		// persisted), so the transcript shows the question open again and the user answers
-		// it a second time. The turn is still parked on the question: nobody picked up
-		// the answer, and the repeat is the only thing that can.
-		const { elicitationId, messageId } = await durableRow("awaiting_input");
-
-		const first = await submitElicitationAnswer({
-			elicitationId,
-			conversationId,
-			action: "accept",
-			content: { q1: "a" },
-		});
-		expect(first).toEqual({ ok: true, resume: true, messageId });
-
-		const repeat = await submitElicitationAnswer({
-			elicitationId,
-			conversationId,
-			action: "decline",
-		});
-
-		expect(repeat).toMatchObject({
-			ok: false,
-			status: 409,
-			answered: { action: "accept", resume: true, messageId },
-		});
-		// The earlier answer stands: the repeat continues it, it does not replace it.
-		expect(await collections.mcpElicitations.findOne({ elicitationId })).toMatchObject({
-			action: "accept",
-			content: { q1: "a" },
-		});
-	});
-
-	it("leaves a continuation that already started alone", async () => {
-		const { elicitationId, messageId } = await durableRow("awaiting_input");
-		await submitElicitationAnswer({
-			elicitationId,
-			conversationId,
-			action: "accept",
-			content: { q1: "a" },
-		});
-		// Every continuation claims the turn as running first.
-		await collections.turnStates.updateOne({ messageId }, { $set: { status: "running" } });
-
-		const repeat = await submitElicitationAnswer({
-			elicitationId,
-			conversationId,
-			action: "decline",
-		});
-
-		expect(repeat).toMatchObject({
-			ok: false,
-			status: 409,
-			answered: { action: "accept", resume: false, messageId },
-		});
+		// A blocking prompt was unblocked by the first write; there is nothing to pick up, so
+		// no recovery data rides along.
+		expect(second).toEqual({ ok: false, status: 409, error: "Already answered." });
 	});
 
 	it("refuses an answer after the server stopped waiting", async () => {
@@ -537,6 +537,150 @@ describe("submitElicitationAnswer", () => {
 		});
 
 		expect(result).toMatchObject({ ok: false, status: 409 });
+	});
+
+	describe("a repeat answer to a durable prompt", () => {
+		it("asks for the continuation the first answer never got", async () => {
+			// The page that answered lost its cue (reloaded, closed, or its run died before it
+			// persisted), so the transcript shows the question open again and the user answers
+			// it a second time. Nothing picked up the answer, and the repeat is what can.
+			const { elicitationId, messageId } = await durableRow();
+			expect(await answer(elicitationId)).toEqual({ ok: true, resume: true, messageId });
+
+			const repeat = await submitElicitationAnswer({
+				elicitationId,
+				conversationId,
+				action: "decline",
+			});
+
+			expect(repeat).toMatchObject({
+				ok: false,
+				status: 409,
+				answered: { action: "accept", resume: true, messageId },
+			});
+			// The earlier answer stands: the repeat continues it, it does not replace it.
+			expect(await collections.mcpElicitations.findOne({ elicitationId })).toMatchObject({
+				action: "accept",
+				resolution: "user",
+				content: { q1: "a" },
+			});
+		});
+
+		it("asks again after a continuation died before it persisted", async () => {
+			// The reaper marks the generation and message interrupted but never moves the
+			// turn state, so it reads `running` for good. That must not pass for continued.
+			const { elicitationId, messageId } = await durableRow({ turn: "running" });
+			await answer(elicitationId);
+
+			const repeat = await submitElicitationAnswer({
+				elicitationId,
+				conversationId,
+				action: "decline",
+			});
+
+			expect(repeat).toMatchObject({
+				ok: false,
+				status: 409,
+				answered: { action: "accept", resume: true, messageId },
+			});
+		});
+
+		it("leaves a continuation that already ran alone, whatever the turn state says", async () => {
+			const { elicitationId, messageId } = await durableRow({ turn: "running", settled: true });
+			await answer(elicitationId);
+
+			const repeat = await submitElicitationAnswer({
+				elicitationId,
+				conversationId,
+				action: "decline",
+			});
+
+			expect(repeat).toMatchObject({
+				ok: false,
+				status: 409,
+				answered: { action: "accept", resume: false, messageId },
+			});
+		});
+
+		it("leaves a continuation that is under way alone", async () => {
+			const { elicitationId, messageId } = await durableRow();
+			await answer(elicitationId);
+			const now = new Date();
+			await collections.generations.insertOne({
+				_id: new ObjectId(),
+				generationId: crypto.randomUUID(),
+				conversationId,
+				messageId,
+				status: "running",
+				seq: 0,
+				lastHeartbeatAt: now,
+				startedAt: now,
+				createdAt: now,
+				updatedAt: now,
+			});
+
+			const repeat = await submitElicitationAnswer({
+				elicitationId,
+				conversationId,
+				action: "decline",
+			});
+
+			expect(repeat).toMatchObject({
+				ok: false,
+				status: 409,
+				answered: { action: "accept", resume: false, messageId },
+			});
+		});
+
+		it("takes a real answer in place of a close the system wrote", async () => {
+			// The run that asked was reaped before it wound down, which closed the row with a
+			// cancel nobody consumed. The user's answer is the first real one.
+			const { elicitationId, messageId } = await durableRow({ closedBy: "aborted" });
+
+			expect(await answer(elicitationId)).toEqual({ ok: true, resume: true, messageId });
+			expect(await collections.mcpElicitations.findOne({ elicitationId })).toMatchObject({
+				status: "resolved",
+				action: "accept",
+				resolution: "user",
+				content: { q1: "a" },
+			});
+		});
+
+		it("reads a cancel from before resolutions were recorded as the system's", async () => {
+			const { elicitationId, messageId } = await durableRow({ closedBy: "legacy" });
+
+			expect(await answer(elicitationId)).toEqual({ ok: true, resume: true, messageId });
+		});
+
+		it("keeps a system close that a continuation already consumed", async () => {
+			const { elicitationId, messageId } = await durableRow({ closedBy: "aborted", settled: true });
+
+			expect(await answer(elicitationId)).toMatchObject({
+				ok: false,
+				status: 409,
+				answered: { action: "cancel", resume: false, messageId },
+			});
+		});
+
+		it("keeps the question open when it cannot tell whether the answer was continued", async () => {
+			const { elicitationId } = await durableRow();
+			await answer(elicitationId);
+			const lookup = vi
+				.spyOn(collections.conversations, "findOne")
+				.mockRejectedValueOnce(new Error("blip"));
+
+			const repeat = await submitElicitationAnswer({
+				elicitationId,
+				conversationId,
+				action: "decline",
+			});
+			lookup.mockRestore();
+
+			// A refusal carrying `answered` would make the composer drop the question with no
+			// continuation queued; a plain failure leaves it there to retry.
+			expect(repeat).toMatchObject({ ok: false, status: 500 });
+			expect(repeat).not.toHaveProperty("answered");
+		});
 	});
 });
 

--- a/src/lib/server/mcp/elicitation.ts
+++ b/src/lib/server/mcp/elicitation.ts
@@ -3,6 +3,7 @@ import { ObjectId } from "mongodb";
 import type { Client } from "@modelcontextprotocol/client";
 import { collections } from "$lib/server/database";
 import { logger } from "$lib/server/logger";
+import { isTurnAlive } from "$lib/server/generation/turnLog";
 import type { McpElicitation, PendingMcpCall } from "$lib/types/McpElicitation";
 import type {
 	AnsweredElicitation,
@@ -109,6 +110,7 @@ async function abandon(
 				$set: {
 					status: "resolved",
 					action: "cancel",
+					resolution,
 					resolvedAt: new Date(),
 					updatedAt: new Date(),
 				},
@@ -269,20 +271,34 @@ export type SubmitResult =
 	| { ok: false; status: 409; error: string; answered?: AnsweredElicitation };
 
 /**
- * Every continuation claims the turn as `running` before it does anything, so a turn still
- * parked on its question is one nobody has continued: the answer landed, and that is all.
+ * Whether anything has picked up a durable prompt's answer. A producer holding the turn, or a
+ * parked call being claimed, is a continuation under way; the Resolved update in the parked
+ * message is one that ran, however it ended. The turn-state document is deliberately not the
+ * judge: a continuation that died leaves it at `running` for good (the reaper never moves
+ * it), which would read as continued forever.
  */
-async function answeredPrompt(doc: McpElicitation): Promise<AnsweredElicitation> {
-	const action = doc.action ?? "cancel";
-	if (!doc.pending) return { action, resume: false };
-	const turn = await collections.turnStates
-		.findOne(
-			{ conversationId: doc.conversationId, messageId: doc.pending.messageId },
-			{ projection: { status: 1 } }
-		)
-		.catch(() => null);
-	return { action, resume: turn?.status === "awaiting_input", messageId: doc.pending.messageId };
+async function continued(
+	conversationId: ObjectId,
+	elicitationId: string,
+	messageId: string
+): Promise<boolean> {
+	const turn = await isTurnAlive(conversationId, messageId);
+	if (turn.alive && turn.status !== "awaiting_input") return true;
+	const conversation = await collections.conversations.findOne(
+		{ _id: conversationId, "messages.id": messageId },
+		{ projection: { "messages.$": 1 } }
+	);
+	return (conversation?.messages[0]?.updates ?? []).some(
+		(update) =>
+			update.type === MessageUpdateType.Elicitation &&
+			update.subtype === MessageElicitationUpdateType.Resolved &&
+			update.elicitationId === elicitationId
+	);
 }
+
+/** See `McpElicitation.resolution` for how rows that predate it are read. */
+const answeredByUser = (doc: McpElicitation): boolean =>
+	doc.resolution ? doc.resolution === "user" : doc.action !== "cancel";
 
 export async function submitElicitationAnswer({
 	elicitationId,
@@ -298,18 +314,39 @@ export async function submitElicitationAnswer({
 	// Scoped by conversation: holding an id is not authority to answer someone else's prompt.
 	const doc = await collections.mcpElicitations.findOne({ elicitationId, conversationId });
 	if (!doc) return { ok: false, status: 404, error: "Unknown elicitation." };
+
+	/** Set when this answer replaces a close nothing consumed; the write below keys on it. */
+	let replaces: Date | undefined;
 	if (doc.status !== "pending") {
-		const answered = await answeredPrompt(doc);
-		return {
-			ok: false,
-			status: 409,
-			error: answered.resume
-				? "Already answered. Continuing with that answer."
-				: "Already answered.",
-			answered,
-		};
-	}
-	if (doc.expiresAt && doc.expiresAt.getTime() <= Date.now()) {
+		// A blocking prompt was unblocked by whatever closed it; there is nothing to pick up.
+		if (!doc.pending) return { ok: false, status: 409, error: "Already answered." };
+		let done: boolean;
+		try {
+			done = await continued(conversationId, elicitationId, doc.pending.messageId);
+		} catch (err) {
+			logger.error({ err, elicitationId }, "[mcp] could not tell whether an answer was continued");
+			// Not a refusal: one that carries `answered` makes the composer drop the question.
+			return { ok: false, status: 500, error: "Could not check the earlier answer. Try again." };
+		}
+		if (done || answeredByUser(doc)) {
+			const answered: AnsweredElicitation = {
+				action: doc.action ?? "cancel",
+				resume: !done,
+				messageId: doc.pending.messageId,
+			};
+			return {
+				ok: false,
+				status: 409,
+				error: answered.resume
+					? "Already answered. Continuing with that answer."
+					: "Already answered.",
+				answered,
+			};
+		}
+		// Closed by the system, never continued: nothing consumed that cancel, so the user's
+		// answer is the first real one and takes its place.
+		replaces = doc.updatedAt;
+	} else if (doc.expiresAt && doc.expiresAt.getTime() <= Date.now()) {
 		return { ok: false, status: 409, error: "This request has expired." };
 	}
 
@@ -361,17 +398,25 @@ export async function submitElicitationAnswer({
 		}
 	}
 
-	// `status: "pending"` makes a double submit a no-op rather than a second, different answer.
+	// Keyed on the state this answer saw, so a double submit is a no-op rather than a second,
+	// different answer, and a replacement lands only on the close it was replacing.
+	const now = new Date();
 	const updated = await collections.mcpElicitations.updateOne(
-		{ elicitationId, conversationId, status: "pending" },
+		{
+			elicitationId,
+			conversationId,
+			...(replaces ? { status: "resolved", updatedAt: replaces } : { status: "pending" }),
+		},
 		{
 			$set: {
 				status: "resolved",
 				action,
-				resolvedAt: new Date(),
-				updatedAt: new Date(),
+				resolution: "user",
+				resolvedAt: now,
+				updatedAt: now,
 				...(validated ? { content: validated } : {}),
 			},
+			...(replaces && !validated ? { $unset: { content: "" } } : {}),
 		}
 	);
 	if (updated.matchedCount === 0) return { ok: false, status: 409, error: "Already answered." };

--- a/src/lib/server/mcp/elicitation.ts
+++ b/src/lib/server/mcp/elicitation.ts
@@ -5,6 +5,7 @@ import { collections } from "$lib/server/database";
 import { logger } from "$lib/server/logger";
 import type { McpElicitation, PendingMcpCall } from "$lib/types/McpElicitation";
 import type {
+	AnsweredElicitation,
 	ElicitationAction,
 	ElicitationRequestPayload,
 	ElicitationResolution,
@@ -264,7 +265,24 @@ export async function handleElicitationRequest(
 
 export type SubmitResult =
 	| { ok: true; resume: boolean; messageId?: string }
-	| { ok: false; status: 400 | 404 | 409 | 500; error: string };
+	| { ok: false; status: 400 | 404 | 500; error: string }
+	| { ok: false; status: 409; error: string; answered?: AnsweredElicitation };
+
+/**
+ * Every continuation claims the turn as `running` before it does anything, so a turn still
+ * parked on its question is one nobody has continued: the answer landed, and that is all.
+ */
+async function answeredPrompt(doc: McpElicitation): Promise<AnsweredElicitation> {
+	const action = doc.action ?? "cancel";
+	if (!doc.pending) return { action, resume: false };
+	const turn = await collections.turnStates
+		.findOne(
+			{ conversationId: doc.conversationId, messageId: doc.pending.messageId },
+			{ projection: { status: 1 } }
+		)
+		.catch(() => null);
+	return { action, resume: turn?.status === "awaiting_input", messageId: doc.pending.messageId };
+}
 
 export async function submitElicitationAnswer({
 	elicitationId,
@@ -280,7 +298,17 @@ export async function submitElicitationAnswer({
 	// Scoped by conversation: holding an id is not authority to answer someone else's prompt.
 	const doc = await collections.mcpElicitations.findOne({ elicitationId, conversationId });
 	if (!doc) return { ok: false, status: 404, error: "Unknown elicitation." };
-	if (doc.status !== "pending") return { ok: false, status: 409, error: "Already answered." };
+	if (doc.status !== "pending") {
+		const answered = await answeredPrompt(doc);
+		return {
+			ok: false,
+			status: 409,
+			error: answered.resume
+				? "Already answered. Continuing with that answer."
+				: "Already answered.",
+			answered,
+		};
+	}
 	if (doc.expiresAt && doc.expiresAt.getTime() <= Date.now()) {
 		return { ok: false, status: 409, error: "This request has expired." };
 	}

--- a/src/lib/types/McpElicitation.ts
+++ b/src/lib/types/McpElicitation.ts
@@ -70,8 +70,8 @@ export type ElicitationAction = "accept" | "decline" | "cancel";
 export type ElicitationResolution = "user" | "expired" | "aborted" | "withdrawn";
 
 /**
- * Sent with the 409 a repeat answer gets. `resume` is true when the call the prompt parked
- * was never continued: the page that answered lost its cue (a reload, a closed tab, a run
+ * Sent with the 409 a repeat answer to a durable prompt gets. `resume` is true when the call
+ * the prompt parked was never continued: the page that answered lost its cue (a reload, a closed tab, a run
  * that died before persisting), so the transcript shows the question open again and this
  * answer is the only thing that can start the continuation.
  */
@@ -105,6 +105,12 @@ export interface McpElicitation extends Timestamps {
 	status: "pending" | "resolved";
 	request: ElicitationRequestPayload;
 	action?: ElicitationAction;
+	/**
+	 * Who closed it. Absent on rows written before this was recorded; for those a durable
+	 * prompt's `cancel` is read as the system's, since a user's cancel that nothing consumed
+	 * loses nothing by being answerable again.
+	 */
+	resolution?: ElicitationResolution;
 	content?: Record<string, ElicitationValue>;
 	/** Absent for a 2026-era prompt: nothing is waiting, so nothing expires. */
 	expiresAt?: Date;

--- a/src/lib/types/McpElicitation.ts
+++ b/src/lib/types/McpElicitation.ts
@@ -69,6 +69,18 @@ export type ElicitationAction = "accept" | "decline" | "cancel";
 /** `withdrawn` is the server giving up on its own request, which it usually does first. */
 export type ElicitationResolution = "user" | "expired" | "aborted" | "withdrawn";
 
+/**
+ * Sent with the 409 a repeat answer gets. `resume` is true when the call the prompt parked
+ * was never continued: the page that answered lost its cue (a reload, a closed tab, a run
+ * that died before persisting), so the transcript shows the question open again and this
+ * answer is the only thing that can start the continuation.
+ */
+export interface AnsweredElicitation {
+	action: ElicitationAction;
+	resume: boolean;
+	messageId?: string;
+}
+
 /** Every string here is server-authored, so it is display text and never markup. */
 export interface ElicitationRequestPayload {
 	elicitationId: string;

--- a/src/lib/utils/sendElicitationAnswer.ts
+++ b/src/lib/utils/sendElicitationAnswer.ts
@@ -1,6 +1,10 @@
 import { base } from "$app/paths";
 import { elicitationToResume } from "$lib/stores/elicitationResume";
-import type { ElicitationAction, ElicitationValue } from "$lib/types/McpElicitation";
+import type {
+	AnsweredElicitation,
+	ElicitationAction,
+	ElicitationValue,
+} from "$lib/types/McpElicitation";
 
 /** Shared, so neither answer path can forget to ask for the parked run to be continued. */
 export async function sendElicitationAnswer({
@@ -13,7 +17,7 @@ export async function sendElicitationAnswer({
 	elicitationId: string;
 	action: ElicitationAction;
 	content?: Record<string, ElicitationValue>;
-}): Promise<{ ok: true } | { ok: false; error: string }> {
+}): Promise<{ ok: true } | { ok: false; error: string; answered?: true }> {
 	let res: Response;
 	try {
 		res = await fetch(`${base}/conversation/${conversationId}/elicitation`, {
@@ -27,23 +31,29 @@ export async function sendElicitationAnswer({
 	}
 
 	const body = await res.json().catch(() => null);
-	if (!res.ok) {
-		const message = (body as { message?: unknown } | null)?.message;
-		return {
-			ok: false,
-			error: typeof message === "string" ? message : "Could not send your answer.",
-		};
-	}
 
 	// A parked call has nothing waiting on it, so answering only records the answer — the
 	// run that continues it has to be started.
-	const parsed = body as { resume?: boolean; messageId?: string } | null;
-	if (parsed?.resume) {
+	const queueResume = (messageId?: string) =>
 		elicitationToResume.set({
 			conversationId,
 			elicitationId,
-			...(parsed.messageId ? { messageId: parsed.messageId } : {}),
+			...(messageId ? { messageId } : {}),
 		});
+
+	if (!res.ok) {
+		const parsed = body as { message?: unknown; answered?: AnsweredElicitation } | null;
+		// An earlier answer stands but never continued the call: the page that sent it lost
+		// its cue, so this attempt is what starts the continuation instead.
+		if (parsed?.answered?.resume) queueResume(parsed.answered.messageId);
+		return {
+			ok: false,
+			error: typeof parsed?.message === "string" ? parsed.message : "Could not send your answer.",
+			...(parsed?.answered ? { answered: true } : {}),
+		};
 	}
+
+	const parsed = body as { resume?: boolean; messageId?: string } | null;
+	if (parsed?.resume) queueResume(parsed.messageId);
 	return { ok: true };
 }

--- a/src/routes/conversation/[id]/elicitation/+server.ts
+++ b/src/routes/conversation/[id]/elicitation/+server.ts
@@ -38,7 +38,12 @@ export const POST: RequestHandler = async ({ params, locals, request }) => {
 		content: parsed.data.content,
 	});
 
-	if (!result.ok) error(result.status, result.error);
+	if (!result.ok) {
+		if (result.status === 409 && result.answered) {
+			return json({ ok: false, message: result.error, answered: result.answered }, { status: 409 });
+		}
+		error(result.status, result.error);
+	}
 
 	// A parked 2026-era call resumes on a fresh run; a blocking one is already unblocked.
 	return json({ ok: true, resume: result.resume, messageId: result.messageId });


### PR DESCRIPTION
## The symptom

A user gets stuck on an assistant question. Every Send or Skip shows "Already answered." in red under the panel, and reloading brings the same question back. The console shows the elicitation endpoint answering 409 to each click.

## Why it happens

Answering an assistant question is two steps. The answer endpoint records the answer, then the page starts a second run that continues the parked turn, and only that run writes the Resolved update into the message. If the page loses its cue between the two steps, the row is resolved but the parked message still lacks the Resolved update, so the transcript re-opens the question. A reload, a closed tab, an answer sent while the page was still loading, or a run that died before persisting all produce it.

Once there, the client had no way out: the 409 carried only a message, and both buttons post.

## The fix

- `submitElicitationAnswer` still refuses a repeat answer to a durable prompt with a 409, but the response now says what stands and whether the parked call was ever continued.
- "Continued" is judged by what could have consumed the answer: a producer live on the turn or a parked call being claimed means one is under way, and otherwise the parked message either carries the Resolved update a continuation writes or it does not. The turn-state document is deliberately not the judge, because a continuation that dies leaves it at `running` for good.
- The elicitation route returns that as JSON rather than through `error()`, which has nowhere to put it.
- `sendElicitationAnswer` queues the continuation on that signal exactly as it does after a successful answer.
- The composer question unregisters itself instead of showing the refusal. The transcript row settles when the continuation reports the recorded answer.

A user's earlier answer is what continues; a different pick on the repeat is not applied.

## Review follow-up

- The finalizer no longer closes durable prompts when a run is reaped. Nothing polls them, and their answer continues the turn whenever it comes, so closing one turned the user's real answer into a replayed cancel.
- Rows now record who resolved them (`resolution`). A system close that nothing consumed gives way to the user's answer instead of standing in for it; rows from before the field existed read a durable prompt's `cancel` as the system's.
- A failed lookup returns a retryable error rather than passing for "not resumable", so the question stays open instead of being dropped with nothing queued.

## Verification

- MCP and generation server specs: 214 pass across 18 files, including eight new repeat-answer cases (never continued, died after claiming the turn, already ran, under way, system close replaced, legacy cancel, consumed system close kept, lookup failure) and one for the finalizer.
- AskQuestion and ElicitationForm browser specs: 31 pass, including three new composer cases.
- svelte-check: 0 errors. eslint and prettier clean on the changed files.

## Unblocking a conversation already in this state

Nothing manual is needed once this is deployed: the next Send on the re-opened question recovers it.

## Left out

Two tabs answering within the same instant could both start the continuation. That window is much smaller than the dead end it replaces; closing it needs a compare-and-swap on the turn claim in the conversation route, which is a separate change.
