### PR TITLE
Fix ML Intern mode for every initial-send path

### DIFF
--- a/src/lib/components/__tests__/ChatWindowStub.svelte
+++ b/src/lib/components/__tests__/ChatWindowStub.svelte
@@ -1,9 +1,15 @@
 <script lang="ts">
 	// Stands in for ChatWindow where a test drives a route: keeps the route's
 	// `files` and `draft` bindings honest without the composer's own traffic.
-	let { files = $bindable([]), draft = $bindable("") }: { files?: File[]; draft?: string } =
-		$props();
+	let {
+		files = $bindable([]),
+		draft = $bindable(""),
+		onmessage,
+	}: { files?: File[]; draft?: string; onmessage?: (content: string) => void } = $props();
 </script>
 
 <textarea data-testid="composer" bind:value={draft}></textarea>
 <span data-testid="file-count">{files.length}</span>
+<button type="button" data-testid="send-message" onclick={() => onmessage?.(draft)}
+	>Send message</button
+>

--- a/src/lib/components/chat/ChatWindow.svelte
+++ b/src/lib/components/chat/ChatWindow.svelte
@@ -205,9 +205,6 @@
 		if (requireAuthUser() || loading || !draft) return;
 		tap();
 		chatScroll.notifySend();
-		// Latches the mode onto the conversation, so the strip stays and swaps its
-		// tool note for the plan progress row. No-op when the mode is off.
-		mlAssistant.startTask();
 		onmessage?.(draft);
 		draft = "";
 	};
@@ -551,9 +548,9 @@
 		if (!lastMessage) return;
 		sendFixRequest(buildResumeMessage(failureDetailOf(lastMessage)));
 	}
-	// The strip is a task status bar only: it slides in on the send that starts an
-	// ML task and stays for the rest of the conversation. Before that the mode
-	// lives in the composer pill, and a chat started without the mode never shows
+	// The strip is a task status bar only: it slides in once the server confirms
+	// the new conversation is an ML task and stays for the rest of it. Before that
+	// the mode lives in the composer pill, and a chat started without the mode never shows
 	// either surface.
 	let mlStripVisible = $derived(ML_ASSISTANT_MODE && mlTaskRunning);
 

