### PR TITLE
fix: don't crash the server on URI paths with invalid percent-encoding

### DIFF
--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -12,7 +12,7 @@ import { config } from "$lib/server/config";
 import { sha256 } from "$lib/utils/sha256";
 import { z } from "zod";
 import { dev } from "$app/environment";
-import { redirect, type Cookies } from "@sveltejs/kit";
+import { type Cookies } from "@sveltejs/kit";
 import { collections } from "$lib/server/database";
 import JSON5 from "json5";
 import { logger } from "$lib/server/logger";
@@ -580,5 +580,9 @@ export async function triggerOauthFlow({ url, locals, cookies }: RequestEvent): 
 		{ sessionId: locals.sessionId, next, url, cookies }
 	);
 
-	throw redirect(302, authorizationUrl);
+	// Return a real 302 response instead of `throw redirect(...)`: this
+	// function is called from the handle hook, where a thrown Redirect that
+	// crosses an unawaited promise boundary becomes an unhandled rejection
+	// and kills the Node process (observed in prod with scanner requests).
+	return new Response(null, { status: 302, headers: { location: authorizationUrl } });
 }

--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -12,7 +12,7 @@ import { config } from "$lib/server/config";
 import { sha256 } from "$lib/utils/sha256";
 import { z } from "zod";
 import { dev } from "$app/environment";
-import { type Cookies } from "@sveltejs/kit";
+import { redirect, type Cookies } from "@sveltejs/kit";
 import { collections } from "$lib/server/database";
 import JSON5 from "json5";
 import { logger } from "$lib/server/logger";
@@ -580,9 +580,5 @@ export async function triggerOauthFlow({ url, locals, cookies }: RequestEvent): 
 		{ sessionId: locals.sessionId, next, url, cookies }
 	);
 
-	// Return a real 302 response instead of `throw redirect(...)`: this
-	// function is called from the handle hook, where a thrown Redirect that
-	// crosses an unawaited promise boundary becomes an unhandled rejection
-	// and kills the Node process (observed in prod with scanner requests).
-	return new Response(null, { status: 302, headers: { location: authorizationUrl } });
+	throw redirect(302, authorizationUrl);
 }

--- a/src/lib/server/hooks/handle.ts
+++ b/src/lib/server/hooks/handle.ts
@@ -59,6 +59,16 @@ export async function handleRequest({ event, resolve }: HandleInput): Promise<Re
 				});
 			}
 
+			// Reject URI paths with invalid percent-encoding (e.g. overlong UTF-8
+			// like %c0%af used by path-traversal scanners) before any further
+			// processing. SvelteKit only turns these into a 400 inside resolve();
+			// the OAuth redirect logic below runs earlier and must not see them.
+			try {
+				decodeURIComponent(event.url.pathname);
+			} catch {
+				return errorResponse(400, "Malformed URI");
+			}
+
 			if (event.route.id === "/admin" || event.route.id?.startsWith("/admin/")) {
 				const ADMIN_SECRET = config.ADMIN_API_SECRET || config.PARQUET_EXPORT_SECRET;
 


### PR DESCRIPTION
## Incident

**This caused a production DoS incident on HuggingChat (Sep 12).** Random internet scanners sending path-traversal probes were repeatedly crashing chat-ui prod pods — each malformed request killed a pod, dropping all in-flight requests. Anyone could take down all replicas with a simple curl loop, no authentication needed. As an emergency mitigation we had to block these requests at the WAF/CDN edge (rule blocking `%c0`/`%c1` sequences on `/chat` paths). This PR is the proper application-level fix.

## Problem

Requests with invalid percent-encoding in the path — e.g. `/chat/..%c0%af..%c0%af..etc/passwd/...` or `/chat/WEB-INF/web.xml%C0%80.jsp` (typical path-traversal scanner probes, `%c0%af`/`%c0%80` are overlong UTF-8 sequences) — crash the whole server process:

```
UnhandledPromiseRejection: This error originated either by throwing inside of an async
function without a catch block, or by rejecting a promise which was not handled with
.catch(). The promise rejected with the reason "#<Redirect>".
    at throwUnhandledRejectionsMode (node:internal/process/promises:392:7)
```

Node's default `--unhandled-rejections=throw` terminates the process, so **any unauthenticated request with such a path takes down the pod**.

## Root cause

SvelteKit calls the `handle` hook even when the pathname fails to decode (`decode_pathname` throws → `resolved_path = null`), and only produces the `400 Malformed URI` error page later, inside `resolve()`. Our handle hook never gets that far for anonymous requests: the OAuth login branch runs first, and `triggerOauthFlow`'s thrown `redirect(302)` ends up crossing an unawaited promise boundary and becomes an unhandled rejection instead of a 302.

## Fix

**Early validation in the handle hook**: if `decodeURIComponent(event.url.pathname)` throws, return a plain 400 before any auth/OAuth logic — mirroring what SvelteKit itself does inside `resolve()`, just earlier. Malformed paths never reach the OAuth branch, so nothing throws a `Redirect` outside SvelteKit's control.

(An earlier revision also converted `triggerOauthFlow` to return a raw 302 `Response` instead of throwing — reverted per review feedback, since SvelteKit needs the thrown `Redirect` to build its data-request redirect payload for client-side navigation.)

## Expected behavior after the fix (please verify in review/CI)

- `curl 'http://localhost:5173/chat/WEB-INF/web.xml%C0%80.jsp'` → 400 `Malformed URI` (previously: process crash)
- Login flow unchanged (OAuth redirect logic untouched)

Note: I haven't run this locally — flagging so reviewers know a smoke test still needs a pass.