### PR TITLE
Shorten the ML Intern spending cap copy

### DIFF
--- a/src/lib/components/chat/MlInternOnboardingModal.svelte
+++ b/src/lib/components/chat/MlInternOnboardingModal.svelte
@@ -80,12 +80,11 @@
 						Set a spending cap
 					</p>
 					<p class="text-sm leading-relaxed">
-						A budget you give ML Intern in the chat is strictly enforced on the Jobs it launches
-						from here, but it is not a complete guarantee: a Job it starts could launch Jobs of its
-						own or use other Hugging Face products. To make sure you never overspend, set a budget
-						in your billing settings too. Jobs and sandboxes are charged to the organization you
-						bill in HuggingChat's settings if you have picked one, and to your own account
-						otherwise; Spaces, dashboards and repositories stay under your own account either way.
+						A budget you give ML Intern in the chat is strictly enforced on the Jobs it launches,
+						but it is not a complete guarantee: those Jobs can start their own or use other Hugging
+						Face products, so set a budget in your billing settings too. Jobs and sandboxes bill to
+						the organization set in HuggingChat's settings, or to you otherwise; Spaces, dashboards
+						and repositories always stay on your account.
 					</p>
 					<a
 						href={BILLING_SETTINGS_URL}


### PR DESCRIPTION
context: modal is cropped

<img width="553" height="832" alt="image" src="https://github.com/user-attachments/assets/e6e37f02-95bd-4462-aea5-784016e8c8ad" />



Trims the "Set a spending cap" paragraph in the ML Intern onboarding modal from 91 to 67 words. It keeps the same four points:

- the chat budget is strictly enforced on the Jobs ML Intern launches, but it is not a complete guarantee, because those Jobs can start their own or use other Hugging Face products
- so set a budget in the Hub billing settings too
- Jobs and sandboxes bill to the organization set in HuggingChat's settings, or to the user otherwise
- Spaces, dashboards and repositories always stay on the user's account

Copy-only change. The modal's component test (`MlInternOnboardingModal.svelte.test.ts`) still passes, since both phrases it checks ("strictly enforced", "not a complete guarantee") are kept.