--- a/src/lib/server/__tests__/conversation-ml-assistant-models.spec.ts
+++ b/src/lib/server/__tests__/conversation-ml-assistant-models.spec.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import superjson from "superjson";
 import { z } from "zod";
 
 const { FAKE_MODELS, mlSet } = vi.hoisted(() => ({
@@ -39,8 +40,8 @@ beforeAll(async () => {
 	await ready;
 });
 
-async function create(locals: App.Locals, body: Record<string, unknown>) {
-	const response = await createConversation({
+async function createResponse(locals: App.Locals, body: Record<string, unknown>) {
+	return createConversation({
 		locals,
 		request: new Request("http://localhost/conversation", {
 			method: "POST",
@@ -48,6 +49,10 @@ async function create(locals: App.Locals, body: Record<string, unknown>) {
 			body: JSON.stringify(body),
 		}),
 	} as never);
+}
+
+async function create(locals: App.Locals, body: Record<string, unknown>) {
+	const response = await createResponse(locals, body);
 	const { conversationId } = (await response.json()) as { conversationId: string };
 	const { ObjectId } = await import("mongodb");
 	return collections.conversations.findOne({ _id: new ObjectId(conversationId) });
@@ -71,6 +76,20 @@ describe.sequential("ML Intern conversations run on the fixed model set", () => 
 		const { locals } = await createTestUser();
 		const conv = await create(locals, { model: "moonshotai/Kimi-K3", mlAssistant: true });
 		expect(conv?.model).toBe("moonshotai/Kimi-K3");
+	});
+
+	it("returns the persisted mode in the create seed", async () => {
+		const { locals } = await createTestUser();
+		const response = await createResponse(locals, {
+			model: "moonshotai/Kimi-K3",
+			mlAssistant: true,
+			mlBudgetUsd: 12,
+		});
+		const body = (await response.json()) as { conversation: string };
+		const seeded = superjson.parse<{ id: string; mlAssistant?: boolean; mlBudget?: unknown }>(
+			body.conversation
+		);
+		expect(seeded).toMatchObject({ mlAssistant: true, mlBudget: expect.any(Object) });
 	});
 
 	it("leaves ordinary conversations alone", async () => {

--- a/src/lib/server/mcp/tools.test.ts
+++ b/src/lib/server/mcp/tools.test.ts
@@ -212,6 +212,7 @@ describe("getOpenAiToolsForMcp per-server cache", () => {
 		expect(second.mapping.search).toMatchObject({
 			fnName: "search",
 			server: "Server A",
+			serverUrl: SERVER_A.url,
 			tool: "search",
 		});
 		// The server's own schema survives the cache round trip: the preflight

--- a/src/lib/server/mcp/tools.ts
+++ b/src/lib/server/mcp/tools.ts
@@ -25,6 +25,8 @@ export type McpToolAnnotations = {
 export interface McpToolMapping {
 	fnName: string;
 	server: string;
+	/** The URL of the server that owns this tool, when available. */
+	serverUrl?: string;
 	tool: string;
 	/** The server's unsanitized inputSchema, for checking arguments before dispatch. */
 	inputSchema?: Record<string, unknown>;
@@ -339,6 +341,7 @@ export async function getOpenAiToolsForMcp(
 			mapping[plainName] = {
 				fnName: plainName,
 				server: server.name,
+				serverUrl: server.url,
 				tool: tool.name,
 				...(tool.inputSchema ? { inputSchema: tool.inputSchema } : {}),
 				...(tool.annotations ? { annotations: tool.annotations } : {}),

--- a/src/lib/server/mlBudget/guard.spec.ts
+++ b/src/lib/server/mlBudget/guard.spec.ts
@@ -357,9 +357,24 @@ describe("withRequiredDiscriminators", () => {
 		function: { name, ...(parameters ? { parameters } : {}) },
 	});
 	const MAPPING = {
-		hf_jobs: { fnName: "hf_jobs", server: "Hugging Face", tool: "hf_jobs" },
-		hf_sandbox: { fnName: "hf_sandbox", server: "Hugging Face", tool: "hf_sandbox" },
-		hf_fs: { fnName: "hf_fs", server: "Hugging Face", tool: "hf_fs" },
+		hf_jobs: {
+			fnName: "hf_jobs",
+			server: "Hugging Face",
+			serverUrl: "https://hf.co/mcp",
+			tool: "hf_jobs",
+		},
+		hf_sandbox: {
+			fnName: "hf_sandbox",
+			server: "Hugging Face",
+			serverUrl: "https://hf.co/mcp",
+			tool: "hf_sandbox",
+		},
+		hf_fs: {
+			fnName: "hf_fs",
+			server: "Hugging Face",
+			serverUrl: "https://hf.co/mcp",
+			tool: "hf_fs",
+		},
 	};
 
 	it("requires the routing discriminator on the gated tools", () => {
@@ -385,6 +400,37 @@ describe("withRequiredDiscriminators", () => {
 		const original = tool("hf_jobs", { type: "object", properties: { operation: {} } });
 		withRequiredDiscriminators([original], MAPPING);
 		expect(original.function.parameters?.required).toBeUndefined();
+	});
+
+	it("leaves a same-named tool on a non-Hub server untouched", () => {
+		const original = tool("custom_jobs", {
+			type: "object",
+			properties: { operation: {}, payload: {} },
+		});
+		const [shaped] = withRequiredDiscriminators([original], {
+			custom_jobs: {
+				fnName: "custom_jobs",
+				server: "custom",
+				serverUrl: "https://other.example/mcp",
+				tool: "hf_jobs",
+			},
+		});
+
+		expect(shaped).toBe(original);
+		expect(shaped?.function.parameters?.required).toBeUndefined();
+	});
+
+	it("fails closed when the mapping has no server URL", () => {
+		const original = tool("hf_jobs", {
+			type: "object",
+			properties: { operation: {}, args: {} },
+		});
+		const [shaped] = withRequiredDiscriminators([original], {
+			hf_jobs: { fnName: "hf_jobs", server: "Hugging Face", tool: "hf_jobs" },
+		});
+
+		expect(shaped).toBe(original);
+		expect(shaped?.function.parameters?.required).toBeUndefined();
 	});
 });
 

--- a/src/lib/server/mlBudget/guard.spec.ts
+++ b/src/lib/server/mlBudget/guard.spec.ts
@@ -3,7 +3,11 @@ import { ObjectId } from "mongodb";
 import { collections, ready } from "$lib/server/database";
 import { MessageUpdateType } from "$lib/types/MessageUpdate";
 import type { MlBudget } from "$lib/types/Conversation";
-import { createMlBudgetGuard, withRequiredDiscriminators } from "./guard";
+import {
+	createMlAssistantOnlyComputeGuard,
+	createMlBudgetGuard,
+	withRequiredDiscriminators,
+} from "./guard";
 import { readMlBudget } from "./budget";
 import { resetPriceCacheForTests } from "./pricing";
 
@@ -100,9 +104,11 @@ describe.sequential("mlBudget guard: what is gated", () => {
 	it("refuses scheduled jobs outright", { timeout: 15000 }, async () => {
 		const id = await insertConversation(budgetOf(100_000_000));
 		const { before } = makeGuard(id);
-		const verdict = await before("hf_jobs", { operation: "scheduled run", args: {} });
-		expect(verdict.allow).toBe(false);
-		if (!verdict.allow) expect(verdict.message).toContain("Scheduled jobs");
+		for (const operation of ["scheduled run", "scheduled uv", "scheduled resume"]) {
+			const verdict = await before("hf_jobs", { operation, args: {} });
+			expect(verdict.allow).toBe(false);
+			if (!verdict.allow) expect(verdict.message).toContain("Scheduled jobs");
+		}
 	});
 
 	// The observed bypass: submission-shaped args with no operation sailed
@@ -125,6 +131,53 @@ describe.sequential("mlBudget guard: what is gated", () => {
 		expect(unknownCmd.allow).toBe(false);
 
 		expect((await readMlBudget(id))?.reservations).toHaveLength(0);
+	});
+});
+
+describe("compute guard outside ML Intern", () => {
+	const guard = createMlAssistantOnlyComputeGuard();
+	const before = (tool: string, args: Record<string, unknown>, serverUrl = HF_URL) =>
+		guard.before({ serverUrl, tool, fnName: tool, args, callUuid: "outside-mode" });
+
+	it("refuses Hub job submissions without affecting reads or stops", async () => {
+		for (const args of [
+			{ operation: "run", args: { flavor: "cpu-basic", timeout: "10m" } },
+			{ operation: "uv", args: { flavor: "cpu-basic", timeout: "10m" } },
+			{ operation: "scheduled resume", args: { id: "schedule" } },
+		]) {
+			const submission = await before("hf_jobs", args);
+			expect(submission.allow).toBe(false);
+			if (!submission.allow) expect(submission.message).toContain("ML Intern");
+		}
+
+		for (const args of [
+			{ operation: "logs", args: { job_id: "job" } },
+			{ operation: "cancel", args: { job_id: "job" } },
+		]) {
+			expect((await before("hf_jobs", args)).allow).toBe(true);
+		}
+	});
+
+	it("refuses Hub sandbox creation without blocking existing-sandbox work", async () => {
+		const creation = await before("hf_sandbox", {
+			cmd: "create",
+			args: ["create", "--flavor", "cpu-basic", "--timeout", "10m"],
+		});
+		expect(creation.allow).toBe(false);
+
+		for (const [tool, args] of [
+			["hf_sandbox_exec", { cmd: "exec", args: ["handle", "python", "-c", "1"] }],
+			["hf_sandbox_fs", { cmd: "cat", args: ["handle", "/tmp/out"] }],
+			["hf_sandbox", { cmd: "terminate", args: ["terminate", "handle"] }],
+		] as const) {
+			expect((await before(tool, args)).allow).toBe(true);
+		}
+	});
+
+	it("does not affect same-named tools on another MCP server", async () => {
+		expect(
+			(await before("hf_jobs", { operation: "run", args: {} }, "https://example.test/mcp")).allow
+		).toBe(true);
 	});
 });
 

--- a/src/lib/server/mlBudget/guard.ts
+++ b/src/lib/server/mlBudget/guard.ts
@@ -216,7 +216,10 @@ export function withRequiredDiscriminators(
 ): OpenAiTool[] {
 	return tools.map((tool) => {
 		const entry = mapping[tool.function.name];
-		const field = entry ? DISCRIMINATOR_BY_TOOL[entry.tool] : undefined;
+		const field =
+			entry && entry.serverUrl !== undefined && isHfMcpServer(entry.serverUrl)
+				? DISCRIMINATOR_BY_TOOL[entry.tool]
+				: undefined;
 		const parameters = tool.function.parameters;
 		if (!field || !parameters) return tool;
 		const required = Array.isArray(parameters.required) ? (parameters.required as string[]) : [];

--- a/src/lib/server/mlBudget/guard.ts
+++ b/src/lib/server/mlBudget/guard.ts
@@ -98,7 +98,6 @@ const FREE_JOB_OPERATIONS = new Set([
 	"scheduled inspect",
 	"scheduled delete",
 	"scheduled suspend",
-	"scheduled resume",
 ]);
 const FREE_SANDBOX_COMMANDS = new Set(["status", "terminate", "ps", "kill"]);
 
@@ -109,10 +108,14 @@ const FREE_SANDBOX_COMMANDS = new Set(["status", "terminate", "ps", "kill"]);
 function classify(call: GuardedToolCall): GatedSubmission | { blocked: string } | null {
 	if (call.tool === "hf_jobs") {
 		const operation = call.args.operation;
-		if (operation === "scheduled run" || operation === "scheduled uv") {
+		if (
+			operation === "scheduled run" ||
+			operation === "scheduled uv" ||
+			operation === "scheduled resume"
+		) {
 			return {
 				blocked:
-					"Scheduled jobs are not available in this session: a recurring run cannot be held to the session budget. Nothing was scheduled. Run the work directly with operation 'run' or 'uv'.",
+					"Scheduled jobs are not available in this session: a recurring run cannot be held to the session budget. Nothing was scheduled or resumed. Run the work directly with operation 'run' or 'uv'.",
 			};
 		}
 		if (typeof operation === "string" && FREE_JOB_OPERATIONS.has(operation)) return null;
@@ -169,6 +172,31 @@ function classify(call: GuardedToolCall): GatedSubmission | { blocked: string } 
 	}
 
 	return null;
+}
+
+/**
+ * Prevents Hub compute from starting outside ML Intern, where no session
+ * budget exists. Operations on already-running compute stay available so an
+ * ordinary chat can inspect or clean up existing work; unknown operations on
+ * the launch tools fail closed because they cannot be proven free.
+ */
+export function createMlAssistantOnlyComputeGuard(): ToolCallGuard {
+	return {
+		allowParking: true,
+		async before(call): Promise<GuardVerdict> {
+			if (!isHfMcpServer(call.serverUrl)) return { allow: true };
+			const classified = classify(call);
+			if (classified === null) return { allow: true };
+			return {
+				allow: false,
+				message:
+					"Refused: Hugging Face jobs and sandboxes can only be started from an ML Intern conversation, where a session budget and billing target are enforced. Start a fresh chat with ML Intern enabled. Nothing was submitted or created.",
+			};
+		},
+		async after() {
+			return undefined;
+		},
+	};
 }
 
 /** The discriminator each gated tool routes on. */

--- a/src/lib/server/textGeneration/mcp/runMcpFlow.spec.ts
+++ b/src/lib/server/textGeneration/mcp/runMcpFlow.spec.ts
@@ -769,6 +769,47 @@ describe("runMcpFlow offering the plan tool", () => {
 	});
 });
 
+describe("runMcpFlow Hub compute boundary", () => {
+	const hubCall = (tool: string, args: Record<string, unknown>) => ({
+		serverUrl: "https://hf.co/mcp?login",
+		tool,
+		fnName: tool,
+		args,
+		callUuid: "guard-probe",
+	});
+
+	it("installs the no-create guard outside ML Intern", async () => {
+		scriptRounds([
+			{ toolCalls: [{ id: "call_1", name: "do_thing", arguments: "{}" }] },
+			{ content: "done" },
+		]);
+		await runFlow();
+
+		const guard = mocks.executeToolCalls.mock.calls[0][0].guard;
+		expect((await guard.before(hubCall("hf_jobs", { operation: "uv", args: {} }))).allow).toBe(
+			false
+		);
+		expect((await guard.before(hubCall("hf_jobs", { operation: "logs", args: {} }))).allow).toBe(
+			true
+		);
+	});
+
+	it("keeps existing-sandbox tools available inside ML Intern", async () => {
+		scriptRounds([
+			{ toolCalls: [{ id: "call_1", name: "do_thing", arguments: "{}" }] },
+			{ content: "done" },
+		]);
+		await runFlow({
+			conv: { _id: new ObjectId(), mlAssistant: true },
+		} as Partial<Parameters<typeof runMcpFlow>[0]>);
+
+		const guard = mocks.executeToolCalls.mock.calls[0][0].guard;
+		expect((await guard.before(hubCall("hf_sandbox_exec", { cmd: "exec", args: [] }))).allow).toBe(
+			true
+		);
+	});
+});
+
 describe("runMcpFlow under the ML Assistant preset", () => {
 	const inMlMode = { conv: { _id: new ObjectId(), mlAssistant: true } } as unknown as Parameters<
 		typeof runMcpFlow

--- a/src/lib/server/textGeneration/mcp/runMcpFlow.ts
+++ b/src/lib/server/textGeneration/mcp/runMcpFlow.ts
@@ -40,7 +40,11 @@ import {
 } from "$lib/server/mlAssistant";
 import { createHubBillingRewrite } from "$lib/server/mcp/hubBilling";
 import { mlAssistantModelEntry } from "$lib/server/mlAssistantModels";
-import { createMlBudgetGuard, withRequiredDiscriminators } from "$lib/server/mlBudget/guard";
+import {
+	createMlAssistantOnlyComputeGuard,
+	createMlBudgetGuard,
+	withRequiredDiscriminators,
+} from "$lib/server/mlBudget/guard";
 import { createRepeatedCallGuard } from "./repeatedCallGuard";
 import { withRepairedToolSchemas } from "$lib/server/mcp/schemaRepair";
 import { createSchemaPreflightGuard } from "$lib/server/mcp/preflightGuard";
@@ -49,6 +53,7 @@ import { ML_ASSISTANT_MIN_COMPLETION_TOKENS } from "$lib/constants/mlAssistant";
 import { withUpstreamRetry } from "../utils/upstreamRetry";
 import { getEnabledBuiltinTools, isNestedAgentTool, shouldSkipMcpFlow } from "../builtinTools";
 import { injectPlanState, PLAN_TOOL_NAME } from "../builtinTools/planTool";
+import { ML_ASSISTANT_MODE } from "$lib/utils/mlAssistantFlag";
 
 export type RunMcpFlowContext = Pick<
 	TextGenerationContext,
@@ -159,11 +164,11 @@ export async function* runMcpFlow({
 	// doctrine is sent, and they must all agree within a run.
 	const mlAssistant = isMlAssistantConversation(conv);
 
-	// Every mode conversation is gated — one without a stored budget is a zero
-	// budget, not an ungated one. Settle already ran this turn
-	// (textGeneration/index.ts), so the ledger the guard reserves against is as
-	// fresh as it gets.
-	const budgetGuard = mlAssistant
+	// In builds that ship the mode, Hub compute cannot be started ungated. In the
+	// mode, a missing stored budget is a zero budget; outside it, submissions and
+	// sandbox creation are refused. Settle already ran this turn (textGeneration/index.ts),
+	// so the ledger the budget guard reserves against is as fresh as it gets.
+	const computeGuard = mlAssistant
 		? createMlBudgetGuard({
 				conversationId: conv._id,
 				generationId: generationId ?? conv._id.toString(),
@@ -175,7 +180,9 @@ export async function* runMcpFlow({
 					(locals as unknown as { hfAccessToken?: string } | undefined)?.hfAccessToken ??
 					(locals as unknown as { token?: string } | undefined)?.token,
 			})
-		: undefined;
+		: ML_ASSISTANT_MODE
+			? createMlAssistantOnlyComputeGuard()
+			: undefined;
 
 	// A job bills the namespace it runs under, so the billing setting travels as
 	// an argument rather than a header — see mcp/hubBilling.ts.
@@ -437,23 +444,23 @@ export async function* runMcpFlow({
 				"[mcp] dropped MCP tools shadowed by builtin tools"
 			);
 		}
-		// In the mode, gated tools advertise their routing discriminator as
-		// required — the Hub's own schema doesn't, and calls without one can only
-		// bounce off the budget gate's fail-closed path.
-		const gatedMcpTools = mlAssistant ? withRequiredDiscriminators(mcpTools, mapping) : mcpTools;
+		// Whenever compute policy is active, gated tools advertise their routing
+		// discriminator as required. The Hub's own schema doesn't, and calls without
+		// one can only bounce off the fail-closed guard without saying read or submit.
+		const gatedMcpTools = computeGuard ? withRequiredDiscriminators(mcpTools, mapping) : mcpTools;
 		// Applied to every conversation, mode or not: the Hub tools whose real
 		// interface is a grammar in prose misfire the same way whoever is calling
 		// them. See mcp/schemaRepair.ts for what the traces showed.
 		const shapedMcpTools = withRepairedToolSchemas(gatedMcpTools, mapping, servers);
 		// Cheapest first, and only the last link may book anything (see
 		// composeGuards): a repeat of a call that already failed the same way, then
-		// arguments that cannot satisfy the tool's own schema, then the budget.
-		// The first two run for every conversation — getting a tool's arguments
-		// wrong is not a mode-specific failure.
+		// arguments that cannot satisfy the tool's own schema, then the compute
+		// policy (a budget in the mode, a no-create boundary outside it). The first
+		// two run for every conversation — malformed arguments are not mode-specific.
 		const guard = [
 			repeatedCallGuard,
 			createSchemaPreflightGuard(mapping),
-			...(budgetGuard ? [budgetGuard] : []),
+			...(computeGuard ? [computeGuard] : []),
 		].reduce(composeGuards);
 		const oaTools = [
 			...builtinTools.map((tool) => tool.definition),

--- a/src/lib/stores/mlAssistant.spec.ts
+++ b/src/lib/stores/mlAssistant.spec.ts
@@ -15,12 +15,12 @@ describe("mlAssistant store", () => {
 		mlAssistant.syncConversation(undefined);
 	});
 
-	it("toggles freely until a task starts, then locks", () => {
+	it("toggles freely until a task is confirmed, then locks", () => {
 		mlAssistant.toggle(true);
 		expect(mlAssistant.enabled).toBe(true);
 		expect(mlAssistant.locked).toBe(false);
 
-		mlAssistant.startTask();
+		mlAssistant.confirmCreation(true);
 		expect(mlAssistant.taskStarted).toBe(true);
 		expect(mlAssistant.locked).toBe(true);
 
@@ -28,9 +28,15 @@ describe("mlAssistant store", () => {
 		expect(mlAssistant.enabled).toBe(true);
 	});
 
-	it("does not start a task while the mode is off", () => {
-		mlAssistant.startTask();
+	it("takes the created conversation's confirmed mode as truth", () => {
+		mlAssistant.toggle(true);
+		mlAssistant.confirmCreation(false);
+		expect(mlAssistant.enabled).toBe(false);
 		expect(mlAssistant.taskStarted).toBe(false);
+
+		mlAssistant.confirmCreation(true);
+		expect(mlAssistant.enabled).toBe(true);
+		expect(mlAssistant.taskStarted).toBe(true);
 	});
 
 	it("reports the running step's status label, then Done", () => {
@@ -57,7 +63,7 @@ describe("mlAssistant store", () => {
 
 	it("adopts the conversation a run started from the home composer creates", () => {
 		mlAssistant.toggle(true);
-		mlAssistant.startTask();
+		mlAssistant.confirmCreation(true);
 		mlAssistant.setPlan([step("Research", "running")]);
 
 		// The created conversation arrives already marked, and keeps its plan.
@@ -69,30 +75,16 @@ describe("mlAssistant store", () => {
 
 	it("does not adopt a plain conversation opened while a create is in flight", () => {
 		mlAssistant.toggle(true);
-		mlAssistant.startTask();
+		expect(mlAssistant.enabled).toBe(true);
 
 		expect(mlAssistant.syncConversation("someone-elses-conversation")).toBe(true);
 		expect(mlAssistant.enabled).toBe(false);
 		expect(mlAssistant.taskStarted).toBe(false);
 	});
 
-	it("unlatches the task when the conversation it was for never got created", () => {
-		mlAssistant.toggle(true);
-		mlAssistant.startTask();
-		mlAssistant.setPlan([step("Research", "running")]);
-
-		mlAssistant.abortTask();
-
-		expect(mlAssistant.taskStarted).toBe(false);
-		expect(mlAssistant.steps).toEqual([]);
-		// The switch is usable again, and the mode stays on so a retry keeps it.
-		expect(mlAssistant.locked).toBe(false);
-		expect(mlAssistant.enabled).toBe(true);
-	});
-
 	it("resets when the conversation changes", () => {
 		mlAssistant.toggle(true);
-		mlAssistant.startTask();
+		mlAssistant.confirmCreation(true);
 		mlAssistant.syncConversation("first");
 
 		expect(mlAssistant.syncConversation("second")).toBe(true);
@@ -102,7 +94,7 @@ describe("mlAssistant store", () => {
 
 	it("resets when leaving a conversation for the home composer", () => {
 		mlAssistant.toggle(true);
-		mlAssistant.startTask();
+		mlAssistant.confirmCreation(true);
 		mlAssistant.syncConversation("first");
 
 		expect(mlAssistant.syncConversation(undefined)).toBe(true);

--- a/src/lib/stores/mlAssistant.svelte.ts
+++ b/src/lib/stores/mlAssistant.svelte.ts
@@ -4,15 +4,15 @@ import type { MlBudgetSnapshot, MlPlanStep, MlPlanStepStatus } from "$lib/types/
  * UI state for ML Assistant mode (see `$lib/utils/mlAssistantFlag`).
  *
  * The mode is a property of the conversation: it can be toggled freely until the
- * first message goes out, and is locked for the rest of the conversation after
- * that. Plan steps are pushed in by whatever drives the run — nothing here
- * invents or advances them, so with no plan source the strip stays on its tool
- * note and the progress row never appears.
+ * first message is accepted by the server, and is locked for the rest of the
+ * conversation after that. Plan steps are pushed in by whatever drives the run —
+ * nothing here invents or advances them, so with no plan source the strip stays
+ * on its tool note and the progress row never appears.
  */
 class MlAssistantStore {
 	/** Preset toggle. Editable until `taskStarted`. */
 	enabled = $state(false);
-	/** Latched by `startTask()` on the send that begins an ML run. */
+	/** Latched after the server creates the conversation for an ML run. */
 	taskStarted = $state(false);
 	/** The plan as reported by the run. Empty until a plan arrives. */
 	steps = $state<MlPlanStep[]>([]);
@@ -50,20 +50,14 @@ class MlAssistantStore {
 		this.enabled = next;
 	}
 
-	/** Called on the send that starts an ML task. No-op unless the mode is on. */
-	startTask() {
-		if (!this.enabled) return;
-		this.taskStarted = true;
-	}
-
-	/**
-	 * Undoes `startTask` when the send it was latched for never produced a
-	 * conversation. Without this a failed create leaves the composer locked in a
-	 * task that does not exist, with no way to switch the mode back off.
-	 */
-	abortTask() {
-		this.taskStarted = false;
-		this.steps = [];
+	/** Applies the mode the server persisted for a successfully created conversation. */
+	confirmCreation(startedInMode: boolean) {
+		this.enabled = startedInMode;
+		this.taskStarted = startedInMode;
+		if (!startedInMode) {
+			this.steps = [];
+			this.budget = undefined;
+		}
 	}
 
 	/**

--- a/src/lib/utils/pendingConversation.ts
+++ b/src/lib/utils/pendingConversation.ts
@@ -1,4 +1,5 @@
 import { browser } from "$app/environment";
+import superjson from "superjson";
 import type { Message } from "$lib/types/Message";
 import type { DeployedSpace, MlBudget } from "$lib/types/Conversation";
 import type { PlanState } from "$lib/types/Plan";
@@ -47,6 +48,27 @@ export function seedPendingConversation(id: string, data: ConversationData): voi
 	if (pending.size > MAX_ENTRIES) {
 		const oldest = pending.keys().next().value;
 		if (oldest !== undefined) pending.delete(oldest);
+	}
+}
+
+/**
+ * Decodes and seeds the conversation embedded in POST /conversation.
+ * Returning the decoded payload lets the caller use the server-persisted mode
+ * as the source of truth for UI state and optimistic sidebar metadata.
+ */
+export function seedCreatedConversation(
+	id: string,
+	serialized: unknown
+): ConversationData | undefined {
+	if (typeof serialized !== "string") return undefined;
+	try {
+		const data = superjson.parse<ConversationData>(serialized);
+		if (!data || data.id !== id || !Array.isArray(data.messages)) return undefined;
+		seedPendingConversation(id, data);
+		return data;
+	} catch {
+		// Malformed seed: the page load falls back to a normal fetch.
+		return undefined;
 	}
 }
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -9,8 +9,7 @@
 	import ChatWindow from "$lib/components/chat/ChatWindow.svelte";
 	import { ERROR_MESSAGES, error } from "$lib/stores/errors";
 	import { storePendingFiles } from "$lib/utils/pendingFiles";
-	import superjson from "superjson";
-	import { seedPendingConversation, type ConversationData } from "$lib/utils/pendingConversation";
+	import { seedCreatedConversation } from "$lib/utils/pendingConversation";
 	import { useSettingsStore } from "$lib/stores/settings.js";
 	import { useConversationsStore } from "$lib/stores/conversations.svelte";
 	import { findCurrentModel } from "$lib/utils/models";
@@ -40,6 +39,7 @@
 	const settings = useSettingsStore();
 
 	async function createConversation(message: string) {
+		const requestedMlAssistant = mlAssistant.enabled;
 		try {
 			$loading = true;
 
@@ -56,7 +56,7 @@
 				model = data.models[0].id;
 			}
 			// The mode runs on its own fixed set; the server enforces this too.
-			if (mlAssistant.taskStarted && data.mlAssistantModels.length > 0) {
+			if (requestedMlAssistant && data.mlAssistantModels.length > 0) {
 				model = data.mlAssistantModels.includes(model) ? model : data.mlAssistantModels[0];
 			}
 			const res = await fetch(`${base}/conversation`, {
@@ -70,9 +70,7 @@
 						($settings.customPromptsEnabled?.[$settings.activeModel] ?? true)
 							? $settings.customPrompts[$settings.activeModel]
 							: "",
-					// The composer latches the mode before handing the message over, so
-					// the conversation this creates is marked with it from the start.
-					mlAssistant: mlAssistant.taskStarted,
+					mlAssistant: requestedMlAssistant,
 				}),
 			});
 
@@ -89,23 +87,13 @@
 				}
 				error.set(errorMessage);
 				console.error("Error while creating conversation: ", errorMessage);
-				// The composer latched the mode for a conversation that never happened.
-				mlAssistant.abortTask();
 				return;
 			}
 
 			const { conversationId, conversation } = await res.json();
-
-			// The create response embeds the conversation payload; hand it to the
-			// conversation page as a one-shot seed so its load skips the GET and
-			// the first generation request starts one round-trip sooner.
-			if (typeof conversation === "string") {
-				try {
-					seedPendingConversation(conversationId, superjson.parse<ConversationData>(conversation));
-				} catch {
-					// Malformed seed: the page load falls back to a normal fetch.
-				}
-			}
+			const createdConversation = seedCreatedConversation(conversationId, conversation);
+			const createdInMlMode = createdConversation?.mlAssistant === true;
+			if (createdConversation) mlAssistant.confirmCreation(createdInMlMode);
 
 			// Pass the first message text via SvelteKit history state (JSON-serializable).
 			// File objects are not serializable, so they are stored in a client-side Map
@@ -120,11 +108,9 @@
 			convsStore.prepend({
 				id: conversationId,
 				title: "New Chat",
-				model,
+				model: createdConversation?.model ?? model,
 				updatedAt: new Date(),
-				// Latched before the create request, so the sidebar row carries the
-				// mode's designation from the moment it appears.
-				mlAssistant: mlAssistant.taskStarted,
+				mlAssistant: createdInMlMode,
 			});
 			await goto(`${base}/conversation/${conversationId}`, {
 				state: { pendingMessage: message, pendingFilesNonce },
@@ -132,8 +118,6 @@
 		} catch (err) {
 			error.set((err as Error).message || ERROR_MESSAGES.default);
 			console.error(err);
-			// The composer latched the mode for a conversation that never happened.
-			mlAssistant.abortTask();
 		} finally {
 			$loading = false;
 		}

--- a/src/routes/linkPrompt.svelte.test.ts
+++ b/src/routes/linkPrompt.svelte.test.ts
@@ -2,9 +2,11 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { tick } from "svelte";
 import { writable } from "svelte/store";
 import type { Component } from "svelte";
+import superjson from "superjson";
 import { appNavigation, renderWithApp } from "$lib/components/__tests__/renderWithApp";
 import { setPage } from "$lib/components/__tests__/appMocks";
 import { loadAttachmentsFromUrls } from "$lib/utils/loadAttachmentsFromUrls";
+import { mlAssistant } from "$lib/stores/mlAssistant.svelte";
 import HomePage from "./+page.svelte";
 import ModelPage from "./models/[...model]/+page.svelte";
 
@@ -14,6 +16,8 @@ vi.mock("$lib/components/chat/ChatWindow.svelte", async () => ({
 vi.mock("$lib/utils/loadAttachmentsFromUrls", () => ({ loadAttachmentsFromUrls: vi.fn() }));
 
 afterEach(() => {
+	mlAssistant.reset();
+	mlAssistant.syncConversation(undefined);
 	vi.unstubAllGlobals();
 	vi.restoreAllMocks();
 });
@@ -21,6 +25,25 @@ afterEach(() => {
 type Loaded = Awaited<ReturnType<typeof loadAttachmentsFromUrls>>;
 
 const LINK = "?q=hello&attachments=https://a.example/file.txt";
+
+function createdResponse(mlAssistant: boolean) {
+	return new Response(
+		JSON.stringify({
+			conversationId: "created",
+			conversation: superjson.stringify({
+				messages: [],
+				title: "New Chat",
+				model: "test",
+				id: "created",
+				updatedAt: new Date(),
+				modelId: "test",
+				shared: false,
+				...(mlAssistant ? { mlAssistant: true } : {}),
+			}),
+		}),
+		{ status: 200 }
+	);
+}
 
 /**
  * Mounts a route on a `q` link whose attachment fetch stays pending until the
@@ -36,27 +59,30 @@ function mountOnLink(component: Component, url: string, params: Record<string, s
 					resolveAttachments = resolve;
 				})
 		);
-	const fetchSpy = vi.fn(
-		async () => new Response(JSON.stringify({ conversationId: "created" }), { status: 200 })
-	);
+	const fetchSpy = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+		const request = JSON.parse(String(init?.body ?? "{}")) as { mlAssistant?: boolean };
+		return createdResponse(request.mlAssistant === true);
+	});
 	vi.stubGlobal("fetch", fetchSpy);
 
 	const settings = Object.assign(
 		writable({ activeModel: "test", customPrompts: {}, welcomeModalSeen: true }),
 		{ instantSet: vi.fn(async () => undefined) }
 	);
+	const prepend = vi.fn();
 	const context = new Map<unknown, unknown>([
 		["settings", settings],
-		["conversationsStore", { prepend: vi.fn() }],
+		["conversationsStore", { prepend }],
 	]);
 	const screen = renderWithApp(
 		component,
-		{ data: { models: [{ id: "test" }], oldModels: [], mlAssistantModels: [] } } as never,
+		{ data: { models: [{ id: "test" }], oldModels: [], mlAssistantModels: ["test"] } } as never,
 		{ context, page: { url, params, data: { loginEnabled: false } } }
 	);
 	return {
 		screen,
 		fetchSpy,
+		prepend,
 		resolveAttachments: (value: Loaded) => resolveAttachments(value),
 	};
 }
@@ -107,5 +133,52 @@ describe.each([
 			"/conversation/created",
 			expect.objectContaining({ state: expect.objectContaining({ pendingMessage: "hello" }) })
 		);
+	});
+
+	it("persists ML Intern from any first-message callback, then locks on confirmation", async () => {
+		const { fetchSpy, prepend } = mountOnLink(component, url.split("?")[0] ?? "/", params);
+		let confirmCreate: (response: Response) => void = () => {};
+		fetchSpy.mockImplementationOnce(
+			() =>
+				new Promise<Response>((resolve) => {
+					confirmCreate = resolve;
+				})
+		);
+		mlAssistant.toggle(true);
+		const composer = document.querySelector('[data-testid="composer"]') as HTMLTextAreaElement;
+		composer.value = "hello";
+		composer.dispatchEvent(new Event("input", { bubbles: true }));
+		document.querySelector<HTMLButtonElement>('[data-testid="send-message"]')?.click();
+
+		const [[, init]] = conversationPosts(fetchSpy);
+		expect(JSON.parse(String(init?.body))).toMatchObject({ mlAssistant: true });
+		expect(mlAssistant.taskStarted).toBe(false);
+
+		confirmCreate(createdResponse(true));
+		await settle();
+
+		expect(mlAssistant.taskStarted).toBe(true);
+		expect(prepend).toHaveBeenCalledWith(expect.objectContaining({ mlAssistant: true }));
+		expect(appNavigation().goto).toHaveBeenCalledWith(
+			"/conversation/created",
+			expect.objectContaining({ state: expect.objectContaining({ pendingMessage: "hello" }) })
+		);
+	});
+
+	it("uses the mode the server returned instead of the requested toggle", async () => {
+		const { fetchSpy, prepend } = mountOnLink(component, url.split("?")[0] ?? "/", params);
+		fetchSpy.mockResolvedValueOnce(createdResponse(false));
+		mlAssistant.toggle(true);
+		const composer = document.querySelector('[data-testid="composer"]') as HTMLTextAreaElement;
+		composer.value = "hello";
+		composer.dispatchEvent(new Event("input", { bubbles: true }));
+		document.querySelector<HTMLButtonElement>('[data-testid="send-message"]')?.click();
+		await settle();
+
+		const [[, init]] = conversationPosts(fetchSpy);
+		expect(JSON.parse(String(init?.body))).toMatchObject({ mlAssistant: true });
+		expect(mlAssistant.enabled).toBe(false);
+		expect(mlAssistant.taskStarted).toBe(false);
+		expect(prepend).toHaveBeenCalledWith(expect.objectContaining({ mlAssistant: false }));
 	});
 });

--- a/src/routes/models/[...model]/+page.svelte
+++ b/src/routes/models/[...model]/+page.svelte
@@ -12,6 +12,7 @@
 	import { useConversationsStore } from "$lib/stores/conversations.svelte";
 	import { ERROR_MESSAGES, error } from "$lib/stores/errors";
 	import { storePendingFiles } from "$lib/utils/pendingFiles";
+	import { seedCreatedConversation } from "$lib/utils/pendingConversation";
 	import { loadAttachmentsFromUrls } from "$lib/utils/loadAttachmentsFromUrls";
 	import {
 		LINK_PARAM_NAMES,
@@ -41,12 +42,13 @@
 	);
 
 	async function createConversation(message: string) {
+		const requestedMlAssistant = mlAssistant.enabled;
 		try {
 			loading = true;
 
 			// The mode runs on its own fixed set; the server enforces this too.
 			const model =
-				mlAssistant.taskStarted &&
+				requestedMlAssistant &&
 				data.mlAssistantModels.length > 0 &&
 				!data.mlAssistantModels.includes(modelId)
 					? data.mlAssistantModels[0]
@@ -62,21 +64,20 @@
 						($settings.customPromptsEnabled?.[modelId] ?? true)
 							? $settings.customPrompts[modelId]
 							: "",
-					// The composer latches the mode before handing the message over, so
-					// the conversation this creates is marked with it from the start.
-					mlAssistant: mlAssistant.taskStarted,
+					mlAssistant: requestedMlAssistant,
 				}),
 			});
 
 			if (!res.ok) {
 				error.set("Error while creating conversation, try again.");
 				console.error("Error while creating conversation: " + (await res.text()));
-				// The composer latched the mode for a conversation that never happened.
-				mlAssistant.abortTask();
 				return;
 			}
 
-			const { conversationId } = await res.json();
+			const { conversationId, conversation } = await res.json();
+			const createdConversation = seedCreatedConversation(conversationId, conversation);
+			const createdInMlMode = createdConversation?.mlAssistant === true;
+			if (createdConversation) mlAssistant.confirmCreation(createdInMlMode);
 
 			// Pass the first message text via SvelteKit history state (JSON-serializable).
 			// File objects are not serializable, so they are stored in a client-side Map
@@ -91,11 +92,9 @@
 			convsStore.prepend({
 				id: conversationId,
 				title: "New Chat",
-				model,
+				model: createdConversation?.model ?? model,
 				updatedAt: new Date(),
-				// Latched before the create request, so the sidebar row carries the
-				// mode's designation from the moment it appears.
-				mlAssistant: mlAssistant.taskStarted,
+				mlAssistant: createdInMlMode,
 			});
 			await goto(`${base}/conversation/${conversationId}`, {
 				state: { pendingMessage: message, pendingFilesNonce },
@@ -103,8 +102,6 @@
 		} catch (err) {
 			error.set(ERROR_MESSAGES.default);
 			console.error(err);
-			// The composer latched the mode for a conversation that never happened.
-			mlAssistant.abortTask();
 		} finally {
 			loading = false;
 		}


### PR DESCRIPTION
## What changed

- Read `mlAssistant.enabled` at conversation creation for the home, model, prompt-example, and fix/resume send paths.
- Lock the client mode only after the server returns the persisted conversation seed, and use that seed as the source of truth for the sidebar and navigation state.
- Add a server-side fail-closed boundary so ordinary conversations cannot create Hugging Face jobs or sandboxes without the ML Intern budget and billing context; reads, stops, and non-Hub MCP servers remain available.
- Add regression coverage for the client send paths, persisted create seed, MCP compute boundary, and scheduled-job edge cases.

## Why

A prompt-example send bypassed the one path that latched ML Intern locally, so the new conversation was persisted as an ordinary chat. That left Hub compute available without the mode's budget, pre-flight, and billing protections.

Closes #2573

## Validation

- `ML_ASSISTANT_MODE=true`: server 1400 tests, SSR 4 tests, client 248 tests passed (serial workers).
- Focused regression suite: 108 tests passed.
- `npm run check`: 0 Svelte diagnostics.
- Production builds passed with both `ML_ASSISTANT_MODE=true` and `false`.
- Changed files pass Prettier and ESLint; `git diff --check` passes.
