### PR TITLE
Confirm deep-link prompts and untrusted attachments before acting on them

### DIFF
--- a/src/lib/components/LinkPromptModal.svelte
+++ b/src/lib/components/LinkPromptModal.svelte
@@ -1,0 +1,125 @@
+<script lang="ts">
+	import { browser } from "$app/environment";
+	import Modal from "$lib/components/Modal.svelte";
+	import { usePublicConfig } from "$lib/utils/PublicConfig.svelte";
+	import type { LinkPromptRequest } from "$lib/utils/linkParams";
+
+	import CarbonClose from "~icons/carbon/close";
+	import CarbonSendAlt from "~icons/carbon/send-alt";
+
+	interface Props {
+		request: LinkPromptRequest;
+		/** The model the link picked, when it came through a model route. */
+		modelName?: string;
+		/** Load the attachments and, for a `q` link, send the prompt. */
+		onconfirm: () => void;
+		/** Drop the link's prompt and attachments entirely. */
+		oncancel: () => void;
+	}
+
+	let { request, modelName, onconfirm, oncancel }: Props = $props();
+
+	const publicConfig = usePublicConfig();
+
+	// Only huggingface.co may frame this app (frame-ancestors, svelte.config.js),
+	// and the Hub's "Ask HuggingChat" box is what does so. Name the source
+	// accordingly. Being framed changes the wording only, never whether we ask:
+	// that box also submits a `q` it read from its own page URL on load, so a
+	// framed prompt is not proof the user typed it.
+	const embedded = browser && window.self !== window.top;
+	const source = embedded
+		? `the page that opened ${publicConfig.PUBLIC_APP_NAME}`
+		: "whoever shared this link";
+
+	const hasAttachments = $derived(request.attachmentUrls.length > 0);
+	const subject = $derived(
+		request.send
+			? hasAttachments
+				? "This prompt and its attachments come"
+				: "This prompt comes"
+			: "These attachments come"
+	);
+
+	// Like ExternalLinkModal: this opens without a user gesture, so the confirm
+	// button is deliberately not auto-focused. A stray Enter must not send.
+</script>
+
+<Modal onclose={oncancel} width="w-[90dvh] md:w-[520px]" labelledBy="link-prompt-title">
+	<div class="flex w-full flex-col gap-5 p-6">
+		<div class="flex items-start justify-between">
+			<h2 id="link-prompt-title" class="text-xl font-semibold text-gray-800 dark:text-gray-200">
+				{request.send ? "Send this prompt?" : "Add these attachments?"}
+			</h2>
+			<button type="button" class="group outline-hidden" onclick={oncancel} aria-label="Close">
+				<CarbonClose
+					class="size-5 text-gray-700 group-hover:text-gray-500 dark:text-gray-300 dark:group-hover:text-gray-400"
+				/>
+			</button>
+		</div>
+
+		<p class="text-sm text-gray-600 dark:text-gray-400">
+			{subject} from {source}. Take a look, and only continue if you trust the source.
+			{#if request.send}
+				Once sent, the model can act on it with any tools you have connected.
+			{/if}
+		</p>
+
+		{#if request.prompt}
+			<div class="flex flex-col gap-1.5">
+				<span class="text-xs font-medium text-gray-500 dark:text-gray-400">
+					{request.send ? "Prompt" : "Prompt, placed in the composer without sending"}
+				</span>
+				<!-- Plain text on purpose: rendered markdown is how a payload hides behind a friendly heading -->
+				<pre
+					class="scrollbar-custom max-h-48 overflow-y-auto rounded-xl border border-gray-200 bg-gray-50 px-3.5 py-2.5 font-mono text-xs break-words whitespace-pre-wrap text-gray-700 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300">{request.prompt}</pre>
+			</div>
+		{/if}
+
+		{#if hasAttachments}
+			<div class="flex flex-col gap-1.5">
+				<span class="text-xs font-medium text-gray-500 dark:text-gray-400">
+					{request.attachmentUrls.length === 1 ? "Attachment" : "Attachments"}
+				</span>
+				<ul class="scrollbar-custom flex max-h-32 flex-col gap-1.5 overflow-y-auto">
+					{#each request.attachmentUrls as url (url.href)}
+						<!-- Built from URL components (host has no userinfo ambiguity) so the
+						     rendered string is byte-identical to the URL that gets fetched -->
+						<li
+							class="rounded-xl border border-gray-200 bg-gray-50 px-3.5 py-2.5 font-mono text-xs break-all text-gray-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-400"
+						>
+							{url.protocol}//<span class="font-semibold text-gray-800 dark:text-gray-200"
+								>{url.host}</span
+							>{url.pathname + url.search + url.hash}
+						</li>
+					{/each}
+				</ul>
+			</div>
+		{/if}
+
+		{#if modelName}
+			<p class="text-xs text-gray-500 dark:text-gray-400">
+				Model: <span class="font-medium text-gray-700 dark:text-gray-300">{modelName}</span>
+			</p>
+		{/if}
+
+		<div class="flex items-center justify-end gap-2">
+			<button
+				type="button"
+				class="inline-flex items-center rounded-xl border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-900 shadow-sm outline-hidden hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600"
+				onclick={oncancel}
+			>
+				Cancel
+			</button>
+			<button
+				type="button"
+				class="inline-flex items-center gap-1.5 rounded-xl border border-gray-900 bg-gray-900 px-3 py-1.5 text-sm font-semibold text-white hover:bg-black focus:ring-2 focus:ring-gray-400 focus:ring-offset-2 focus:outline-hidden dark:border-gray-100 dark:bg-gray-100 dark:text-gray-900 dark:hover:bg-white dark:focus:ring-offset-gray-800"
+				onclick={onconfirm}
+			>
+				{request.send ? "Send" : "Add attachments"}
+				{#if request.send}
+					<CarbonSendAlt class="size-3.5" />
+				{/if}
+			</button>
+		</div>
+	</div>
+</Modal>

--- a/src/lib/components/Modal.svelte
+++ b/src/lib/components/Modal.svelte
@@ -1,3 +1,9 @@
+<script module lang="ts">
+	// Modals can overlap: one opens while another is still fading out. The app
+	// behind them stays inert until the last one is gone.
+	let openModals = 0;
+</script>
+
 <script lang="ts">
 	import { onDestroy, onMount } from "svelte";
 	import { cubicOut } from "svelte/easing";
@@ -50,6 +56,7 @@
 	}
 
 	onMount(() => {
+		openModals += 1;
 		document.getElementById("app")?.setAttribute("inert", "true");
 		modalEl?.focus();
 		tap();
@@ -59,7 +66,8 @@
 
 	onDestroy(() => {
 		if (!browser) return;
-		document.getElementById("app")?.removeAttribute("inert");
+		openModals -= 1;
+		if (openModals === 0) document.getElementById("app")?.removeAttribute("inert");
 		window.removeEventListener("keydown", handleKeydown, { capture: true });
 	});
 </script>

--- a/src/lib/components/Portal.svelte
+++ b/src/lib/components/Portal.svelte
@@ -19,6 +19,15 @@
 	});
 </script>
 
-<div bind:this={el} class="contents">
-	{@render children?.()}
+<!--
+	The outer div is the node Svelte owns for this component, and it never
+	moves. Tearing a block down walks the DOM from that node to the block's end
+	anchor; a node that was moved into body makes the walk run along body
+	instead and remove every later sibling there, other portals included. So
+	only the inner div goes to body, and this component removes it itself.
+-->
+<div class="contents">
+	<div bind:this={el} class="contents">
+		{@render children?.()}
+	</div>
 </div>

--- a/src/lib/components/Portal.svelte.test.ts
+++ b/src/lib/components/Portal.svelte.test.ts
@@ -1,0 +1,54 @@
+import PortalInBlock from "./__tests__/PortalInBlock.svelte";
+import { render } from "vitest-browser-svelte";
+import { describe, expect, it, vi } from "vitest";
+
+const inBody = (label: string) => document.body.querySelector(`[data-portal="${label}"]`);
+
+/** The Modal backdrop fades out for 300ms before its block is torn down. */
+const gone = (label: string) =>
+	vi.waitFor(() => expect(inBody(label)).toBeNull(), { timeout: 2000 });
+
+describe("Portal", () => {
+	it("moves its content into document.body and removes it on teardown", async () => {
+		const a = render(PortalInBlock, { label: "a" });
+		const content = inBody("a");
+		expect(content).not.toBeNull();
+		expect(a.container.contains(content)).toBe(false);
+		await a.rerender({ show: false });
+		await gone("a");
+	});
+
+	it("leaves the node Svelte owns where it was rendered", () => {
+		// Regression. The node moved into body used to be the portal's own root.
+		// For a server-rendered dialog (the welcome modal on a first visit) that
+		// root is the start of the hydrated block's DOM range while the range's
+		// end anchor stays in the original tree, so tearing the block down walked
+		// body from the moved node and removed every later sibling there: a
+		// second modal opened while the first was fading out simply vanished.
+		// Hydration is out of reach here; the guard is the shape that makes the
+		// walk safe: an owned placeholder that never leaves the tree.
+		const a = render(PortalInBlock, { label: "a" });
+		const placeholder = a.container.querySelector("div.contents");
+		expect(placeholder).not.toBeNull();
+		expect(placeholder?.childElementCount).toBe(0);
+		// The moved node is the nearest portal wrapper above the content, parented by body.
+		expect(inBody("a")?.closest("div.contents")?.parentElement).toBe(document.body);
+	});
+
+	it("tearing one portal down leaves the portals opened after it alone", async () => {
+		const a = render(PortalInBlock, { label: "a" });
+		const b = render(PortalInBlock, { label: "b" });
+		const marker = document.createElement("div");
+		marker.dataset.portal = "marker";
+		document.body.appendChild(marker);
+		try {
+			await a.rerender({ show: false });
+			await gone("a");
+			expect(inBody("b")).not.toBeNull();
+			expect(inBody("marker")).not.toBeNull();
+		} finally {
+			marker.remove();
+			b.unmount();
+		}
+	});
+});

--- a/src/lib/components/__tests__/ChatWindowStub.svelte
+++ b/src/lib/components/__tests__/ChatWindowStub.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+	// Stands in for ChatWindow where a test drives a route: keeps the route's
+	// `files` and `draft` bindings honest without the composer's own traffic.
+	let { files = $bindable([]), draft = $bindable("") }: { files?: File[]; draft?: string } =
+		$props();
+</script>
+
+<textarea data-testid="composer" bind:value={draft}></textarea>
+<span data-testid="file-count">{files.length}</span>

--- a/src/lib/components/__tests__/PortalInBlock.svelte
+++ b/src/lib/components/__tests__/PortalInBlock.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+	import Modal from "../Modal.svelte";
+
+	let { show = true, label }: { show?: boolean; label: string } = $props();
+</script>
+
+<!-- The shape every dialog in the app takes: a Modal inside a block. The
+     block's end anchor stays in this tree, the Modal's backdrop fades out on
+     teardown, and its content lives in body through Portal. -->
+{#if show}
+	<Modal><p data-portal={label}>{label}</p></Modal>
+{/if}

--- a/src/lib/utils/linkParams.spec.ts
+++ b/src/lib/utils/linkParams.spec.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vitest";
+import {
+	isTrustedAttachmentUrl,
+	linkPromptNeedsConfirmation,
+	readLinkPromptRequest,
+} from "./linkParams";
+import { MAX_PARAM_LENGTH } from "./urlParams";
+
+const params = (query: string) => new URLSearchParams(query);
+const url = (href: string) => new URL(href);
+
+describe("readLinkPromptRequest", () => {
+	it("returns null when the URL carries nothing for the composer", () => {
+		expect(readLinkPromptRequest(params(""))).toBeNull();
+		expect(readLinkPromptRequest(params("foo=bar"))).toBeNull();
+		expect(readLinkPromptRequest(params("q=&prompt=&attachments="))).toBeNull();
+		expect(readLinkPromptRequest(params("q=%20%20"))).toBeNull();
+	});
+
+	it("reads q as a request to send", () => {
+		expect(readLinkPromptRequest(params("q=hello"))).toEqual({
+			prompt: "hello",
+			attachmentUrls: [],
+			send: true,
+		});
+	});
+
+	it("reads prompt as a prefill", () => {
+		expect(readLinkPromptRequest(params("prompt=hello"))).toEqual({
+			prompt: "hello",
+			attachmentUrls: [],
+			send: false,
+		});
+	});
+
+	it("lets q win over prompt", () => {
+		const request = readLinkPromptRequest(params("prompt=draft&q=send"));
+		expect(request?.prompt).toBe("send");
+		expect(request?.send).toBe(true);
+	});
+
+	it("falls back to prompt when q is blank", () => {
+		const request = readLinkPromptRequest(params("q=%20&prompt=draft"));
+		expect(request?.prompt).toBe("draft");
+		expect(request?.send).toBe(false);
+	});
+
+	it("ignores an over-long prompt the same way the old handler did", () => {
+		const request = readLinkPromptRequest(params(`q=${"a".repeat(MAX_PARAM_LENGTH + 1)}`));
+		expect(request).toBeNull();
+	});
+
+	it("collects attachments from comma-separated and repeated params", () => {
+		const request = readLinkPromptRequest(
+			params(
+				"attachments=https://a.example/1.md,https://a.example/2.md&attachments=https://b.example/3.md"
+			)
+		);
+		expect(request?.attachmentUrls.map((u) => u.href)).toEqual([
+			"https://a.example/1.md",
+			"https://a.example/2.md",
+			"https://b.example/3.md",
+		]);
+		expect(request?.prompt).toBeNull();
+		expect(request?.send).toBe(false);
+	});
+
+	it("drops attachment URLs that could never be fetched, and duplicates", () => {
+		const request = readLinkPromptRequest(
+			params(
+				"attachments=javascript:alert(1),ftp://x/y,https://u:p@a.example/z,not a url,https://a.example/1.md,https://a.example/1.md"
+			)
+		);
+		expect(request?.attachmentUrls.map((u) => u.href)).toEqual(["https://a.example/1.md"]);
+	});
+});
+
+describe("isTrustedAttachmentUrl", () => {
+	it("accepts the sources the Hub and the docs site attach", () => {
+		expect(
+			isTrustedAttachmentUrl(url("https://huggingface.co/docs/transformers/main/en/index.md"))
+		).toBe(true);
+		expect(
+			isTrustedAttachmentUrl(
+				url("https://huggingface.co/buckets/huggingchat/papers-content/resolve/2501.12345.md")
+			)
+		).toBe(true);
+		expect(
+			isTrustedAttachmentUrl(
+				url("https://huggingface.co/buckets/huggingchat/docs-chat/resolve/reachy-skill.md")
+			)
+		).toBe(true);
+		expect(isTrustedAttachmentUrl(url("https://hf.co/docs/hub/index.md"))).toBe(true);
+		expect(isTrustedAttachmentUrl(url("https://HuggingFace.co/docs/hub/index.md"))).toBe(true);
+	});
+
+	it("rejects user-uploaded content on the same host", () => {
+		expect(
+			isTrustedAttachmentUrl(url("https://huggingface.co/datasets/someone/x/resolve/main/evil.txt"))
+		).toBe(false);
+		expect(
+			isTrustedAttachmentUrl(url("https://huggingface.co/someone/x/resolve/main/evil.txt"))
+		).toBe(false);
+		expect(
+			isTrustedAttachmentUrl(
+				url("https://huggingface.co/buckets/someone/papers-content/resolve/x.md")
+			)
+		).toBe(false);
+		expect(isTrustedAttachmentUrl(url("https://huggingface.co/docs"))).toBe(false);
+		expect(isTrustedAttachmentUrl(url("https://huggingface.co/docsx/evil.md"))).toBe(false);
+	});
+
+	it("cannot be escaped with dot segments, encoded or not", () => {
+		expect(
+			isTrustedAttachmentUrl(url("https://huggingface.co/docs/../someone/x/resolve/main/evil.txt"))
+		).toBe(false);
+		expect(
+			isTrustedAttachmentUrl(
+				url("https://huggingface.co/docs/%2e%2e/someone/x/resolve/main/evil.txt")
+			)
+		).toBe(false);
+		expect(
+			isTrustedAttachmentUrl(
+				url("https://huggingface.co/docs/.%2E/someone/x/resolve/main/evil.txt")
+			)
+		).toBe(false);
+	});
+
+	it("rejects other hosts, schemes, ports and credentials", () => {
+		expect(isTrustedAttachmentUrl(url("https://arxiv.org/pdf/2501.12345"))).toBe(false);
+		expect(isTrustedAttachmentUrl(url("https://huggingface.co.evil.com/docs/x.md"))).toBe(false);
+		expect(isTrustedAttachmentUrl(url("https://evil.com/huggingface.co/docs/x.md"))).toBe(false);
+		expect(isTrustedAttachmentUrl(url("http://huggingface.co/docs/x.md"))).toBe(false);
+		expect(isTrustedAttachmentUrl(url("https://huggingface.co:8443/docs/x.md"))).toBe(false);
+		expect(isTrustedAttachmentUrl(url("https://user@huggingface.co/docs/x.md"))).toBe(false);
+	});
+});
+
+describe("linkPromptNeedsConfirmation", () => {
+	const trusted = "https://huggingface.co/docs/hub/index.md";
+	const untrusted = "https://evil.example/payload.txt";
+
+	it("always asks before sending", () => {
+		expect(linkPromptNeedsConfirmation({ prompt: "hi", attachmentUrls: [], send: true })).toBe(
+			true
+		);
+		expect(
+			linkPromptNeedsConfirmation({ prompt: "hi", attachmentUrls: [url(trusted)], send: true })
+		).toBe(true);
+	});
+
+	it("lets a prefill with trusted attachments straight through", () => {
+		expect(linkPromptNeedsConfirmation({ prompt: "hi", attachmentUrls: [], send: false })).toBe(
+			false
+		);
+		expect(
+			linkPromptNeedsConfirmation({ prompt: "hi", attachmentUrls: [url(trusted)], send: false })
+		).toBe(false);
+		expect(
+			linkPromptNeedsConfirmation({ prompt: null, attachmentUrls: [url(trusted)], send: false })
+		).toBe(false);
+	});
+
+	it("asks when any attachment comes from somewhere we do not publish", () => {
+		expect(
+			linkPromptNeedsConfirmation({
+				prompt: "hi",
+				attachmentUrls: [url(trusted), url(untrusted)],
+				send: false,
+			})
+		).toBe(true);
+		expect(
+			linkPromptNeedsConfirmation({ prompt: null, attachmentUrls: [url(untrusted)], send: false })
+		).toBe(true);
+	});
+});

--- a/src/lib/utils/linkParams.ts
+++ b/src/lib/utils/linkParams.ts
@@ -1,0 +1,87 @@
+import { parseExternalUrl } from "./externalLink";
+import { sanitizeUrlParam } from "./urlParams";
+
+/**
+ * What a deep link into the home or model route asked for. Read once on
+ * mount, held in memory, never persisted: the URL is stripped of these
+ * params as soon as they are read so a reload or Back cannot replay them.
+ */
+export interface LinkPromptRequest {
+	/** Text from `q` or `prompt`; `q` wins when both are present. */
+	prompt: string | null;
+	/**
+	 * Attachments the link asked to load, in link order and deduplicated. Only
+	 * absolute http(s) URLs without credentials survive parsing; anything else
+	 * could never be fetched and is dropped.
+	 */
+	attachmentUrls: URL[];
+	/** Whether the link asked for the prompt to be sent (`q`) rather than prefilled (`prompt`). */
+	send: boolean;
+}
+
+export const LINK_PARAM_NAMES = ["q", "prompt", "attachments"] as const;
+
+/**
+ * Attachment sources that need no confirmation: content Hugging Face itself
+ * publishes, matched by path prefix. The Hub's "Ask HuggingChat" boxes and
+ * the docs "Copy page" menu attach a docs page as markdown, a per-library
+ * skill prompt, and the paper markdown from the papers bucket.
+ *
+ * A host is not enough: user repos live on the same host and anyone can
+ * upload a file to one, so every entry names a path prefix. arXiv is left
+ * out on purpose — no producer links it, and anyone can publish there.
+ */
+const TRUSTED_ATTACHMENT_PATH_PREFIXES = [
+	"/docs/",
+	"/buckets/huggingchat/papers-content/resolve/",
+	"/buckets/huggingchat/docs-chat/resolve/",
+];
+const TRUSTED_ATTACHMENT_HOSTS = new Set(["huggingface.co", "hf.co"]);
+
+export function isTrustedAttachmentUrl(url: URL): boolean {
+	if (url.protocol !== "https:") return false;
+	if (url.username || url.password) return false;
+	// A non-default port would be a different service on the same name.
+	if (url.port !== "") return false;
+	if (!TRUSTED_ATTACHMENT_HOSTS.has(url.hostname.toLowerCase())) return false;
+	// `URL` has already resolved dot segments, percent-encoded ones included,
+	// so a prefix test on the pathname cannot be escaped with `..`.
+	return TRUSTED_ATTACHMENT_PATH_PREFIXES.some((prefix) => url.pathname.startsWith(prefix));
+}
+
+/**
+ * Parse `?attachments=`: comma-separated in one param, repeated params, or
+ * both.
+ */
+function parseAttachmentUrls(params: URLSearchParams): URL[] {
+	const seen = new Set<string>();
+	const urls: URL[] = [];
+	for (const param of params.getAll("attachments")) {
+		for (const raw of param.split(",")) {
+			const url = parseExternalUrl(raw.trim());
+			if (!url || seen.has(url.href)) continue;
+			seen.add(url.href);
+			urls.push(url);
+		}
+	}
+	return urls;
+}
+
+/** `null` when the URL carries nothing for the composer. */
+export function readLinkPromptRequest(params: URLSearchParams): LinkPromptRequest | null {
+	const q = sanitizeUrlParam(params.get("q"));
+	const prompt = q ?? sanitizeUrlParam(params.get("prompt"));
+	const attachmentUrls = parseAttachmentUrls(params);
+	if (!prompt && attachmentUrls.length === 0) return null;
+	return { prompt, attachmentUrls, send: q !== null };
+}
+
+/**
+ * Whether the link needs the user's say-so before anything is fetched or
+ * sent: one that asks to send, or one that brings content from somewhere we
+ * do not publish ourselves. A `prompt` link with trusted attachments only
+ * prefills, and the user still presses send, so it goes straight through.
+ */
+export function linkPromptNeedsConfirmation(request: LinkPromptRequest): boolean {
+	return request.send || request.attachmentUrls.some((url) => !isTrustedAttachmentUrl(url));
+}

--- a/src/lib/utils/loadAttachmentsFromUrls.ts
+++ b/src/lib/utils/loadAttachmentsFromUrls.ts
@@ -7,26 +7,6 @@ export interface AttachmentLoadResult {
 }
 
 /**
- * Parse attachment URLs from query parameters
- * Supports both comma-separated (?attachments=url1,url2) and multiple params (?attachments=url1&attachments=url2)
- */
-function parseAttachmentUrls(searchParams: URLSearchParams): string[] {
-	const urls: string[] = [];
-
-	// Get all 'attachments' parameters
-	const attachmentParams = searchParams.getAll("attachments");
-
-	for (const param of attachmentParams) {
-		// Split by comma in case multiple URLs are in one param
-		const splitUrls = param.split(",").map((url) => url.trim());
-		urls.push(...splitUrls);
-	}
-
-	// Filter out empty strings
-	return urls.filter((url) => url.length > 0);
-}
-
-/**
  * Extract filename from URL or Content-Disposition header
  */
 function extractFilename(url: string, contentDisposition?: string | null): string {
@@ -64,13 +44,12 @@ function extractFilename(url: string, contentDisposition?: string | null): strin
 }
 
 /**
- * Load files from remote URLs via server-side proxy
+ * Load files from remote URLs via the server-side proxy. The caller decides
+ * which URLs to load and when — see `readLinkPromptRequest` for how they are
+ * parsed off a deep link, and the routes for the confirmation that precedes
+ * this for untrusted sources.
  */
-export async function loadAttachmentsFromUrls(
-	searchParams: URLSearchParams
-): Promise<AttachmentLoadResult> {
-	const urls = parseAttachmentUrls(searchParams);
-
+export async function loadAttachmentsFromUrls(urls: string[]): Promise<AttachmentLoadResult> {
 	if (urls.length === 0) {
 		return { files: [], errors: [] };
 	}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -14,10 +14,16 @@
 	import { useSettingsStore } from "$lib/stores/settings.js";
 	import { useConversationsStore } from "$lib/stores/conversations.svelte";
 	import { findCurrentModel } from "$lib/utils/models";
-	import { sanitizeUrlParam } from "$lib/utils/urlParams";
-	import { onMount, tick } from "svelte";
+	import { onDestroy, onMount, tick } from "svelte";
 	import { loading } from "$lib/stores/loading.js";
 	import { loadAttachmentsFromUrls } from "$lib/utils/loadAttachmentsFromUrls";
+	import {
+		LINK_PARAM_NAMES,
+		linkPromptNeedsConfirmation,
+		readLinkPromptRequest,
+		type LinkPromptRequest,
+	} from "$lib/utils/linkParams";
+	import LinkPromptModal from "$lib/components/LinkPromptModal.svelte";
 	import { requireAuthUser } from "$lib/utils/auth";
 	import { mlAssistant } from "$lib/stores/mlAssistant.svelte";
 
@@ -28,6 +34,8 @@
 	let hasModels = $derived(Boolean(data.models?.length));
 	let files: File[] = $state([]);
 	let draft = $state("");
+	/** A deep link waiting on the user's say-so; see LinkPromptModal. */
+	let linkRequest = $state<LinkPromptRequest | null>(null);
 
 	const settings = useSettingsStore();
 
@@ -131,60 +139,66 @@
 		}
 	}
 
-	onMount(async () => {
+	onMount(() => {
 		try {
-			// Check if auth is required before processing any query params
-			const hasQ = page.url.searchParams.has("q");
-			const hasPrompt = page.url.searchParams.has("prompt");
-			const hasAttachments = page.url.searchParams.has("attachments");
+			const request = readLinkPromptRequest(page.url.searchParams);
+			if (!request) return;
+			// Redirects to login and comes back to this URL, params included.
+			if (requireAuthUser()) return;
 
-			if ((hasQ || hasPrompt || hasAttachments) && requireAuthUser()) {
-				return; // Redirecting to login, will return to this URL after
+			// The request lives in memory from here on. Strip it from the URL so a
+			// reload or Back/Forward cannot replay it.
+			const url = new URL(page.url);
+			for (const name of LINK_PARAM_NAMES) url.searchParams.delete(name);
+			tick().then(() => {
+				replaceState(url, page.state);
+			});
+
+			// A link that sends, or one that brings in content we do not publish
+			// ourselves, is shown to the user first. Nothing is fetched before then.
+			if (linkPromptNeedsConfirmation(request)) {
+				linkRequest = request;
+			} else {
+				void applyLinkRequest(request);
 			}
+		} catch (err) {
+			console.error("Failed to process URL parameters:", err);
+		}
+	});
 
-			// Handle attachments parameter first
-			if (hasAttachments) {
-				const result = await loadAttachmentsFromUrls(page.url.searchParams);
+	// A confirmed request can still be loading attachments when the user moves
+	// on. Once this page is gone it must neither attach nor send: a send from
+	// here navigates, and would pull the user back into a conversation they
+	// never saw being created.
+	let unmounted = false;
+	onDestroy(() => {
+		unmounted = true;
+	});
+
+	/** Runs once the user confirmed, or straight away when nothing needed confirming. */
+	async function applyLinkRequest(request: LinkPromptRequest) {
+		linkRequest = null;
+		try {
+			if (request.attachmentUrls.length > 0) {
+				const result = await loadAttachmentsFromUrls(request.attachmentUrls.map((url) => url.href));
+				if (unmounted) return;
 				files = result.files;
-
-				// Show errors if any
 				if (result.errors.length > 0) {
 					console.error("Failed to load some attachments:", result.errors);
 					error.set(
 						`Failed to load ${result.errors.length} attachment(s). Check console for details.`
 					);
 				}
-
-				// Clean up URL
-				const url = new URL(page.url);
-				url.searchParams.delete("attachments");
-				history.replaceState({}, "", url);
 			}
-
-			const query = sanitizeUrlParam(page.url.searchParams.get("q"));
-			if (query) {
-				void createConversation(query);
-				const url = new URL(page.url);
-				url.searchParams.delete("q");
-				tick().then(() => {
-					replaceState(url, page.state);
-				});
-				return;
-			}
-
-			const promptQuery = sanitizeUrlParam(page.url.searchParams.get("prompt"));
-			if (promptQuery && !draft) {
-				draft = promptQuery;
-				const url = new URL(page.url);
-				url.searchParams.delete("prompt");
-				tick().then(() => {
-					replaceState(url, page.state);
-				});
+			if (request.send && request.prompt) {
+				await createConversation(request.prompt);
+			} else if (request.prompt && !draft) {
+				draft = request.prompt;
 			}
 		} catch (err) {
 			console.error("Failed to process URL parameters:", err);
 		}
-	});
+	}
 
 	let currentModel = $derived(findCurrentModel(data.models, data.oldModels, $settings.activeModel));
 </script>
@@ -202,6 +216,16 @@
 		bind:files
 		bind:draft
 	/>
+	<!-- A first visit also opens the layout's welcome modal. One dialog at a time:
+	     the request waits in memory until that one is dismissed. -->
+	{#if linkRequest && $settings.welcomeModalSeen}
+		{@const request = linkRequest}
+		<LinkPromptModal
+			{request}
+			onconfirm={() => applyLinkRequest(request)}
+			oncancel={() => (linkRequest = null)}
+		/>
+	{/if}
 {:else}
 	<div class="mx-auto my-20 max-w-xl rounded-xl border p-6 text-center dark:border-gray-700">
 		<h2 class="mb-2 text-xl font-semibold">No models available</h2>

--- a/src/routes/linkPrompt.svelte.test.ts
+++ b/src/routes/linkPrompt.svelte.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { tick } from "svelte";
+import { writable } from "svelte/store";
+import type { Component } from "svelte";
+import { appNavigation, renderWithApp } from "$lib/components/__tests__/renderWithApp";
+import { setPage } from "$lib/components/__tests__/appMocks";
+import { loadAttachmentsFromUrls } from "$lib/utils/loadAttachmentsFromUrls";
+import HomePage from "./+page.svelte";
+import ModelPage from "./models/[...model]/+page.svelte";
+
+vi.mock("$lib/components/chat/ChatWindow.svelte", async () => ({
+	default: (await import("$lib/components/__tests__/ChatWindowStub.svelte")).default,
+}));
+vi.mock("$lib/utils/loadAttachmentsFromUrls", () => ({ loadAttachmentsFromUrls: vi.fn() }));
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+	vi.restoreAllMocks();
+});
+
+type Loaded = Awaited<ReturnType<typeof loadAttachmentsFromUrls>>;
+
+const LINK = "?q=hello&attachments=https://a.example/file.txt";
+
+/**
+ * Mounts a route on a `q` link whose attachment fetch stays pending until the
+ * test resolves it, with the conversation POST stubbed to succeed.
+ */
+function mountOnLink(component: Component, url: string, params: Record<string, string> = {}) {
+	let resolveAttachments: (value: Loaded) => void = () => {};
+	vi.mocked(loadAttachmentsFromUrls)
+		.mockReset()
+		.mockImplementation(
+			() =>
+				new Promise<Loaded>((resolve) => {
+					resolveAttachments = resolve;
+				})
+		);
+	const fetchSpy = vi.fn(
+		async () => new Response(JSON.stringify({ conversationId: "created" }), { status: 200 })
+	);
+	vi.stubGlobal("fetch", fetchSpy);
+
+	const settings = Object.assign(
+		writable({ activeModel: "test", customPrompts: {}, welcomeModalSeen: true }),
+		{ instantSet: vi.fn(async () => undefined) }
+	);
+	const context = new Map<unknown, unknown>([
+		["settings", settings],
+		["conversationsStore", { prepend: vi.fn() }],
+	]);
+	const screen = renderWithApp(
+		component,
+		{ data: { models: [{ id: "test" }], oldModels: [], mlAssistantModels: [] } } as never,
+		{ context, page: { url, params, data: { loginEnabled: false } } }
+	);
+	return {
+		screen,
+		fetchSpy,
+		resolveAttachments: (value: Loaded) => resolveAttachments(value),
+	};
+}
+
+async function confirmSend() {
+	await tick();
+	const send = [...document.querySelectorAll("button")].find(
+		(button) => button.textContent?.trim() === "Send"
+	);
+	expect(send).toBeDefined();
+	send?.click();
+	await tick();
+	expect(loadAttachmentsFromUrls).toHaveBeenCalledTimes(1);
+}
+
+const settle = () => new Promise((resolve) => setTimeout(resolve, 50));
+
+const conversationPosts = (fetchSpy: ReturnType<typeof vi.fn>) =>
+	fetchSpy.mock.calls.filter(([input]) => String(input).endsWith("/conversation"));
+
+describe.each([
+	["home route", HomePage as Component, `/${LINK}`, {}],
+	["model route", ModelPage as Component, `/models/test${LINK}`, { model: "test" }],
+])("%s", (_name, component, url, params) => {
+	it("does not send once the user has left while an attachment was still loading", async () => {
+		const { screen, fetchSpy, resolveAttachments } = mountOnLink(component, url, params);
+		await confirmSend();
+
+		// The user opens another conversation before the attachment arrives.
+		setPage({ url: "/conversation/existing", params: { id: "existing" } });
+		await screen.unmount();
+		resolveAttachments({ files: [], errors: [] });
+		await settle();
+
+		expect(conversationPosts(fetchSpy)).toHaveLength(0);
+		expect(appNavigation().goto).not.toHaveBeenCalled();
+	});
+
+	it("still sends when the user stays on the page", async () => {
+		const { fetchSpy, resolveAttachments } = mountOnLink(component, url, params);
+		await confirmSend();
+
+		resolveAttachments({ files: [], errors: [] });
+		await settle();
+
+		expect(conversationPosts(fetchSpy)).toHaveLength(1);
+		expect(appNavigation().goto).toHaveBeenCalledWith(
+			"/conversation/created",
+			expect.objectContaining({ state: expect.objectContaining({ pendingMessage: "hello" }) })
+		);
+	});
+});

--- a/src/routes/models/[...model]/+page.svelte
+++ b/src/routes/models/[...model]/+page.svelte
@@ -2,7 +2,7 @@
 	import { page } from "$app/state";
 	import { base } from "$app/paths";
 	import { goto, replaceState } from "$app/navigation";
-	import { onMount, tick } from "svelte";
+	import { onDestroy, onMount, tick } from "svelte";
 	import { usePublicConfig } from "$lib/utils/PublicConfig.svelte";
 
 	import ChatWindow from "$lib/components/chat/ChatWindow.svelte";
@@ -12,8 +12,14 @@
 	import { useConversationsStore } from "$lib/stores/conversations.svelte";
 	import { ERROR_MESSAGES, error } from "$lib/stores/errors";
 	import { storePendingFiles } from "$lib/utils/pendingFiles";
-	import { sanitizeUrlParam } from "$lib/utils/urlParams";
 	import { loadAttachmentsFromUrls } from "$lib/utils/loadAttachmentsFromUrls";
+	import {
+		LINK_PARAM_NAMES,
+		linkPromptNeedsConfirmation,
+		readLinkPromptRequest,
+		type LinkPromptRequest,
+	} from "$lib/utils/linkParams";
+	import LinkPromptModal from "$lib/components/LinkPromptModal.svelte";
 	import { requireAuthUser } from "$lib/utils/auth";
 
 	let { data } = $props();
@@ -104,55 +110,31 @@
 		}
 	}
 
-	onMount(async () => {
+	/** A deep link waiting on the user's say-so; see LinkPromptModal. */
+	let linkRequest = $state<LinkPromptRequest | null>(null);
+
+	onMount(() => {
 		try {
-			// Check if auth is required before processing any query params
-			const hasQ = page.url.searchParams.has("q");
-			const hasPrompt = page.url.searchParams.has("prompt");
-			const hasAttachments = page.url.searchParams.has("attachments");
+			const request = readLinkPromptRequest(page.url.searchParams);
+			if (request) {
+				// Redirects to login and comes back to this URL, params included.
+				if (requireAuthUser()) return;
 
-			if ((hasQ || hasPrompt || hasAttachments) && requireAuthUser()) {
-				return; // Redirecting to login, will return to this URL after
-			}
+				// The request lives in memory from here on. Strip it from the URL so a
+				// reload or Back/Forward cannot replay it.
+				const url = new URL(page.url);
+				for (const name of LINK_PARAM_NAMES) url.searchParams.delete(name);
+				tick().then(() => {
+					replaceState(url, page.state);
+				});
 
-			// Handle attachments parameter first
-			if (hasAttachments) {
-				const result = await loadAttachmentsFromUrls(page.url.searchParams);
-				files = result.files;
-
-				// Show errors if any
-				if (result.errors.length > 0) {
-					console.error("Failed to load some attachments:", result.errors);
-					error.set(
-						`Failed to load ${result.errors.length} attachment(s). Check console for details.`
-					);
+				// A link that sends, or one that brings in content we do not publish
+				// ourselves, is shown to the user first. Nothing is fetched before then.
+				if (linkPromptNeedsConfirmation(request)) {
+					linkRequest = request;
+				} else {
+					void applyLinkRequest(request);
 				}
-
-				// Clean up URL
-				const url = new URL(page.url);
-				url.searchParams.delete("attachments");
-				history.replaceState({}, "", url);
-			}
-
-			const query = sanitizeUrlParam(page.url.searchParams.get("q"));
-			if (query) {
-				void createConversation(query);
-				const url = new URL(page.url);
-				url.searchParams.delete("q");
-				tick().then(() => {
-					replaceState(url, page.state);
-				});
-				return;
-			}
-
-			const promptQuery = sanitizeUrlParam(page.url.searchParams.get("prompt"));
-			if (promptQuery && !draft) {
-				draft = promptQuery;
-				const url = new URL(page.url);
-				url.searchParams.delete("prompt");
-				tick().then(() => {
-					replaceState(url, page.state);
-				});
 			}
 		} catch (err) {
 			console.error("Failed to process URL parameters:", err);
@@ -160,6 +142,40 @@
 
 		settings.instantSet({ activeModel: modelId });
 	});
+
+	// A confirmed request can still be loading attachments when the user moves
+	// on. Once this page is gone it must neither attach nor send: a send from
+	// here navigates, and would pull the user back into a conversation they
+	// never saw being created.
+	let unmounted = false;
+	onDestroy(() => {
+		unmounted = true;
+	});
+
+	/** Runs once the user confirmed, or straight away when nothing needed confirming. */
+	async function applyLinkRequest(request: LinkPromptRequest) {
+		linkRequest = null;
+		try {
+			if (request.attachmentUrls.length > 0) {
+				const result = await loadAttachmentsFromUrls(request.attachmentUrls.map((url) => url.href));
+				if (unmounted) return;
+				files = result.files;
+				if (result.errors.length > 0) {
+					console.error("Failed to load some attachments:", result.errors);
+					error.set(
+						`Failed to load ${result.errors.length} attachment(s). Check console for details.`
+					);
+				}
+			}
+			if (request.send && request.prompt) {
+				await createConversation(request.prompt);
+			} else if (request.prompt && !draft) {
+				draft = request.prompt;
+			}
+		} catch (err) {
+			console.error("Failed to process URL parameters:", err);
+		}
+	}
 </script>
 
 <svelte:head>
@@ -194,3 +210,14 @@
 	bind:files
 	bind:draft
 />
+<!-- A first visit also opens the layout's welcome modal. One dialog at a time:
+     the request waits in memory until that one is dismissed. -->
+{#if linkRequest && $settings.welcomeModalSeen}
+	{@const request = linkRequest}
+	<LinkPromptModal
+		{request}
+		modelName={modelId}
+		onconfirm={() => applyLinkRequest(request)}
+		oncancel={() => (linkRequest = null)}
+	/>
+{/if}


### PR DESCRIPTION
## What

A link into the home or model route could act with no user gesture. `?q=` created a conversation and sent the prompt on load, and `?attachments=` fetched arbitrary URLs through the proxy and attached them. Whoever wrote the link chose the prompt, the files, and on the model route the model, and the model could then act on all of it with whatever tools the user has connected.

This PR puts the user in front of that:

- A `?q=` link opens a confirmation showing the prompt as plain text, each attachment URL with its host emphasized, and the model when the link picked one. Nothing is fetched or sent before the user confirms. Cancel drops the link.
- `?attachments=` from a source we do not publish ourselves gets the same confirmation. Confirming fetches and attaches without sending.
- `?prompt=` links whose attachments come from an allowlist of Hugging Face paths (docs pages, and the papers and docs-chat buckets, which is what the Hub's own "Ask HuggingChat" boxes and the docs "Copy page" menu produce) keep working with no modal: prefill plus chips, the user still presses send.
- The params are stripped from the URL as soon as they are read, so a reload or Back cannot replay them.
- On a first visit the welcome modal shows first, then the confirmation.

| Light | Dark |
| --- | --- |
| ![Send this prompt, light](https://github.com/user-attachments/assets/c5936589-e278-4c0d-bdf2-1ff398cec43f) | ![Send this prompt, dark](https://github.com/user-attachments/assets/2101bf57-2ff8-439a-b59e-dd6bbd5fb360) |
| ![Add these attachments, light](https://github.com/user-attachments/assets/65ff4e5e-a2e2-442e-8510-0f40ffb65766) | ![Add these attachments, dark](https://github.com/user-attachments/assets/29a3159a-90f8-4857-b1d3-871edc212a48) |

## Also in here

- **Portal teardown bug.** Portal moved the node Svelte owns for it into `body`. When the block holding a server-rendered dialog was torn down (the welcome modal on a first visit), Svelte walked the DOM from that node toward an end anchor that stayed in the original tree, so the walk ran along `body` and removed every later sibling there, other portals included. A modal opened while the welcome modal was fading out simply vanished. The outer div now stays where it was rendered and only an inner div moves. Separate commit, with a browser test that fails on the old shape.
- **Modal `inert` counting.** One modal finishing its fade-out no longer lifts `inert` from the app while another is still open.
- **Navigation race.** A confirmed request whose attachment was still loading when the user opened another conversation used to send anyway and pull them into the new conversation. Guarded with an unmount flag and covered by a browser test on both routes.

## Follow-ups, not in this PR

- The Hub's "Ask HuggingChat" box submits a `q` it reads from its own page URL on load, so a Hub link can still start a send from inside the sidebar. That is a Hub-side change, and until it lands the confirmation also shows in the framed case.
- Approval for tool calls the model makes on its own, which is the deeper fix for what a link can do once sent.

## Tests

- `linkParams.spec.ts`: parsing, the allowlist including dot-segment and encoded escapes, and the confirmation decision.
- `Portal.svelte.test.ts`: the owned placeholder stays put and later portals survive a teardown.
- `linkPrompt.svelte.test.ts`: both routes, leaving during an attachment fetch does not send, staying does.
