### PR TITLE
Sync models from router (+5 added)

### DIFF
--- a/chart/env/dev.yaml
+++ b/chart/env/dev.yaml
@@ -91,6 +91,11 @@ envVars:
   MODELS: >
     [
       { "id": "omni", "supportsArtifacts": true },
+      { "id": "deepseek-ai/DeepSeek-V4.1-Flash", "description": "Native multimodal 552B MoE for agentic coding, adjustable thinking, and 1M context.", "parameters": { "max_tokens": 49152 }, "supportsReasoning": true, "supportsArtifacts": true },
+      { "id": "zai-org/GLM-4.5", "description": "Flagship GLM agent model unifying advanced reasoning, coding, and tool-using capabilities.", "supportsReasoning": true, "supportsArtifacts": true },
+      { "id": "swiss-ai/Apertus-v1.5-70B", "description": "Open Swiss multimodal model, massively multilingual with 256K context.", "supportsArtifacts": true },
+      { "id": "swiss-ai/Apertus-v1.5-8B", "description": "Compact open Swiss multilingual model with image and audio input." },
+      { "id": "swiss-ai/Apertus-8B-Instruct-2509", "description": "Open, multilingual, trained on compliant data transparent global assistant." },
       { "id": "deepseek-ai/DeepSeek-V4-Flash-Vision-Exp", "description": "Experimental vision-language V4-Flash for multimodal agents and adjustable thinking.", "parameters": { "max_tokens": 49152 }, "supportsReasoning": true, "supportsArtifacts": true },
       { "id": "inclusionAI/Ling-3.0-flash-VL", "description": "Vision-language Ling-3.0-flash MoE for image, video, and GUI agent tasks.", "supportsReasoning": true, "supportsArtifacts": true },
       { "id": "inclusionAI/Ling-3.0-flash-Fin", "description": "Finance-tuned Ling-3.0-flash for grounded research, valuation, and spreadsheet workflows.", "supportsReasoning": true, "supportsArtifacts": true },

--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -101,6 +101,11 @@ envVars:
   MODELS: >
     [
       { "id": "omni", "supportsArtifacts": true },
+      { "id": "deepseek-ai/DeepSeek-V4.1-Flash", "description": "Native multimodal 552B MoE for agentic coding, adjustable thinking, and 1M context.", "parameters": { "max_tokens": 49152 }, "supportsReasoning": true, "supportsArtifacts": true },
+      { "id": "zai-org/GLM-4.5", "description": "Flagship GLM agent model unifying advanced reasoning, coding, and tool-using capabilities.", "supportsReasoning": true, "supportsArtifacts": true },
+      { "id": "swiss-ai/Apertus-v1.5-70B", "description": "Open Swiss multimodal model, massively multilingual with 256K context.", "supportsArtifacts": true },
+      { "id": "swiss-ai/Apertus-v1.5-8B", "description": "Compact open Swiss multilingual model with image and audio input." },
+      { "id": "swiss-ai/Apertus-8B-Instruct-2509", "description": "Open, multilingual, trained on compliant data transparent global assistant." },
       { "id": "deepseek-ai/DeepSeek-V4-Flash-Vision-Exp", "description": "Experimental vision-language V4-Flash for multimodal agents and adjustable thinking.", "parameters": { "max_tokens": 49152 }, "supportsReasoning": true, "supportsArtifacts": true },
       { "id": "inclusionAI/Ling-3.0-flash-VL", "description": "Vision-language Ling-3.0-flash MoE for image, video, and GUI agent tasks.", "supportsReasoning": true, "supportsArtifacts": true },
       { "id": "inclusionAI/Ling-3.0-flash-Fin", "description": "Finance-tuned Ling-3.0-flash for grounded research, valuation, and spreadsheet workflows.", "supportsReasoning": true, "supportsArtifacts": true },


### PR DESCRIPTION
Follow-up to #2572. Adds the models the router started serving since that sync. `chart/env/prod.yaml` and `chart/env/dev.yaml` carry the same changes and end with 137 entries (136 router models plus the `omni` alias). Nothing was deprecated this time.

## Added

| Model | Reasoning | Artifacts | Notes |
|---|---|---|---|
| `deepseek-ai/DeepSeek-V4.1-Flash` | yes | yes (552B) | Native multimodal MoE with 1M context. Novita (the only live provider) lists reasoning as supported. Also sets `max_tokens: 49152` to match the other V4-Flash entries. |

## Restored

These four came back on the router right after #2572 removed them. Their previous entries are restored word for word:

- `zai-org/GLM-4.5` (reasoning, artifacts)
- `swiss-ai/Apertus-v1.5-70B` (artifacts)
- `swiss-ai/Apertus-v1.5-8B`
- `swiss-ai/Apertus-8B-Instruct-2509`

## For reviewers

DeepSeek-V4.1-Flash's model card describes reasoning effort as a continuous 1 to 100 value, while chat-ui sends `low` / `medium` / `high`. chat-ui only forwards `reasoning_effort` when a user picks a level, so default requests are unaffected either way. If a provider rejects the string values, only the explicit effort selector would be affected for this model.
