### PR TITLE
Announce DeepSeek-V4.1-Flash in the feature banner

### DIFF
--- a/chart/env/dev.yaml
+++ b/chart/env/dev.yaml
@@ -60,7 +60,7 @@ envVars:
   PUBLIC_ORIGIN: ""
   PUBLIC_PLAUSIBLE_SCRIPT_URL: "https://plausible.io/js/pa-Io_oigECawqdlgpf5qvHb.js"
   PUBLIC_FEATURE_ANNOUNCEMENTS: >
-    [{"title": "Kimi K3 is here", "description": "Moonshot's 2.8T open-weight MoE, with native vision and a 1M-token context window.", "link": "/models/moonshotai/Kimi-K3", "cta": "Chat with Kimi K3", "maxDate": "2026-09-15"}, {"title": "New DeepSeek V4 Flash", "description": "DeepSeek's updated 284B MoE with adjustable thinking, stronger agentic coding, and a 1M-token context window.", "link": "/models/deepseek-ai/DeepSeek-V4-Flash-0731", "cta": "Chat with V4 Flash", "maxDate": "2026-09-01"}, {"title": "New GLM-5.3-Flash", "description": "Z.ai's natively multimodal 320B MoE, outperforming GLM-5.2 at one-tenth the price.", "link": "/models/zai-org/GLM-5.3-Flash", "cta": "Chat with GLM-5.3-Flash", "maxDate": "2026-09-30"}]
+    [{"title": "Kimi K3 is here", "description": "Moonshot's 2.8T open-weight MoE, with native vision and a 1M-token context window.", "link": "/models/moonshotai/Kimi-K3", "cta": "Chat with Kimi K3", "maxDate": "2026-09-15"}, {"title": "New GLM-5.3-Flash", "description": "Z.ai's natively multimodal 320B MoE, outperforming GLM-5.2 at one-tenth the price.", "link": "/models/zai-org/GLM-5.3-Flash", "cta": "Chat with GLM-5.3-Flash", "maxDate": "2026-09-30"}, {"title": "New DeepSeek V4.1 Flash", "description": "DeepSeek's natively multimodal 552B MoE, with frontier-level agentic coding and a 1M-token context window.", "link": "/models/deepseek-ai/DeepSeek-V4.1-Flash", "cta": "Chat with V4.1 Flash", "maxDate": "2026-10-10"}]
 
   TASK_MODEL: "meta-llama/Llama-3.1-8B-Instruct"
   # Tombstone: unread by current code, kept so any old pod still on the pre-#2265

--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -70,7 +70,7 @@ envVars:
   PUBLIC_ORIGIN: "https://huggingface.co"
   PUBLIC_PLAUSIBLE_SCRIPT_URL: "https://plausible.io/js/pa-Io_oigECawqdlgpf5qvHb.js"
   PUBLIC_FEATURE_ANNOUNCEMENTS: >
-    [{"title": "Kimi K3 is here", "description": "Moonshot's 2.8T open-weight MoE, with native vision and a 1M-token context window.", "link": "/models/moonshotai/Kimi-K3", "cta": "Chat with Kimi K3", "maxDate": "2026-09-15"}, {"title": "New DeepSeek V4 Flash", "description": "DeepSeek's updated 284B MoE with adjustable thinking, stronger agentic coding, and a 1M-token context window.", "link": "/models/deepseek-ai/DeepSeek-V4-Flash-0731", "cta": "Chat with V4 Flash", "maxDate": "2026-09-01"}, {"title": "New GLM-5.3-Flash", "description": "Z.ai's natively multimodal 320B MoE, outperforming GLM-5.2 at one-tenth the price.", "link": "/models/zai-org/GLM-5.3-Flash", "cta": "Chat with GLM-5.3-Flash", "maxDate": "2026-09-30"}]
+    [{"title": "Kimi K3 is here", "description": "Moonshot's 2.8T open-weight MoE, with native vision and a 1M-token context window.", "link": "/models/moonshotai/Kimi-K3", "cta": "Chat with Kimi K3", "maxDate": "2026-09-15"}, {"title": "New GLM-5.3-Flash", "description": "Z.ai's natively multimodal 320B MoE, outperforming GLM-5.2 at one-tenth the price.", "link": "/models/zai-org/GLM-5.3-Flash", "cta": "Chat with GLM-5.3-Flash", "maxDate": "2026-09-30"}, {"title": "New DeepSeek V4.1 Flash", "description": "DeepSeek's natively multimodal 552B MoE, with frontier-level agentic coding and a 1M-token context window.", "link": "/models/deepseek-ai/DeepSeek-V4.1-Flash", "cta": "Chat with V4.1 Flash", "maxDate": "2026-10-10"}]
 
   TASK_MODEL: "meta-llama/Llama-3.1-8B-Instruct"
   # Tombstone: unread by current code, kept so any old pod still on the pre-#2265


### PR DESCRIPTION
Points the home-screen feature banner at DeepSeek-V4.1-Flash, which went live in #2574.

- Adds a "New DeepSeek V4.1 Flash" announcement (link `/models/deepseek-ai/DeepSeek-V4.1-Flash`, CTA "Chat with V4.1 Flash"), shown until 2026-10-10.
- Drops the "New DeepSeek V4 Flash" entry, which expired on 2026-09-01.
- Kimi K3 and GLM-5.3-Flash stay in the list. The banner shows the last unexpired entry, so the new announcement replaces the GLM-5.3-Flash one that is on screen today.

Same change in `chart/env/prod.yaml` and `chart/env/dev.yaml`. Checked by running `getActiveAnnouncement` against both files, which returns the new V4.1 Flash entry.
